### PR TITLE
Always generate .cmt files

### DIFF
--- a/_tags.in
+++ b/_tags.in
@@ -1,1 +1,2 @@
 true: short_paths
+true: annot, bin_annot


### PR DESCRIPTION
The latest oasis automagically adds this line to the generated _tags file, but older versions potentially do not
