### PR TITLE
Bap table intersections fix + Bap table tests

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -221,7 +221,8 @@ Library image_test
   CompiledObject: best
   BuildDepends:   bap
   Install:        false
-  Modules:        Test_image
+  Modules:        Test_image,
+                  Test_table
 
 Library benchmarks
   Path:           benchmarks

--- a/lib/bap_image/bap_image.ml
+++ b/lib/bap_image/bap_image.ml
@@ -177,7 +177,7 @@ let words_of_table word_size tab =
   let words_of_memory mem tab =
     Memory.foldi ~word_size mem ~init:tab
       ~f:(fun addr word tab ->
-          match Memory.view ~word_size ~from:addr mem with
+          match Memory.view ~word_size ~from:addr ~words:1 mem with
           | Error err ->
             eprintf "\nSkipping with error: %s\n"
               (Error.to_string_hum err);

--- a/lib/bap_image/bap_table.ml
+++ b/lib/bap_image/bap_table.ml
@@ -57,8 +57,11 @@ let empty = {
 }
 
 let fold_intersections tab x ~init ~f =
-  let min, min_addr = Mem.first_byte x, Mem.min_addr x in
   let max, max_addr = Mem.last_byte x,  Mem.max_addr x in
+  let min_addr = Mem.min_addr x in
+  let min = match Map.min_elt tab.map with
+    | Some (m,_) -> m
+    | None -> max in
   Map.fold_range_inclusive tab.map ~min ~max ~init
     ~f:(fun ~key ~data init ->
         match Mem.compare_with key min_addr,

--- a/lib_test/bap/run_tests.ml
+++ b/lib_test/bap/run_tests.ml
@@ -5,6 +5,7 @@ let suite =
     Test_bitvector.suite;
     Test_conceval.suite;
     Test_image.suite;
+    Test_table.suite;
     Test_leb128.suite;
   ]
 

--- a/lib_test/bap_image/test_table.ml
+++ b/lib_test/bap_image/test_table.ml
@@ -1,0 +1,127 @@
+open Core_kernel.Std
+open OUnit2
+open Or_error
+open Word_size
+open Format
+
+open Bap.Std
+open Image_common
+open Image_backend
+open Bap_table
+
+let create_addr = function
+  | W32 -> Addr.of_int ~width:32
+  | W64 -> Addr.of_int ~width:64
+
+let empty_table = Bap_table.empty
+
+let create_mem ?(addr_size=W32) ?(start_addr=0x00) ?(size=0x08) () =
+  let addr = create_addr W32 start_addr in
+  let contents = Bigstring.init size ~f:(fun i -> char_of_int (i+0x61)) in
+  let m = Bap_memory.create LittleEndian addr contents in
+  match m with
+  | Ok m -> m
+  | Error err -> assert_failure (Error.to_string_hum err)
+
+let table =
+  let mem = create_mem () in
+  let t = Bap_table.add empty_table mem "Tagged" in
+  match t with
+  | Ok t -> t
+  | Error err -> assert_failure (Error.to_string_hum err)
+
+let test_table_len ctxt =
+  assert_equal 0 (Bap_table.length empty_table)
+
+let test_table_len2 ctxt =
+  assert_equal 1 (Bap_table.length table)
+
+let test_find ctxt =
+  let mem_to_find = create_mem () in
+  Bap_table.find table mem_to_find |> function
+  | Some x -> assert_equal "Tagged" x
+  | None -> assert_failure "Not found"
+
+let test_mem ctxt =
+  let mem_to_find = create_mem () in
+  assert_bool "Memory not found" (Bap_table.mem table mem_to_find)
+
+let get_mem_tag = function
+  | Some (_,x) -> x
+  | None -> assert_failure "No memory contents"
+
+let mem_low = create_mem ~start_addr:0x00 ~size:0x10 ()
+let mem_high = create_mem ~start_addr:0x20 ~size:0x10 ()
+
+(* Construct a new table tab *)
+let tab =
+  let t = Bap_table.add empty_table mem_low "lo" >>= fun t ->
+  Bap_table.add t mem_high "hi" >>= fun t -> return t in
+  match t with
+  | Ok t -> t
+  | Error err -> assert_failure (Error.to_string_hum err)
+
+(* Tests if the mem range intersects with the mem expected regions *)
+let test_intersections ctxt ~start_addr ~size ~expect =
+  let mem_intersect = create_mem ~start_addr ~size () in
+  let result = Bap_table.intersections tab mem_intersect in
+  let regions = Seq.fold result ~init:[] ~f:(fun acc x -> (snd x) :: acc) in
+  let printer l = Sexp.to_string_hum (sexp_of_list sexp_of_string l) in
+  assert_equal ~ctxt ~printer expect regions
+
+let str_printer expect_err = Sexp.to_string_hum (sexp_of_string expect_err)
+
+let test_next ctxt =
+  let result = Bap_table.next tab mem_low |> get_mem_tag in
+  let msg = "Wrong next element" in
+  assert_equal ~ctxt ~printer:str_printer ~msg "hi" result
+
+let test_prev ctxt =
+  let result = Bap_table.prev tab mem_high |> get_mem_tag in
+  let msg = "Wrong prev element" in
+  assert_equal ~ctxt ~printer:str_printer ~msg "lo" result
+
+let test_min ctxt =
+  let result = Bap_table.min tab |> get_mem_tag in
+  let msg = "Wrong lowest memory binding" in
+  assert_equal ~ctxt ~printer:str_printer ~msg "lo" result
+
+let test_max ctxt =
+  let result = Bap_table.max tab |> get_mem_tag in
+  let msg = "Wrong highest memory binding" in
+  assert_equal ~ctxt ~printer:str_printer ~msg "hi" result
+
+let test_one_to_one ctxt =
+  let tab2 =
+    let extra = create_mem ~start_addr:0x50 ~size:0x30 () in
+    let t = Bap_table.add empty_table mem_low "reg1" >>= fun t ->
+    Bap_table.add t mem_high "reg2" >>= fun t ->
+    Bap_table.add t extra "reg3" >>= fun t -> return t in
+    match t with
+    | Ok t -> t
+    | Error err -> assert_failure (Error.to_string_hum err) in
+  let link_table = link ~one_to:one String.hashable tab tab2 in
+  assert_equal "reg2" (link_table "hi")
+
+let suite = "Table" >::: [
+    "table_length_zero" >:: test_table_len;
+    "table_length_nonzero" >:: test_table_len2;
+    "test_find" >:: test_find;
+    "test_mem" >:: test_mem;
+    "test_intersections1" >::
+      test_intersections ~start_addr:0x00 ~size:0x30 ~expect:["hi";"lo"];
+    "test_intersections2" >::
+      test_intersections ~start_addr:0x0F ~size:0x30 ~expect:["hi";"lo"];
+    "test_intersections3" >::
+      test_intersections ~start_addr:0x10 ~size:0x10 ~expect:[];
+    "test_intersections4" >::
+      test_intersections ~start_addr:0x10 ~size:0x30 ~expect:["hi"];
+    "test_intersections5" >::
+      test_intersections ~start_addr:0x21 ~size:0x01 ~expect:["hi"];
+    "test_intersections6" >::
+      test_intersections ~start_addr:0x21 ~size:0x20 ~expect:["hi"];
+    "test_next" >:: test_next;
+    "test_prev" >:: test_prev;
+    "test_min" >:: test_min;
+    "test_max" >:: test_max;
+  ]

--- a/lib_test/bap_image/test_table.mli
+++ b/lib_test/bap_image/test_table.mli
@@ -1,0 +1,1 @@
+val suite : OUnit2.test


### PR DESCRIPTION
@ivg the way I fixed the intersections bug we talked about was to just get the `min` memory from the table and start folding from that address. If there's no memory in the table this just gets set equal to `max` of the 'intersector' memory--your suggestions are welcome.
