### PR TITLE
ARM lifting.

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -183,13 +183,26 @@ Library disasm
   BuildDepends:  bap.image,
                  bap.types
   Modules:       Bap_disasm,
+                 Bap_disasm_arm,
+                 Bap_disasm_arm_bit,
+                 Bap_disasm_arm_branch,
+                 Bap_disasm_arm_env,
+                 Bap_disasm_arm_flags,
+                 Bap_disasm_arm_lifter,
+                 Bap_disasm_arm_mem,
+                 Bap_disasm_arm_mem_shift,
+                 Bap_disasm_arm_mov,
+                 Bap_disasm_arm_mul,
+                 Bap_disasm_arm_shift,
+                 Bap_disasm_arm_types,
+                 Bap_disasm_arm_utils,
                  Bap_disasm_basic,
                  Bap_disasm_prim,
                  Bap_insn_kind
+
   CCOpt:         $cc_optimization
   CCLib:         $cxxlibs
   CSources:      disasm.h, disasm.c, disasm_stubs.c
-
 
 Library llvm
   Path:          lib/bap_disasm

--- a/lib/bap_disasm/bap_disasm.ml
+++ b/lib/bap_disasm/bap_disasm.ml
@@ -15,3 +15,10 @@ type reg = Reg.t with bin_io, compare, sexp
 type imm = Imm.t with bin_io, compare, sexp
 type fmm = Fmm.t with bin_io, compare, sexp
 type (+'a,+'k) insn
+
+
+(** ARM instruction set  *)
+module Arm = struct
+  include Bap_disasm_arm
+  module Lift = Bap_disasm_arm_lifter
+end

--- a/lib/bap_disasm/bap_disasm_arm.ml
+++ b/lib/bap_disasm/bap_disasm_arm.ml
@@ -1,0 +1,94 @@
+open Core_kernel.Std
+open Or_error
+
+open Bap_types.Std
+open Bap_disasm_arm_types
+
+
+let sexpable_of_string t_of_sexp name =
+  try Some (t_of_sexp @@ Sexp.of_string name)
+  with Sexp.Of_sexp_error _ -> None
+
+
+module Cond = struct
+  include Cond
+  include Regular.Make(struct
+      type t = cond with bin_io, compare, sexp
+      let hash (cond : t) = Hashtbl.hash cond
+      let module_name = "Bap_disasm_arm.Cond"
+      let pp fmt cond =
+        Format.fprintf fmt "%a" Sexp.pp (sexp_of_t cond)
+    end)
+  let of_int_exn = function
+    | 0 ->  `EQ
+    | 1 ->  `NE
+    | 2 ->  `CS
+    | 3 ->  `CC
+    | 4 ->  `MI
+    | 5 ->  `PL
+    | 6 ->  `VS
+    | 7 ->  `VC
+    | 8 ->  `HI
+    | 9 ->  `LS
+    | 10 -> `GE
+    | 11 -> `LT
+    | 12 -> `GT
+    | 13 -> `LE
+    | 14 -> `AL
+    | n -> invalid_argf "not a condition: %d" n ()
+
+  let create w =
+    Word.to_int w >>= fun w ->
+    try_with (fun () -> of_int_exn w)
+
+end
+
+
+module Reg = struct
+  let create reg =
+    sexpable_of_string reg_of_sexp (Basic.Reg.name reg)
+
+  include Regular.Make(struct
+      type t = reg with bin_io, compare, sexp
+      let hash (reg : t) = Hashtbl.hash reg
+      let module_name = "Bap_disasm_arm.Reg"
+      let pp fmt reg =
+        Format.fprintf fmt "%a" Sexp.pp (sexp_of_t reg)
+    end)
+  include Reg
+
+end
+
+module Op = struct
+  include Regular.Make(struct
+      type t = op with bin_io, compare, sexp
+      let module_name = "Bap_disasm_arm.Op"
+      let pp fmt op =
+        Format.fprintf fmt "%a" Sexp.pp (sexp_of_t op)
+      let hash (op : op) = Hashtbl.hash op
+    end)
+  include Op
+
+  let create : Basic.op -> op option =
+    let open Option.Monad_infix in
+    function
+    | Basic.Op.Fmm fmm -> None
+    | Basic.Op.Reg reg -> Reg.create reg >>| fun reg -> Reg reg
+    | Basic.Op.Imm imm ->
+      Basic.Imm.to_word ~width:32 imm >>| fun imm -> Imm imm
+end
+
+module Insn = struct
+  let create insn =
+    sexpable_of_string insn_of_sexp (Basic.Insn.name insn)
+
+  include Regular.Make(struct
+      type t = insn with bin_io, compare, sexp
+      let module_name = "Bap_disasm_arm.Op"
+      let pp fmt insn =
+        Format.fprintf fmt "%a" Sexp.pp (sexp_of_t insn)
+      let hash (insn : t) = Hashtbl.hash insn
+    end)
+  include Insn
+
+end

--- a/lib/bap_disasm/bap_disasm_arm.mli
+++ b/lib/bap_disasm/bap_disasm_arm.mli
@@ -1,0 +1,44 @@
+(** Types for ARM instructions.
+    The type definitions itself can be viewed in a
+    [Bap_disasm_arm_types] module. This one extends them with a
+    [Regular] functions.
+*)
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_disasm_arm_types
+
+(** Arm instruction  *)
+module Insn : sig
+  (** [create basic_insn] lifts ARM instruction from a basic instruction  *)
+  val create : ('a,'b) Basic.insn -> insn option
+
+  include module type of Insn
+  include Regular with type t := t
+end
+
+(** ARM instruction operands  *)
+module Op : sig
+  type t = Op.t =
+    | Reg of reg                (** register *)
+    | Imm of word               (** immidiate  *)
+
+  (** lifts operand from a basic one  *)
+  val create : Basic.op -> op option
+  include Regular with type t := t
+end
+
+
+module Reg : sig
+  (** lifts basic register to a ARM one  *)
+  val create : Basic.reg -> reg option
+
+  include module type of Reg
+  include Regular with type t := t
+end
+
+module Cond : sig
+  (** decodes condition value from a word  *)
+  val create : word -> cond Or_error.t
+  include module type of Cond
+  include Regular with type t := t
+end

--- a/lib/bap_disasm/bap_disasm_arm_bit.ml
+++ b/lib/bap_disasm/bap_disasm_arm_bit.ml
@@ -1,0 +1,78 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Or_error
+
+open Bap_disasm_arm_types
+open Bap_disasm_arm_utils
+
+module Env = Bap_disasm_arm_env
+module Shift = Bap_disasm_arm_shift
+
+let bits_of_size = function
+  | `H -> 16
+  | `B -> 8
+
+
+let wordm x = Ok (Word.of_int x ~width:32)
+
+let extend ~dest ~src ?src2 sign size ~rot cond =
+  let rot = assert_imm _here_ rot in
+  let dest = assert_reg _here_ dest in
+  let amount = match Word.Int.((!$rot * wordm 8)) with
+    | Ok amount -> amount
+    | Error err -> fail _here_ "failed to obtain amount" in
+  let rotated, (_ : exp) =
+    if Word.is_zero amount then
+      exp_of_op src, Exp.int (Word.zero 32)
+    else
+      Shift.lift_c ~src:(exp_of_op src)
+        `ROR ~shift:(Exp.int amount) reg32_t in
+  let extracted =
+    Exp.(cast Cast.low (bits_of_size size) rotated) in
+  let extent = cast_of_sign sign 32 extracted in
+  let final = match src2 with
+    | Some s2 -> Exp.(exp_of_op s2 + extent)
+    | None    -> extent in
+  exec [assn (Env.of_reg dest) final] cond
+
+let bit_extract ~dest ~src sign ~lsb ~widthminus1 cond =
+  let dest = assert_reg _here_ dest in
+  let lsb = assert_imm _here_ lsb in
+  let widthminus1 = assert_imm _here_ widthminus1 in
+  let int_of_imm imm = match Word.to_int imm with
+    | Ok imm -> imm
+    | Error err -> fail _here_ "can't cast word to int: %s" @@
+      Error.to_string_hum err  in
+  let low = int_of_imm lsb in
+  let high = low + (int_of_imm widthminus1) in
+  let extracted = Exp.extract high low (exp_of_op src) in
+  let final = cast_of_sign sign 32 extracted in
+  exec [assn (Env.of_reg dest) final] cond
+
+let get_lsb_width instr : int * int =
+  let open Word.Int_exn in
+  let width = Word.bitwidth instr in
+  let (!$) = Word.of_int ~width in
+  let lsb = (instr lsr !$7) land !$0x1f in
+  let msb = (instr lsr !$16) land !$0x1f in
+  let width = abs (msb - lsb + !$1) in
+  match Word.(to_int lsb, to_int width) with
+  | Ok lsb, Ok width -> lsb,width
+  | _ -> fail _here_ "failed to get_lsb_width"
+
+let bit_field_insert ~dest ~src raw cond =
+  let dest = assert_reg _here_ dest in
+  let d   = Env.of_reg dest in
+  let d_e = Exp.var d in
+  let lsb, width = get_lsb_width raw in
+  let extracted = Exp.extract (width - 1) 0 (exp_of_op src) in
+  let ext_h b s = Exp.extract 31 b s in
+  let ext_l b s = Exp.extract b 0 s in
+  let inst = match lsb + width - 1, lsb with
+    | 31, 0 -> extracted
+    | 31, l -> Exp.concat extracted (ext_l (l - 1) d_e)
+    | m,  0 -> Exp.concat (ext_h (m + 1) d_e) extracted
+    | m,  l -> Exp.concat (Exp.concat
+                             (ext_h (m + 1) d_e) extracted)
+                 (ext_l (l - 1) d_e) in
+  exec [Stmt.move d inst] cond

--- a/lib/bap_disasm/bap_disasm_arm_bit.mli
+++ b/lib/bap_disasm/bap_disasm_arm_bit.mli
@@ -1,0 +1,12 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_disasm_arm_types
+
+
+
+val extend : dest:op -> src:op -> ?src2:op -> sign -> [< `B | `H ] -> rot:op -> op -> stmt list
+
+val bit_field_insert : dest:op -> src:op -> Word.t -> op -> stmt list
+
+
+val bit_extract : dest:op -> src:op -> sign -> lsb:op -> widthminus1:op -> op -> stmt list

--- a/lib/bap_disasm/bap_disasm_arm_branch.ml
+++ b/lib/bap_disasm/bap_disasm_arm_branch.ml
@@ -1,0 +1,38 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Or_error
+
+open Bap_disasm_arm_types
+open Bap_disasm_arm_utils
+
+module Arm = Bap_disasm_arm
+module Mem = Bap_disasm_arm_mem
+module Env = Bap_disasm_arm_env
+module Shift = Bap_disasm_arm_shift
+
+let pc_offset = Word.(of_int 8 ~width:32)         (* PC is ahead by some bytes in ARM *)
+let word = Word.of_int ~width:32
+
+
+let lift operand ?link ?x:_ ?cond addr =
+  let target =
+    match operand with
+    | Op.Reg r -> Exp.var (Env.of_reg r)
+    | Op.Imm offset ->
+      let width = Word.bitwidth offset in
+      let _1 = Word.one 32 in
+      let min_32 = Word.Int_exn.(_1 lsl Word.of_int 31 ~width) in
+      let offset = if offset = min_32 then Word.zero 32 else offset in
+      let r = Word.Int_exn.(addr + pc_offset + offset) in
+      Exp.int r in
+  (* TODO detect change to thumb in `x` *)
+  let jump_instr = [Stmt.jmp target] in
+  let link_instr =
+    let next_addr = Word.Int_exn.(addr + pc_offset - word 4) in
+    match link with
+    | Some true -> [Stmt.move Env.lr Exp.(int next_addr)]
+    | _         -> [] in
+  let stmts = link_instr @ jump_instr in
+  match cond with
+  | Some c -> exec stmts c
+  | None -> stmts

--- a/lib/bap_disasm/bap_disasm_arm_branch.mli
+++ b/lib/bap_disasm/bap_disasm_arm_branch.mli
@@ -1,0 +1,5 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_disasm_arm_types
+
+val lift : op -> ?link:bool -> ?x:bool -> ?cond:op -> word -> stmt list

--- a/lib/bap_disasm/bap_disasm_arm_env.ml
+++ b/lib/bap_disasm/bap_disasm_arm_env.ml
@@ -1,0 +1,90 @@
+open Core_kernel.Std
+open Bap_types.Std
+
+module Arm = Bap_disasm_arm
+
+let (%:) name typ = Var.create name typ
+
+
+let nil = Arm.Reg.to_string `nil %: reg32_t
+
+let make_register reg ty = Arm.Reg.to_string reg %: ty
+let reg32 reg = make_register reg reg32_t
+
+(* Saved Program Status Register *)
+let spsr = reg32 `SPSR
+let cpsr = reg32 `CPSR
+
+
+(* Memory definition *)
+(* let mem = new_var "mem32" (TMem (Reg 32, Reg 8)) *)
+
+(* Arithmetic flags, individually *)
+let nf = "NF" %: bool_t
+let zf = "ZF" %: bool_t
+let cf = "CF" %: bool_t
+let vf = "VF" %: bool_t
+let qf = "QF" %: bool_t
+let ge = Array.init 4 ~f:(fun n -> sprintf "GE%d" n %: bool_t)
+
+
+(* Thumb if-then state register *)
+let itstate = Arm.Reg.to_string `ITSTATE %: reg8_t
+
+(* Core registers: link register, program counter, stack pointer *)
+let lr = reg32 `LR
+let pc = reg32 `PC
+let sp = reg32 `SP
+
+(* 32-bit general-purpose registers *)
+let r0  = reg32 `R0
+let r1  = reg32 `R1
+let r2  = reg32 `R2
+let r3  = reg32 `R3
+let r4  = reg32 `R4
+let r5  = reg32 `R5
+let r6  = reg32 `R6
+let r7  = reg32 `R7
+let r8  = reg32 `R8
+let r9  = reg32 `R9
+let r10 = reg32 `R10
+let r11 = reg32 `R11
+let r12 = reg32 `R12
+
+(* Core registers are aliased to r13-15 in ARM *)
+let r13 = sp
+let r14 = lr
+let r15 = pc
+
+let var_of_gpr : Arm.Reg.gpr -> var = function
+  | `R0  -> r0
+  | `R1  -> r1
+  | `R2  -> r2
+  | `R3  -> r3
+  | `R4  -> r4
+  | `R5  -> r5
+  | `R6  -> r6
+  | `R7  -> r7
+  | `R8  -> r8
+  | `R9  -> r9
+  | `R10 -> r10
+  | `R11 -> r11
+  | `R12 -> r12
+  | `LR  -> lr
+  | `PC  -> pc
+  | `SP  -> sp
+
+let var_of_ccr : Arm.Reg.ccr -> var = function
+  | `CPSR -> cpsr
+  | `SPSR -> spsr
+  | `ITSTATE -> itstate
+
+let of_reg : Arm.Reg.t -> var = function
+  | `nil -> nil
+  | #Arm.Reg.gpr as reg -> var_of_gpr reg
+  | #Arm.Reg.ccr as reg -> var_of_ccr reg
+
+
+let new_var name = Var.create name reg32_t
+let new_tmp name = Var.create ~tmp:true name reg32_t
+let new_mem name = Var.create name (mem32_t `r32)

--- a/lib/bap_disasm/bap_disasm_arm_env.mli
+++ b/lib/bap_disasm/bap_disasm_arm_env.mli
@@ -1,0 +1,41 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_disasm_arm_types
+
+val nil : var
+val spsr : var
+val cpsr : var
+val nf : var
+val zf : var
+val cf : var
+val vf : var
+val qf : var
+val ge : var array
+val itstate : var
+val lr : var
+val pc : var
+val sp : var
+val r0 : var
+val r1 : var
+val r2 : var
+val r3 : var
+val r4 : var
+val r5 : var
+val r6 : var
+val r7 : var
+val r8 : var
+val r9 : var
+val r10 : var
+val r11 : var
+val r12 : var
+val r13 : var
+val r14 : var
+val r15 : var
+
+val of_reg : reg -> var
+
+val new_var : string -> var
+
+val new_tmp : string -> var
+
+val new_mem : string -> var

--- a/lib/bap_disasm/bap_disasm_arm_flags.ml
+++ b/lib/bap_disasm/bap_disasm_arm_flags.ml
@@ -1,0 +1,49 @@
+open Core_kernel.Std
+open Bap_types.Std
+
+open Bap_disasm_arm_types
+open Bap_disasm_arm_utils
+
+module Arm = Bap_disasm_arm
+module Env = Bap_disasm_arm_env
+module Shift = Bap_disasm_arm_shift
+
+
+
+let set_nzf r t = [
+  Stmt.move Env.nf (msb r);
+  Stmt.move Env.zf Exp.(r = zero t);
+]
+
+let set_vnzf_add s1 s2 r t =
+  Stmt.move Env.vf (msb Exp.((lnot (s1 lxor s2)) land (s1 lxor r)))
+  :: set_nzf r t
+
+let set_add s1 s2 r t =
+  Stmt.move Env.cf Exp.(r < s1) :: set_vnzf_add s1 s2 r t
+
+let set_vnzf_sub s1 s2 r t =
+  Stmt.move Env.vf (msb Exp.((s1 lxor s2) land (s1 lxor r))) ::
+  set_nzf r t
+
+let set_sub s1 s2 r t =
+  Stmt.move Env.cf Exp.(s2 <= s1) :: set_vnzf_sub s1 s2 r t
+
+let set_adc s1 s2 r t =
+  let sum_with_carry =
+    let extend = Exp.cast Exp.Cast.unsigned (bitlen t + 1) in
+    Exp.(extend s1 + extend s2 + extend (var Env.cf)) in
+  Stmt.move Env.cf (msb sum_with_carry) :: set_vnzf_add s1 s2 r t
+
+let set_sbc s1 s2 r t = set_adc s1 Exp.(lnot s2) r t
+
+let set_cf_data ~imm ~data =
+  let value =
+    let width = Word.bitwidth imm in
+    if Word.(of_int ~width 255 >= imm && imm >= zero width) then
+      let width = Word.bitwidth data in
+      if Word.(Int_exn.(data land of_int ~width 0xf00) = zero width)
+      then Exp.var Env.cf
+      else Exp.int Word.b0
+    else msb Exp.(int imm) in
+  Stmt.move Env.cf value

--- a/lib/bap_disasm/bap_disasm_arm_flags.mli
+++ b/lib/bap_disasm/bap_disasm_arm_flags.mli
@@ -1,0 +1,19 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_disasm_arm_types
+
+val set_nzf : exp -> typ -> stmt list
+
+val set_vnzf_add : exp -> exp -> exp -> typ -> stmt list
+
+val set_add : exp -> exp -> exp -> typ -> stmt list
+
+val set_sub : exp -> exp -> exp -> typ -> stmt list
+
+val set_vnzf_sub : exp -> exp -> exp -> typ -> stmt list
+
+val set_adc : exp -> exp -> exp -> typ -> stmt list
+
+val set_sbc : exp -> exp -> exp -> typ -> stmt list
+
+val set_cf_data : imm:word -> data:word -> stmt

--- a/lib/bap_disasm/bap_disasm_arm_lifter.ml
+++ b/lib/bap_disasm/bap_disasm_arm_lifter.ml
@@ -1,0 +1,1067 @@
+open Core_kernel.Std
+open Or_error
+open Bap_types.Std
+
+open Bap_disasm_arm_types
+open Bap_disasm_arm_utils
+
+module Basic = Bap_disasm_basic
+module Arm = Bap_disasm_arm
+module Bit = Bap_disasm_arm_bit
+module Branch = Bap_disasm_arm_branch
+module Env = Bap_disasm_arm_env
+module Mem = Bap_disasm_arm_mem
+module Mem_shift = Bap_disasm_arm_mem_shift
+module Mov = Bap_disasm_arm_mov
+module Mul = Bap_disasm_arm_mul
+module Shift = Bap_disasm_arm_shift
+module Flags = Bap_disasm_arm_flags
+
+open Op
+
+let word = Word.of_int ~width:32
+let int32 x = Exp.int (word x)
+
+
+let string_of_ops ops =
+  Format.asprintf "%a" Sexp.pp (sexp_of_array sexp_of_op ops)
+
+let lift_move mem ops (insn : Arm.Insn.move) : stmt list =
+  let open Mov in
+  match insn, ops with
+  | `MOVi,  [|dest; src; cond; _; wflag|]
+  | `MOVr,  [|dest; src; cond; _; wflag|] ->
+    lift ~dest src `MOV mem cond ~wflag
+  | `MOVsr, [|dest; src; sreg; simm; cond; _; wflag|] ->
+    lift ~dest src `MOV mem cond ~wflag ~sreg ~simm
+  | `MOVsi, [|dest; src; shift_imm; cond; _; wflag|] ->
+    lift ~dest src `MOV ~simm:shift_imm mem cond ~wflag
+
+  | `MVNi, [|dest; src; cond; _; wflag|]
+  | `MVNr, [|dest; src; cond; _; wflag|] ->
+    lift ~dest src `MVN mem cond ~wflag
+
+  | `MVNsr, [|dest; src; shift_reg; shift_imm; cond; _; wflag|] ->
+    lift ~dest src `MVN ~sreg:shift_reg ~simm:shift_imm
+      mem cond ~wflag
+
+  | `MVNsi, [|dest; src; shift_imm; cond; _; wflag|] ->
+    lift ~dest src `MVN ~simm:shift_imm mem cond ~wflag
+
+  | `ANDri, [|dest; src1; src2; cond; _; wflag|]
+  | `ANDrr, [|dest; src1; src2; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `AND mem cond ~wflag
+
+  | `ANDrsr, [|dest; src1; src2; shift_reg; shift_imm; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `AND ~sreg:shift_reg ~simm:shift_imm
+      mem cond ~wflag
+
+  | `ANDrsi, [|dest; src1; src2; shift_imm; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `AND ~simm:shift_imm
+      mem cond ~wflag
+
+  | `BICri, [|dest; src1; src2; cond; _; wflag|]
+  | `BICrr, [|dest; src1; src2; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `BIC mem cond ~wflag
+
+  | `BICrsr, [|dest; src1; src2; shift_reg; shift_imm; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `BIC ~sreg:shift_reg ~simm:shift_imm
+      mem cond ~wflag
+
+  | `BICrsi, [|dest; src1; src2; shift_imm; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `BIC ~simm:shift_imm
+      mem cond ~wflag
+
+  | `EORri, [|dest; src1; src2; cond; _; wflag|]
+  | `EORrr, [|dest; src1; src2; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `EOR mem cond ~wflag
+
+  | `EORrsr, [|dest; src1; src2; shift_reg; shift_imm; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `EOR ~sreg:shift_reg ~simm:shift_imm
+      mem cond ~wflag
+
+  | `EORrsi, [|dest; src1; src2; shift_imm; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `EOR ~simm:shift_imm
+      mem cond ~wflag
+
+  | `ORRri, [|dest; src1; src2; cond; _; wflag|]
+  | `ORRrr, [|dest; src1; src2; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `ORR mem cond ~wflag
+
+  | `ORRrsr, [|dest; src1; src2; shift_reg; shift_imm; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `ORR ~sreg:shift_reg ~simm:shift_imm
+      mem cond ~wflag
+
+  | `ORRrsi, [|dest; src1; src2; shift_imm; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `ORR ~simm:shift_imm
+      mem cond ~wflag
+
+  | `TEQri, [|src1; src2; cond; _|]
+  | `TEQrr, [|src1; src2; cond; _|] ->
+    lift src1 ~src2 `EOR mem cond ~wflag:(Reg `CPSR)
+
+  | `TEQrsr, [|src1; src2; shift_reg; shift_imm; cond; _|] ->
+    lift src1 ~src2 `EOR ~sreg:shift_reg ~simm:shift_imm
+      mem cond ~wflag:(Reg `CPSR)
+
+  | `TEQrsi, [|_dest; src1; src2; shift_imm; cond; _|] ->
+    lift src1 ~src2 `EOR ~simm:shift_imm
+      mem cond ~wflag:(Reg `CPSR)
+
+  | `TSTri, [|src1; src2; cond; _|]
+  | `TSTrr, [|src1; src2; cond; _|] ->
+    lift src1 ~src2 `AND mem cond ~wflag:(Reg `CPSR)
+
+  | `TSTrsr, [|src1; src2; shift_reg; shift_imm; cond; _|] ->
+    lift src1 ~src2 `AND ~sreg:shift_reg ~simm:shift_imm
+      mem cond ~wflag:(Reg `CPSR)
+
+  | `TSTrsi, [|src1; src2; shift_imm; cond; _|] ->
+    lift src1 ~src2 `AND ~simm:shift_imm
+      mem cond ~wflag:(Reg `CPSR)
+
+  | `ADDri, [|dest; src1; src2; cond; _; wflag|]
+  | `ADDrr, [|dest; src1; src2; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `ADD mem cond ~wflag
+
+  | `ADDrsr, [|dest; src1; src2; shift_reg; shift_imm; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `ADD ~sreg:shift_reg ~simm:shift_imm
+      mem cond ~wflag
+
+  | `ADDrsi, [|dest; src1; src2; shift_imm; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `ADD ~simm:shift_imm
+      mem cond ~wflag
+
+  | `SUBri, [|dest; src1; src2; cond; _; wflag|]
+  | `SUBrr, [|dest; src1; src2; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `SUB mem cond ~wflag
+
+  | `SUBrsr, [|dest; src1; src2; shift_reg; shift_imm; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `SUB ~sreg:shift_reg ~simm:shift_imm
+      mem cond ~wflag
+
+  | `SUBrsi, [|dest; src1; src2; shift_imm; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `SUB ~simm:shift_imm
+      mem cond ~wflag
+
+  | `ADCri, [|dest; src1; src2; cond; _; wflag|]
+  | `ADCrr, [|dest; src1; src2; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `ADC mem cond ~wflag
+
+  | `ADCrsr, [|dest; src1; src2; shift_reg; shift_imm; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `ADC ~sreg:shift_reg ~simm:shift_imm
+      mem cond ~wflag
+
+  | `ADCrsi, [|dest; src1; src2; shift_imm; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `ADC ~simm:shift_imm
+      mem cond ~wflag
+
+  | `SBCri, [|dest; src1; src2; cond; _; wflag|]
+  | `SBCrr, [|dest; src1; src2; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `SBC mem cond ~wflag
+
+  | `SBCrsr, [|dest; src1; src2; shift_reg; shift_imm; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `SBC ~sreg:shift_reg ~simm:shift_imm
+      mem cond ~wflag
+
+  | `SBCrsi, [|dest; src1; src2; shift_imm; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `SBC ~simm:shift_imm
+      mem cond ~wflag
+
+  | `RSBri, [|dest; src1; src2; cond; _; wflag|]
+  | `RSBrr, [|dest; src1; src2; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `RSB mem cond ~wflag
+
+  | `RSBrsr, [|dest; src1; src2; shift_reg; shift_imm; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `RSB ~sreg:shift_reg ~simm:shift_imm
+      mem cond ~wflag
+
+  | `RSBrsi, [|dest; src1; src2; shift_imm; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `RSB ~simm:shift_imm
+      mem cond ~wflag
+
+  | `RSCri, [|dest; src1; src2; cond; _; wflag|]
+  | `RSCrr, [|dest; src1; src2; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `RSC mem cond ~wflag
+
+  | `RSCrsr, [|dest; src1; src2; shift_reg; shift_imm; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `RSC ~sreg:shift_reg ~simm:shift_imm
+      mem cond ~wflag
+
+  | `RSCrsi, [|dest; src1; src2; shift_imm; cond; _; wflag|] ->
+    lift ~dest src1 ~src2 `RSC ~simm:shift_imm
+      mem cond ~wflag
+
+  | `CMPri, [|src1; src2; cond; _|]
+  | `CMPrr, [|src1; src2; cond; _|] ->
+    lift src1 ~src2 `SUB mem cond ~wflag:(Reg `CPSR)
+
+  | `CMPrsr, [|src1; src2; shift_reg; shift_imm; cond; _|] ->
+    lift src1 ~src2 `SUB ~sreg:shift_reg ~simm:shift_imm
+      mem cond ~wflag:(Reg `CPSR)
+
+  | `CMPrsi, [|src1; src2; shift_imm; cond; _|] ->
+    lift src1 ~src2 `SUB ~simm:shift_imm
+      mem cond ~wflag:(Reg `CPSR)
+
+  | `CMNri, [|src1; src2; cond; _|]
+  | `CMNzrr, [|src1; src2; cond; _|] ->
+    lift src1 ~src2 `ADD mem cond ~wflag:(Reg `CPSR)
+
+  | `CMNzrsr, [|src1; src2; shift_reg; shift_imm; cond; _|] ->
+    lift src1 ~src2 `ADD ~sreg:shift_reg ~simm:shift_imm
+      mem cond ~wflag:(Reg `CPSR)
+
+  | `CMNzrsi, [|src1; src2; shift_imm; cond; _|] ->
+    lift src1 ~src2 `ADD ~simm:shift_imm
+      mem cond ~wflag:(Reg `CPSR)
+
+  (** Special Data Instructions *)
+
+  | `MOVi16, [|Reg dest; src; cond; _wflag|] ->
+    exec [Stmt.move (Env.of_reg dest) (exp_of_op src)] cond
+
+  | `MOVTi16, [|Reg dest; _; src; cond; _wflag|] ->
+    let dest = Env.of_reg dest in
+    [Stmt.move dest Exp.(var dest lor exp_of_op src lsl int32 16)] |>
+    fun ins -> exec ins cond
+  | insn,ops ->
+    fail _here_ "ops %s doesn't match move insn %s"
+      (string_of_ops ops) (Arm.Insn.to_string (insn :> insn))
+
+
+let lift_bits mem ops (insn : Arm.Insn.bits ) =
+  let open Bit in
+  match insn, ops with
+  (* extends *)
+  | `UXTB, [|dest; src; rot; cond; _|] ->
+    extend ~dest ~src Unsigned `B ~rot cond
+
+  | `UXTH, [|dest; src; rot; cond; _|] ->
+    extend ~dest ~src Unsigned `H ~rot cond
+
+  | `SXTB, [|dest; src; rot; cond; _|] ->
+    extend ~dest ~src Signed `B ~rot cond
+
+  | `SXTH, [|dest; src; rot; cond; _|] ->
+    extend ~dest ~src Signed `H ~rot cond
+
+  | `UXTAB, [|dest; src; shift; rot; cond; _|] ->
+    extend ~dest ~src:shift ~src2:src Unsigned `B ~rot cond
+
+  | `UXTAH, [|dest; src; shift; rot; cond; _|] ->
+    extend ~dest ~src:shift ~src2:src Unsigned `H ~rot cond
+
+  | `SXTAB, [|dest; src; shift; rot; cond; _|] ->
+    extend ~dest ~src:shift ~src2:src Signed `B ~rot cond
+
+  | `SXTAH, [|dest; src; shift; rot; cond; _|] ->
+    extend ~dest ~src:shift ~src2:src Signed `H ~rot cond
+
+  (* extracts *)
+  | `UBFX, [|dest; src; lsb; widthminus1; cond; _|] ->
+    bit_extract ~dest ~src Unsigned ~lsb ~widthminus1 cond
+
+  | `SBFX, [|dest; src; lsb; widthminus1; cond; _|] ->
+    bit_extract ~dest ~src Signed   ~lsb ~widthminus1 cond
+
+
+  (* bit field *)
+  | `BFI, [|dest; _unknown; src; _bmask; cond; _|] ->
+    bit_field_insert ~dest ~src mem cond
+
+  | `BFC, [|dest; _unknown; _bmask; cond; _|] ->
+    bit_field_insert ~dest ~src:(Imm (word 0)) mem cond
+
+  (* bit reverse *)
+  | `RBIT, [|dest; src; cond; _|] ->
+    let dest = assert_reg _here_ dest in
+    let v = Env.new_tmp "v"  in
+    let r = Env.new_tmp "r"  in
+    let s = Env.new_tmp "s"  in
+    let open Exp in
+    let open Stmt in
+    exec [
+      move v (exp_of_op src lsr int32 1);
+      move r (exp_of_op src);
+      move s (int32 31);
+      While (Exp.(var v <> int32 0), [
+          Move (r, Var r lsl int32 1);
+          Move (r, Var r lor (Var v land int32 1));
+          Move (s, Var s - int32 1);
+        ]);
+      Move (Env.of_reg dest, Var r lsl Var s);
+    ] cond
+
+  (* Swap bytes *)
+  | `SWPB, [|Reg dest; Reg src1; Reg src2; cond; _|] ->
+    let temp = Var.create ~tmp:true "x" reg8_t in
+    let dest = Env.of_reg dest in
+    let src1 = Env.of_reg src1 |> Exp.var in
+    let src2 = Env.of_reg src2 |> Exp.var in
+    let mem = Env.new_mem "mem" in
+    exec [
+      assn temp Exp.(load (var mem) src2 LittleEndian `r8);
+      Stmt.move mem
+        Exp.(store (var mem) src2 (extract 7 0 src1) LittleEndian `r8);
+      assn dest Exp.(cast Cast.unsigned 32 (var temp));
+    ] cond
+
+  (* Pack half *)
+  | `PKHTB, [|Reg dest; src1; src2; shift; cond; _|] ->
+    (* shift is always asr *)
+    let shifted, _ =
+      Shift.lift_c ~src:(exp_of_op src2) `ASR
+        ~shift:(exp_of_op shift) reg32_t in
+    exec [
+      assn (Env.of_reg dest)
+        Exp.(extract 31 16 (exp_of_op src1) ^
+             extract 15  0  shifted)
+    ] cond
+  (* reverses *)
+  | `REV, [|Reg dest; src; cond; _|] ->
+    let s = exp_of_op src in
+    let i24 = int32 24 in
+    let i8 = int32 8 in
+    let umask = int32 0xff0000 in
+    let lmask = int32 0xff00 in
+    let rev =
+      let open Exp in
+      s              lsl i24 lor
+      s              lsr i24 lor
+      (s land umask) lsr i8  lor
+      (s land lmask) lsl i8
+    in
+    exec [assn (Env.of_reg dest) rev] cond
+  | `REV16, [|Reg dest; src; cond; _|] ->
+    let s = exp_of_op src in
+    let i16 = int32 16 in
+    let rev = Exp.(s lsl i16 lor s lsr i16) in
+    exec [assn (Env.of_reg dest) rev] cond
+  | `CLZ, [|Reg dest; src; cond; _|] ->
+    let shift = Env.new_tmp "shift" in
+    let accum = Env.new_tmp "accum" in
+    let open Exp in
+    exec [
+      Stmt.move shift (exp_of_op src);
+      Stmt.move accum (int32 32);
+      Stmt.While (var shift <> int32 0, [
+          Stmt.move shift (var shift lsr int32 1);
+          Stmt.move accum (var accum - int32 1);
+        ]);
+      Stmt.move (Env.of_reg dest) (var accum);
+
+    ] cond
+  | insn,ops ->
+    fail _here_ "ops %s doesn't match bits insn %s"
+      (string_of_ops ops) (Arm.Insn.to_string (insn :> insn))
+
+
+
+
+let lift_mult ops insn =
+  let open Mul in
+  match insn,ops with
+  | `MUL, [|Reg dest; src1; src2; cond; _rflag; wflag|] ->
+    let flags = Flags.set_nzf Exp.(var (Env.of_reg dest)) reg32_t in
+    exec [
+      assn (Env.of_reg dest) Exp.(exp_of_op src1 * exp_of_op src2)
+    ] ~flags ~wflag cond
+
+  | `MLA, [|Reg dest; src1; src2; addend; cond; _rflag; wflag|] ->
+    let flags = Flags.set_nzf Exp.(var Exp.(Env.of_reg dest)) reg32_t in
+    exec [
+      assn (Env.of_reg dest)
+        Exp.(exp_of_op addend + exp_of_op src1 * exp_of_op src2)
+    ] ~flags ~wflag cond
+
+  | `MLS, [|Reg dest; src1; src2; addend; cond; _|] ->
+    exec [
+      Stmt.move (Env.of_reg dest)
+        Exp.(exp_of_op addend - exp_of_op src1 * exp_of_op src2)
+    ] cond
+
+  | `UMULL, [|lodest; hidest; src1; src2; cond; _rflag; wflag|] ->
+    lift_mull ~lodest ~hidest ~src1 ~src2 Unsigned ~wflag cond
+
+  | `SMULL, [|lodest; hidest; src1; src2; cond; _rflag; wflag|] ->
+    lift_mull ~lodest ~hidest ~src1 ~src2 Signed ~wflag cond
+
+  | `UMLAL, [|lodest; hidest; src1; src2;
+              _loadd; _hiadd; cond; _rflag; wflag|] ->
+    lift_mull ~lodest ~hidest ~src1 ~src2 Unsigned ~addend:true ~wflag cond
+
+  | `SMLAL, [|lodest; hidest; src1; src2;
+              _loadd; _hiadd; cond; _rflag; wflag|] ->
+    lift_mull ~lodest ~hidest ~src1 ~src2 Signed ~addend:true ~wflag cond
+
+  (* signed 16bit mul plus a 32bit bit accum, Q *)
+  | `SMLABB, [|dest; src1; src2; accum; cond; _wflag|] ->
+    lift_smul ~dest ~src1 ~src2 ~accum ~q:true BB cond
+
+  (* signed 16bit mul *)
+  | `SMULBB, [|dest; src1; src2; cond; _wflag|] ->
+    lift_smul ~dest ~src1 ~src2 BB cond
+
+  (* two signed 16bit muls plus 32bit accum and optional xchg, Q*)
+  | `SMLAD, [|dest; src1; src2; accum; cond; _wflag|] ->
+    lift_smul ~dest ~src1 ~src2 ~accum ~q:true D cond
+
+  (* two signed 16bit muls and optional xchg, Q *)
+  | `SMUAD, [|dest; src1; src2; cond; _wflag|] ->
+    lift_smul ~dest ~src1 ~src2 ~q:true D cond
+
+  (* signed 16bit times signed 32bit added to 32bit accum, Q *)
+  | `SMLAWB, [|dest; src1; src2; accum; cond; _wflag|] ->
+    lift_smul ~dest ~src1 ~src2 ~accum ~q:true WB cond
+
+  (* signed 16bit mul *)
+  | `SMULTB, [|dest; src1; src2; cond; _wflag|] ->
+    lift_smul ~dest ~src1 ~src2 TB cond
+
+  (* signed 16bit mul plus 64bit accum *)
+  | `SMLALBT, [|dest; hidest; src1; src2; cond; _wflag|] ->
+    lift_smul ~dest ~hidest ~src1 ~src2 ~accum:dest ~hiaccum:hidest BT cond
+
+  | insn,ops ->
+    fail _here_ "ops %s doesn't match mult insn %s"
+      (string_of_ops ops) (Arm.Insn.to_string (insn :> insn))
+
+
+let lift_mem_multi ops insn =
+  match insn, Array.to_list ops with
+  | `STMDA, base :: cond :: _wr_flag :: dest_list ->
+    let insns = Mem_shift.lift_m (List.rev dest_list)
+        base DA NoUpdate St in
+    exec insns cond
+
+  | `STMDA_UPD, base :: _unknown :: cond :: _wr_flag :: dest_list ->
+    let insns = Mem_shift.lift_m (List.rev dest_list)
+        base DA Update St in
+    exec insns cond
+
+  | `LDMIB, base :: cond :: _wr_flag :: dest_list ->
+    let insns = Mem_shift.lift_m dest_list base IB NoUpdate Ld in
+    exec insns cond
+
+  | `LDMIB_UPD, base :: _unknown :: cond :: _wr_flag :: dest_list ->
+    let insns = Mem_shift.lift_m dest_list base IB Update Ld in
+    exec insns cond
+
+  | `STMIB, base :: cond :: _wr_flag :: dest_list ->
+    let insns = Mem_shift.lift_m dest_list base IB NoUpdate St in
+    exec insns cond
+
+  | `STMIB_UPD, base :: _unknown :: cond :: _wr_flag :: dest_list ->
+    let insns = Mem_shift.lift_m dest_list base IB Update St in
+    exec insns cond
+
+  | `LDMDB, base :: cond :: _wr_flag :: dest_list ->
+    let insns = Mem_shift.lift_m (List.rev dest_list)
+        base DB NoUpdate Ld in
+    exec insns cond
+
+  | `LDMDB_UPD, base :: _unknown :: cond :: _wr_flag :: dest_list ->
+    let insns = Mem_shift.lift_m (List.rev dest_list)
+        base DB Update Ld in
+    exec insns cond
+
+  | `STMDB, base :: cond :: _wr_flag :: dest_list ->
+    let insns = Mem_shift.lift_m (List.rev dest_list)
+        base DB NoUpdate St in
+    exec insns cond
+
+  | `STMDB_UPD, base :: _unknown :: cond :: _wr_flag :: dest_list ->
+    let insns = Mem_shift.lift_m (List.rev dest_list)
+        base DB Update St in
+    exec insns cond
+
+  | `LDMIA, base ::  cond ::  _wr_flag ::  dest_list  ->
+    let insns = Mem_shift.lift_m dest_list base IA NoUpdate Ld in
+    exec insns cond
+
+  | `LDMIA_UPD, base :: _unknown :: cond :: _wr_flag :: dest_list  ->
+    let insns = Mem_shift.lift_m dest_list base IA Update Ld in
+    exec insns cond
+
+  | `STMIA, base :: cond :: _wr_flag :: dest_list ->
+    let insns = Mem_shift.lift_m dest_list base IA NoUpdate St in
+    exec insns cond
+
+  | `STMIA_UPD, base :: _unknown :: cond :: _wr_flag :: dest_list ->
+    let insns = Mem_shift.lift_m dest_list base IA Update St in
+    exec insns cond
+
+  | `LDMDA, base :: cond :: _wr_flag :: dest_list ->
+    let insns = Mem_shift.lift_m (List.rev dest_list)
+        base DA NoUpdate Ld in
+    exec insns cond
+
+  | `LDMDA_UPD, base :: _unknown :: cond :: _wr_flag :: dest_list ->
+    let insns = Mem_shift.lift_m (List.rev dest_list)
+        base DA Update Ld in
+    exec insns cond
+
+  | _ ->
+    fail _here_ "ops %s doesn't match multi arg insn %s"
+      (string_of_ops ops) (Arm.Insn.to_string (insn :> insn))
+
+
+let lift_mem ops insn =
+  let open Mem in
+
+  match insn, ops with
+  | `STRD, [|dest1; dest2; base; reg_off; Imm imm_off; cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_neg reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~dest2 ~base ~offset
+        Offset Unsigned D St in
+    exec insns cond
+
+  | `LDRD, [|dest1; dest2; base; reg_off; Imm imm_off; cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_neg reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~dest2 ~base ~offset
+        Offset Unsigned D Ld in
+    exec insns cond
+
+  | `STRD_POST, [|dest1; dest2; base; _unknown; reg_off; Imm imm_off;
+                  cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_neg reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~dest2 ~base ~offset
+        PostIndex Unsigned D St in
+    exec insns cond
+
+  | `LDRD_POST, [|dest1; dest2; base; _unknown; reg_off; Imm imm_off;
+                  cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_neg reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~dest2 ~base ~offset
+        PostIndex Unsigned D Ld
+    in
+    exec insns cond
+
+  | `STRD_PRE, [|_unknown; dest1; dest2; base; reg_off; Imm imm_off;
+                 cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_neg reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~dest2 ~base ~offset
+        PreIndex Unsigned D St
+    in
+    exec insns cond
+
+  | `LDRD_PRE, [|dest1; dest2; _unknown; base; reg_off; Imm imm_off;
+                 cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_neg reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~dest2 ~base ~offset
+        PreIndex Unsigned D Ld
+    in
+    exec insns cond
+
+  | `STRH, [|dest1; base; reg_off; Imm imm_off; cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_neg reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~base ~offset
+        Offset Unsigned H St
+    in
+    exec insns cond
+
+  | `LDRH, [|dest1; base; reg_off; Imm imm_off; cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_neg reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~base ~offset
+        Offset Unsigned H Ld
+    in
+    exec insns cond
+
+  | `STRH_PRE, [|_unknown; dest1; base; reg_off; Imm imm_off; cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_neg reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~base ~offset
+        PreIndex Unsigned H St
+    in
+    exec insns cond
+
+  | `LDRH_PRE, [|dest1; _unknown; base; reg_off; Imm imm_off; cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_neg reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~base ~offset
+        PreIndex Unsigned H Ld
+    in
+    exec insns cond
+
+  | `STRH_POST, [|_unknown; dest1; base; reg_off; Imm imm_off; cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_neg reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~base ~offset
+        PostIndex Unsigned H St
+    in
+    exec insns cond
+
+  (* Unlike the convention of all other load and store instructions, for some
+   * instructions the sign bit is set in the immediate when the operand
+   * is POSITIVE. Insructions that are affected by this are marked with
+   * "POS_SIGN_BIT"
+   **)
+  (* POS_SIGN_BIT *)
+  | `STRHTr, [|_unknown; dest1; base; reg_off; Imm imm_off; cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_pos reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~base ~offset
+        PostIndex Unsigned H St
+    in
+    exec insns cond
+
+  | `LDRH_POST, [|dest1; _unknown; base; reg_off; Imm imm_off; cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_neg reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~base ~offset
+        PostIndex Unsigned H Ld
+    in
+    exec insns cond
+
+  (* POS_SIGN_BIT *)
+  | `LDRHTr, [|dest1; _unknown; base; reg_off; Imm imm_off; cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_pos reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~base ~offset PostIndex Unsigned H Ld
+    in
+    exec insns cond
+
+  | `LDRSH, [|dest1; base; reg_off; Imm imm_off; cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_neg reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~base ~offset Offset Signed H Ld
+    in
+    exec insns cond
+
+  | `LDRSH_PRE, [|dest1; _unknown; base; reg_off; Imm imm_off; cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_neg reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~base ~offset PreIndex Signed H Ld
+    in
+    exec insns cond
+
+  | `LDRSH_POST, [|dest1; _unknown; base; reg_off; Imm imm_off; cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_neg reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~base ~offset PostIndex Signed H Ld
+    in
+    exec insns cond
+
+  (* POS_SIGN_BIT *)
+  | `LDRSHTr, [|dest1; _unknown; base; reg_off; Imm imm_off; cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_pos reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~base ~offset PostIndex Signed H Ld
+    in
+    exec insns cond
+
+  (* POS_SIGN_BIT *)
+  | `LDRSHTi, [|dest1; _unknown; base; Imm imm_off; cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_pos (Op.Reg `nil) imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~base ~offset PostIndex Signed H Ld
+    in
+    exec insns cond
+
+  | `LDRSB, [|dest1; base; reg_off; Imm imm_off; cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_neg reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~base ~offset Offset Signed B Ld
+    in
+    exec insns cond
+
+  | `LDRSB_PRE, [|dest1; _unknown; base; reg_off; Imm imm_off; cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_neg reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~base ~offset PreIndex Signed B Ld
+    in
+    exec insns cond
+
+  | `LDRSB_POST, [|dest1; _unknown; base; reg_off; Imm imm_off; cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_neg reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~base ~offset PostIndex Signed B Ld
+    in
+    exec insns cond
+
+  (* POS_SIGN_BIT *)
+  | `LDRSBTr, [|dest1; _unknown; base; reg_off; Imm imm_off; cond; _|] ->
+    let offset = Mem_shift.mem_offset_reg_or_imm_pos reg_off imm_off in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~base ~offset PostIndex Signed B Ld
+    in
+    exec insns cond
+
+  | `STRi12, [|dest1; base; offset; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset Offset Unsigned W St
+    in
+    exec insns cond
+
+  | `LDRi12, [|dest1; base; offset; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset Offset Unsigned W Ld
+    in
+    exec insns cond
+
+  | `STRBi12, [|dest1; base; offset; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset Offset Unsigned B St
+    in
+    exec insns cond
+
+  | `LDRBi12, [|dest1; base; offset; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset Offset Unsigned B Ld
+    in
+    exec insns cond
+
+  | `STRrs, [|dest1; base; offset; shift; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset ~shift
+        Offset Unsigned W St
+    in
+    exec insns cond
+
+  | `LDRrs, [|dest1; base; offset; shift; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset ~shift
+        Offset Unsigned W Ld
+    in
+    exec insns cond
+
+  | `STRBrs, [|dest1; base; offset; shift; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset ~shift
+        Offset Unsigned B St
+    in
+    exec insns cond
+
+  | `LDRBrs, [|dest1; base; offset; shift; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset ~shift
+        Offset Unsigned B Ld
+    in
+    exec insns cond
+
+  | `STR_POST_IMM, [|_unknown; dest1; base; _invalid; Imm offset; cond; _|] ->
+    let offset =
+      Mem_shift.repair_imm offset ~sign_mask:0x1000 ~imm_mask:0xfff `NEG
+    in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~base ~offset PostIndex Unsigned W St
+    in
+    exec insns cond
+
+  | `LDR_POST_IMM, [|dest1; _unknown; base; _invalid; Imm offset; cond; _|] ->
+    let offset =
+      Mem_shift.repair_imm offset ~sign_mask:0x1000 ~imm_mask:0xfff `NEG
+    in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~base ~offset PostIndex Unsigned W Ld
+    in
+    exec insns cond
+
+  | `STRB_POST_IMM,  [|_unknown; dest1; base; _invalid; Imm offset; cond; _|]
+  | `STRBT_POST_IMM, [|_unknown; dest1; base; _invalid; Imm offset; cond; _|]
+    ->
+    let offset =
+      Mem_shift.repair_imm offset ~sign_mask:0x1000 ~imm_mask:0xfff `NEG
+    in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~base ~offset PostIndex Unsigned B St
+    in
+    exec insns cond
+
+  | `LDRB_POST_IMM,  [|dest1; _unknown; base; _invalid; Imm offset; cond; _|]
+  | `LDRBT_POST_IMM, [|dest1; _unknown; base; _invalid; Imm offset; cond; _|]
+    ->
+    let offset =
+      Mem_shift.repair_imm offset ~sign_mask:0x1000 ~imm_mask:0xfff `NEG
+    in
+    let insns =
+      Mem_shift.lift_r_exp ~dest1 ~base ~offset PostIndex Unsigned B Ld
+    in
+    exec insns cond
+
+  | `STR_POST_REG,  [|_unknown; dest1; base; offset; shift; cond; _|]
+  | `STRT_POST_REG, [|_unknown; dest1; base; offset; shift; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset ~shift
+        PostIndex Unsigned W St
+    in
+    exec insns cond
+
+  | `LDR_POST_REG,  [|dest1; _unknown; base; offset; shift; cond; _|]
+  | `LDRT_POST_REG, [|dest1; _unknown; base; offset; shift; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset ~shift
+        PostIndex Unsigned W Ld
+    in
+    exec insns cond
+
+  | `STRB_POST_REG,  [|_unknown; dest1; base; offset; shift; cond; _|]
+  | `STRBT_POST_REG, [|_unknown; dest1; base; offset; shift; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset ~shift
+        PostIndex Unsigned B St
+    in
+    exec insns cond
+
+  | `LDRB_POST_REG,  [|dest1; _unknown; base; offset; shift; cond; _|]
+  | `LDRBT_POST_REG, [|dest1; _unknown; base; offset; shift; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset ~shift
+        PostIndex Unsigned B Ld
+    in
+    exec insns cond
+
+  | `STR_PRE_IMM, [|_unknown; dest1; base; offset; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset PreIndex Unsigned W St
+    in
+    exec insns cond
+
+  | `LDR_PRE_IMM, [|dest1; _unknown; base; offset; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset PreIndex Unsigned W Ld
+    in
+    exec insns cond
+
+  | `STRB_PRE_IMM, [|_unknown; dest1; base; offset; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset PreIndex Unsigned B St
+    in
+    exec insns cond
+
+  | `LDRB_PRE_IMM, [|dest1; _unknown; base; offset; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset PreIndex Unsigned B Ld
+    in
+    exec insns cond
+
+  | `STR_PRE_REG, [|_unknown; dest1; base; offset; shift; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset ~shift
+        PreIndex Unsigned W St
+    in
+    exec insns cond
+
+  | `LDR_PRE_REG, [|dest1; _unknown; base; offset; shift; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset ~shift
+        PreIndex Unsigned W Ld
+    in
+    exec insns cond
+
+  | `STRB_PRE_REG, [|_unknown; dest1; base; offset; shift; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset ~shift
+        PreIndex Unsigned B St
+    in
+    exec insns cond
+
+  | `LDRB_PRE_REG, [|dest1; _unknown; base; offset; shift; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset ~shift
+        PreIndex Unsigned B Ld
+    in
+    exec insns cond
+
+  (* Exclusive access, we may later want to do something special to these *)
+
+  | `LDREX, [|dest1; base; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset:(Imm (word 0))
+        Offset Unsigned W Ld
+    in
+    exec insns cond
+
+  | `LDREXB, [|dest1; base; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset:(Imm (word 0))
+        Offset Unsigned B Ld
+    in
+    exec insns cond
+
+  | `LDREXH, [|dest1; base; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1 ~base ~offset:(Imm (word 0))
+        Offset Unsigned H Ld
+    in
+    exec insns cond
+
+  (* multidest is one of the multireg combinations *)
+  | `LDREXD, [|multidest; base; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1:multidest ~base ~offset:(Imm (word 0))
+        Offset Unsigned D Ld
+    in
+    exec insns cond
+
+  | `STREX, [|Reg dest1; src1; base; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1:src1 ~base ~offset:(Imm (word 0))
+        Offset Unsigned W St in
+    let result = [Stmt.move (Env.of_reg dest1) (int32 0)] in
+    exec (insns @ result) cond
+
+  | `STREXB, [|Reg dest1; src1; base; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1:src1 ~base ~offset:(Imm (word 0))
+        Offset Unsigned B St
+    in
+    let result = [Stmt.move (Env.of_reg dest1) (int32 0)] in
+    exec (insns @ result) cond
+
+  | `STREXH, [|Reg dest1; src1; base; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1:src1 ~base ~offset:(Imm (word 0))
+        Offset Unsigned H St
+    in
+    let result = [Stmt.move (Env.of_reg dest1) (int32 0)] in
+    exec (insns @ result) cond
+
+  (* multisrc is one of the multireg combinations *)
+  | `STREXD, [|Reg dest1; multisrc; base; cond; _|] ->
+    let insns =
+      Mem_shift.lift_r_op ~dest1:multisrc ~base ~offset:(Imm (word 0))
+        Offset Unsigned D St
+    in
+    let result = [Stmt.move (Env.of_reg dest1) (int32 0)] in
+    exec (insns @ result) cond
+  | #Insn.mem_multi as insn, ops -> lift_mem_multi ops insn
+  | insn,ops ->
+    fail _here_ "ops %s doesn't match mem access insn %s"
+      (string_of_ops ops) (Arm.Insn.to_string (insn :> insn))
+
+
+(** Branching instructions *)
+
+let lift_branch mem ops insn =
+  let addr = Memory.min_addr mem in
+  match insn, ops with
+
+  | `Bcc, [|offset; cond; _|] ->
+    Branch.lift offset ~cond addr
+
+  | `BL, [|offset; cond; _|]
+  | `BL_pred, [|offset; cond; _|] ->
+    Branch.lift offset ~cond ~link:true addr
+
+  | `BX_RET, [|cond; _|] ->
+    Branch.lift (Reg `LR) ~cond ~x:true addr
+
+  | `BX, [|target|] ->
+    Branch.lift target ~x:true addr
+
+  | `BX_pred, [|target; cond; _|] ->
+    Branch.lift target ~cond ~x:true addr
+
+  | `BLX, [|target|] ->
+    Branch.lift target ~link:true ~x:true addr
+
+  | `BLX_pred, [|target; cond; _|] ->
+    Branch.lift target ~cond ~link:true ~x:true addr
+
+  | `BLXi, [|offset|] ->
+    Branch.lift offset ~link:true ~x:true addr
+
+  | insn,ops ->
+    fail _here_ "ops %s doesn't match branch insn %s"
+      (string_of_ops ops) (Arm.Insn.to_string (insn :> insn))
+
+
+let lift_special ops insn =
+  match insn, ops with
+  (* supervisor call *)
+  | `SVC, [|Imm word; cond; _|] ->
+    exec [Stmt.special (Format.asprintf "svc %a" Word.pp word)] cond
+
+  | `MRS, [|Reg dest; cond; _|] ->
+    let get_bits flag src lsb =
+      Exp.(src lor (cast Cast.unsigned 32 (var flag) lsl int32 lsb)) in
+    let d = Env.of_reg dest in
+    let vd = Exp.var d in
+    exec [
+      Stmt.move d (int32 0);
+      Stmt.move d (get_bits Env.nf vd 31);
+      Stmt.move d (get_bits Env.zf vd 30);
+      Stmt.move d (get_bits Env.cf vd 29);
+      Stmt.move d (get_bits Env.vf vd 28);
+      Stmt.move d (get_bits Env.qf vd 27);
+      Stmt.move d (get_bits Env.ge.(3) vd 19);
+      Stmt.move d (get_bits Env.ge.(2) vd 18);
+      Stmt.move d (get_bits Env.ge.(1) vd 17);
+      Stmt.move d (get_bits Env.ge.(0) vd 16);
+    ] cond
+
+  (* Move to special from register
+   * For MSR an immediate with bit x set means:
+   * bit 0 is CPSR_c (is not valid in ARMv7)
+   * bit 1 is CPSR_x (is not valid in ARMv7)
+   * bit 2 is APSR_g
+   * bit 3 is APSR_nzcvq
+   **)
+  | `MSR, [|Imm imm; Reg src; cond; _|] ->
+    let src = Exp.var (Env.of_reg src) in
+    let (:=) flag bit = Stmt.move flag (Exp.extract bit bit src) in
+    let s1 =
+      if Word.(Int_exn.(imm land word 0x8) = word 0x8) then [
+        Env.nf := 31;
+        Env.zf := 30;
+        Env.cf := 29;
+        Env.vf := 28;
+        Env.qf := 27;
+      ] else [] in
+    let s2 =
+      if Word.(Int_exn.(imm land word 0x4) = word 0x4) then [
+        Env.ge.(3) := 19;
+        Env.ge.(2) := 18;
+        Env.ge.(1) := 17;
+        Env.ge.(0) := 16;
+      ] else [] in
+    exec (s1 @ s2) cond
+  (* All of these are nops in User mode *)
+  | `CPS2p, _ | `DMB, _ | `DSB, _ | `HINT, _ | `PLDi12, _ -> []
+
+  | insn,ops ->
+    fail _here_ "ops %s doesn't match special insn %s"
+      (string_of_ops ops) (Arm.Insn.to_string (insn :> insn))
+
+let arm_ops_exn ops () =
+  Array.map (ops) ~f:(fun op ->
+      Option.value_exn
+        ~here:_here_
+        ~error:(Error.create "unsupported operand" op Basic.Op.sexp_of_t )
+        (Arm.Op.create op))
+
+let arm_ops ops = try_with (arm_ops_exn ops)
+
+
+let insn_exn mem insn =
+  let open Arm.Insn in
+  let name = Basic.Insn.name insn in
+  Memory.(Addr.Int.(!$(max_addr mem) - !$(min_addr mem)))
+  >>= Word.to_int >>= fun s -> Size.of_int ((s+1) * 8) >>= fun size ->
+  Memory.get ~scale:(size ) mem >>| fun word ->
+  match Arm.Insn.create insn with
+  | None -> [Stmt.special (sprintf "unsupported: %s" name)]
+  | Some arm_insn -> match arm_ops (Basic.Insn.ops insn) with
+    | Error err -> [Stmt.special (Error.to_string_hum err)]
+    | Ok ops -> match arm_insn with
+      | #move as op -> lift_move word ops op
+      | #bits as op -> lift_bits word ops op
+      | #mult as op -> lift_mult ops op
+      | #mem  as op -> lift_mem  ops op
+      | #branch as op -> lift_branch mem ops op
+      | #special as op -> lift_special ops op
+
+let insn mem insn =
+  try insn_exn mem insn with
+  | Lifting_failed msg -> errorf "%s:%s" (Basic.Insn.name insn) msg
+  | exn -> of_exn exn

--- a/lib/bap_disasm/bap_disasm_arm_lifter.mli
+++ b/lib/bap_disasm/bap_disasm_arm_lifter.mli
@@ -1,0 +1,7 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_disasm_arm_types
+
+(** [insn mem basic] takes a basic instruction and a memory and
+    returns a sequence of BIL statements. *)
+val insn : mem -> ('a,'k) Basic.insn -> stmt list Or_error.t

--- a/lib/bap_disasm/bap_disasm_arm_mem.mli
+++ b/lib/bap_disasm/bap_disasm_arm_mem.mli
@@ -1,0 +1,15 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_disasm_arm_types
+
+val lift_r :
+  dst1:var ->
+  ?dst2:var ->
+  base:var ->
+  offset:exp ->
+  mode_r ->
+  sign ->
+  size ->
+  operation -> stmt list
+
+val lift_m : var list -> var -> mode_m -> update_m -> operation -> stmt list

--- a/lib/bap_disasm/bap_disasm_arm_mem_shift.ml
+++ b/lib/bap_disasm/bap_disasm_arm_mem_shift.ml
@@ -1,0 +1,111 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Or_error
+
+open Bap_disasm_arm_types
+open Bap_disasm_arm_utils
+
+module Arm = Bap_disasm_arm
+module Mem = Bap_disasm_arm_mem
+module Env = Bap_disasm_arm_env
+module Shift = Bap_disasm_arm_shift
+
+
+
+let string_of_opt_op = function
+  | None -> "unspecified"
+  | Some reg -> Arm.Op.to_string reg
+
+module Z = Word.Int_exn
+
+let word x = Word.of_int x ~width:32
+
+
+let repair_imm (src : word) ~sign_mask ~imm_mask rtype : exp =
+  let bit_set =
+    Word.(Z.(word sign_mask land src) = word sign_mask) in
+  let negate =
+    (bit_set && rtype = `NEG) ||
+    (not bit_set && rtype = `POS) in
+  let offset = Z.(src land word imm_mask) in
+  Exp.int (if negate then Z.neg offset else offset)
+
+let repair_reg reg imm ~sign_mask rtype =
+  let bit_set =
+    Word.(Z.(word sign_mask land imm) = word sign_mask) in
+  let negate =
+    (bit_set && rtype = `NEG) || (not bit_set && rtype = `POS)
+  in
+  let m_one = Word.(ones (bitwidth imm))  in
+  if negate then Exp.(int m_one * reg) else reg
+
+
+
+
+let lift_r_op ~dest1 ?dest2 ?shift ~base ~offset mode sign size operation =
+  let base = assert_reg _here_ base |> Env.of_reg in
+  let (offset : exp) =
+    match offset with
+    | Op.Reg _ -> fail _here_ "got register instead of imm"
+    | Op.Imm w ->
+      let width = Word.bitwidth w in
+      let _1 = Word.one 32 in
+      let min_32 = Word.Int_exn.(_1 lsl Word.of_int 31 ~width) in
+      if Word.(w = min_32)
+      then Exp.(int Word.(zero width))
+      else Exp.(int w) in
+
+  let offset = match shift with
+    | Some s -> Shift.lift_mem ~src:offset s reg32_t
+    | None -> offset in
+
+  match dest1, dest2 with
+  | (Op.Reg (#Reg.gpr as d1), Some (Op.Reg (#Reg.gpr as d2))) ->
+    Mem.lift_r ~dst1:(Env.of_reg d1) ~dst2:(Env.of_reg d2)
+      ~base ~offset mode sign size operation
+  | Op.Reg (#Reg.gpr as d), None  ->
+    Mem.lift_r ~dst1:(Env.of_reg d) ~base ~offset mode sign size
+      operation
+  | op1,op2 -> fail _here_ "Unexpected arguments: %s, %s"
+                 (Arm.Op.to_string op1)
+                 (string_of_opt_op op2)
+
+let lift_r_exp ~dest1 ?dest2 ~base ~offset mode sign size operation =
+  let dest1 = assert_reg _here_ dest1 |> Env.of_reg in
+  let base = assert_reg _here_ base |> Env.of_reg in
+  match dest2 with
+  | Some dest2 ->
+    let dest2 = assert_reg _here_ dest2 |> Env.of_reg in
+    Mem.lift_r ~dst1:dest1 ~dst2:dest2
+      ~base ~offset mode sign size operation
+  | None ->
+    Mem.lift_r ~dst1:dest1
+      ~base ~offset mode sign size operation
+
+
+let lift_m dest_list base mode update operation =
+  let base = assert_reg _here_ base in
+  let dest_list = List.map  dest_list
+      ~f:(fun d -> assert_reg _here_ d |> Env.of_reg) in
+  let base = Env.of_reg base in
+  Mem.lift_m dest_list base mode update operation
+
+
+(* Decides whether to use the register or immediate as the offset value
+ * Also performs conversion to remove the negative bit and the
+ **)
+let mem_offset_reg_or_imm_neg reg_off imm_off =
+  match reg_off with
+  | Op.Reg #Reg.nil ->
+    repair_imm imm_off ~sign_mask:0x100 ~imm_mask:0xff `NEG
+  | Op.Reg (#Reg.gpr as reg) ->
+    repair_reg Exp.(var (Env.of_reg reg)) imm_off ~sign_mask:0x100 `NEG
+  | op -> fail _here_ "unexpected operand: %s" (Arm.Op.to_string op)
+
+let mem_offset_reg_or_imm_pos reg_off imm_off =
+  match reg_off with
+  | Op.Reg #Reg.nil ->
+    repair_imm imm_off ~sign_mask:0x100 ~imm_mask:0xff `POS
+  | Op.Reg (#Reg.gpr as reg) ->
+    repair_reg Exp.(var (Env.of_reg reg)) imm_off ~sign_mask:0x1 `POS
+  | op -> fail _here_ "unexpected operand: %s" (Arm.Op.to_string op)

--- a/lib/bap_disasm/bap_disasm_arm_mem_shift.mli
+++ b/lib/bap_disasm/bap_disasm_arm_mem_shift.mli
@@ -1,0 +1,59 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_disasm_arm_types
+
+(** Combine Mem and Shift *)
+
+
+
+val lift_r_exp :
+  dest1:op ->
+  ?dest2:op ->
+  base:op ->
+  offset:exp ->
+  mode_r ->
+  sign ->
+  size ->
+  operation -> stmt list
+
+
+val lift_r_op :
+  dest1:op ->
+  ?dest2:op ->
+  ?shift:op ->
+  base:op ->
+  offset:op ->
+  mode_r ->
+  sign ->
+  size ->
+  operation -> stmt list
+
+
+val lift_m : op list -> op -> mode_m -> update_m -> operation -> stmt list
+
+(** takes a word and converts it to an exp that is the offset for some
+    memory instructions sign_mask - a bitmask that determines the bit
+    in src that is the repair bit imm_mask - a bitmask that determines
+    which bits in src are the immediate type - whether a set mask
+    indicates a positive or negative immediate.  **)
+val repair_imm : word -> sign_mask:int -> imm_mask:int -> repair -> exp
+
+(** takes a word and a register and converts it to an exp that is the
+    offset for some memory instructions sign_mask - a bitmask that
+    determines the bit in src that is the negative bit rtype - whether
+    a set mask indicates a positive or negative operand.  *)
+
+val repair_reg : exp -> word -> sign_mask:int -> repair -> exp
+
+
+(** Decides whether to use the register or immediate as the offset
+    value Also performs conversion to remove the negative bit and the *)
+
+
+(** Decides whether to use the register or immediate as the offset
+    value Also performs conversion to remove the negative bit and the *)
+
+val mem_offset_reg_or_imm_neg : op -> word -> exp
+
+
+val mem_offset_reg_or_imm_pos : op -> word -> exp

--- a/lib/bap_disasm/bap_disasm_arm_mov.ml
+++ b/lib/bap_disasm/bap_disasm_arm_mov.ml
@@ -1,0 +1,85 @@
+open Core_kernel.Std
+open Bap_types.Std
+
+open Bap_disasm_arm_types
+open Bap_disasm_arm_utils
+open Bap_disasm_arm_flags
+
+module Arm = Bap_disasm_arm
+module Env = Bap_disasm_arm_env
+module Shift = Bap_disasm_arm_shift
+
+let lift ?dest src1 ?src2 (itype ) ?sreg ?simm raw ~wflag cond =
+  let dest : var = match dest with
+    | None     -> Env.new_tmp "dest"
+    | Some (Op.Reg reg) -> Env.of_reg reg
+    | Some (Op.Imm _) -> fail _here_ "dest is not a reg" in
+  let s1 : exp = exp_of_op src1 in
+  let s2 : exp = match src2 with
+    | Some src -> exp_of_op src
+    | None     -> zero reg32_t in
+
+  let unshifted = Env.new_tmp "unshifted" in
+
+  (* Do the register shift *)
+  let s1, s2, stmts, carry =
+    match itype, sreg, simm with
+    | `MOV, Some sreg, Some simm
+    | `MVN, Some sreg, Some simm ->
+      let shifted, carry = Shift.lift_r
+          ~src:Exp.(var unshifted) simm
+          ~shift:(exp_of_op sreg) reg32_t in
+      shifted, s2, [Stmt.move unshifted s1], carry
+    | _, Some sreg, Some simm ->
+      let shifted, carry = Shift.lift_r
+          ~src:Exp.(var unshifted) simm
+          ~shift:(exp_of_op sreg) reg32_t in
+      s1, shifted, [Stmt.move unshifted s2], carry
+    | `MOV, None, Some simm
+    | `MVN, None, Some simm ->
+      let shifted, carry = Shift.lift_i
+          ~src:Exp.(var unshifted) simm reg32_t in
+      shifted, s2, [Stmt.move unshifted s1], carry
+    | _, None, Some simm ->
+      let shifted, carry = Shift.lift_i
+          ~src:Exp.(var unshifted) simm reg32_t in
+      s1, shifted, [Stmt.move unshifted s2], carry
+    | _ -> s1, s2, [], Exp.var Env.cf in
+
+  let stmts, flags = match itype, src1, src2 with
+    | `MOV, Op.Imm i64, _
+    | `MVN, Op.Imm i64, _
+    | `AND, _,         Some (Op.Imm i64)
+    | `BIC, _,         Some (Op.Imm i64)
+    | `EOR, _,         Some (Op.Imm i64)
+    | `ORR, _,         Some (Op.Imm i64) ->
+      stmts, set_cf_data i64 raw :: set_nzf Exp.(var dest) reg32_t
+    | #move, _, _ ->
+      stmts, Stmt.move Env.cf carry :: set_nzf Exp.(var dest) reg32_t
+    | #arth as itype1, _, _ ->
+      let orig1 = Env.new_tmp "orig1" in
+      let orig2 = Env.new_tmp "orig2" in
+      let v1,v2,vd = Exp.(var orig1, var orig2, var dest) in
+      let flags = match itype1 with
+        | `SUB -> set_sub v1 v2 vd reg32_t
+        | `RSB -> set_sub v2 v1 vd reg32_t
+        | `ADD -> set_add v1 v2 vd reg32_t
+        | `ADC -> set_adc v1 v2 vd reg32_t
+        | `SBC -> set_sbc v1 v2 vd reg32_t
+        | `RSC -> set_sbc v2 v1 vd reg32_t in
+      stmts @ [Stmt.move orig1 s1; Stmt.move orig2 s2], flags in
+  let vcf = Exp.var Env.cf in
+  let oper = match itype with
+    | `AND -> Exp.(s1 land s2)
+    | `BIC -> Exp.(s1 land lnot s2)
+    | `EOR -> Exp.(s1 lxor s2)
+    | `MOV -> s1
+    | `MVN -> Exp.(lnot s1)
+    | `ORR -> Exp.(s1 lor s2)
+    | `SUB -> Exp.(s1 - s2)
+    | `RSB -> Exp.(s2 - s1)
+    | `ADD -> Exp.(s1 + s2)
+    | `ADC -> Exp.(s1 + s2 + cast Cast.unsigned 32 vcf)
+    | `SBC -> Exp.(s1 + lnot s2 + cast Cast.unsigned 32 vcf)
+    | `RSC -> Exp.(lnot s1 + s2 + cast Cast.unsigned 32 vcf) in
+  exec (stmts @ [assn dest oper]) ~flags ~wflag cond

--- a/lib/bap_disasm/bap_disasm_arm_mov.mli
+++ b/lib/bap_disasm/bap_disasm_arm_mov.mli
@@ -1,0 +1,15 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_disasm_arm_types
+
+val lift :
+  ?dest:op ->
+  op ->
+  ?src2:op ->
+  data_oper ->
+  ?sreg:op ->
+  ?simm:op ->
+  Word.t ->
+  wflag:op ->
+  op ->
+  stmt list

--- a/lib/bap_disasm/bap_disasm_arm_mul.ml
+++ b/lib/bap_disasm/bap_disasm_arm_mul.ml
@@ -1,0 +1,79 @@
+open Core_kernel.Std
+open Bap_types.Std
+
+open Bap_disasm_arm_types
+open Bap_disasm_arm_utils
+
+module Mov = Bap_disasm_arm_mov
+module Env = Bap_disasm_arm_env
+module Shift = Bap_disasm_arm_shift
+module Flags = Bap_disasm_arm_flags
+
+
+let new_tmp name = Var.create ~tmp:true name reg64_t
+
+let lift_mull ~lodest ~hidest ~src1 ~src2 sign ?addend ~wflag cond =
+  let lodest = assert_reg _here_ lodest in
+  let hidest = assert_reg _here_ hidest in
+  let s1_64, s2_64 =
+    let cast src = cast_of_sign sign 64 (exp_of_op src) in
+    cast src1, cast src2 in
+  let result = new_tmp "result" in
+  let eres  = Exp.var result in
+  let flags = Flags.set_nzf eres reg64_t in
+  let opn = match addend with
+    | Some _ -> Exp.(s1_64 * s2_64 +
+                     concat (exp_of_reg hidest) (exp_of_reg lodest))
+    | None   -> Exp.(s1_64 * s2_64) in
+  let insns = [
+    Stmt.move result opn;
+    Stmt.move (Env.of_reg lodest) Exp.(extract 31 0 eres);
+    Stmt.move (Env.of_reg hidest) Exp.(extract 63 32 eres);
+  ] in
+  exec insns ~flags ~wflag cond
+
+let lift_smul ~dest ?hidest ~src1 ~src2 ?accum ?hiaccum ?q size cond =
+  let dest = assert_reg _here_ dest in
+  let src1 = exp_of_op src1 in
+  let src2 = exp_of_op src2 in
+  let excast hi lo s = Exp.(cast Cast.signed 64 (extract hi lo s)) in
+  let top  = excast 31 16 in
+  let bot  = excast 15 0 in
+  let top32 = excast 47 16 in
+  let res = new_tmp "result_64" in
+  let result =
+    let open Exp in
+    match size with
+    | BB -> bot src1 * bot src2
+    | BT -> bot src1 * top src2
+    | TB -> top src1 * bot src2
+    | TT -> top src1 * top src2
+    | D  -> top src1 * top src2 + bot src1 * bot src2
+    | DX -> top src1 * bot src2 + bot src1 * top src2
+    | WB -> top32 (cast Cast.signed 64 (src1 * bot src2))
+    | WT -> top32 (cast Cast.signed 64 (src1 * top src2))  in
+  let result =
+    let open Exp in
+    match accum, hiaccum with
+    | None,   None     -> result
+    | Some a, None     -> result + cast Cast.signed 64 (exp_of_op a)
+    | Some a, Some hia -> result + concat (exp_of_op hia) (exp_of_op a)
+    | _ -> fail _here_ "Cannot specify only a hi accumulator" in
+  let qflag =
+    match q with
+    | Some true ->
+      [Stmt.move Env.qf Exp.(excast 31 0 (var res) <> (var res))]
+    | _ -> [] in
+  let instr =
+    match hidest with
+    | Some (Op.Reg hid) -> [
+        Stmt.move res result;
+        Stmt.move (Env.of_reg hid)  Exp.(extract 63 32 (var res));
+        Stmt.move (Env.of_reg dest) Exp.(extract 31 0  (var res));
+      ]
+    | None -> [
+        Stmt.move res result;
+        Stmt.move (Env.of_reg dest) Exp.(extract 31 0 (var res));
+      ]
+    | _ -> fail _here_ "unexpected operand type" in
+  exec (instr @ qflag) cond

--- a/lib/bap_disasm/bap_disasm_arm_mul.mli
+++ b/lib/bap_disasm/bap_disasm_arm_mul.mli
@@ -1,0 +1,15 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_disasm_arm_types
+
+val lift_mull :
+  lodest:op ->
+  hidest:op ->
+  src1:op -> src2:op -> sign -> ?addend:'a -> wflag:op -> op -> stmt list
+
+val lift_smul :
+  dest:op ->
+  ?hidest:Op.t ->
+  src1:op ->
+  src2:op ->
+  ?accum:op -> ?hiaccum:op -> ?q:bool -> smul_size -> op -> stmt list

--- a/lib/bap_disasm/bap_disasm_arm_shift.ml
+++ b/lib/bap_disasm/bap_disasm_arm_shift.ml
@@ -1,0 +1,115 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Or_error
+
+open Bap_disasm_arm_types
+open Bap_disasm_arm_utils
+
+module Env = Bap_disasm_arm_env
+
+
+let shift_of_word op = match Word.to_int op with
+  | Ok 1 -> `ASR
+  | Ok 2 -> `LSL
+  | Ok 3 -> `LSR
+  | Ok 4 -> `ROR
+  | Ok 5 -> `RRX
+  | _ -> fail _here_ "Imm %s, doesn't stand for shift"
+           (Word.to_string op)
+
+
+
+
+
+let shift_c ~src shift_type ~shift t =
+  let bits = bitlen t in
+  let bits_e = Exp.int (Word.of_int bits ~width:bits) in
+  let nth_bit n e = Exp.(cast Cast.low 1 (e lsr n)) in
+  let e1 = Exp.int (Word.one bits) in
+  match shift_type with
+  | `ASR ->
+    let shifted = Exp.(src asr shift) in
+    let carry = nth_bit Exp.(shift - e1) src in
+    shifted, carry
+  | `LSL ->
+    let shifted = Exp.(src lsl shift) in
+    let carry = Exp.(ite (shift <> int (Word.zero bits))
+                       (nth_bit Exp.(bits_e - shift) src)
+                       (var Env.cf)) in
+    shifted, carry
+  | `LSR ->
+    let shifted = Exp.(src lsr shift) in
+    let carry = nth_bit Exp.(shift - e1) src in
+    shifted, carry
+  | `ROR ->
+    let ret1 = Exp.(src lsr shift) in
+    let ret2 = Exp.(src lsl (bits_e - shift)) in
+    let shifted = Exp.(ret1 lor ret2) in
+    let carry = nth_bit Exp.(shift - e1) src in
+    shifted, carry
+  | `RRX ->
+    let ret1 = Exp.(src lsr e1) in
+    let carryin = Exp.(cast Cast.unsigned bits (var Env.cf) lsl (bits_e - e1)) in
+    let shifted = Exp.(ret1 lor carryin) in
+    let carry = nth_bit Exp.(int (Word.zero 0)) src in
+    shifted, carry
+
+let r_shift ~src shift_type ~shift t =
+  let shift_type = assert_imm _here_ shift_type in
+  shift_c ~src (shift_of_word shift_type) ~shift t
+
+let i_shift ~src shift_type t =
+  let shift_type = assert_imm _here_ shift_type in
+  let width = bitlen t in
+  let mask = Word.of_int 7 ~width in
+  let three = Word.of_int 3 ~width in
+  (* lower three bits are type*)
+  let r =
+    Word.Int.(!$shift_type land !$mask) >>| shift_of_word >>= fun shift_t ->
+    (* other bits are immediate *)
+    Word.Int.((!$shift_type land (lnot !$mask)) lsr !$three) >>= fun shift_amt ->
+    return (shift_t, shift_amt) in
+  match r with
+  | Error err -> fail _here_ "%s" Error.(to_string_hum err)
+  | Ok (shift_t, shift_amt) ->
+    shift_c ~src shift_t ~shift:Exp.(int shift_amt) t
+
+(* decodes a shifted operand for a memory operation
+ * src - the operand to be shifted
+ * shift - an int64,
+ *            bits 11 through 0 represent the shift amount
+ *            bits 12 represents whether the expression is added or subtracted
+ *            bits 15 through 13 represent the shift type, valid shift types
+ *              are number 1 through 5
+ * typ - the type
+ **)
+let mem_shift ~src shift typ =
+  let shift = assert_imm _here_ shift in
+  let width = bitlen typ in
+  let word = Word.of_int ~width in
+  let wordm n = Ok (word n) in
+  let shift_typ w =
+    Word.Int.((!$w land wordm 0xE000) lsr wordm 13) >>| shift_of_word in
+  (* Gets the shift amount from the immediate *)
+  let shift_amt w = Word.Int.(!$w land wordm 0xFFF) >>| Exp.int in
+  (* Converts the shift to a negative if the negative bit is set *)
+  let to_neg w exp =
+    if Word.Int.(wordm 0x1000 land !$w = wordm 0x1000) then
+      Exp.(int (Word.ones width) * exp)
+    else
+      exp in
+  let r = shift_typ shift >>= fun t -> shift_amt shift >>= fun amt ->
+    return (t,amt) in
+  match r with
+  | Error err -> fail _here_ "%s" Error.(to_string_hum err)
+  | Ok (t,amount) ->
+    let exp, _ = shift_c ~src t ~shift:amount typ in
+    to_neg shift exp
+
+let lift_c = shift_c
+
+let lift_i = i_shift
+
+let lift_r = r_shift
+
+let lift_mem = mem_shift

--- a/lib/bap_disasm/bap_disasm_arm_shift.mli
+++ b/lib/bap_disasm/bap_disasm_arm_shift.mli
@@ -1,0 +1,49 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_disasm_arm_types
+
+(** Need the operand and the carry flag value src - the source, if you
+    intend to use the carry bit, this must not be the destination of the
+    shift expression.  This means it must be a temp that contains the
+    value of the source not the actual source itself shift_type - the type
+    of shift shift - must be a exp that is the amount of the shift
+    (ignored for rrx)
+*)
+val lift_c : src:exp -> shift -> shift:exp -> typ -> exp * exp
+
+
+(** decodes a register shifted operand
+ * src - the operand to be shifted, cannot be the destination
+ *        in practice this means it must be a temp variable.
+ * shift_type - an int64, bits 2 through 0 represent the shift type
+ *              valid shift types are number 1 through 5
+ * shift - the value to shift by
+ * t - the type
+ **)
+
+val lift_r : src:exp -> op -> shift:exp -> typ -> exp * exp
+
+
+(** decodes an immediate shifted operand
+ * src - the operand to be shifted, cannot be the destination
+ *        in practice this means it must be a temp variable.
+ * shift_type - an int64, bits 2 through 0 represent the shift type
+ *              valid shift types are number 1 through 5
+ *              bits 3 and higher represent the shift amount if this is an
+ *              immediate shift. For register shifts these upper bits are 0.
+ *              If the shift type is RRX, a shift amount of 1 is implied.
+ * t - the type
+ **)
+val lift_i : src:exp -> op -> typ -> exp * exp
+
+
+(** decodes a shifted operand for a memory operation
+ * src - the operand to be shifted
+ * shift - an int64,
+ *            bits 11 through 0 represent the shift amount
+ *            bits 12 represents whether the expression is added or subtracted
+ *            bits 15 through 13 represent the shift type, valid shift types
+ *              are number 1 through 5
+ * typ - the type
+ **)
+val lift_mem : src:exp -> op -> typ -> exp

--- a/lib/bap_disasm/bap_disasm_arm_types.ml
+++ b/lib/bap_disasm/bap_disasm_arm_types.ml
@@ -1,0 +1,355 @@
+open Core_kernel.Std
+open Bap_types.Std
+
+module Basic = Bap_disasm_basic
+module Memory = Bap_memory
+
+type mem = Memory.t
+
+
+exception Lifting_failed of string
+
+
+
+module Cond = struct
+  type t = [
+    | `EQ
+    | `NE
+    | `CS
+    | `CC
+    | `MI
+    | `PL
+    | `VS
+    | `VC
+    | `HI
+    | `LS
+    | `GE
+    | `LT
+    | `GT
+    | `LE
+    | `AL
+  ] with bin_io, compare, sexp, enumerate
+end
+
+type cond = Cond.t
+with bin_io, compare, sexp, enumerate
+
+
+module Reg = struct
+  type nil = [ `nil ]
+  with bin_io, compare, sexp, enumerate
+
+  (** General purpose registers  *)
+  type gpr = [
+    | `R0
+    | `R1
+    | `R2
+    | `R3
+    | `R4
+    | `R5
+    | `R6
+    | `R7
+    | `R8
+    | `R9
+    | `R10
+    | `R11
+    | `R12
+    | `LR
+    | `PC
+    | `SP
+  ] with bin_io, compare, sexp, enumerate
+
+
+  type gpr_or_nil = [nil | gpr]
+  with bin_io, compare, sexp, enumerate
+
+  (** conditition code registers  *)
+  type ccr = [
+    | `CPSR
+    | `SPSR
+    | `ITSTATE
+  ] with bin_io, compare, sexp, enumerate
+
+
+  type ccr_or_nil = [nil | ccr ]
+  with bin_io, compare, sexp, enumerate
+
+  type non_nil = [gpr | ccr]
+  with bin_io, compare, sexp, enumerate
+
+  type t = [nil | non_nil]
+  with bin_io, compare, sexp, enumerate
+end
+
+type reg = Reg.t
+with bin_io, compare, sexp
+
+module Op = struct
+  type t =
+    | Reg of reg
+    | Imm of word
+  with bin_io, compare, sexp
+end
+
+type op = Op.t
+with bin_io, compare, sexp
+
+module Insn = struct
+  type move = [
+    | `ADCri
+    | `ADCrr
+    | `ADCrsi
+    | `ADCrsr
+    | `ADDri
+    | `ADDrr
+    | `ADDrsi
+    | `ADDrsr
+    | `ANDri
+    | `ANDrr
+    | `ANDrsi
+    | `ANDrsr
+    | `BICri
+    | `BICrr
+    | `BICrsi
+    | `BICrsr
+    | `CMNri
+    | `CMNzrr
+    | `CMNzrsi
+    | `CMNzrsr
+    | `CMPri
+    | `CMPrr
+    | `CMPrsi
+    | `CMPrsr
+    | `EORri
+    | `EORrr
+    | `EORrsi
+    | `EORrsr
+    | `MOVTi16
+    | `MOVi
+    | `MOVi16
+    | `MOVr
+    | `MOVsi
+    | `MOVsr
+    | `MVNi
+    | `MVNr
+    | `MVNsi
+    | `MVNsr
+    | `ORRri
+    | `ORRrr
+    | `ORRrsi
+    | `ORRrsr
+    | `RSBri
+    | `RSBrr
+    | `RSBrsi
+    | `RSBrsr
+    | `RSCri
+    | `RSCrr
+    | `RSCrsi
+    | `RSCrsr
+    | `SBCri
+    | `SBCrr
+    | `SBCrsi
+    | `SBCrsr
+    | `SUBri
+    | `SUBrr
+    | `SUBrsi
+    | `SUBrsr
+    | `TEQri
+    | `TEQrr
+    | `TEQrsi
+    | `TEQrsr
+    | `TSTri
+    | `TSTrr
+    | `TSTrsi
+    | `TSTrsr
+  ] with bin_io, compare, sexp, enumerate
+
+  type bits = [
+    | `BFC
+    | `BFI
+    | `PKHTB
+    | `RBIT
+    | `SBFX
+    | `SWPB
+    | `SXTAB
+    | `SXTAH
+    | `SXTB
+    | `SXTH
+    | `UBFX
+    | `UXTAB
+    | `UXTAH
+    | `UXTB
+    | `UXTH
+    | `REV
+    | `REV16
+    | `CLZ
+  ] with bin_io, compare, sexp, enumerate
+
+  type mult = [
+    | `MLA
+    | `MLS
+    | `MUL
+    | `SMLABB
+    | `SMLAD
+    | `SMLAL
+    | `SMLALBT
+    | `SMLAWB
+    | `SMUAD
+    | `SMULBB
+    | `SMULL
+    | `SMULTB
+    | `UMLAL
+    | `UMULL
+  ] with bin_io, compare, sexp, enumerate
+
+
+  type mem_multi = [
+    | `LDMDA
+    | `LDMDA_UPD
+    | `LDMDB
+    | `LDMDB_UPD
+    | `LDMIA
+    | `LDMIA_UPD
+    | `LDMIB
+    | `LDMIB_UPD
+    | `STMDA
+    | `STMDA_UPD
+    | `STMDB
+    | `STMDB_UPD
+    | `STMIA
+    | `STMIA_UPD
+    | `STMIB
+    | `STMIB_UPD
+  ] with bin_io, compare, sexp, enumerate
+
+
+  type mem = [
+    | mem_multi
+    | `LDRBT_POST_IMM
+    | `LDRBT_POST_REG
+    | `LDRB_POST_IMM
+    | `LDRB_POST_REG
+    | `LDRB_PRE_IMM
+    | `LDRB_PRE_REG
+    | `LDRBi12
+    | `LDRBrs
+    | `LDRD
+    | `LDRD_POST
+    | `LDRD_PRE
+    | `LDREX
+    | `LDREXB
+    | `LDREXD
+    | `LDREXH
+    | `LDRH
+    | `LDRHTr
+    | `LDRH_POST
+    | `LDRH_PRE
+    | `LDRSB
+    | `LDRSBTr
+    | `LDRSB_POST
+    | `LDRSB_PRE
+    | `LDRSH
+    | `LDRSHTi
+    | `LDRSHTr
+    | `LDRSH_POST
+    | `LDRSH_PRE
+    | `LDRT_POST_REG
+    | `LDR_POST_IMM
+    | `LDR_POST_REG
+    | `LDR_PRE_IMM
+    | `LDR_PRE_REG
+    | `LDRi12
+    | `LDRrs
+    | `STRBT_POST_IMM
+    | `STRBT_POST_REG
+    | `STRB_POST_IMM
+    | `STRB_POST_REG
+    | `STRB_PRE_IMM
+    | `STRB_PRE_REG
+    | `STRBi12
+    | `STRBrs
+    | `STRD
+    | `STRD_POST
+    | `STRD_PRE
+    | `STREX
+    | `STREXB
+    | `STREXD
+    | `STREXH
+    | `STRH
+    | `STRHTr
+    | `STRH_POST
+    | `STRH_PRE
+    | `STRT_POST_REG
+    | `STR_POST_IMM
+    | `STR_POST_REG
+    | `STR_PRE_IMM
+    | `STR_PRE_REG
+    | `STRi12
+    | `STRrs
+  ] with bin_io, compare, sexp, enumerate
+
+  type branch = [
+    | `BL
+    | `BLX
+    | `BLX_pred
+    | `BLXi
+    | `BL_pred
+    | `BX
+    | `BX_RET
+    | `BX_pred
+    | `Bcc
+  ] with bin_io, compare, sexp, enumerate
+
+  type special = [
+    | `CPS2p
+    | `DMB
+    | `DSB
+    | `HINT
+    | `MRS
+    | `MSR
+    | `PLDi12
+    | `SVC
+  ] with bin_io, compare, sexp, enumerate
+
+
+  type t = [
+    | move
+    | bits
+    | mult
+    | mem
+    | branch
+    | special
+  ] with bin_io, compare, sexp, enumerate
+end
+
+type insn = Insn.t
+with bin_io, compare, sexp
+
+
+
+(** Memory access operations *)
+
+(** Types for single-register memory access *)
+type mode_r = Offset | PreIndex | PostIndex
+type sign = Signed | Unsigned
+type operation = Ld | St
+type size = B | H | W | D
+
+(** Types for multiple-register memory access *)
+type mode_m = IA | IB | DA | DB
+type update_m = Update | NoUpdate
+
+(** Types for data movement operations  *)
+type arth = [`ADD | `ADC | `SBC | `RSC | `SUB | `RSB ]
+type move = [`AND | `BIC | `EOR | `MOV | `MVN | `ORR ]
+type data_oper = [ arth | move]
+
+
+type repair = [`POS | `NEG]
+
+
+(* shift types *)
+type shift = [`ASR | `LSL | `LSR | `ROR | `RRX]
+
+
+type smul_size = BB | BT | TB | TT | D | DX | WB | WT

--- a/lib/bap_disasm/bap_disasm_arm_utils.ml
+++ b/lib/bap_disasm/bap_disasm_arm_utils.ml
@@ -1,0 +1,92 @@
+open Core_kernel.Std
+open Bap_types.Std
+
+open Bap_disasm_arm_types
+module Arm = Bap_disasm_arm
+module Env = Bap_disasm_arm_env
+
+let fail here fmt =
+  ksprintf (fun msg ->
+      let msg = sprintf "%s: %s"
+          (Source_code_position.to_string here) msg in
+      raise (Lifting_failed msg)) fmt
+
+let assert_reg loc = function
+  | Op.Imm _ -> fail loc "expected reg"
+  | Op.Reg reg -> reg
+
+let assert_imm loc = function
+  | Op.Reg _ -> fail loc "expected imm"
+  | Op.Imm imm -> imm
+
+
+let assert_cond loc op =
+  match Arm.Cond.create (assert_imm loc op) with
+  | Ok cond -> cond
+  | Error err -> fail loc "bad argument (cond): %s" @@
+    Error.to_string_hum err
+
+
+let assn d s =
+  if d = Env.pc then Stmt.jmp s else Stmt.move d s
+
+let bitlen = function
+  | Type.Imm len -> len
+  | Type.Mem (_,size) -> Size.to_bits size
+
+let exec
+    (stmts : stmt list)
+    ?(flags : stmt list option)
+    ?(wflag : op option)
+    (cond : op) : stmt list =
+  (* write to the flags if wflag is CPSR *)
+  let cond = assert_cond _here_ cond in
+  let stmts = match flags, wflag with
+    | Some f, Some (Op.Reg `CPSR) -> stmts @ f
+    | _ -> stmts in
+  (* generates an expression for the given McCond *)
+  let set_cond mccond =
+    let z = Exp.var Env.zf in
+    let c = Exp.var Env.cf in
+    let v = Exp.var Env.vf in
+    let n = Exp.var Env.nf in
+    let f = Exp.int (Word.of_bool false) in
+    let t = Exp.int (Word.of_bool true) in
+    match cond with
+    | `EQ -> Exp.(z = t)
+    | `NE -> Exp.(z = f)
+    | `CS -> Exp.(c = t)
+    | `CC -> Exp.(c = f)
+    | `MI -> Exp.(n = t)
+    | `PL -> Exp.(n = f)
+    | `VS -> Exp.(v = t)
+    | `VC -> Exp.(v = f)
+    | `HI -> Exp.((c = t) land (z = f))
+    | `LS -> Exp.((c = f) lor  (z = t))
+    | `GE -> Exp.(n = v)
+    | `LT -> Exp.(n <> v)
+    | `GT -> Exp.((z = f) land (n =  v))
+    | `LE -> Exp.((z = t) lor  (n <> v))
+    | `AL -> t in
+  (* We shortcut if the condition = all *)
+  match cond with
+  | `AL -> stmts
+  | _ -> [Stmt.If (set_cond cond, stmts, [])]
+
+
+let exp_of_reg reg = Exp.var (Env.of_reg reg)
+
+let exp_of_op = function
+  | Op.Reg reg -> exp_of_reg reg
+  | Op.Imm word -> Exp.int word
+
+let cast_type = function
+  | Signed -> Exp.Cast.signed
+  | Unsigned -> Exp.Cast.unsigned
+
+let cast_of_sign sign size exp = Exp.cast (cast_type sign) size exp
+
+
+
+let msb r = Exp.(cast Cast.high 1 r)
+let zero ty = Exp.int (Word.zero (bitlen ty))

--- a/lib/bap_disasm/bap_disasm_arm_utils.mli
+++ b/lib/bap_disasm/bap_disasm_arm_utils.mli
@@ -1,0 +1,28 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_disasm_arm_types
+
+val assn : var -> exp -> stmt
+
+val fail : Source_code_position.t -> ('a,unit,string,'b) format4 -> 'a
+
+val bitlen : typ -> int
+
+val exec : stmt list -> ?flags:stmt list -> ?wflag:op -> op -> stmt list
+
+val exp_of_op : op -> exp
+
+val exp_of_reg : reg -> exp
+
+val cast_of_sign : sign -> int -> exp -> exp
+
+
+val assert_reg : Source_code_position.t -> op -> reg
+
+val assert_imm : Source_code_position.t -> op -> word
+
+val assert_cond : Source_code_position.t -> op -> cond
+
+val msb : exp -> exp
+
+val zero : typ -> exp

--- a/lib/bap_disasm/bap_disasm_basic.ml
+++ b/lib/bap_disasm/bap_disasm_basic.ml
@@ -18,11 +18,6 @@ type pred = [
   |  kind
 ] with sexp,compare
 
-
-
-(** Invariant:
-    If data is not forced, then operand is from current queue.
-*)
 type 'a oper = {
   oper : int;
   insn : int;
@@ -139,7 +134,12 @@ module Imm = struct
     | None -> Int64.of_int n.imm_small
     | Some x -> x
 
-  let to_word t = to_int64 t |> Word.of_int64
+  let to_word t ~width =
+    let n = to_int64 t in
+    match Word.bitsub ~hi:(width-1) (Word.of_int64 n) with
+    | Ok word -> Some word
+    | Error _ -> None
+
 
   module T = struct
     type t = imm

--- a/lib/bap_disasm/bap_disasm_basic.mli
+++ b/lib/bap_disasm/bap_disasm_basic.mli
@@ -234,7 +234,7 @@ end
 (** Integer immediate operand  *)
 module Imm : sig
   type t = imm
-  val to_word  : t -> word
+  val to_word  : t -> width:int -> word option
   val to_int64 : t -> int64
   val to_int   : t -> int option
   include Regular with type t := t

--- a/lib/bap_image/bap_memory.ml
+++ b/lib/bap_image/bap_memory.ml
@@ -176,10 +176,12 @@ let compare_with mem addr =
   if Addr.between ~low ~high addr then `addr_is_inside else
   if Addr.(addr < low) then `addr_is_below else `addr_is_above
 
-let get ?(word_size=`r8) t addr : word or_error =
-  (getter t word_size).safe ~pos_ref:(ref addr)
+let get ?disp ?index ?(scale=`r8) ?addr t : word or_error =
+  let base = Option.value addr ~default:t.addr in
+  let addr = Addr.memref ?disp ?index ~scale base in
+  (getter t scale).safe ~pos_ref:(ref addr)
 
-let (^) t addr = get t addr
+let (^) t addr = get ~addr t
 let (^!) t addr = ok_exn (t ^ addr)
 
 module Input = struct

--- a/lib/bap_image/bap_memory.mli
+++ b/lib/bap_image/bap_memory.mli
@@ -29,7 +29,7 @@ val last_byte : t -> t
 
 (** [get word_size mem addr] reads memory value from the specified
     address. [word_size] default to [`r8] *)
-val get : ?word_size:size -> t -> addr -> word Or_error.t
+val get : ?disp:int -> ?index:int -> ?scale:size -> ?addr:addr -> t -> word Or_error.t
 
 (** [m^n] dereferences a byte at address [n]  *)
 val (^) : t -> addr -> word Or_error.t

--- a/lib/bap_types/bap_bil.ml
+++ b/lib/bap_types/bap_bil.ml
@@ -6,23 +6,22 @@ with bin_io, compare, sexp
 
 module Exp = struct
   type t =
-    (** Load    (arr,  idx,  endian,  size) *)
+    (** Load    (mem,  idx,  endian,  size) *)
     | Load    of t * t * endian * size
-    (** Store   (arr,  idx,  val,  endian,  size) *)
+    (** Store   (mem,  idx,  val,  endian,  size) *)
     | Store   of t * t * t * endian * size
     | BinOp   of binop * t * t
     | UnOp    of unop * t
     | Var     of var
     | Int     of word
     (** Cast to a new type *)
-    | Cast    of cast * size * t
+    | Cast    of cast * nat1 * t
     | Let     of var * t * t
     | Unknown of string * typ
-    (* Expression types below here are just syntactic sugar for the above *)
     | Ite     of t * t * t
     (** Extract hbits to lbits of e (Reg type) *)
-    | Extract of int * int * t
-    (** Concat two reg tressions together *)
+    | Extract of nat1 * nat1 * t
+    (** Concat two reg expressions together *)
     | Concat  of t * t
   with bin_io, compare, sexp, variants
 end

--- a/lib/bap_types/bap_common.ml
+++ b/lib/bap_types/bap_common.ml
@@ -46,13 +46,16 @@ with bin_io, compare, sexp
 type addr_size = [ `r32 | `r64 ] Size.p
 with bin_io, compare, sexp
 
+type nat1 = int
+with bin_io, compare, sexp
 
 (** The IR type of a BIL expression *)
 module Type = struct
   type t =
-    | Bool                      (** a one-bit flag  *)
-    | Reg  of size              (** imidiate value of [size]  *)
-    | TMem of addr_size * size  (** memory with a specifed addr_size *)
+    (** [Imm n] - n-bit immidiate   *)
+    | Imm of nat1
+    (** [Mem (a,t)]memory with a specifed addr_size *)
+    | Mem of addr_size * size
   with bin_io, compare, sexp, variants
 end
 

--- a/lib/bap_types/bap_exp.ml
+++ b/lib/bap_types/bap_exp.ml
@@ -92,10 +92,10 @@ module PP = struct
     | Load (mem, idx, edn, s) ->
       fprintf fmt "%a[%a, %a]:%a" pp mem pp idx pp_edn edn Bap_size.pp s
     | Store (mem, idx, exp, edn, s) ->
-      fprintf fmt "%a with [%a, %a]:%a <- %a"
+      fprintf fmt "@[<v2>%a with@;[%a, %a]:%a <- %a@]"
         pp mem pp idx pp_edn edn Bap_size.pp s pp exp
     | Ite (ce, te, fe) ->
-      fprintf fmt "if %a then %a else %a" pp ce pp te pp fe
+      fprintf fmt "@[<v2>if %a@;then %a@;else %a@]" pp ce pp te pp fe
     | Extract (hi, lo, exp) ->
       fprintf fmt "extract: %d:%d[%a]" hi lo pp exp
     | Concat (le, re) ->
@@ -106,8 +106,8 @@ module PP = struct
       fprintf fmt "%a(%a)" pp_unop op pp exp
     | Var var -> Bap_var.pp fmt var
     | Int bv  -> Bap_bitvector.pp fmt bv
-    | Cast (ct, s, exp) ->
-      fprintf fmt "%a:%a[%a]" pp_cast ct Bap_size.pp s pp exp
+    | Cast (ct, n, exp) ->
+      fprintf fmt "%a:%d[%a]" pp_cast ct n pp exp
     | Let (var, def, body) ->
       fprintf fmt "let %a = %a in %a" Bap_var.pp var pp def pp body
     | Unknown (s, typ) ->

--- a/lib/bap_types/bap_stmt.ml
+++ b/lib/bap_types/bap_stmt.ml
@@ -4,7 +4,7 @@ open Format
 
 let rec pp fmt s =
   let open Bap_bil.Stmt in match s with
-  | Move (var, exp) -> fprintf fmt "%a = %a" Bap_var.pp var Bap_exp.pp exp
+  | Move (var, exp) -> fprintf fmt "@[<v2>%a = %a@]" Bap_var.pp var Bap_exp.pp exp
   | Jmp exp -> fprintf fmt "jmp %a" Bap_exp.pp exp
   | Special s -> fprintf fmt "special (%s)" s
   | While (cond, body) ->
@@ -24,6 +24,7 @@ and pp_else fmt = function
 
 let pp_stmts fmt ss =
   fprintf fmt "@[<v0>@[<v2>{@\n%a@]@\n}@]" pp_list ss
+
 
 include Regular.Make(struct
     include Bap_bil.Stmt

--- a/lib/bap_types/bap_type.ml
+++ b/lib/bap_types/bap_type.ml
@@ -9,22 +9,21 @@ module T = struct
   let module_name = "Bap_type"
 
   let pp fmt = function
-    | Bool  -> fprintf fmt "bool"
-    | Reg r -> fprintf fmt "%a" Bap_size.pp r
-    | TMem (idx, elm) ->
+    | Imm n -> fprintf fmt "u%u" n
+    | Mem (idx, elm) ->
       fprintf fmt "%a?%a" Bap_size.pp (idx :> size) Bap_size.pp elm
 
   let hash = Hashtbl.hash
 end
 
 module Export = struct
-  let bool_t  = bool
-  let reg8_t  = reg `r8
-  let reg16_t = reg `r16
-  let reg32_t = reg `r32
-  let reg64_t = reg `r64
-  let mem32_t = tmem `r32
-  let mem64_t = tmem `r64
+  let bool_t  = imm  1
+  let reg8_t  = imm  8
+  let reg16_t = imm 16
+  let reg32_t = imm 32
+  let reg64_t = imm 64
+  let mem32_t = mem `r32
+  let mem64_t = mem `r64
 end
 
 

--- a/lib/bap_types/bap_var.ml
+++ b/lib/bap_types/bap_var.ml
@@ -14,7 +14,7 @@ module T = struct
   let module_name = "Bap_var"
 
   let pp fmt v =
-    Format.fprintf fmt "%s_%d:%a" v.var v.uid Bap_type.pp v.typ
+    Format.fprintf fmt "%s:%a" v.var Bap_type.pp v.typ
 end
 
 include T

--- a/lib/bap_types/bil_piqi.ml
+++ b/lib/bap_types/bil_piqi.ml
@@ -74,14 +74,12 @@ let binop_of_piqi = function
   | `sle -> SLE
 
 let rec type_to_piqi : typ -> Stmt_piqi.typ = function
-  | Bool  -> `bool
-  | Reg s ->  (s :> Stmt_piqi.typ)
-  | TMem (t, t') -> `tmem {Stmt_piqi.Tmem.index_type = t; element_type = t';}
+  | Imm s ->  `imm s
+  | Mem (t, t') -> `mem {Stmt_piqi.Mem.index_type = t; element_type = t';}
 
 let rec type_of_piqi = function
-  | `bool -> Bool
-  | `tmem {P.Tmem.index_type; element_type} -> TMem (index_type, element_type)
-  | #size as n ->  Reg n
+  | `imm n -> Imm n
+  | `mem {P.Mem.index_type; element_type} -> Mem (index_type, element_type)
 
 
 let var_to_piqi v =

--- a/lib/bap_types/conceval.ml
+++ b/lib/bap_types/conceval.ml
@@ -165,7 +165,6 @@ let handle_binop op l r : value =
 
 let handle_cast cast_kind size v =
   let open Exp.Cast in
-  let size = Size.to_bits size in
   let cast v = match cast_kind with
     | UNSIGNED -> Word.bitsub_exn ~hi:size v
     | SIGNED   -> Word.bitsub_exn ~hi:size (Word.signed v)
@@ -180,7 +179,8 @@ let rec eval_exp state exp =
     | Load (arr, idx, endian, t) ->
       (match Memory.load (eval_exp state arr) (eval_exp state idx) endian t with
        | Some v -> v
-       | None -> Un ("Load from uninitialized memory", Type.reg t))
+       | None -> Un ("Load from uninitialized memory",
+                     Type.imm Size.(to_bits t)))
     | Store (arr, idx, v, endian, t) ->
       Memory.store (eval_exp state arr) (eval_exp state idx) (eval_exp state v)
         endian t

--- a/lib/bap_types/exp.piqi
+++ b/lib/bap_types/exp.piqi
@@ -112,7 +112,7 @@
   ]
   .field [
     .name size
-    .type size
+    .type int
   ]
   .field [
     .name exp

--- a/lib/bap_types/type.piqi
+++ b/lib/bap_types/type.piqi
@@ -1,8 +1,7 @@
 .variant [
   .name typ
-  .option [.name bool]
-  .option [.type size]
-  .option [.type tmem]
+  .option [.type imm]
+  .option [.type mem]
 ]
 
 .variant [
@@ -19,9 +18,13 @@
   .option [.name r64]
 ]
 
+.alias [
+  .name imm
+  .type int
+]
 
 .record [
-  .name tmem
+  .name mem
   .field [
     .name index-type
     .type addr-size

--- a/lib_test/bap_image/test_image.ml
+++ b/lib_test/bap_image/test_image.ml
@@ -92,8 +92,8 @@ let print_list r =
 
 let to_list ~word_size backend ~expect ctxt =
   let data = String.Table.find_exn files backend in
-  let r = Image.of_string ~backend data >>| fun (img,errs) ->
-    assert_bool "to_list: no warning" (errs = []);
+  let r = Image.of_string ~backend data >>| fun (img,warns) ->
+    assert_bool "to_list: no warning" (warns = []);
     Table.to_sequence (Image.words img word_size) |>
     Seq.map ~f:snd |>  Seq.to_list in
   let width = Size.to_bits word_size in


### PR DESCRIPTION
This PR adds ARM lifter, aka ARM disassembler.

The original disassembler was refactored into 13 separate modules with
clearly defined interfaces, so that we can later address the code.

The code is rewritten against new `Bap_types.Std`, all reference to Z
are removed, and all bit-logic is performed with bitvectors.

Polymorphic variants are used to represent instruction opcodes. That
allows us to perform matching on instruction classes. Thanks to that,
lifter was split into several functions.

All data types, like registers and instructions are now written
manually, and only the supported set of values are represented. No more,
thousands of instructions.

Lifter is quite fast, about 50 us per instruction. Although, I didn't
made any optimizations, and there are plenty of opportunities for doing
it.

What concering correctness, in all coreutils we have about 1% of unknown
instructions and 1% of lifting failures (all in one place - wrong
argument type of the offset operand, an issue will be created soon).

Also, I've slightly fixed BIL typesystem, since my last edition was to
strict and doesn't allow many valid BIL programs.
