### PR TITLE
[Iss #31] Updated version number to 0.9.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 ## Installing `bap` dependencies
 
-The easiest way to install the dependencies of `bap` is to use the `opam`
-package manager:
+The easiest way to install the OCaml dependencies of `bap` is to use
+the `opam` package manager:
 
 ```bash
 $ opam install bitstring core_kernel zarith
@@ -40,6 +40,10 @@ We also recommend you install `utop` for running BAP.
 ```bash
 $ opam install utop
 ```
+
+Finally, you need to now install LLVM.  LLVM often changes their APIs,
+so we have had to standardize against one.  BAP currently compiles
+against llvm-3.4, which we have confirmed works on OSX and Ubuntu.
 
 ## Compiling and installing `bap`
 

--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.4
 Name:        bap
-Version:     0.2
+Version:     0.9
 Synopsis:    BAP Core Library
 Authors:     BAP Team
 Maintainers: Ivan Gotovchits <ivg@ieee.org>


### PR DESCRIPTION
The last release of BAP previous to the move to GitHub was 0.8.
The current release is 0.9.  We will move to 1.0-alpha once we
are feature complete with 0.8:
- Disassembler
- Lifting for x86 and ARM
- CFG generation
- SMT binding
- Python bindings.

See issue #31 history for discussion.
