### PR TITLE
[Iss #36] Changed output of immediates from decimal to hex.

### DIFF
--- a/lib/bap_disasm/bap_disasm_basic.ml
+++ b/lib/bap_disasm/bap_disasm_basic.ml
@@ -146,7 +146,11 @@ module Imm = struct
     with bin_io, sexp, compare
     let module_name = "Bap_disasm_basic.Imm"
     let pp fmt t =
-      Format.fprintf fmt "%Ld" (to_int64 t)
+      let x = to_int64 t in
+      if Int64.is_negative x then 
+        Format.fprintf fmt "-0x%Lx" (Int64.abs x)
+      else
+        Format.fprintf fmt "0x%Lx" x
 
     let hash {data = n} =
       if fits n.imm_small

--- a/lib/bap_disasm/llvm_disasm.cpp
+++ b/lib/bap_disasm/llvm_disasm.cpp
@@ -208,8 +208,9 @@ public:
                 output_error(triple, cpu, "failed to create instruction printer");
             return {nullptr, bap_disasm_unsupported_target};
         }
-
-
+        /* Make the default for immediates to be in hex */
+        printer->setPrintImmHex(true);
+          
         shared_ptr<llvm::MCDisassembler>
             dis(target->createMCDisassembler(*sub_info));
 


### PR DESCRIPTION
This change affects the default printer in the C++ LLVM code, as
well as the BAP LLVM operand printing code.
