### PR TITLE
Fix some minor build issues.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SETUP = ocaml setup.ml
+CONFIGURE = ./configure
 PIQI=piqi
 OCI=ocp-indent
 
@@ -11,7 +12,7 @@ doc: setup.data build
 test: setup.data build
 	$(SETUP) -test $(TESTFLAGS)
 
-all:
+all: setup.data
 	$(SETUP) -all $(ALLFLAGS)
 
 install: setup.data
@@ -23,19 +24,17 @@ uninstall: setup.data
 reinstall: setup.data
 	$(SETUP) -reinstall $(REINSTALLFLAGS)
 
-clean:
+clean: setup.data
 	$(SETUP) -clean $(CLEANFLAGS)
 
-distclean:
+distclean: setup.data
 	$(SETUP) -distclean $(DISTCLEANFLAGS)
 
 setup.data:
-	$(SETUP) -configure $(CONFIGUREFLAGS)
+	$(CONFIGURE) $(CONFIGUREFLAGS)
 
 configure:
-	$(SETUP) -configure $(CONFIGUREFLAGS)
-
-.PHONY: build doc test all install uninstall reinstall clean distclean configure
+	$(CONFIGURE) $(CONFIGUREFLAGS)
 
 
 .PHONY: check

--- a/_oasis
+++ b/_oasis
@@ -43,6 +43,10 @@ Flag serialization
   Description: Build serialization library
   Default: false
 
+Flag llvm_static
+  Description: Links with llvm in a static mode
+  Default: true
+
 Flag benchmarks
   Description: Build and run benchmarks
   Default: false
@@ -214,7 +218,7 @@ Library llvm
                  bap.types
   Modules:       Bap_llvm
   CCOpt:         $cc_optimization
-  CCLib:         $llvm_mainlib $cxxlibs $llvm_ldflags
+  CCLib:         $llvm_lib $cxxlibs $llvm_ldflags
   CSources:      llvm_disasm.h, llvm_disasm.c, llvm_stubs.c
   XMETAExtraLines: plugin_system = "bap.disasm"
 

--- a/configure
+++ b/configure
@@ -21,5 +21,6 @@ for i in "$@"; do
   esac
 done
 
+[ -f setup.ml ] || oasis -quiet setup
 ocaml preconfig.ml
 ocaml setup.ml -configure "$@"

--- a/setup.ml.in
+++ b/setup.ml.in
@@ -1,3 +1,6 @@
+#use "topfind";;
+#require "unix";;
+
 let definition_end = BaseEnv.var_ignore
 
 let ctxt = !BaseContext.default
@@ -37,7 +40,7 @@ let llvm_version () : unit =
     ~cli:BaseEnv.CLIWith
     ~short_desc:(fun () -> "libllvm version (e.g., 3.4)")
     "llvm_version"
-    (fun () -> "3.4") |>
+    (fun () -> "") |>
   definition_end
 
 let llvm_config () : unit =
@@ -110,11 +113,45 @@ let cc_optimization () : unit =
     (fun () -> "-O2") |>
   definition_end
 
+let llvm_lib () : unit =
+  BaseEnv.var_define
+    ~hide:true
+    ~dump:true
+    ~short_desc:(fun () -> "LLVM library(ies) to link with")
+    "llvm_lib"
+    (fun () ->
+       let llvm_static = BaseEnv.var_get "llvm_static" in
+       let lib = if llvm_static = "true"
+         then "llvm_libs"
+         else "llvm_mainlib" in
+       BaseEnv.var_get lib) |>
+  definition_end
+
+let is_defined var : bool =
+  try (BaseEnv.var_get var) |> ignore; true with exn -> false
+
+let is_undefined var : bool = not (is_defined var)
+
+let is_set_to var value : bool =
+  is_defined var && BaseEnv.var_get var = value
+
+
+let check =
+  let open OASISMessage in
+  List.iter (fun (causes,expected,message) ->
+      if List.for_all (fun (v,e) -> is_set_to v e) causes &&
+         List.exists is_undefined expected
+      then error ~ctxt message)
+
 
 let define definitions =
   List.iter (fun f -> try f () with exn -> ()) definitions
 
 let () =
+
+  Unix.putenv "OCAMLFIND_IGNORE_DUPS_IN" @@
+  BaseEnv.var_get "standard_library";
+
   define [
     piqic;
     cxx;
@@ -128,5 +165,12 @@ let () =
     llvm "ldflags";
     llvm "cflags";
     llvm "libs";
+    llvm_lib;
   ];
+
   setup ();
+
+  check [
+    ["llvm","true"], ["llvm_lib"], "can't find llvm library";
+    ["serialization", "true"], ["piqic"], "can't find piqic compiler";
+  ];


### PR DESCRIPTION
1. Configure script will now explicitly check, that llvm is found
   and give a sane error message otherwise
2. Since we ship Makefile and configure, then we should assume,
   that users will not read documentation and just run make or
   ./configure or both. Now, scripts will auto-magically figure out
   what is happening and run oasis by themselves.
3. Everybody reports the warning from oasis as errors. It is really
   frustrating. Many even stop after seeing the warning. This PR will
   reduce the amount of warnings. First of all oasis is called inside
   configure script with -quiet option. Next, the proper environment
   variables are set, so that ocamlfind eschew to emit extra warnings.
4. Many systems by default name llvm-config just as llvm-config, and do
   not provide files with explicit version numbers, unlike ubuntu does.
   This PR addresses this issue, using by default `llvm-config` on
   linux, and `llvm-config-mp-3.4` on macosx. Adding explicit version
   requirements with command line argument `--with-llvm-version=<ver>`
   will append the <ver> to the filename.
