### PR TITLE
Fix some minor build issues.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,41 +1,40 @@
-SETUP = ocaml setup.ml
+SETUP = ocaml setup.ml -quiet
+CONFIGURE = ./configure
 PIQI=piqi
 OCI=ocp-indent
 
 build: setup.data
-	$(SETUP) -build $(BUILDFLAGS)
+	$(SETUP) -build $(BAPBUILDFLAGS)
 
 doc: setup.data build
-	$(SETUP) -doc $(DOCFLAGS)
+	$(SETUP) -doc $(BAPDOCFLAGS)
 
 test: setup.data build
-	$(SETUP) -test $(TESTFLAGS)
+	$(SETUP) -test $(BAPTESTFLAGS)
 
-all:
-	$(SETUP) -all $(ALLFLAGS)
+all: setup.data
+	$(SETUP) -all $(BAPALLFLAGS)
 
 install: setup.data
-	$(SETUP) -install $(INSTALLFLAGS)
+	$(SETUP) -install $(BAPINSTALLFLAGS)
 
 uninstall: setup.data
-	$(SETUP) -uninstall $(UNINSTALLFLAGS)
+	$(SETUP) -uninstall $(BAPUNINSTALLFLAGS)
 
 reinstall: setup.data
-	$(SETUP) -reinstall $(REINSTALLFLAGS)
+	$(SETUP) -reinstall $(BAPREINSTALLFLAGS)
 
-clean:
-	$(SETUP) -clean $(CLEANFLAGS)
+clean: setup.data
+	$(SETUP) -clean $(BAPCLEANFLAGS)
 
-distclean:
-	$(SETUP) -distclean $(DISTCLEANFLAGS)
+distclean: setup.data
+	$(SETUP) -distclean $(BAPDISTCLEANFLAGS)
 
-setup.data:
-	$(SETUP) -configure $(CONFIGUREFLAGS)
+setup.data: *.in
+	$(CONFIGURE) $(BAPCONFIGUREFLAGS)
 
 configure:
-	$(SETUP) -configure $(CONFIGUREFLAGS)
-
-.PHONY: build doc test all install uninstall reinstall clean distclean configure
+	$(CONFIGURE) $(BAPCONFIGUREFLAGS)
 
 
 .PHONY: check

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ environment.
 $ opam install oasis
 ```
 
-We also recommend you install `utop` for running BAP.  
+We also recommend you install `utop` for running BAP.
 
 ```bash
 $ opam install utop
@@ -48,20 +48,28 @@ against llvm-3.4, which we have confirmed works on OSX and Ubuntu.
 ## Compiling and installing `bap`
 
 Once all the dependencies of `bap` have been installed, we can start the actual
-build. In a development version, you need to start by executing `oasis setup`.
-If you are building from a release, e.g., you have just downloaded a tarball,
-then you can skip this step. Now, run the following commands:
+build. Now, run the following commands:
 
 ```bash
-$ oasis setup  #needed only if you have cloned from git
-$ ./configure --prefix=$(opam config var prefix)
 $ make
 $ make install
 ```
 
-The `./configure` script will check that everything is OK. If not, it will
-terminate with error messages displayed on the console. Please be sure to check
-the console output.
+This will run take care to run all configuration scripts for you. If
+you want to provide some specific flags to `configure`, then you need
+either to invoke it manually with `./configure` or provide them to
+make using `BAPCONFIGUREFLAGS` environment variable.
+
+Note: if you have chosen prefix that require super-user privileges,
+then you need to run `make install` using either `sudo`, e.g., `sudo
+make install` or switch to a super-user mode. Although it is not
+required, we suggest to install `bap` in to `opam` stack. In this case
+a proper prefix can be generated using `opam config var` command,
+e.g.,
+
+```bash
+./configure --prefix=$(opam config var prefix)
+```
 
 If you have installed `bap` previously, then use the command `make reinstall`
 instead of `make install`. However, this will *not* work if `setup.log` has been

--- a/_oasis
+++ b/_oasis
@@ -43,6 +43,10 @@ Flag serialization
   Description: Build serialization library
   Default: false
 
+Flag llvm_static
+  Description: Links with llvm in a static mode
+  Default: true
+
 Flag benchmarks
   Description: Build and run benchmarks
   Default: false
@@ -214,7 +218,7 @@ Library llvm
                  bap.types
   Modules:       Bap_llvm
   CCOpt:         $cc_optimization
-  CCLib:         $llvm_mainlib $cxxlibs $llvm_ldflags
+  CCLib:         $llvm_lib $cxxlibs $llvm_ldflags
   CSources:      llvm_disasm.h, llvm_disasm.c, llvm_stubs.c
   XMETAExtraLines: plugin_system = "bap.disasm"
 

--- a/configure
+++ b/configure
@@ -21,5 +21,6 @@ for i in "$@"; do
   esac
 done
 
+[ -f setup.ml ] || oasis -quiet setup
 ocaml preconfig.ml
 ocaml setup.ml -configure "$@"

--- a/setup.ml.in
+++ b/setup.ml.in
@@ -1,3 +1,5 @@
+#load "unix.cma";;
+
 let definition_end = BaseEnv.var_ignore
 
 let ctxt = !BaseContext.default
@@ -37,7 +39,7 @@ let llvm_version () : unit =
     ~cli:BaseEnv.CLIWith
     ~short_desc:(fun () -> "libllvm version (e.g., 3.4)")
     "llvm_version"
-    (fun () -> "3.4") |>
+    (fun () -> "") |>
   definition_end
 
 let llvm_config () : unit =
@@ -49,12 +51,13 @@ let llvm_config () : unit =
     "llvm_config"
     (fun () ->
        (* assume macports if we're on mac os x *)
-       let mp = if
-         BaseEnv.var_get "system" = "macosx" then "-mp" else "" in
+       let macosx = BaseEnv.var_get "system" = "macosx" in
        let ver = match BaseEnv.var_get "llvm_version" with
+         | "" when macosx -> "-mp-3.4"
          | "" -> ""
-         | ver -> "-"^ver in
-       OASISFileUtil.which ~ctxt ("llvm-config" ^ mp ^ ver)) |>
+         | ver when macosx -> "-mp-" ^ ver
+         | ver -> "-" ^ ver in
+       OASISFileUtil.which ~ctxt ("llvm-config" ^ ver)) |>
   definition_end
 
 let llvm var () : unit =
@@ -110,11 +113,46 @@ let cc_optimization () : unit =
     (fun () -> "-O2") |>
   definition_end
 
+let llvm_lib () : unit =
+  BaseEnv.var_define
+    ~hide:true
+    ~dump:true
+    ~short_desc:(fun () -> "LLVM library(ies) to link with")
+    "llvm_lib"
+    (fun () ->
+       let llvm_static = BaseEnv.var_get "llvm_static" in
+       let lib = if llvm_static = "true"
+         then "llvm_libs"
+         else "llvm_mainlib" in
+       BaseEnv.var_get lib) |>
+  definition_end
+
+let is_defined var : bool =
+  try (BaseEnv.var_get var) |> ignore; true with exn -> false
+
+let is_undefined var : bool = not (is_defined var)
+
+let is_set_to var value : bool =
+  is_defined var && BaseEnv.var_get var = value
+
+
+let check =
+  let open OASISMessage in
+  let error msg = error ~ctxt msg; exit 1 in
+  List.iter (fun (causes,expected,message) ->
+      if List.for_all (fun (v,e) -> is_set_to v e) causes &&
+         List.exists is_undefined expected
+      then error message)
+
 
 let define definitions =
   List.iter (fun f -> try f () with exn -> ()) definitions
 
 let () =
+
+  Unix.putenv "OCAMLFIND_IGNORE_DUPS_IN" @@
+  BaseEnv.var_get "standard_library";
+
   define [
     piqic;
     cxx;
@@ -128,5 +166,17 @@ let () =
     llvm "ldflags";
     llvm "cflags";
     llvm "libs";
+    llvm_lib;
   ];
+
   setup ();
+
+  check [
+    ["llvm","true"], ["llvm_lib"],
+    "  Failed to find llvm library, consider using --with-llvm-version
+     or --with-llvm-config command line options, to point me on a
+     correct version of LLVM. ";
+
+    ["serialization", "true"], ["piqic"],
+    "Failed find piqic compiler";
+  ];


### PR DESCRIPTION
1. Configure script will now explicitly check, that llvm is found
   and give a sane error message otherwise.
2. Since we ship Makefile and configure files, we should assume, that
   users will not read our documentation and just run make or
   ./configure or both. Now, scripts will auto-magically figure out what
   is happening and run oasis by themselves if needed. Actually, the
   true way now is just to call `make`, since it will prevent users from
   accidentally ignoring errors in configure script.
3. Everybody reports the warning from oasis as errors. It is really
   frustrating. Many even stop after seeing the warning. This PR will
   reduce the amount of warnings. First of all oasis is called inside
   configure script with -quiet option. Next, the proper environment
   variables are set, so that ocamlfind eschew to emit extra warnings.
4. Many systems by default name llvm-config just as llvm-config, and do
   not provide files with explicit version numbers, unlike ubuntu does.
   This PR addresses this issue, using by default `llvm-config` on
   linux, and `llvm-config-mp-3.4` on macosx. Adding explicit version
   requirements with command line argument `--with-llvm-version=<ver>`
   will append the <ver> to the filename.
