### PR TITLE
This PR is a result of integration with QIRA.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ myocamlbuild.ml
 /setup.log
 /setup.ml
 /_tags
+/python/*.pyc
+/python/bap.egg-info/

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,5 +1,5 @@
-OPAM_DEPENDS="core_kernel.111.28.00 oasis zarith bitstring utop cmdliner faillib ezjsonm lwt-zmq uri.1.7.2 re cohttp.0.15.0"
-SYS_DEPENDS="libgmp-dev time llvm-3.4-dev libzmq3-dev aspcud"
+OPAM_DEPENDS=`cat opam.deps opam.opt.deps`
+SYS_DEPENDS=`cat apt.deps apt.opt.deps`
 
 case "$OCAML_VERSION,$OPAM_VERSION" in
 4.02.1,1.2.0) ppa=avsm/ocaml42+opam12 ;;

--- a/README.md
+++ b/README.md
@@ -2,29 +2,31 @@
 
 [![Build Status](https://travis-ci.org/BinaryAnalysisPlatform/bap.svg?branch=master)](https://travis-ci.org/BinaryAnalysisPlatform/bap)
 
-`Bap` library provides basic facilities for performing binary analysis in OCaml.
+`Bap` library provides basic facilities for performing binary analysis
+in OCaml and other languages.
 
 # <a name="Installation"></a>Installation
 
 ## Installing `bap` dependencies
 
+### Installing system dependencies
+
+There are few system libraries that bap depends on. We provide a file
+`apt.deps` that contains package names as they are in Ubuntu
+Trusty. Depending on your OS and distribution, you may need to adjust
+this names. But, on most Debian-based Linux distribution, this should work:
+
+```bash
+$ sudo apt-get install $(cat apt.deps)
+```
+
+### Installing OCaml dependencies
+
 The easiest way to install the OCaml dependencies of `bap` is to use
 the `opam` package manager:
 
 ```bash
-$ opam install bitstring core_kernel zarith
-```
-
-_Note:_ The most up-to-date source of our dependency list is in our travis
-automation script `.travis-ci.sh`. The variable `SYS_DEPENDS` lists dependencies
-that should be installed on your system using `apt-get`; the variable
-`OPAM_DEPENDS` lists dependencies that can be installed via `opam`.
-
-If you would like to use our serialization library, then please also install the
-`piqi` package as follows:
-
-```bash
-$ opam install piqi
+$ opam install $(cat opam.deps)
 ```
 
 If you are using a development version, e.g., you have just cloned this from
@@ -40,10 +42,6 @@ We also recommend you install `utop` for running BAP.
 ```bash
 $ opam install utop
 ```
-
-Finally, you need to now install LLVM.  LLVM often changes their APIs,
-so we have had to standardize against one.  BAP currently compiles
-against llvm-3.4, which we have confirmed works on OSX and Ubuntu.
 
 ## Compiling and installing `bap`
 
@@ -117,6 +115,66 @@ in any OCaml top-level:
 And everything should work just out of box, i.e. it will load all the
 dependencies, install top-level printers, etc.
 
+## Using from Python
+
+You can install `bap` python bindings with `pip`.
+
+```bash
+$ pip install bap/python
+```
+
+Where `bap/python` is a path to bap python bindings. Adjust it
+according to your setup. Also, you may need to use `sudo` or to
+activate your `virtualenv` if you're using one.
+
+If you don't like `pip`, then you can just go to `bap/python` folder
+and copy-paste the contents to whatever place you like, and use it as
+desired.
+
+After bindings are properly installed, you can start to use it:
+
+```python
+    >>> import bap
+    >>> print '\n'.join(insn.asm for insn in bap.disasm("\x48\x83\xec\x08"))
+        decl    %eax
+        subl    $0x8, %esp
+```
+
+A more complex example:
+
+```python
+    >>> img = bap.image('coreutils_O0_ls')
+    >>> sym = img.get_symbol('main')
+    >>> print '\n'.join(insn.asm for insn in bap.disasm(sym))
+        push    {r11, lr}
+        add     r11, sp, #0x4
+        sub     sp, sp, #0xc8
+        ... <snip> ...
+```
+
+For more information, read builtin documentation, for example with
+`ipython`:
+
+```python
+    >>> bap?
+```
+
+## Using from shell
+
+We're shipping a `bap-mc` executable that can disassemble arbitrary
+strings. Read `bap-mc --help` for more information.
+
+## Using from other languages
+
+BAP exposes most of its functionality using `JSON`-based RPC protocol,
+specified
+[Public API Draft](https://github.com/BinaryAnalysisPlatform/bap/wiki/Public-API-%5Bdraft%5D)
+doument. The protocol is implemented by `bap-server` program that is
+shipped with bap by default. You can talk with server using `HTTP`
+protocol, or extend it with any other transporting protocol you would
+like.
+
+
 ## Compiling your program with `bap`
 
 Similar to the top-level, you can use our `bapbuild` script to compile a program
@@ -138,18 +196,22 @@ should add `bap` to the `BuildDepends` field. If you are using `ocamlbuild` with
 the `ocamlfind` plugin, then you should add `package(bap)` or `pkg_bap` to your
 `_tags` file.
 
+## Extending BAP
+
+BAP can be extended using plugin system. That means, that you can use
+`bap` library, to extend the `bap` library! See our
+[blog](http://binaryanalysisplatform.github.io/bap_plugins/) for more
+information.
+
+
 ## Learning BAP
 
-TBD
-
-# Development
-
-TBD
+The best source of information about BAP is it's source code, that is
+well-documented. There are also
+[blog](http://binaryanalysisplatform.github.io/bap_plugins/) and
+[wiki](https://github.com/BinaryAnalysisPlatform/bap/wiki/), where you
+can find some useful information.
 
 # License
 
 Please see the `LICENSE` file for licensing information.
-
-# TODO
-
-TBD

--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.4
 Name:        bap
-Version:     0.9
+Version:     0.9.1
 Synopsis:    BAP Core Library
 Authors:     BAP Team
 Maintainers: Ivan Gotovchits <ivg@ieee.org>
@@ -57,6 +57,10 @@ Flag disassemblers
 Flag server
   Description: Build BAP server
   Default: true
+
+Flag zmq
+  Description: Build ZMQ transports for BAP server
+  Default: false
 
 Flag llvm
  Description: Build with llvm backend
@@ -287,12 +291,18 @@ Library core_lwt
                   Core_lwt_pool,
                   Core_lwt_stream
 
+Library zmq
+  Path:           src/server
+  Build$:         flag(server) && flag(zmq)
+  CompiledObject: best
+  Install:        true
+  Modules:        Zmq_client, Zmq_server
 
 Executable "bap-server"
   Path:           src/server
   Build$:         flag(server)
   CompiledObject: best
-  BuildDepends:   bap, lwt-zmq, ezjsonm, uri, cohttp.lwt, core_lwt
+  BuildDepends:   bap, ezjsonm, uri, cohttp.lwt, core_lwt
   Install:        true
   MainIs:         start_server.ml
 

--- a/apt.deps
+++ b/apt.deps
@@ -1,0 +1,3 @@
+libgmp-dev
+llvm-3.4-dev
+time

--- a/apt.opt.deps
+++ b/apt.opt.deps
@@ -1,0 +1,1 @@
+libzmq3-dev

--- a/lib/bap_disasm/llvm_disasm.cpp
+++ b/lib/bap_disasm/llvm_disasm.cpp
@@ -304,8 +304,10 @@ public:
     // invalid instruction doesn't satisfy any predicate except is_invalid.
     bool satisfies(bap_disasm_insn_p_type p) const {
         bool current_invalid = current.code == 0;
-        if (p == is_invalid || current_invalid) {
-            return (p == is_invalid) && current_invalid;
+        if (p == is_invalid) {
+            return current_invalid;
+        } else if (current_invalid) {
+            return false;
         } else if (p == is_true) {
             return true;
         } else {

--- a/lib/bap_image/image_elf.ml
+++ b/lib/bap_image/image_elf.ml
@@ -115,10 +115,23 @@ let img_of_elf data elf : Img.t Or_error.t =
     | ELFCLASS64 -> `r64 in
   let addr = addr_maker addr_size in
   let entry = addr elf.e_entry in
-  let arch = match elf.e_machine with
-    | EM_386 -> Ok Arch.X86_32
-    | EM_X86_64 -> Ok Arch.X86_64
-    | EM_ARM -> Ok Arch.ARM
+  let arch = match elf.e_machine, endian with
+    | EM_386, _ -> Ok `x86
+    | EM_X86_64, _ -> Ok `x86_64
+    | EM_ARM, LittleEndian -> Ok `armv7
+    | EM_ARM, BigEndian -> Ok `armeb
+    | EM_AARCH64, LittleEndian -> Ok `aarch64
+    | EM_AARCH64, BigEndian -> Ok `aarch64_be
+    | EM_SPARC,_ -> Ok `sparc
+    | EM_SPARCV9,_ -> Ok `sparcv9
+    | EM_PPC,_ -> Ok `ppc
+    | EM_PPC64, BigEndian -> Ok `ppc64
+    | EM_PPC64, LittleEndian -> Ok `ppc64le
+    | EM_S390,_ -> Ok `systemz
+    | EM_MIPS, BigEndian -> Ok `mips
+    | EM_MIPS, LittleEndian -> Ok `mipsel
+    | EM_MIPS_X, BigEndian -> Ok `mips64
+    | EM_MIPS_X, LittleEndian -> Ok `mips64el
     | _ -> errorf "can't load file, unsupported platform" in
   let sections,errors =
     Seq.filter_mapi elf.e_segments (create_section addr) |>

--- a/lib/bap_types/bap_arch.ml
+++ b/lib/bap_types/bap_arch.ml
@@ -11,18 +11,47 @@ module T = struct
   let module_name = "Bap_arch"
 
   let to_string = function
-    | X86_32 -> "X86_32"
-    | X86_64 -> "X86_64"
-    | ARM    -> "ARM"
-
+    | `x86 -> "i386"
+    | arch -> Sexp.to_string (sexp_of_t arch)
   let pp ch arch = Format.fprintf ch "%s" (to_string arch)
 
+  let normalize s =
+    match Fn.compose String.lowercase String.strip s with
+    | "x86" | "x86-32" | "x86_32" | "ia32" | "ia-32"
+    | "i386"| "i486" | "i586" | "i686" -> "x86"
+    | "x86-64" | "x86_64" | "amd64" | "x64" | "x86_64h" -> "x86_64"
+    | "powerpc" -> "ppc"
+    | "xscale"  -> "arm"
+    | "thumbv4t" -> "armv4t"
+    | "armv5t" | "armv5e" | "thumbv5" | "thumbv5e" -> "armv5"
+    | "thumbv6" -> "armv6"
+    | "thumbv7" -> "armv7"
+    | "powerpc64" | "ppu" -> "ppc64"
+    | "sparc64" -> "sparcv9"
+    | "s390x" -> "systemz"
+    | "arm64" -> "aarch64"
+    | "arm64_be" -> "aarch64_be"
+    | s -> s
+
+  let of_string_exn s =
+    t_of_sexp (sexp_of_string (normalize s))
+
   let of_string s =
-    match Fn.compose String.uppercase String.strip s with
-    | "X86" | "X86-32" | "X86_32" | "IA32" | "IA-32" | "I386" -> Some X86_32
-    | "X86-64" | "X86_64" | "AMD64" | "x64" -> Some X86_64
-    | "arm" | "ARM" -> Some ARM
-    | s -> None
+    Option.try_with (fun () -> of_string_exn s)
+
+  let addr_size : t -> addr_size = function
+    | #arm | `x86 | `ppc | `mips | `mipsel | `sparc
+    | `nvptx | `hexagon |  `r600 | `xcore  -> `r32
+
+    | #aarch64 | `mips64el |`sparcv9|`ppc64le|`x86_64
+    | `ppc64|`nvptx64 | `systemz | `mips64 -> `r64
+
+  let endian : t -> endian = function
+    | `armeb  | `aarch64_be | `thumbeb -> BigEndian
+    | `mipsel | `mips64el | `ppc64le -> LittleEndian
+    | #arm | #x86 | #aarch64 | #r600
+    | #hexagon | #nvptx | #xcore -> LittleEndian
+    | #ppc | #mips | #sparc | #systemz   -> BigEndian
 end
 
 (* derive Identifiable interface from Core *)

--- a/lib/bap_types/bap_arch.mli
+++ b/lib/bap_types/bap_arch.mli
@@ -4,5 +4,9 @@ open Bap_common
 
 val of_string : string -> arch option
 
+val addr_size : arch -> addr_size
+
+val endian : arch -> endian
+
 (** [arch] type implements [Idenfifiable]  interface  *)
 include Regular with type t := arch

--- a/lib/bap_types/bap_common.ml
+++ b/lib/bap_types/bap_common.ml
@@ -117,14 +117,82 @@ with bin_io, compare, sexp
 
 (** Supported architectures  *)
 module Arch = struct
-  type t =
-    | X86_32
-    | X86_64
-    | ARM
-  with bin_io, compare, enumerate, sexp, variants
+  type x86 = [
+    | `x86
+    | `x86_64
+  ] with bin_io, compare, enumerate, sexp
+
+  type arm = [
+    | `arm
+    | `armeb
+    | `armv4
+    | `armv4t
+    | `armv5
+    | `armv6
+    | `armv7
+    | `thumb
+    | `thumbeb
+  ] with bin_io, compare, enumerate, sexp
+
+  type aarch64 = [
+    | `aarch64
+    | `aarch64_be
+  ]
+  with bin_io, compare, enumerate, sexp
+
+  type ppc = [
+    | `ppc
+    | `ppc64
+    | `ppc64le
+  ]
+  with bin_io, compare, enumerate, sexp
+
+  type mips = [
+    | `mips
+    | `mipsel
+    | `mips64
+    | `mips64el
+  ]
+  with bin_io, compare, enumerate, sexp
+
+  type sparc = [
+    | `sparc
+    | `sparcv9
+  ]
+  with bin_io, compare, enumerate, sexp
+
+  type nvptx = [
+    | `nvptx
+    | `nvptx64
+  ]
+  with bin_io, compare, enumerate, sexp
+
+  type hexagon = [`hexagon]
+  with bin_io, compare, enumerate, sexp
+
+  type r600 = [`r600]
+  with bin_io, compare, enumerate, sexp
+
+  type systemz = [`systemz]
+  with bin_io, compare, enumerate, sexp
+
+  type xcore = [`xcore]
+  with bin_io, compare, enumerate, sexp
+
+  type t = [
+    | aarch64
+    | arm
+    | hexagon
+    | mips
+    | nvptx
+    | ppc
+    | r600
+    | sparc
+    | systemz
+    | x86
+    | xcore
+  ] with bin_io, compare, enumerate, sexp, variants
 end
-
-
 
 (** {2 Common type abbreviations}
     You will see them later.

--- a/lib_test/bap_image/test_image.ml
+++ b/lib_test/bap_image/test_image.ml
@@ -56,7 +56,7 @@ let nonempty = function
 let create ?(addr_size=`r32) ?(endian=LittleEndian) ~syms ss name =
   let sections = nonempty (ss addr_size name) in
   let symbols = syms in
-  let arch = Arch.ARM in
+  let arch = `arm in
   let entry = create_addr addr_size 0 in
   let load _ =
     Some (Img.Fields.create ~arch ~addr_size ~endian ~entry ~sections ~symbols) in

--- a/opam.deps
+++ b/opam.deps
@@ -1,0 +1,12 @@
+base-unix
+bitstring
+cmdliner
+cohttp.0.15.0
+core_kernel.111.28.00
+ezjsonm
+faillib
+lwt
+oasis
+re
+uri.1.7.2
+zarith

--- a/opam.opt.deps
+++ b/opam.opt.deps
@@ -1,0 +1,2 @@
+lwt-zmq
+utop

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -99,6 +99,6 @@ following attributes:
 
 Where data is actual string of bytes.
 """
-__all__ = ['disasm', 'image']
+__all__ = ['disasm', 'image', 'adt', 'asm', 'arm', 'bil']
 
 from .bap import disasm, image

--- a/python/asm.py
+++ b/python/asm.py
@@ -34,7 +34,7 @@ def map_eval(ss):
 
 
 class Insn(object) :
-    def __init__(self, name, addr, size, asm, kinds, operands, target=None, bil=[], **kw):
+    def __init__(self, name, addr, size, asm, kinds, operands, target=None, bil=None, **kw):
         self.name  = name
         self.addr  = int(addr)
         self.size  = int(size)
@@ -45,14 +45,25 @@ class Insn(object) :
         self.bil = bil
         self.__dict__.update(kw)
 
+    def has_kind(self, k):
+        return exists(self.kinds, lambda x: isinstance(x,k))
+
     def __repr__(self):
-        return 'Insn("{name}", {addr:#010x}, {size}, "{asm}", {kinds}, {operands}, {target}, {bil})'.\
+        return 'Insn("{name}", {addr:#010x}, {size}, "{asm}", {kinds}, {operands})'.\
           format(**self.__dict__)
 
 class Op(ADT)        : pass
 class Reg(Op)        : pass
 class Imm(Op)        : pass
 class Fmm(Op)        : pass
+
+
+def exists(cont,f):
+    try:
+        r = (x for x in cont if f(x)).next()
+        return True
+    except StopIteration:
+        return False
 
 
 if __name__ == "__main__":

--- a/src/bap_mc/bap_mc.ml
+++ b/src/bap_mc/bap_mc.ml
@@ -1,12 +1,21 @@
 open Core_kernel.Std open Or_error open OUnit2
 open Bap.Std
+
 open Disasm
+module Disasm = Disasm.Basic
 
 exception Bad_user_input
-exception No_disassembly
+exception No_disassembly of mem * int * int
 exception Convert_imm_exn of string
 exception Create_mem_exn
 exception Stdin_exn
+
+let no_disassembly state boff =
+  let mem = Disasm.memory state in
+  let addr = Disasm.addr state in
+  let stop = Addr.to_int addr |> ok_exn in
+
+  raise (No_disassembly (mem, boff, stop))
 
 let create_memory addr s =
   Memory.create LittleEndian Addr.(of_int64 addr) @@
@@ -17,12 +26,12 @@ let create_memory addr s =
 let print_kinds insn =
   let output = Insn.kinds insn
                |> List.map ~f:(fun kind ->
-                   Sexp.to_string_hum (Insn.Kind.sexp_of_t kind))
+                   Sexp.to_string_hum (Disasm.sexp_of_kind kind))
                |> String.concat ~sep:", " in
   printf "%-4s;; %s\n" " " output
 
 let print_insn insn width o_reg_format o_imm_format =
-  let open Op in
+  let open Disasm.Op in
   let init = [Sexp.Atom (Insn.name insn)] in
   let res =
     Insn.ops insn
@@ -52,16 +61,22 @@ let print_asm insn f_inst =
   else printf "%-4s%s" " " s
 
 let print_disasm width f_asm f_inst f_kinds o_reg_format o_imm_format
-    state mem insn disasm =
+    state mem insn off =
   if f_kinds then print_kinds insn;
   if f_inst then print_insn insn width o_reg_format o_imm_format;
   if f_asm then print_asm insn f_inst;
   if (f_asm || f_inst) then print_newline ();
-  Basic.step state ()
+  Disasm.step state (Disasm.addr state |> Addr.to_int |> ok_exn)
 
 (* Convert strings to binary string representation "\x01\x02..." *)
 let to_bin_str s f =
-  try String.split ~on:' ' s |> List.map ~f |> String.concat |> Scanf.unescaped
+  let seps = [' '; ','; ';'] in
+  let separated = List.exists seps ~f:(String.mem s) in
+  let bytes = if separated
+    then String.split_on_chars ~on:seps s
+    else List.init (String.length s / 2) ~f:(fun n ->
+        String.slice s (n*2) (n*2+2)) in
+  try bytes |> List.map ~f |> String.concat |> Scanf.unescaped
   with Scanf.Scan_failure _ -> raise Bad_user_input
 
 let disasm s o_arch f_asm f_inst f_kinds o_reg_format o_imm_format =
@@ -69,7 +84,7 @@ let disasm s o_arch f_asm f_inst f_kinds o_reg_format o_imm_format =
     match s with
     | "" -> In_channel.input_line In_channel.stdin
     | _ -> Some s in
-  Disasm.Basic.create ~backend:"llvm" o_arch >>= fun dis ->
+  Disasm.create ~backend:"llvm" o_arch >>= fun dis ->
   let input = match input_src with
     | Some input ->
       begin match String.prefix input 2 with
@@ -80,14 +95,15 @@ let disasm s o_arch f_asm f_inst f_kinds o_reg_format o_imm_format =
         | _ -> let f x = "\\x" ^ x in to_bin_str input f
       end
     | None -> raise Stdin_exn in
-  let mem_of_input = create_memory 0x0L input in
   (* arm instructions tend to be longer, so increase the printed width *)
   let width = if o_arch = "arm" then 65 else 50 in
   let hit =
     print_disasm width f_asm f_inst f_kinds o_reg_format o_imm_format in
-  let invalid state disasm = raise No_disassembly in
-  Disasm.Basic.run dis ~return:ident ~stop_on:[`Valid] ~invalid ~hit ~init:()
-    mem_of_input;
+  let invalid state mem off = no_disassembly state off in
+  let mem = create_memory 0x0L input in
+  let _pos : int =
+    Disasm.run dis ~return:ident ~stop_on:[`Valid] ~invalid ~hit ~init:0
+      mem in
   return ()
 
 open Cmdliner
@@ -132,6 +148,7 @@ let cmd =
     `I (".BR", " 0x31 0xd2 0x48 0xf7 0xf3"); `Noblank;
     `I (".BR", " \\\\x31\\\\xd2\\\\x48\\\\xf7\\\\xf3"); `Noblank;
     `I (".BR", " 31 d2 48 f7 f3");
+    `I (".BR", " 31d248f7f3");
     `I ("INPUT: Supplied via stdin or on the command-line",
         "echo \"0x31 0xd2 0x48 0xf7 0xf3\" | bap-mc  --show-inst --show-asm");
     `S "SEE ALSO";
@@ -144,20 +161,31 @@ let () =
   Plugins.load ();
   let err = Format.std_formatter in
   try match Term.eval cmd ~catch:false ~err with
+    | `Ok Ok () -> exit 0
+    | `Ok Error err ->
+      eprintf "%s\n" Error.(to_string_hum err); exit 2
     | `Error `Parse -> exit 64
-    | `Error _ -> exit 1
-    | _ -> exit 0
+    | `Error _ -> exit 2
+    | _ -> exit 1
+
   with e ->
-    let fin s n = print_endline s; exit n in
+    let fin n s = eprintf "%s\n" s; exit n in
     match e with
     | Bad_user_input ->
-      fin "Could not parse: malformed input" 65
+      fin 65 "Could not parse: malformed input"
     | Convert_imm_exn imm ->
-      fin (sprintf "Unable to convert Imm hex value [%s] to int" imm) 1
+      sprintf "Unable to convert Imm hex value [%s] to int" imm |>
+      fin 1
     | Create_mem_exn ->
-      fin "Internal error: cannot create memory for dissasembly backend" 1
+      fin 1 "Internal error: cannot create memory for dissasembly backend"
     | Stdin_exn ->
-      fin "Could not read from stdin" 1
-    | No_disassembly ->
-      fin (sprintf "Invalid instruction encountered, disassembly stopped") 1
-    | _ -> fin "Could not disassemble input" 1
+      fin 1 "Could not read from stdin"
+    | No_disassembly (mem,boff,stop)->
+      let dump = Memory.hexdump mem in
+      let line = boff / 16 in
+      let pos off = line * 77 + (off mod 16) * 3 + 9 in
+      dump.[pos boff] <- '(';
+      dump.[pos stop] <- ')';
+      sprintf "Invalid instruction at offset %d:\n%s" boff dump |>
+      fin 1
+    | _ -> fin 1 "Could not disassemble input"

--- a/src/byteweight/byteweight.ml
+++ b/src/byteweight/byteweight.ml
@@ -29,37 +29,37 @@ let anon_fun s = bin := Some s
 
 let output oc fsi =
   Sequence.iter fsi ~f:(fun addr ->
-    Printf.fprintf oc "%s\n" @@ Addr.to_string addr
-  );
+      Printf.fprintf oc "%s\n" @@ Addr.to_string addr
+    );
   Out_channel.close oc
 
 
 let fsi_bin_fn bin =
   let r =
     Image.create bin >>| fun (img, _) -> begin
-      let code_sections = Table.filter (Image.sections img) ~f:Image.Sec.is_executable in
-      (* TODO: currently the architecture is hard-coded. Check if we add
-       * architecture as an option or figure out the architecture of binary by
-       * calling some detection method *)
-      let fn_table = Fn_table.create ~signatures:!f_wpt ~work_on_bytes:!work_on_bytes Arch.ARM
+    let code_sections = Table.filter (Image.sections img) ~f:Image.Sec.is_executable in
+    (* TODO: currently the architecture is hard-coded. Check if we add
+     * architecture as an option or figure out the architecture of binary by
+     * calling some detection method *)
+    let fn_table = Fn_table.create ~signatures:!f_wpt ~work_on_bytes:!work_on_bytes `arm
         ~sections:code_sections in
-      Fn_table.addrs fn_table
-    end in
+    Fn_table.addrs fn_table
+  end in
   match r with
-    | Ok fsi -> fsi
-    | Error err ->
-        eprintf "Program failed with: %s\n" @@
-        Error.to_string_hum err; Sequence.empty
+  | Ok fsi -> fsi
+  | Error err ->
+    eprintf "Program failed with: %s\n" @@
+    Error.to_string_hum err; Sequence.empty
 
 (* main *)
 let () =
   Plugins.load ();
   let () = Arg.parse arg_specs anon_fun usage in
   match !bin, !d_bin with
-    (* TODO: currently for every binary signature file has to be read again
-     * because Fn_table.create interfaces (which targets at segments and one connot decide the
-     * architecture before calling create) *)
-    | None, Some d_i -> (
+  (* TODO: currently for every binary signature file has to be read again
+   * because Fn_table.create interfaces (which targets at segments and one connot decide the
+   * architecture before calling create) *)
+  | None, Some d_i -> (
       match !d_out with
       | None ->
         let err =
@@ -67,18 +67,18 @@ let () =
         raise (Arg.Bad err)
       | Some d_o ->
         let bins = List.map
-          ~f:(Filename.concat d_i)
-          (Array.to_list (Sys.readdir d_i)) in
+            ~f:(Filename.concat d_i)
+            (Array.to_list (Sys.readdir d_i)) in
         List.iter ~f:(fun bin ->
-          Printf.printf "%s\n%!" bin;
-          let fs_seq = fsi_bin_fn bin in
-          let oc =
-            let bin_out = Filename.concat d_o (Filename.basename bin) in
-            open_out bin_out in
-          output oc fs_seq
-        ) bins
+            Printf.printf "%s\n%!" bin;
+            let fs_seq = fsi_bin_fn bin in
+            let oc =
+              let bin_out = Filename.concat d_o (Filename.basename bin) in
+              open_out bin_out in
+            output oc fs_seq
+          ) bins
     )
-    | Some i, None ->
-      let fs_seq = fsi_bin_fn i in
-      output !out fs_seq
-    | _ -> raise (Arg.Bad usage)
+  | Some i, None ->
+    let fs_seq = fsi_bin_fn i in
+    output !out fs_seq
+  | _ -> raise (Arg.Bad usage)

--- a/src/server/.merlin
+++ b/src/server/.merlin
@@ -1,4 +1,5 @@
 B ../../_build/src/server
+B ../../_build/lwt
 REC
 PKG ezjsonm
 PKG lwt
@@ -9,3 +10,4 @@ PKG cohttp.lwt
 PKG cohttp
 
 S .
+S ../../lwt

--- a/src/server/adt.ml
+++ b/src/server/adt.ml
@@ -32,8 +32,6 @@ module Exp = struct
   open Exp
   open Var
 
-
-
   let rec pp ch = function
     | Load (x,y,e,s) ->
       pr ch "Load(%a,%a,%a,%a)" pp x pp y pp_endian e pp_size s

--- a/src/server/manager.ml
+++ b/src/server/manager.ml
@@ -134,11 +134,12 @@ let add_image ?file img =
   Ids.add_exn t.images ~key:img_id ~data:resource;
   Lwt.return (Or_error.return img_id)
 
-let add_memory arch endian addr uri : id Lwt.Or_error.t =
+let add_memory arch addr uri : id Lwt.Or_error.t =
   Transport.fetch_resource uri >>=? fun data ->
   let pos = Bigsubstring.pos data in
   let len = Bigsubstring.length data in
   let data = Bigsubstring.base data in
+  let endian = Arch.endian arch in
   match Memory.create ~pos ~len endian addr data with
   | Error err ->
     Error.tag_arg err "fetching chunk from" uri Uri.sexp_of_t |>

--- a/src/server/manager.mli
+++ b/src/server/manager.mli
@@ -36,7 +36,7 @@ val add_image  : ?file:string -> image -> id Lwt.Or_error.t
 
 (** fetches memory chunk from a given [uri], and adds it to the
     resource pool *)
-val add_memory : arch -> endian -> addr -> Uri.t -> id Lwt.Or_error.t
+val add_memory : arch -> addr -> Uri.t -> id Lwt.Or_error.t
 
 (** fetched image from a given [url], and stores it among other
     resources *)

--- a/src/server/mmap_client.ml
+++ b/src/server/mmap_client.ml
@@ -64,6 +64,7 @@ let main () =
         let data = Lwt_bytes.map_file ~fd ~shared:false () in
         let entry = {data; path} in
         Weak_set.add files entry;
+        Lwt.Unix.close (Lwt.Unix.of_unix_file_descr fd) >>= fun () ->
         substring_of_entry uri entry in
   Transport.register_resource_fetcher ~scheme fetch
 

--- a/src/server/rpc.mli
+++ b/src/server/rpc.mli
@@ -31,7 +31,7 @@ module Request : sig
   val accept : t ->
     init:(string -> 'a) ->
     load_file:(?loader:string -> Uri.t -> 'a) ->
-    load_chunk:(addr -> arch -> endian -> Uri.t -> 'a) ->
+    load_chunk:(addr -> arch -> Uri.t -> 'a) ->
     get_insns:(?backend:res_id -> Disasm.Basic.pred list -> res_id -> 'a) ->
     get_resource:(res_id -> 'a) -> 'a Or_error.t
 end

--- a/src/server/start_server.ml
+++ b/src/server/start_server.ml
@@ -39,7 +39,5 @@ let () =
   let module F = File_fetcher in
   let module M = Mmap_client in
   let module N = Mmap_server in
-  let module Z = Zmq_server in
-  let module C = Zmq_client in
   let () = Plugins.load () in
   Lwt.Main.run @@ main ()


### PR DESCRIPTION
The PR will bring us the following:

1. BAP now support 25 different architectures.
   Also Arch module can now infer address size and endianness from the
   specified architecture.

2. Bap server doesn't require address size or endian.
   Only arch is required, everything else can be inferred from it.

3. Addresses in Public API is no longer an ADT but a string encoded
   number, with value specified strictly in hexes.

4. BIL and ADT classes are extended.
   Added some helpers, and also add named properties to BIL entities.

5. Updated README.md and simplified installation.
   This will resolve #62

6. Packaged server a little more accurately, although it still
   not pluginized (see #67)

7. Hardened `bap.py` for multithreaded environment
   bap will try to autospawn one server per process, and multiple
   bap proxies will be created per thread

8. bap-mc now accepts more user inputs:
   1. bytes can be separated with spaces, commas and semicolons
   2. bytes can be left without separators

9. bap-mc will now error in case of error
   This is to resolve #47 and others

10. bap-mc will now properly handle invalid instructions
   Previously there was a bug, as a result error handler was applied
   prematurely. Also, I've extended error handler with pretty-printer
   that will output dump, highlighting failed piece of code.

11. readbin will linear sweep executable sections

12. bap-server if ordered to disassemble the whole image will
   disassemble only executable part of the file. I think this is a more
   reasonable behavior, rather than previously to disassemble the whole
   file including data sections.