### PR TITLE
Preliminary support for OPAM.

### DIFF
--- a/configure
+++ b/configure
@@ -26,10 +26,4 @@ done
 
 ocaml preconfig.ml
 
-case `ocaml -vnum` in
-    4.01.*)
-       sed -i 's/mark_tag_used/ignore/' myocamlbuild.ml
-    ;;
-esac
-
 ocaml setup.ml -configure "$@"

--- a/myocamlbuild.ml.in
+++ b/myocamlbuild.ml.in
@@ -44,10 +44,11 @@ let dispatch = function
 
 let mark_tags () =
   let open Ocamlbuild_plugin in
-  mark_tag_used "pkg_core_bench";
-  mark_tag_used "tests";
-  mark_tag_used "pkg_piqirun"
-
+  (* Uncomment the following in OCaml 4.02, to remove warnings. *)
+  (* mark_tag_used "pkg_core_bench"; *)
+  (* mark_tag_used "tests"; *)
+  (* mark_tag_used "pkg_piqirun" *)
+  ()
 
 let () =
   mark_tags ();

--- a/opam
+++ b/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+name: "bap"
+version: "0.9.1"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+ 	"base-unix"
+ 	"bitstring"
+	"cmdliner"
+	"cohttp" {= "0.15.0"}
+	"core_kernel" {= "111.28.0"}
+	"ezjsonm" {= "0.4.0"}
+	"faillib"
+	"lwt"
+	"oasis" {build}
+	"re"
+	"uri" {= "1.7.2"}
+	"zarith"
+]
+available: [ocaml-version >= "4.01"]

--- a/opam.deps
+++ b/opam.deps
@@ -3,7 +3,7 @@ bitstring
 cmdliner
 cohttp.0.15.0
 core_kernel.111.28.00
-ezjsonm
+ezjsonm.0.4.0
 faillib
 lwt
 oasis


### PR DESCRIPTION
This opam configuration is as simple as possible, without optional dependencies and 
trying to figure out what system packages do we have. Just for a start.

Also, I've also noticed, that sed trick in the configure script is not
crossplatfrom. It even doesn't work on Mac OS X. So, I've removed
it and commented tagging instructions in myocamlbuild. As a consequence
we will have warnings on OCaml 4.02.