### PR TITLE
Fixes issue in lifter where register offsets were not accounted for.

### DIFF
--- a/lib/bap_disasm/bap_disasm_arm_mem_shift.ml
+++ b/lib/bap_disasm/bap_disasm_arm_mem_shift.ml
@@ -46,7 +46,7 @@ let lift_r_op ~dest1 ?dest2 ?shift ~base ~offset mode sign size operation =
   let base = assert_reg _here_ base |> Env.of_reg in
   let (offset : exp) =
     match offset with
-    | Op.Reg _ -> fail _here_ "got register instead of imm"
+    | Op.Reg r -> Exp.(var (Env.of_reg r))
     | Op.Imm w ->
       let width = Word.bitwidth w in
       let _1 = Word.one 32 in


### PR DESCRIPTION
When working with bap instructions in Qira, I came across the following instruction that did not have BIL associated with it:
```
ldr	r2, [r3, r2]
```

The lifter was failing because it falsely assumed that offsets cannot be registers in loads. This PR fixes that bug.