### PR TITLE
add argument to objdump for reading raw binary code, some refactoring/typo fixes

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -160,7 +160,8 @@ Library bap_image
   BuildDepends:  bap.elf,
                  bap.dwarf,
                  bap.types
-  Modules:       Bap_image,
+  Modules:       Bap_fileutils,
+                 Bap_image,
                  Bap_memory,
                  Bap_table,
                  Image_backend,

--- a/lib/bap_image/bap_fileutils.ml
+++ b/lib/bap_image/bap_fileutils.ml
@@ -1,0 +1,18 @@
+open Core_kernel.Std
+open Bap_types.Std
+
+let mapfile path : Bigstring.t option =
+  let fd = Unix.(openfile path [O_RDONLY] 0o400) in
+  try
+    let size = Unix.((fstat fd).st_size) in
+    let data = Bigstring.map_file ~shared:false fd size in
+    Unix.close fd;
+    Some data
+  with exn ->
+    Unix.close fd;
+    None
+
+let readfile path : Bigstring.t =
+  match mapfile path with
+    | Some data -> data
+    | None -> Bigstring.of_string (In_channel.read_all path)

--- a/lib/bap_image/bap_fileutils.mli
+++ b/lib/bap_image/bap_fileutils.mli
@@ -1,0 +1,6 @@
+(**Helper IO functions. *)
+
+open Core_kernel.Std
+open Bap_types.Std
+
+val readfile : string -> Bigstring.t

--- a/lib/bap_image/bap_image.ml
+++ b/lib/bap_image/bap_image.ml
@@ -245,24 +245,8 @@ let of_bigstring ?backend data =
 let of_string ?backend data =
   of_bigstring ?backend (Bigstring.of_string data)
 
-let mapfile path : Bigstring.t option =
-  let fd = Unix.(openfile path [O_RDONLY] 0o400) in
-  try
-    let size = Unix.((fstat fd).st_size) in
-    let data = Bigstring.map_file ~shared:false fd size in
-    Unix.close fd;
-    Some data
-  with exn ->
-    Unix.close fd;
-    None
-
-let readfile path : Bigstring.t =
-  match mapfile path with
-  | Some data -> data
-  | None -> Bigstring.of_string (In_channel.read_all path)
-
 let create ?backend path : result =
-  try_with (fun () -> readfile path) >>= fun data ->
+  try_with (fun () -> Bap_fileutils.readfile path) >>= fun data ->
   match backend with
   | None -> autoload data (Some path)
   | Some backend -> of_backend backend data (Some path)

--- a/lib/bap_image/bap_memory.ml
+++ b/lib/bap_image/bap_memory.ml
@@ -156,6 +156,9 @@ let create ?(pos=0) ?len endian addr data : t Or_error.t =
     let get = create_getters endian addr pos size data in
     return {endian; data; addr; off=pos; size; get }
 
+let of_file endian addr path : t Or_error.t =
+  create endian addr (Bap_fileutils.readfile path)
+
 let min_addr t : addr = t.addr
 
 let max_addr t : addr =

--- a/lib/bap_image/bap_memory.mli
+++ b/lib/bap_image/bap_memory.mli
@@ -13,6 +13,8 @@ val create
   -> addr
   -> Bigstring.t -> t Or_error.t
 
+val of_file : endian -> addr -> string -> t Or_error.t
+
 (** [view word_size ~from ~words mem] returns a new memory
     that represents the specified region of memory [mem]. [copy]
     function performs deep copy.

--- a/lib/bap_image/image_elf.ml
+++ b/lib/bap_image/image_elf.ml
@@ -156,7 +156,7 @@ let of_data_err (data : bigstring) : Img.t Or_error.t =
   Elf.Parse.from_bigstring data >>= img_of_elf data
 
 let of_data (data : Bigstring.t) : Img.t option =
-  match of_data_err data  with
+  match of_data_err data with
   | Ok img -> Some img
   | Error err ->
     eprintf "Elf_backend: failed with exn: %s" @@

--- a/src/readbin/cmdline.ml
+++ b/src/readbin/cmdline.ml
@@ -15,11 +15,11 @@ let symsfile : string option Term.t =
 let cfg_format : 'a list Term.t =
   Arg.(value & vflag_all [`with_name] [
       `with_name, info ["labels-with-name"]
-        ~doc: "put block name on graph labels";
+        ~doc: "Put block name on graph labels";
       `with_asm, info ["labels-with-asm"]
-        ~doc:"put assembler instructions on graph labels";
+        ~doc:"Put assembler instructions on graph labels";
       `with_bil, info ["labels-with-bil"]
-        ~doc:"put bil instructions on graph labels";
+        ~doc:"Put bil instructions on graph labels";
     ])
 
 let output_phoenix : _ Term.t =
@@ -79,23 +79,31 @@ let no_optimizations : bool Term.t =
   let doc = "Disable all kinds of optimizations" in
   Arg.(value & flag & info ["no-optimizations"] ~doc)
 
+let binaryarch : _ Term.t =
+  let doc =
+    sprintf
+      "Parse input file as raw binary with specified \
+      architecture, e.g. x86, arm, etc." in
+  Arg.(value & opt (some string) None &
+       info ["binary"] ~doc)
+
 
 let create
-    a b c d e f g h i k l = Options.Fields.create
-    a b c d e f g h i k l
+    a b c d e f g h i k l m = Options.Fields.create
+    a b c d e f g h i k l m
 let program =
   let doc = "Disassemble binary" in
   let man = [
     `S "DESCRIPTION";
     `P "$(tname) disassembles $(i,FILE) and outputs results in a
-          user ajustable form.";
+          user adjustable form.";
     `S "SYMBOL TABLES";
     `P "Although $(tname) will try to extract symbols from \
         the binary file, you can also provide symbols externally, \
         using `-s' option. The argument to this option must be a \
         file containing s-expressions. Each s expression is list \
         of three atoms: name, starting address, ending address (i.e. \
-        an address of the byte that immidiately follows the last \
+        an address of the byte that immediately follows the last \
         byte of the symbol).";
     `S "BUGS";
     `P "Report bugs to \
@@ -106,8 +114,9 @@ let program =
         $filename $symsfile $cfg_format
         $output_phoenix $output_dump $demangle
         $no_resolve $keep_alive
-        $no_inline $keep_consts $no_optimizations),
-  Term.info "bap-objdump" ~version:"0.9.2" ~doc ~man
+        $no_inline $keep_consts $no_optimizations
+        $binaryarch),
+  Term.info "bap-objdump" ~version:"0.9.3" ~doc ~man
 
 let parse () = match Term.eval program with
   | `Ok opts -> Ok opts

--- a/src/readbin/options.ml
+++ b/src/readbin/options.ml
@@ -16,6 +16,7 @@ type t = {
   no_inline : bool;
   keep_consts : bool;
   no_optimizations : bool;
+  binaryarch : string option;
 } with sexp, fields
 
 module type Provider = sig

--- a/src/readbin/readbin.ml
+++ b/src/readbin/readbin.ml
@@ -8,20 +8,16 @@ open Image
 module Program(Conf : Options.Provider) = struct
   open Conf
 
-  let disassemble img mem =
-    let syms = match options.symsfile with
-      | Some filename ->
-        Symtab.read ?demangle:options.demangle ~filename mem
-      | None -> Table.map (symbols img) ~f:Symbol.name in
-    let roots =
-      Seq.(Table.regions syms >>| Memory.min_addr |> to_list) in
-    let disasm = disassemble ~roots (arch img) mem in
+  let disassemble ?(syms=Table.empty) ?roots arch mem =
+    let disasm = match roots with
+      | Some x -> disassemble ~roots:x arch mem
+      | None -> disassemble arch mem in
     let module Env = struct
       let options = options
       let cfg = Disasm.blocks disasm
       let base = mem
       let syms = syms
-      let arch = arch img
+      let arch = arch
     end in
     let module Printing = Printing.Make(Env) in
     let module Helpers = Helpers.Make(Env) in
@@ -41,17 +37,37 @@ module Program(Conf : Options.Provider) = struct
       let dest = Phoenix.store () in
       printf "Phoenix data was stored in %s folder@." dest
 
+  let disassemble_img img arch mem =
+    let syms = match options.symsfile with
+      | Some filename ->
+        Symtab.read ?demangle:options.demangle ~filename mem
+      | None -> Table.map (symbols img) ~f:Symbol.name in
+    let roots =
+      Seq.(Table.regions syms >>| Memory.min_addr |> to_list) in
+      disassemble ~syms ~roots arch mem
+
   let main () =
-    Image.create options.filename >>= fun (img,warns) ->
-    List.iter warns ~f:(eprintf "Warning: %a\n" Error.pp);
-    printf "%-20s: %a\n" "Arch"  Arch.pp (arch img);
-    printf "%-20s: %a\n" "Entry" Addr.pp (entry_point img);
-    printf "%-20s: %d\n" "Symbols" (Table.length (symbols img));
-    printf "%-20s: %d\n" "Sections" (Table.length (sections img));
-    Table.iteri (sections img) ~f:(fun mem s ->
-        if Section.is_executable s then
-          disassemble img mem);
-    return (List.length warns)
+    match options.binaryarch with
+      | None -> (Image.create options.filename >>= fun (img,warns) ->
+        List.iter warns ~f:(eprintf "Warning: %a\n" Error.pp);
+        printf "%-20s: %a\n" "Arch"  Arch.pp (arch img);
+        printf "%-20s: %a\n" "Entry" Addr.pp (entry_point img);
+        printf "%-20s: %d\n" "Symbols" (Table.length (symbols img));
+        printf "%-20s: %d\n" "Sections" (Table.length (sections img));
+        Table.iteri (sections img) ~f:(fun mem s ->
+            if Section.is_executable s then
+              disassemble_img img (arch img) mem);
+        return (List.length warns))
+      | Some s -> match Arch.of_string s with
+        | None -> eprintf "unrecognized architecture\n"; return 1
+        | Some arch ->
+          printf "%-20s: %a\n" "Arch"  Arch.pp arch;
+          let width_of_arch = arch |> Arch.addr_size |> Size.to_bits in
+          let addr = Addr.of_int ~width:width_of_arch 0 in
+          match Memory.of_file (Arch.endian arch) addr options.filename with
+            | Ok m -> disassemble arch m; return 0
+            | Error e -> eprintf "failed to create memory: %s\n" (Error.to_string_hum e);
+              return 1
 end
 
 let start options =
@@ -61,6 +77,7 @@ let start options =
   Program.main ()
 
 let () =
+  at_exit (pp_print_flush err_formatter);
   Printexc.record_backtrace true;
   Plugins.load ();
   match Cmdline.parse () >>= start with


### PR DESCRIPTION
bap-objdump: add argument for reading raw binary code
bap-fileutils: refactor file i/o utility code out from bap_memory and bap_image
bap-memory: add of_file constructor function