### PR TITLE
>= deps

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -70,12 +70,8 @@ Flag zmq
   Default: false
 
 Flag llvm
- Description: Build with llvm backend
- Default: true
-
-Flag server
- Description: Build BAP server
- Default: true
+  Description: Build with llvm backend
+  Default: true
 
 Library bap
   Path:            lib/bap
@@ -305,10 +301,13 @@ Library core_lwt
                   Core_lwt_pool,
                   Core_lwt_stream
 
-Library zmq
+Library zmq_transport
   Path:           src/server
   Build$:         flag(server) && flag(zmq)
   CompiledObject: best
+  FindlibParent:  bap
+  FindlibName:    zmq_transport
+  BuildDepends:   lwt-zmq
   Install:        true
   Modules:        Zmq_client, Zmq_server
 

--- a/opam
+++ b/opam
@@ -8,13 +8,14 @@ bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
 dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
-  ["./configure" "--prefix=%{prefix}%" "--enable-docs"]
+  ["./configure" "--prefix=%{prefix}%" "--enable-docs" "--%{lwt-zmq:enable}%-zmq"]
   [make]
 ]
 install: [make "install"]
 remove: [
   ["ocamlfind" "remove" "bap"]
   ["ocamlfind" "remove" "core_lwt"]
+  ["rm" "-f" "%{bin}%/bap-bw-train" "%{bin}%/bap-mc" "%{bin}%/bap-objdump" "%{bin}%/bap-server" "%{bin}%/baptop"]
 ]
 
 build-doc: [make "doc"]
@@ -23,16 +24,19 @@ depends: [
  	"base-unix"
  	"bitstring"
 	"cmdliner"
-	"cohttp" {= "0.15.0"}
-	"core_kernel" {= "111.28.0"}
-	"ezjsonm" {= "0.4.0"}
+	"cohttp" {>= "0.15.0"}
+	"core_kernel" {>= "111.28.0"}
+	"ezjsonm" {>= "0.4.0"}
 	"faillib"
 	"lwt"
 	"oasis" {build}
-    "ocamlgraph"
+	"ocamlgraph"
 	"re"
-	"uri" {= "1.7.2"}
-    "utop"
+	"uri" {>= "1.7.2"}
 	"zarith"
 ]
+depopts: [
+	"lwt-zmq"
+]
 available: [ocaml-version >= "4.01"]
+messages: "Before using baptop, you should install utop." {! utop:installed}

--- a/opam.deps
+++ b/opam.deps
@@ -1,12 +1,13 @@
 base-unix
 bitstring
 cmdliner
-cohttp.0.15.0
-core_kernel.111.28.00
-ezjsonm.0.4.0
+cohttp>=0.15.0
+core_kernel>=111.28.00
+ezjsonm>=0.4.0
 faillib
 lwt
 oasis
 re
-uri.1.7.2
+uri>=1.7.2
 zarith
+ocamlgraph

--- a/opam.opt.deps
+++ b/opam.opt.deps
@@ -1,3 +1,2 @@
-ocamlgraph
 lwt-zmq
 utop


### PR DESCRIPTION
It'd be nice to be able to install bap without downgrading core_kernel, and the newer versions of libraries seem to work fine. So unless there's any reason to fix bap to the old versions of packages I propose using >= dep constraints.

Also added the `rm` for uninstalling binaries.