### PR TITLE
Preparation for x86 integration.

### DIFF
--- a/lib/bap_disasm/bap_signatures.ml
+++ b/lib/bap_disasm/bap_signatures.ml
@@ -10,9 +10,9 @@ let entry ?(comp="default") ~mode arch =
 let default_path =
   try Sys.getenv "BAP_SIGFILE"
   with Not_found ->
-    Config.prefix / "share" / "bap" / "sigs.db"
+    Config.prefix / "share" / "bap" / "sigs.zip"
 
-let load ?comp ?path ~mode arch =
+let load_exn ?comp ?path ~mode arch =
   let path = Option.value path ~default:default_path in
   let zip = Zip.open_in path in
   let entry_path = entry ?comp ~mode arch in
@@ -22,6 +22,10 @@ let load ?comp ?path ~mode arch =
     with Not_found -> None in
   Zip.close_in zip;
   r
+
+let load ?comp ?path ~mode arch =
+  try load_exn ?comp ?path ~mode arch with exn -> None
+
 
 (* for some reason Zip truncates the output file, and doesn't provide
    us an option to append anything to for it. *)

--- a/src/byteweight/byteweight.ml
+++ b/src/byteweight/byteweight.ml
@@ -41,7 +41,7 @@ let matching =
   FileUtil.(And (Is_file, Not ignored))
 
 let train meth length comp db paths =
-  let db = Option.value db ~default:"sigs.db" in
+  let db = Option.value db ~default:"sigs.zip" in
   let collect path =
     FileUtil.find matching path (fun xs x -> x :: xs) [] in
   let files = List.map paths
@@ -126,7 +126,7 @@ let install src dst = try_with begin fun () ->
   end
 
 let update url dst =
-  let old = Filename.temp_file "bap_old_sigs" ".db" in
+  let old = Filename.temp_file "bap_old_sigs" ".zip" in
   if Sys.file_exists dst
   then FileUtil.cp [dst] old;
   fetch dst url >>| fun () ->
@@ -186,11 +186,11 @@ module Cmdline = struct
     let doc = "Url of the binary signatures" in
     let default = sprintf
         "https://github.com/BinaryAnalysisPlatform/bap/\
-         releases/download/v%s/sigs.db" Config.pkg_version in
+         releases/download/v%s/sigs.zip" Config.pkg_version in
     Arg.(value & opt string default & info ["url"] ~doc)
 
   let src : string Term.t =
-    Arg.(value & pos 0 non_dir_file "sigs.db" & info []
+    Arg.(value & pos 0 non_dir_file "sigs.zip" & info []
            ~doc:"Signatures file" ~docv:"SRC")
   let dst : string Term.t =
     Arg.(value & pos 1 string Signatures.default_path &
@@ -198,7 +198,7 @@ module Cmdline = struct
 
   let output : string Term.t =
     let doc = "Output filename" in
-    Arg.(value & opt string "sigs.db" & info ["o"] ~doc)
+    Arg.(value & opt string "sigs.zip" & info ["o"] ~doc)
 
   let print_name : bool Term.t =
     let doc = "Print symbol's name." in

--- a/src/readbin/ida.ml
+++ b/src/readbin/ida.ml
@@ -104,9 +104,9 @@ let run_script self script_to =
       FileUtil.rm [script; result]);
   result
 
-let get_symbols ?demangle t mem =
+let get_symbols ?demangle t arch mem =
   let result = run_script t extract_symbols in
-  Symbols.read ?demangle ~filename:result mem
+  Symbols.read ?demangle ~filename:result arch  mem
 
 let close self = self.close ()
 

--- a/src/readbin/ida.mli
+++ b/src/readbin/ida.mli
@@ -19,7 +19,7 @@ type t
 val create : ?ida:string -> string -> t Or_error.t
 
 (** [get_symbols ?demangle ida mem] extract symbols from binary, using IDA *)
-val get_symbols : ?demangle:Options.demangle -> t -> mem -> string table
+val get_symbols : ?demangle:Options.demangle -> t -> arch -> mem -> string table
 
 (** [close ida] finish interaction with IDA and clean all resources  *)
 val close : t -> unit

--- a/src/readbin/readbin.ml
+++ b/src/readbin/readbin.ml
@@ -14,7 +14,7 @@ module Program(Conf : Options.Provider) = struct
       let module BW = Bap_byteweight.Bytes in
       match Bap_signatures.load ~mode:"bytes" arch with
       | None ->
-        eprintf "No signatures found@.Please, use `bap-byteweight'\
+        eprintf "No signatures found@.Please, use `bap-byteweight' \
                  utility to fetch/create/install them.@.%!";
         None
       | Some data ->
@@ -77,14 +77,14 @@ module Program(Conf : Options.Provider) = struct
     let demangle = options.demangle in
     let usr_syms = match options.symsfile with
       | Some filename ->
-        Symbols.read ?demangle ~filename mem
+        Symbols.read ?demangle ~filename arch mem
       | None -> Table.empty in
     let ida_syms = match options.use_ida with
       | None -> Table.empty
       | Some ida ->
         let result =
           Ida.(with_file ?ida options.filename
-                 (fun ida -> get_symbols ?demangle ida mem)) in
+                 (fun ida -> get_symbols ?demangle ida arch mem)) in
         match result with
         | Ok syms -> syms
         | Error err ->

--- a/src/readbin/symbols.ml
+++ b/src/readbin/symbols.ml
@@ -50,7 +50,7 @@ let demangle_name ?(how=`internal) name =
     | `internal -> demangle_native name
   else name
 
-let read ?demangle ~filename base  : string table =
+let read ?demangle ~filename arch base  : string table =
   let demangle name = match demangle with
     | None -> name
     | Some how -> demangle_name ~how name in
@@ -61,7 +61,8 @@ let read ?demangle ~filename base  : string table =
           try
             let (name,es,ef) = sym_of_sexp sexp in
             let words = Int64.(ef - es |> to_int_exn) in
-            let from = Addr.of_int64 ~width:32 es in
+            let width = Arch.addr_size arch |> Size.to_bits in
+            let from = Addr.of_int64 ~width es in
             let mem = Memory.view ~from ~words base |> ok_exn in
             let name = demangle name in
             Table.add syms mem name |> ok_exn

--- a/src/readbin/symbols.mli
+++ b/src/readbin/symbols.mli
@@ -25,4 +25,4 @@ open Bap.Std
 
 *)
 
-val read : ?demangle:Options.demangle -> filename:string -> mem -> string table
+val read : ?demangle:Options.demangle -> filename:string -> arch -> mem -> string table


### PR DESCRIPTION
This PR contains fixes, that will allow to pass CI test for x86 and
x86_64 lifter.

It includes the ability to retrieve signatures for x86, that was
uploaded to github (For some reason, github doesn't allow us to release
files with other extensions, so this PR renames `sigs.db` to
`sigs.zip`). Also, there're some small fixes, like hardcoded 32 bits
address widths in readbin.