### PR TITLE
Make bap utilities standalone executables.

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -83,7 +83,9 @@ Library bap
                    bap.image,
                    bap.types,
                    dynlink,
-                   findlib
+                   findlib,
+                   bap.image.elf_backend,
+                   bap.llvm
   Modules:         Bap,
                    Bap_plugin,
                    Bap_plugins

--- a/lib/bap/bap_load_plugins.ml
+++ b/lib/bap/bap_load_plugins.ml
@@ -5,7 +5,6 @@ let load pkg =
   let cmd = sprintf "#require \"%s\";;" (Bap_plugin.name pkg) in
   Bap_toplevel.eval cmd
 
-
 let () =
   Bap_plugins.all () |>
   List.iter ~f:(fun pkg -> match load pkg with

--- a/lib/bap/bap_plugin.ml
+++ b/lib/bap/bap_plugin.ml
@@ -11,9 +11,11 @@ type t = {
 } with fields
 
 let init_findlib = lazy (
-  Dynlink.init ();
-  Dynlink.allow_unsafe_modules true;
-  Findlib.init ())
+  try
+    Dynlink.init ();
+    Dynlink.allow_unsafe_modules true;
+    Findlib.init ()
+  with _ -> ())
 
 let create_exn ~system name =
   let module Pkg = Fl_package_base in

--- a/lib/bap/bap_plugins.ml
+++ b/lib/bap/bap_plugins.ml
@@ -4,7 +4,11 @@ open Core_kernel.Std
 let systems = [
   "bap.image";
   "bap.disasm"
+]
 
+let internal = [
+  (module Image_elf : Unit);
+  (module Bap_llvm  : Unit);
 ]
 
 let string_of_or_error = function

--- a/lib/bap_image/image_elf.ml
+++ b/lib/bap_image/image_elf.ml
@@ -1,10 +1,13 @@
 open Core_kernel.Std
 open Or_error
 
-open Bap.Std
-open Elf.Types
+open Bap_types.Std
+open Bap_elf.Types
 open Image_backend
 open Image_common
+
+module Dwarf = Bap_dwarf
+module Elf = Bap_elf
 
 let name = "bap-elf"
 

--- a/src/readbin/cmdline.ml
+++ b/src/readbin/cmdline.ml
@@ -126,9 +126,16 @@ let use_ida : string option option Term.t =
   Arg.(value & opt ~vopt:(Some None)
          (some (some string)) None & info ["use-ida"] ~doc)
 
+let sigsfile : string option Term.t =
+  let doc = "Path to the signature file. No needed by default, \
+             usually it is enough to run `bap-byteweight update'." in
+  Arg.(value & opt (some non_dir_file) None & info ["sigs"] ~doc)
+
+
+
 let create
-    a b c d e f g h i k l m n o p q r s = Options.Fields.create
-    a b c d e f g h i k l m n o p q r s
+    a b c d e f g h i k l m n o p q r s t = Options.Fields.create
+    a b c d e f g h i k l m n o p q r s t
 let program =
   let doc = "Disassemble binary" in
   let man = [
@@ -154,7 +161,7 @@ let program =
         $no_resolve $keep_alive
         $no_inline $keep_consts $no_optimizations
         $binaryarch $verbose $bw_disable $bw_length $bw_threshold
-        $print_symbols $use_ida),
+        $print_symbols $use_ida $sigsfile),
   Term.info "bap-objdump"
     ~version:Config.pkg_version ~doc ~man
 

--- a/src/readbin/options.ml
+++ b/src/readbin/options.ml
@@ -23,6 +23,7 @@ type t = {
   bw_threshold : float;
   print_symbols : [`with_name | `with_addr | `with_size] list;
   use_ida : string option option;
+  sigfile : string option;
 } with sexp, fields
 
 module type Provider = sig

--- a/src/readbin/readbin.ml
+++ b/src/readbin/readbin.ml
@@ -12,7 +12,8 @@ module Program(Conf : Options.Provider) = struct
     if options.bw_disable then None
     else
       let module BW = Bap_byteweight.Bytes in
-      match Bap_signatures.load ~mode:"bytes" arch with
+      let path = options.sigfile in
+      match Bap_signatures.load ?path ~mode:"bytes" arch with
       | None ->
         eprintf "No signatures found@.Please, use `bap-byteweight' \
                  utility to fetch/create/install them.@.%!";


### PR DESCRIPTION
This will resolve BinaryAnalysisPlatform/qira#69,
and partially fix #64, since loading plugins still won't work out of
box, until one defines the OCAMLPATH variable.