### PR TITLE
Housekeeping

### DIFF
--- a/myocamlbuild.ml.in
+++ b/myocamlbuild.ml.in
@@ -43,12 +43,11 @@ let dispatch = function
 
 
 let mark_tags () =
+  let mark_tag_used = ignore in
   let open Ocamlbuild_plugin in
-  (* Uncomment the following in OCaml 4.02, to remove warnings. *)
-  (* mark_tag_used "pkg_core_bench"; *)
-  (* mark_tag_used "tests"; *)
-  (* mark_tag_used "pkg_piqirun" *)
-  ()
+  mark_tag_used "pkg_core_bench";
+  mark_tag_used "tests";
+  mark_tag_used "pkg_piqirun"
 
 let () =
   mark_tags ();

--- a/opam
+++ b/opam
@@ -33,8 +33,8 @@ remove: [
 depends: [
  	"base-unix"
  	"bitstring"
-	"cmdliner"
-	"cohttp"
+	"cmdliner" {>= "0.9.6"}
+	"cohttp" {>= "0.15.0"}
 	"core_kernel" {>= "111.28.0"}
 	"ezjsonm" {>= "0.4.0"}
 	"faillib"

--- a/postinstall.ml.ab
+++ b/postinstall.ml.ab
@@ -4,6 +4,8 @@
 
 open Printf
 
+let (/) = Filename.concat
+              
 let tools = [
   "bap-mc";
   "bap-objdump";
@@ -17,10 +19,12 @@ let create_man prog =
   man
 
 let main () =
+  let scripts = ["bapbuild"; "baptop"] in
   let men = List.map create_man tools in
   let dst = "$mandir/man1" in
   FileUtil.mkdir ~parent:true dst;
   FileUtil.cp men dst;
-  FileUtil.cp ["bapbuild"; "baptop"] "$bindir"
+  FileUtil.cp scripts "$bindir";
+  List.iter (fun name -> Unix.chmod ("$bindir" / name) 0o700) scripts
 
 let () = main ()


### PR DESCRIPTION
This is PR fixes some issues with BAP infrastructure:

Added checking x bit for installed tools
=======================================

Unfortunately `FileUtil.cp` doesn't preserve permissions, and I'm not
sure that it is very easy to do in a cross-platform way.

tricked ocamlbuild to ignore unused tags
========================================

should work across different compiler versions.

added constraints to opam
=========================

we really can't compile without it, and without aspucd the solver can
give us very old version.