### PR TITLE
Fix bapbuild plugin compilation

### DIFF
--- a/bapbuild
+++ b/bapbuild
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 for target; do :; done
-args=`echo "$@" | sed 's/.plugin/.cmxs/'`
+args=`echo "$@" | sed 's/.plugin/.cmxa/'`
 
 ocamlbuild \
     -use-ocamlfind \
@@ -21,10 +21,16 @@ ocamlbuild \
     $args
 result=$?
 
-source="_build/`basename $target .plugin 2>/dev/null`.cmxs"
+name=`basename $target .plugin 2>/dev/null`
+source="_build/$name.cmxa"
 
 if [ -f "$source" ]; then
-    cp $source $target
+    CMD=`grep -A1 "Target: b.cmxa" _build/_log | grep -v "Target" | sed 's/.cmxa/.cmxs/' | sed 's/-a/-shared/'`
+    cd _build
+    $CMD
+    cp "$name.cmxs" "../$target"
+    cd ..
+    chmod a-x $target
 fi
 
 exit $result

--- a/src/byteweight/byteweight.ml
+++ b/src/byteweight/byteweight.ml
@@ -250,7 +250,9 @@ module Cmdline = struct
       `P "bap-byteweight is a toolkit for training, fetching, testing\
           and installing byteweight signatures."
     ] in
-    Term.(pure usage $ choice_names), Term.info "bap-byteweight" ~doc ~man
+    Term.(pure usage $ choice_names),
+    Term.info "bap-byteweight"
+      ~version:Config.pkg_version ~doc ~man
 
   let eval () = Term.eval_choice default
       [train; find; fetch; install; update; symbols]


### PR DESCRIPTION
With this PR one can build plugin consisting of several
files (previously you will see a link-time errors).

Moreover, it will fix an issue with bap-byteweight that didn't
understand `--version` option.