### PR TITLE
Add bap.plugins support to bapbuild.

### DIFF
--- a/bapbuild
+++ b/bapbuild
@@ -1,13 +1,14 @@
 #!/bin/sh
 
 for target; do :; done
-args=`echo "$@" | sed 's/.plugin/.cmxa/'`
+args=`echo "$@" | sed 's/\.plugin$/.cmxa/'`
 
 ocamlbuild \
     -use-ocamlfind \
     -classic-display \
     -syntax camlp4o \
     -pkg bap \
+    -pkg bap.plugins \
     -pkg core_kernel \
     -pkg sexplib.syntax,comparelib.syntax,fieldslib.syntax,variantslib.syntax \
     -pkg bin_prot.syntax \


### PR DESCRIPTION
With this PR bapbuild will automatically load bap.plugins library, that
doesn't mean that you shouldn't call to `Plugins.load ()` anymore,
although, this behavior can be added.