### PR TITLE
add `r128 and `r256 to support YMM lifting

### DIFF
--- a/lib/bap_types/bap_common.ml
+++ b/lib/bap_types/bap_common.ml
@@ -33,6 +33,8 @@ module Size = struct
     | `r16
     | `r32
     | `r64
+    | `r128
+    | `r256
   ] with bin_io, compare, sexp, variants
 
   type 'a p = 'a constraint 'a = [< all]

--- a/lib/bap_types/bap_size.ml
+++ b/lib/bap_types/bap_size.ml
@@ -8,6 +8,8 @@ let to_bits : 'a -> int = function
   | `r16  -> 16
   | `r32  -> 32
   | `r64  -> 64
+  | `r128  -> 128
+  | `r256  -> 256
 
 let to_bytes x = to_bits x / 8
 
@@ -16,6 +18,8 @@ let of_int : int -> size Or_error.t = function
   | 16  -> Ok `r16
   | 32  -> Ok `r32
   | 64  -> Ok `r64
+  | 128 -> Ok `r128
+  | 256 -> Ok `r256
   | n   -> errorf "unsupported word size: %d" n
 
 let of_int_exn n = ok_exn (of_int n)


### PR DESCRIPTION
Lifting i386 XMM & YMM instructions currently returns a "unsupported word size: 128" error, e.g. for `f3 0f 7f 04 38	movdqu %xmm0,(%eax,%edi,1)`. Adding these \`r128 and \`r256 cases makes lifting work again.