### PR TITLE
slight change to ADT repr

### DIFF
--- a/python/adt.py
+++ b/python/adt.py
@@ -69,6 +69,8 @@ class ADT(object):
                 return '0x{0:x}'.format(x)
             elif isinstance(x, ADT):
                 return str(x)
+            elif isinstance(x, tuple):
+                return "(" + ", ".join(qstr(i) for i in x) + ")"
             else:
                 return '"{0}"'.format(x)
         def args():


### PR DESCRIPTION
Recurse into tuple args when printing. This looks better especially for empty tuples, which show up a lot as clauses in If statements.

For example, before this change: 
`If(EQ(AND(Int(0x8049a00, 0x20), Int(0xf, 0x20)), Int(0x0, 0x20)), "()", CpuExn(0xd))` 
and after: 
`If(EQ(AND(Int(0x8049a00, 0x20), Int(0xf, 0x20)), Int(0x0, 0x20)), (), CpuExn(0xd))` 