### PR TITLE
Interface to OCamlGraph

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -213,7 +213,8 @@ Library disasm
   FindlibName:   disasm
   BuildDepends:  bap.image,
                  bap.types,
-                 camlzip
+                 camlzip,
+                 ocamlgraph
   Modules:       Bap_disasm,
                  Bap_disasm_arm,
                  Bap_disasm_arm_bit,

--- a/lib/bap_disasm/bap_disasm_block.ml
+++ b/lib/bap_disasm/bap_disasm_block.ml
@@ -1,10 +1,13 @@
 open Core_kernel.Std
 open Bap_types.Std
 open Bap_disasm_basic
+open Image_internal_std
 
 module Rec = Bap_disasm_rec
 module Insn = Bap_disasm_insn
 type insn = Insn.t with compare, bin_io, sexp
+type edge = Rec.edge with compare, sexp
+type jump = Rec.jump with compare, sexp
 
 
 let insns_of_decoded_list init : (mem * insn) seq =
@@ -29,3 +32,41 @@ let leader blk = insns blk |> Seq.hd_exn |> snd
 let of_rec_block = Fn.id
 
 let () = Pretty_printer.register ("Bap_disasm_block.pp")
+
+module Edge = struct
+  type t = edge with compare
+  let default = `Fall
+end
+
+module Graph =
+  Graph.Persistent.Digraph.AbstractLabeled(struct
+    type nonrec t = t option
+  end)(Edge)
+
+module Vis = Addr.Set
+
+let unresolved = Graph.V.create None
+
+let to_graph ?bound entry =
+  let bounded addr =
+    Option.value_map bound
+      ~default:true ~f:(fun m -> Memory.contains m addr) in
+  let skip visited blk =
+    let addr = addr blk in
+    Vis.mem visited addr || not (bounded addr) in
+  let rec build gr vis src =
+    if skip vis src then (gr,vis)
+    else Seq.fold ~init:(gr,Vis.add vis (addr src)) (dests src)
+        ~f:(fun (gr,vis) -> function
+            | `Unresolved kind ->
+              let src = Graph.V.create (Some src) in
+              let kind = (kind :> edge) in
+              let edge = Graph.E.create src kind unresolved in
+              Graph.add_edge_e gr edge, vis
+            | `Block (dst,kind) ->
+              let v1 = Graph.V.create (Some src)
+              and v2 = Graph.V.create (Some dst) in
+              let edge = Graph.E.create v1 kind v2 in
+              let gr = Graph.add_edge_e gr edge in
+              build gr vis dst) in
+  build Graph.empty Vis.empty entry |> fst

--- a/lib/bap_disasm/bap_disasm_rec.ml
+++ b/lib/bap_disasm/bap_disasm_rec.ml
@@ -130,6 +130,13 @@ type error = [
 type decoded =  mem * insn option * stmt list option
 with sexp_of
 
+type jump = [
+  | `Jump     (** unconditional jump                  *)
+  | `Cond     (** conditional jump                    *)
+] with compare, sexp
+
+type edge = [jump | `Fall] with compare,sexp
+
 type block = {
   addr : addr;
   mem : mem Lazy.t;
@@ -142,8 +149,8 @@ type block = {
 }
 
 and blk_dest = [
-  | `Block of block * [`Jump | `Cond | `Fall]
-  | `Unresolved of [`Jump | `Cond ]
+  | `Block of block * edge
+  | `Unresolved of jump
 ]
 
 

--- a/lib/bap_disasm/bap_disasm_rec.mli
+++ b/lib/bap_disasm/bap_disasm_rec.mli
@@ -10,6 +10,12 @@ type block with compare, sexp_of
 type insn = full_insn
 type lifter = mem -> insn -> bil Or_error.t
 type decoded = mem * insn option * bil option with sexp_of
+type jump = [
+  | `Jump     (** unconditional jump                  *)
+  | `Cond     (** conditional jump                    *)
+] with compare, sexp
+
+type edge = [jump | `Fall] with compare,sexp
 
 type error = [
   | `Failed_to_disasm of mem
@@ -26,9 +32,10 @@ val errors : t -> error list
 
 module Block : sig
   type t = block with compare, sexp_of
+
   type dest = [
-    | `Block of block * [`Jump | `Cond | `Fall]
-    | `Unresolved of    [`Jump | `Cond ]
+    | `Block of block * edge
+    | `Unresolved of    jump
   ] with compare, sexp_of
   val addr : t -> addr
   val memory : t -> mem

--- a/lib/bap_disasm/bap_disasm_symtab.mli
+++ b/lib/bap_disasm/bap_disasm_symtab.mli
@@ -9,3 +9,12 @@ type t = string table
     provided, then only calls
 *)
 val create : addr list -> mem -> block table -> t
+
+module Graph : Graph.Sig.P
+  with type V.label = mem * string (** function body *)
+   and type E.label = addr         (** callsite  *)
+
+
+(** [to_graph blocks syms] creates a callgraph. Edges of the graph
+    are labeled with a callsite *)
+val to_graph : block table -> t -> Graph.t

--- a/opam.deps
+++ b/opam.deps
@@ -1,10 +1,10 @@
 base-unix
 bitstring
 camlzip
-cmdliner
-cohttp
+cmdliner.0.9.6
+cohttp.0.15.0
 core_kernel
-ezjsonm
+ezjsonm.0.4.0
 faillib
 fileutils
 lwt

--- a/opam.opt.deps
+++ b/opam.opt.deps
@@ -1,3 +1,2 @@
 ocamlgraph
-lwt-zmq
 utop


### PR DESCRIPTION
This PR brings two new data structures:
- Symtab.Graph - a callgraph as a persistent OCamlGraph's graph
- Block.Graph - a control-flow graph as it is.

Two new functions are provided.

- Block.to_graph will build a graph given the entry block and
  possible memory boundaries

- Symtab.to_graph will build a callgraph preserving information
  about call places.