### PR TITLE
As per small commit messages edited bap-mc for disassembling on command line and revived piqi translation ability

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -45,7 +45,7 @@ Document bap
 
 Flag serialization
   Description: Build serialization library
-  Default: false
+  Default: true
 
 Flag llvm_static
   Description: Links with llvm in a static mode
@@ -106,7 +106,6 @@ Library top
             Bap_install_printers,
             Bap_load_plugins,
             Bap_toplevel
-
   BuildDepends: compiler-libs, bap, bap.plugins
 
 Library types
@@ -154,7 +153,7 @@ Library serialization
   BuildTools: ocamlbuild, piqi
   DataFiles:    *.piqi
   CompiledObject: best
-  BuildDepends: piqirun, bap.types
+  BuildDepends: piqilib,piqirun,piqirun.pb,piqirun.ext,bap.types
   Modules:   Bil_piqi,
              Stmt_piqi,
              Stmt_piqi_ext
@@ -375,7 +374,7 @@ Executable "bap-mc"
   MainIs:         bap_mc.ml
   Install:        true
   CompiledObject: best
-  BuildDepends:   bap, bap.plugins, cmdliner
+  BuildDepends:   bap, bap.plugins, cmdliner, bap.types.serialization
 
 Executable "bap-byteweight"
   Path:           src/byteweight

--- a/baptop
+++ b/baptop
@@ -1,3 +1,4 @@
 #!/bin/sh
-
-exec utop -require bap.top "$@"
+# for bil serialization do: -required "bap.types.serialization"
+# disabled by default to reduce breakage liklihood
+exec utop -require "bap.top" "$@"

--- a/opam
+++ b/opam
@@ -24,6 +24,7 @@ install: [
 remove: [
   ["ocamlfind" "remove" "bap"]
   ["ocamlfind" "remove" "core_lwt"]
+  ["ocamlfind" "remove" "piqi"]
   ["rm" "-rf" bap:doc]
   ["rm" "-f" "%{prefix}%/share/bap/sigs.zip"]
   ["rm" "-f" "%{man}%/man1/bap-mc.1"]
@@ -55,6 +56,7 @@ depends: [
 	"uri"
     "utop"
 	"zarith"
+    "piqi" {>= "0.7.4"}
 ]
 
 depexts: [

--- a/opam.deps
+++ b/opam.deps
@@ -14,3 +14,4 @@ ocurl
 re
 uri
 zarith
+piqi


### PR DESCRIPTION
Also, this requires that you update your piqi to the latest version, built so that the interpreter can find the function it needs dynamically. A pull request was sent to the piqi repo maintainer in order that this be done, when it's finished do an opam upgrade piqi.