### PR TITLE
Introduce ABI and CPU.

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -218,6 +218,8 @@ Library disasm
                  camlzip,
                  ocamlgraph
   Modules:       Bap_disasm,
+                 Bap_disasm_abi,
+                 Bap_disasm_abi_helpers,
                  Bap_disasm_arm,
                  Bap_disasm_arm_bit,
                  Bap_disasm_arm_branch,
@@ -231,6 +233,7 @@ Library disasm
                  Bap_disasm_arm_shift,
                  Bap_disasm_arm_types,
                  Bap_disasm_arm_utils,
+                 Bap_disasm_stub_lifter,
                  Bap_disasm_x86,
                  Bap_disasm_x86_lifter,
                  Bap_disasm_x86_env,

--- a/lib/bap_disasm/bap_disasm.ml
+++ b/lib/bap_disasm/bap_disasm.ml
@@ -108,8 +108,9 @@ let of_rec r =
   {blocks; memmap; insns; mems_of_insn}
 
 let lifter_of_arch = function
-  | #Arch.arm -> Some Bap_disasm_arm_lifter.insn
-  | #Arch.x86 as arch -> Some (Bap_disasm_x86_lifter.insn arch)
+  | #Arch.arm -> Some Bap_disasm_arm_lifter.lift
+  | `x86    -> Some (Bap_disasm_x86_lifter.IA32.lift)
+  | `x86_64 -> Some (Bap_disasm_x86_lifter.AMD64.lift)
   | _ -> None
 
 let linear_sweep arch mem : (mem * insn option) list Or_error.t =

--- a/lib/bap_disasm/bap_disasm_abi.ml
+++ b/lib/bap_disasm/bap_disasm_abi.ml
@@ -1,0 +1,113 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_image_std
+
+(** Base type definitions for ABI.
+
+    ABI can be written from scratch, or derived from the existing
+    one. New ABI can be registered in the system using
+    [Target.ABI.register] function, where [Target] refers to a
+    specific architecture, e.g., [ARM], [AMD64], etc.
+
+    To obtain a list of available ABI for a given function symbol, use
+    [Target.ABI.create] function. If you're lucky it will return a
+    singleton list. Otherwise, you may find [ABI] module helpful.
+
+*)
+
+(** Application Binary Interface.
+
+    Under this name, we're gathering several different concepts, like:
+
+    - calling convention
+    - stack frame organization
+    - data representation
+    - special functions
+
+    Later we may extend the ABI class to handle system calls, type
+    inference and other stuff.
+
+
+    Each ABI object is constructed specifically to a particular
+    symbol using the following functional constructor, of the
+    following type:
+
+    [?image:image -> ?sym:string -> mem -> block -> abi option]
+
+    ABI constructors are registered in the target specific lifter,
+    and constructed for each symbol. Afterwards a set of most
+    (and equally) applicable ABIs is provided to a calling part,
+    to which it is left the final decision on how to disambiguate
+    them. *)
+class type abi = object
+  (** unique identifier of the ABI.
+      Used to communicate between to ABI's.
+
+      The order of id parts should be from more specific, to less
+      specific, i.e. in reverse order (so that deriving classes can
+      easily append their own parts). The architecture shouldn't be
+      specified in the id, as two ABIs from different architectures
+      should never met.
+
+      A good start whould be to use:
+      [specific; compiler; os; vendor]
+
+      Example: ["unknown; ""linux"; "gnueabi"; "*exit"].
+
+      Will encode an ABI of [exit] family of functions for ARM linux
+      gnueabi. The recommended printing format for the ABI is to
+      append the arch name and print all constituents of the name from
+      right to left, using "-" symbol as a separator.
+
+      In any case, the meaning of the identifier is specific to a
+      particular family of ABIs, that are, usually inherit the same
+      parent or set of parents. *)
+  method id : string list
+
+  (** [self#specific] is [true] if this ABI is specific
+      for the provided function. The [specific] ABI is always more
+      preferrable to non-specific one. If more than one specific
+      ABIs is applicable for the provided symbol, than the normal
+      resolution process will be used (see method [choose])
+  *)
+  method specific : bool
+
+  (** [self#choose other] used to sort a set of applicable ABI.
+
+      Must return:
+      - [0] if [other] abi is not known or is considered equaly
+        applicable for the given context.
+      - [1] if [other] abi is known, and [self] is preferrable
+        to [other]
+      - [-1] if [other] abi is more preferrable. This value can
+        be even returned when the other abi is not known to [self].
+
+      In case of inconsistency the solving mechanism will consider
+      inconsistent abi's as equal. The examples of inconsistent
+      comparison results are: both abis preferred each other, or
+      both abis claimed that they are preferrable. *)
+  method choose : abi -> int
+
+  (** [return_value] returns an expression, that can be used to return
+      a value from a function. Use [Bil.concat] to represent return
+      value that doesn't fit into one register  *)
+  method return_value : exp
+
+
+  (** [args] returns a list of expressions that represents
+      arguments of the given function. Each expression can be
+      annotated with suggested name  *)
+  method args : (string option * exp) list
+
+  (** [vars] returns a list of expressions, that represents
+      local variables of the function  *)
+  method vars : (string option * exp) list
+
+  (** [records] returns a list of records, found in the symbol.  *)
+  method records : (string option * exp) list list
+end
+
+(** symbol name may be provided if known. Also an access
+    to the whole binary image is provided if there is one. *)
+type abi_constructor =
+  ?image:image -> ?sym:string -> mem -> Bap_disasm_block.t -> abi option

--- a/lib/bap_disasm/bap_disasm_abi_helpers.ml
+++ b/lib/bap_disasm/bap_disasm_abi_helpers.ml
@@ -1,0 +1,63 @@
+(*  *)
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_image_std
+open Bap_disasm_abi
+
+
+class stub : abi = object
+  method id = ["unknown"; "unknown"; "unknown"]
+  method specific = false
+  method choose _ = -1
+  method return_value = Bil.unknown "unknown" reg8_t
+  method args = []
+  method vars = []
+  method records = []
+end
+
+let merge_id x y =
+  let rec loop acc x y = match x,y with
+    | [],[] -> List.concat (List.rev acc)
+    | x::xs,[]|[],x::xs -> loop ([x]::acc) xs []
+    | x::xs, y::ys -> loop ([x;y]::acc) xs ys in
+  loop [] x y |> List.remove_consecutive_duplicates
+    ~equal:String.equal
+
+
+let either_or_first x y = match x,y with
+  | [],x | x,[] -> x
+  | x,y -> x
+
+let join x y : abi = object
+  inherit stub as stub
+  method id = merge_id x#id y#id
+  method specific = x#specific || y#specific
+  method choose other = max (x#choose other) (y#choose other)
+  method return_value =
+    if Exp.compare x#return_value stub#return_value = 0
+    then x#return_value
+    else y#return_value
+  method args = either_or_first x#args y#args
+  method vars = either_or_first x#vars y#vars
+  method records = either_or_first x#records y#records
+end
+
+let merge = function
+  | [] -> new stub
+  | xs -> List.reduce_exn xs ~f:join
+
+
+let to_string arch abi =
+  Arch.to_string arch :: List.rev abi |> String.concat ~sep:"-"
+
+
+let cmp x y = match x#choose y, y#choose x with
+  | p,q when p = q -> 0
+  | p,_ -> p
+
+let create_abi_getter (registered : abi_constructor list ref) =
+  fun ?all ?image ?sym mem blk ->
+    List.filter_map !registered (fun cs -> cs ?image ?sym mem blk) |>
+    List.sort ~cmp |> function
+    | [] -> []
+    | x :: _ as xs -> List.take_while xs ~f:(fun y -> cmp x y = 0)

--- a/lib/bap_disasm/bap_disasm_abi_helpers.mli
+++ b/lib/bap_disasm/bap_disasm_abi_helpers.mli
@@ -1,0 +1,24 @@
+(** A set of helper functions and classes  *)
+open Bap_types.Std
+open Bap_image_std
+open Bap_disasm_abi
+
+
+(** [merge abis] create an abi that tries to take best from all
+    provided abi. If the input list is empty, then the stub abi
+    will be returned. *)
+val merge : abi list -> abi
+
+val merge_id : string list -> string list -> string list
+
+(** ABI that understands nothing. All methods are dump stubs. *)
+class stub : abi
+
+val to_string : arch -> string list -> string
+
+(**/**)
+val create_abi_getter :
+  abi_constructor list ref ->
+  ?all:bool -> (** defaults to false  *)
+  ?image:image ->
+  ?sym:string -> mem -> Bap_disasm_block.t -> abi list

--- a/lib/bap_disasm/bap_disasm_arm_env.mli
+++ b/lib/bap_disasm/bap_disasm_arm_env.mli
@@ -2,7 +2,6 @@ open Core_kernel.Std
 open Bap_types.Std
 open Bap_disasm_arm_types
 
-val nil : var
 val spsr : var
 val cpsr : var
 val nf : var
@@ -28,9 +27,6 @@ val r9 : var
 val r10 : var
 val r11 : var
 val r12 : var
-val r13 : var
-val r14 : var
-val r15 : var
 
 val of_reg : reg -> var
 

--- a/lib/bap_disasm/bap_disasm_arm_lifter.ml
+++ b/lib/bap_disasm/bap_disasm_arm_lifter.ml
@@ -1,7 +1,9 @@
 open Core_kernel.Std
 open Or_error
 open Bap_types.Std
-
+open Bap_disasm_abi
+open Bap_disasm_abi_helpers
+open Bap_disasm_types
 open Bap_disasm_arm_types
 open Bap_disasm_arm_utils
 
@@ -1060,7 +1062,76 @@ let insn_exn mem insn =
       | #branch as op -> lift_branch mem ops op
       | #special as op -> lift_special ops op
 
-let insn mem insn =
+let lift mem insn =
   try insn_exn mem insn with
   | Lifting_failed msg -> errorf "%s:%s" (Basic.Insn.name insn) msg
   | exn -> of_exn exn
+
+
+module CPU : CPU = struct
+  open Bap_disasm_arm_env
+
+  let mem = mem
+  let pc = pc
+  let sp = sp
+
+
+  let regs = Var.Set.of_list [
+      r0; r1; r2; r3; r4;
+      r5; r6; r7; r8; r9;
+      r10; r11; r12;
+      pc;  sp; lr;
+      spsr; cpsr; itstate;
+    ]
+
+  (* although PC is stricly speaking is GPR we will rule it out *)
+  let non_gpr = Var.Set.of_list [
+      pc; spsr; cpsr; itstate;
+    ]
+
+  let gpr = Var.Set.diff regs non_gpr
+
+  let perms = Var.Set.of_list [
+      r4; r5; r6; r7; r8; r9; r10; r11;
+    ]
+
+  let flags = Var.Set.of_list @@ [
+      nf; zf; cf; qf;
+    ] @ Array.to_list ge
+
+  let nf = nf
+  let zf = zf
+  let cf = cf
+  let vf = vf
+
+  let is = Var.equal
+
+  let is_reg = Set.mem regs
+  let is_sp = is sp
+  let is_bp = is r11
+  let is_pc = is pc
+  let addr_of_pc m = Addr.(Memory.min_addr m ++ 8)
+  let is_flag = Set.mem flags
+  let is_zf = is zf
+  let is_cf = is cf
+  let is_vf = is vf
+  let is_nf = is nf
+
+  let is_return = is r0
+  let is_formal = function
+    | 0 -> is r0
+    | 1 -> is r1
+    | 2 -> is r2
+    | 3 -> is r3
+    | _ -> fun _ -> false
+
+  let is_permanent = Set.mem perms
+  let is_mem = is mem
+end
+
+
+let registered = ref []
+
+let register_abi abi = registered := abi :: !registered
+
+let get_abi = create_abi_getter registered

--- a/lib/bap_disasm/bap_disasm_std.ml
+++ b/lib/bap_disasm/bap_disasm_std.ml
@@ -1,3 +1,13 @@
+(** The export module for the disasm library.
+    Everything in this module will finish in the `Bap.Std` namespace.
+
+    For intra-bap development consider to open this module, if you're
+    outside this library or any dependent libraries.
+
+*)
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_image_std
 include Bap_disasm_types
 include Bap_disasm
 module Insn    = Bap_disasm_insn
@@ -19,3 +29,68 @@ module Disasm_expert = struct
   module Insn = Bap_disasm_basic.Insn
   module Block = Bap_disasm_rec.Block
 end
+
+(** include type definitions of the ABI  *)
+include Bap_disasm_abi
+
+(** Packs all ABI in one module.  *)
+module ABI = struct
+  include Bap_disasm_abi_helpers
+  module ARM = struct
+  end
+
+  module IA32 = struct
+  end
+
+  module AMD64 = struct
+  end
+end
+
+module type Target = sig
+  module CPU : CPU
+
+  (** registers given ABI under the given target   *)
+  val register_abi : abi_constructor -> unit
+  (** [lift mem insn] lifts provided instruction to BIL.
+      Usually you do not need to call this function directly, as
+      [disassemble] function will do the lifting.
+  *)
+
+  (** creates a set of ABI for the provided symbol.
+      Until [all] parameter is set to true the ABI will be
+      disambiguated, using [choose] method. Only equally
+      valid ABI are returned. *)
+  val get_abi :
+    ?all:bool -> (** defaults to false  *)
+    ?image:image ->
+    ?sym:string -> mem -> Bap_disasm_block.t -> abi list
+
+  val lift : mem -> ('a,'k) Basic.insn -> bil Or_error.t
+end
+
+(** {2 Lifted targets}
+    All targets implement at least [Target] interface.
+*)
+
+
+(** ARM architecture  *)
+module ARM  = struct
+  include Bap_disasm_arm
+  include Bap_disasm_arm_lifter
+end
+
+module AMD64 = struct
+  include Bap_disasm_x86_lifter.AMD64
+end
+
+module IA32 = struct
+  include Bap_disasm_x86_lifter.IA32
+end
+
+module Stub = Bap_disasm_stub_lifter
+
+let target_of_arch = function
+  | `arm -> (module ARM : Target)
+  | `x86_64 -> (module AMD64 : Target)
+  | `x86 -> (module IA32)
+  | _ -> (module Stub : Target)

--- a/lib/bap_disasm/bap_disasm_stub_lifter.ml
+++ b/lib/bap_disasm/bap_disasm_stub_lifter.ml
@@ -1,0 +1,33 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_image_std
+
+let lift _ _ = Or_error.error_string "not implemented"
+
+let register_abi _ = ()
+let get_abi ?all ?image ?sym mem blk = []
+
+module CPU = struct
+  let gpr = Var.Set.empty
+  let nil = Var.create "nil" reg8_t
+  let mem = nil
+  let pc = nil
+  let sp = nil
+  let sp = nil
+  let zf = nil
+  let cf = nil
+  let vf = nil
+  let nf = nil
+  let addr_of_pc = Memory.max_addr
+  let no _ = false
+  let is_reg = no
+  let is_flag = no
+  let is_sp = no
+  let is_bp = no
+  let is_pc = no
+  let is_zf = no
+  let is_cf = no
+  let is_vf = no
+  let is_nf = no
+  let is_mem = no
+end

--- a/lib/bap_disasm/bap_disasm_stub_lifter.mli
+++ b/lib/bap_disasm/bap_disasm_stub_lifter.mli
@@ -4,8 +4,8 @@ open Bap_image_std
 open Bap_disasm_types
 open Bap_disasm_abi
 
-(** [insn mem basic] takes a basic instruction and a memory and
-    returns a sequence of BIL statements. *)
+
+
 val lift : mem -> ('a,'k) Basic.insn -> stmt list Or_error.t
 
 

--- a/lib/bap_disasm/bap_disasm_types.ml
+++ b/lib/bap_disasm/bap_disasm_types.ml
@@ -1,6 +1,6 @@
+open Core_kernel.Std
 open Bap_types.Std
-open Bap_image
-open Image_internal_std
+open Bap_image_std
 
 module Basic = Bap_disasm_basic
 module Rec = Bap_disasm_rec
@@ -16,8 +16,48 @@ type reg = Reg.t with bin_io, compare, sexp
 type imm = Imm.t with bin_io, compare, sexp
 type fmm = Fmm.t with bin_io, compare, sexp
 type kind = Kind.t with bin_io, compare, sexp
-(** ARM instruction set  *)
-module Arm = struct
-  include Bap_disasm_arm
-  module Lift = Bap_disasm_arm_lifter
+
+
+(** A BIL model of CPU.
+
+    In general this is a model of a processor architecture, involving
+    ALU, processing unit, registers and memory.
+*)
+module type CPU = sig
+
+  (** {3 Minimum set of required definitions} *)
+
+  (** A set of general purpose registers *)
+  val gpr : Var.Set.t
+
+  (** Memory  *)
+  val mem : var
+
+  (** Program counter  *)
+  val pc  : var
+
+  (** Stack pointer  *)
+  val sp  : var
+
+  (** {4 Flag registers}  *)
+  val zf  : var
+  val cf  : var
+  val vf  : var
+  val nf  : var
+
+  val addr_of_pc : mem -> addr
+
+  (** {3 Predicates}  *)
+  val is_reg : var -> bool
+  val is_flag : var -> bool
+
+  val is_sp : var -> bool
+  val is_bp : var -> bool
+  val is_pc : var -> bool
+
+  val is_zf : var -> bool
+  val is_cf : var -> bool
+  val is_vf : var -> bool
+  val is_nf : var -> bool
+  val is_mem : var -> bool
 end

--- a/lib/bap_disasm/bap_disasm_x86_lifter.ml
+++ b/lib/bap_disasm/bap_disasm_x86_lifter.ml
@@ -2,7 +2,9 @@
 
 open Core_kernel.Std
 open Bap_types.Std
-
+open Bap_disasm_types
+open Bap_disasm_abi
+open Bap_disasm_abi_helpers
 open Bap_disasm_x86_types
 open Bap_disasm_x86_utils
 open Bap_disasm_x86_env
@@ -29,7 +31,7 @@ module ToIR = struct
     match s with
     | None -> Stmt.Move (mem, Exp.(Store (Var mem, a, e, LittleEndian, sz)))
     | Some v -> Stmt.Move (mem, Exp.(Store (Var mem, Var v + a, e,
-                                   LittleEndian, sz)))
+                                            LittleEndian, sz)))
 
   let storem mode t a e =
     Stmt.Move (mode, Exp.(Store (Var mode, a, e, LittleEndian, t)))
@@ -154,7 +156,7 @@ module ToIR = struct
 
   (* Double width assignments, as used by multiplication *)
   let assn_dbl_s mode s has_rex has_vex t e =
-      match op_dbl t with
+    match op_dbl t with
     | (t,o) :: [] -> [assn_s mode s has_rex has_vex t o e], op2e_s mode s has_rex t o
     | l ->
       let tmp = Var.create ~tmp:true "t" (Type.Imm (!!t * 2)) in
@@ -217,7 +219,7 @@ module ToIR = struct
     let var_acc = Exp.Var acc in
     let t' = !!t in
     (* extra parens do not change semantics but do make it pretty
-    print nicer *)
+       print nicer *)
     let open Exp in
     exp_not (Cast (Cast.LOW, !!bool_t,
                    ((Let(acc, (r lsr (int_exp 4 t')) lxor r, Let(acc, (var_acc lsr (int_exp 2 t')) lxor var_acc, (var_acc lsr (int_exp 1 t')) lxor var_acc))))))
@@ -294,1160 +296,1160 @@ module ToIR = struct
     let ah_e = ah_e mode in
     let disfailwith = disfailwith mode in
     let unimplemented = unimplemented mode in function
-    | Nop -> []
-    | Bswap(t, op) ->
-      let e = match t with
-        | Type.Imm 32 | Type.Imm 64 -> let (op', t') = op2e_keep_width t op in
-          reverse_bytes op' t'
-        | _ -> disfailwith "bswap: Expected 32 or 64 bit type"
-      in
-      [assn t op e]
-    | Retn (op, far_ret) when pref = [] || pref = [repz]  || pref = [repnz]->
-      let temp = Var.create ~tmp:true "ra" mt in
-      let load_stmt = if far_ret
-        then (* TODO Mess with segment selectors here *)
-          unimplemented "long retn not supported"
-        else Stmt.Move (temp, load_s mode seg_ss (size_of_typ mt) rsp_e)
-      in
-      let rsp_stmts =
-        Stmt.Move (rsp, Exp.(rsp_e + (Int (mi (bytes_of_width mt)))))::
-        (match op with
-         | None -> []
-         | Some(t, src) ->
-           [Stmt.Move (rsp, Exp.(rsp_e + (op2e t src)))]
-        ) in
-      load_stmt::
-      rsp_stmts@
-      [Stmt.Jmp (Exp.Var temp)]
-    | Mov(t, dst, src, condition) ->
-      let c_src = (match condition with
-          | None -> op2e t src
-          | Some c -> Exp.Ite (c, op2e t src, op2e t dst))
-      in
-      (* Find base by looking at LDT or GDT *)
-      let base_e e =
-        (* 0 = GDT, 1 = LDT *)
-        let ti = Exp.Extract (3, 3, e) in
-        let base = Exp.Ite (ti, Exp.var ldt, Exp.var gdt) in
-        (* Extract index into table *)
-        let entry_size, entry_shift = match mode with
-          | X86 -> reg64_t, 6  (* "1<<6 = 64" *)
-          | X8664 -> reg128_t, 7 (* "1<<7 = 128" *)
+      | Nop -> []
+      | Bswap(t, op) ->
+        let e = match t with
+          | Type.Imm 32 | Type.Imm 64 -> let (op', t') = op2e_keep_width t op in
+            reverse_bytes op' t'
+          | _ -> disfailwith "bswap: Expected 32 or 64 bit type"
         in
-        let index = Exp.(Cast (Cast.UNSIGNED, !!mt, (Extract (15, 4, e)) lsl (Int (mi entry_shift)))) in
-        (* Load the table entry *)
-        let table_entry = load_s mode None (size_of_typ entry_size) (Exp.(base + index)) in
-        (* Extract the base *)
-        concat_explist
-          ((match mode with
-              | X86 -> []
-              | X8664 -> (Exp.Extract (95, 64, table_entry)) :: [])
-           @  (Exp.Extract (63, 56, table_entry))
-              :: (Exp.Extract (39, 32, table_entry))
-              :: (Exp.Extract (31, 16, table_entry))
-              :: [])
-      in
-      let bs =
-        let dst_e = op2e t dst in
-        if dst = o_fs && !compute_segment_bases then [Stmt.Move (fs_base, base_e dst_e)]
-        else if dst = o_gs && !compute_segment_bases then [Stmt.Move (gs_base, base_e dst_e)]
-        else []
-      in
-      assn t dst c_src :: bs
-    | Movs(Type.Imm _bits as t) ->
-      let stmts =
-        store_s mode seg_es t rdi_e (load_s mode seg_es (size_of_typ t) rsi_e)
-        :: string_incr mode t rsi
-        :: string_incr mode t rdi
-        :: []
-      in
-      if pref = [] then
-        stmts
-      else if List.mem pref repz || List.mem pref repnz then
-        (* movs has only rep instruction others just considered to be rep *)
-        rep_wrap ~mode ~addr ~next stmts
-      else
-        unimplemented "unsupported prefix for movs"
-    | Movzx(t, dst, ts, src) ->
-      [assn t dst Exp.(Cast (Cast.UNSIGNED, !!t, op2e ts src))]
-    | Movsx(t, dst, ts, src) ->
-      [assn t dst Exp.(Cast (Cast.SIGNED, !!t, op2e ts src))]
-    | Movdq(ts, s, td, d, align) ->
-      let (s, al) = match s with
-        | Ovec _ | Oreg _-> op2e ts s, []
-        | Oaddr a -> op2e ts s, [a]
-        | Oimm _ | Oseg _ -> disfailwith "invalid source operand for movdq"
-      in
-      let (d, al) = match d with
-        (* Behavior is to clear the xmm bits *)
-        | Ovec _ -> assn td d Exp.(Cast (Cast.UNSIGNED, !!td, s)), al
-        | Oreg _ -> assn td d s, al
-        | Oaddr a -> assn td d s, a::al
-        | Oimm _ | Oseg _ -> disfailwith "invalid dest operand for movdq"
-      in
-      (* sources tell me that movdqa raises a general protection exception
-       * if its operands aren't aligned on a 16-byte boundary *)
-      let im i = Exp.Int (int_of_mode mode i) in
-      let al =
-        if align then
-          List.map ~f:(fun a -> Stmt.If (Exp.((a land im 15) = im 0), [], [Cpu_exceptions.general_protection])) al
-        else []
-      in
-      d::al
-    | Movoffset((tdst, dst), offsets) ->
-      (* If a vex prefix is present, then extra space is filled with 0.
-         Otherwise, the bits are preserved. *)
-      let padding hi lo =
-        if hi < lo then []
-        else if has_vex then [int_exp 0 (hi - lo + 1)]
-        else [Exp.Extract (hi, lo, op2e tdst dst)]
-      in
-      let offsets = List.sort ~cmp:(fun {offdstoffset=o1; _} {offdstoffset=o2; _} -> Int.compare o1 o2) offsets in
-      let add_exp (elist,nextbit) {offlen; offtyp; offop; offsrcoffset; offdstoffset} =
-        Exp.Extract ((!!offlen + offsrcoffset - 1), offsrcoffset, (op2e offtyp offop))
-        :: padding (offdstoffset - 1) nextbit
-        @ elist, offdstoffset + !!offlen
-      in
-      let elist, nextbit = List.fold_left ~f:add_exp ~init:([],0) offsets in
-      let elist = padding (!!tdst - 1) nextbit @ elist in
-      [assn tdst dst (concat_explist elist)]
-    | Punpck(t, et, o, d, s, vs) ->
-      let nelem = match t, et with
-        | Type.Imm n, Type.Imm n' -> n / n'
-        | _ -> disfailwith "invalid"
-      in
-      assert (nelem mod 2 = 0);
-      let nelem_per_src = nelem / 2 in
-      let halft = Type.Imm (!!t / 2) in
-      let castf = match o with
-        | High -> fun e -> Exp.(Cast (Cast.HIGH, !!halft, e))
-        | Low -> fun e -> Exp.(Cast (Cast.LOW, !!halft, e))
-      in
-      let se, de = castf (op2e t s), castf (op2e t d) in
-      let st, dt = Var.create ~tmp:true "s" halft, Var.create ~tmp:true "d" halft in
-      let et' = !!et in
-      let mape i =
-        [extract_element et' (Exp.Var st) i; extract_element et' (Exp.Var dt) i]
-      in
-      let e = concat_explist (List.concat (List.map ~f:mape (List.range ~stride:(-1) ~stop:`inclusive (nelem_per_src-1) 0))) in
-      let dest = match vs with
-        | None -> d
-        | Some vdst -> vdst
-      in
-      [Stmt.Move (st, se);
-       Stmt.Move (dt, de);
-       assn t dest e]
-    | Ppackedbinop(t, et, fbop, _, d, s, vs) ->
-      let nelem = match t, et with
-        | Type.Imm n, Type.Imm n' -> n / n'
-        | _ -> disfailwith "invalid"
-      in
-      let getelement o i =
-        (* assumption: immediate operands are repeated for all vector
-           elements *)
-        match o with
-        | Oimm _ -> op2e et o
-        | _ -> extract_element !!et (op2e t o) i
-      in
-      let f i =
-        fbop (getelement d i) (getelement s i)
-      in
-      let e = concat_explist (List.map ~f:f (List.range ~stride:(-1) ~stop:`inclusive (nelem-1) 0)) in
-      (match vs with
-       | None -> [assn t d e]
-       | Some vdst -> [assn t vdst e])
-    | Pbinop(t, fbop, _s, o1, o2, vop) ->
-      (match vop with
-       | None -> [assn t o1 (fbop (op2e t o1) (op2e t o2))]
-       | Some vop -> [assn t o1 (fbop (op2e t vop) (op2e t o2))])
-    | Pcmp (t,elet,bop,_,dst,src,vsrc) ->
-      let elebits = !!elet in
-      let ncmps = !!t / elebits in
-      let src = match src with
-        | Ovec _ -> op2e t src
-        | Oaddr a -> load (size_of_typ t) a
-        | Oreg _ | Oimm _ | Oseg _ -> disfailwith "invalid"
-      in
-      let dst, vsrc = match vsrc with
-        | None -> dst, dst
-        | Some vsrc -> dst, vsrc
-      in
-      let compare_region i =
-        let byte1 = Exp.Extract(i*elebits-1, (i-1)*elebits, src) in
-        let byte2 = Exp.Extract(i*elebits-1, (i-1)*elebits, op2e t vsrc) in
-        let tmp = Var.create ~tmp:true ("t" ^ string_of_int i) elet in
-        let ltw n t = (BV.of_int64 n ~width:t) |> Exp.int in
-        Exp.Var tmp, Stmt.Move (tmp, Exp.(Ite (BinOp (bop, byte1, byte2), ltw (-1L) !!elet, ltw 0L !!elet)))
-      in
-      let indices = List.init ~f:(fun i -> i + 1) ncmps in (* list 1-nbytes *)
-      let comparisons = List.map ~f:compare_region indices in
-      let temps, cmps = List.unzip comparisons in
-      begin match List.rev temps with
-        | [] -> disfailwith "Pcmp element size mismatch" (* XXX what's actually going on in Pcmp? *)
-        | t_first::t_rest ->
-          (* could also be done with shifts *)
-          let store_back = List.fold_left ~f:(fun acc i -> Exp.Concat(acc,i)) ~init:t_first t_rest in
-          cmps @ [assn t dst store_back] end
-    | Pmov (t, dstet, srcet, dst, src, ext, _) ->
-      let nelem = match t, dstet with
-        | Type.Imm n, Type.Imm n' -> n / n'
-        | _ -> disfailwith "invalid"
-      in
-      let getelt op i = extract_element !!srcet (op2e t op) i in
-      let extcast =
-        let open Exp in
-        match ext with
-        | Cast.UNSIGNED | Cast.SIGNED -> fun e -> Exp.Cast (ext, !!dstet, e)
-        | _ -> disfailwith "invalid"
-      in
-      let extend i = extcast (getelt src i) in
-      let e = concat_explist (List.map ~f:extend (List.range ~stride:(-1) ~stop:`inclusive (nelem-1) 0)) in
-      [assn t dst e]
-    | Pmovmskb (t,dst,src) ->
-      let nbytes = bytes_of_width t in
-      let src = match src with
-        | Ovec _ -> op2e t src
-        | _ -> disfailwith "invalid operand"
-      in
-      let get_bit i = Exp.Extract(i*8-1, i*8-1, src) in
-      let byte_indices = List.init ~f:(fun i -> i + 1) nbytes in (* list 1-nbytes *)
-      let all_bits = List.rev (List.map ~f:get_bit byte_indices) in
-      (* could also be done with shifts *)
-      let padt = Type.Imm(32 - nbytes) in
-      let or_together_bits = List.fold_left ~f:(fun acc i -> Exp.Concat(acc,i)) ~init:(int_exp 0 (!!padt)) all_bits in
-      [assn reg32_t dst or_together_bits]
-    | Palignr (t,dst,src,vsrc,imm) ->
-      let (dst_e, t_concat) = op2e_keep_width t dst in
-      let (src_e, t_concat') = op2e_keep_width t src in
-      (* previously, this code called Typecheck.infer_ast.
-       * We're now just preserving the widths, so here we assert
-       * that our 2 "preserved widths" are the same. *)
-      assert (!!t_concat = !!t_concat');
-      let imm = op2e t imm in
-      let conct = Exp.(dst_e ^ src_e) in
-      let shift = Exp.(conct lsr (Cast (Cast.UNSIGNED, !!t_concat, imm lsl (int_exp 3 !!t)))) in
-      let high, low = match t with
-        | Type.Imm 256 -> 255, 0
-        | Type.Imm 128 -> 127, 0
-        | Type.Imm 64 -> 63, 0
-        | _ -> disfailwith "impossible: used non 64/128/256-bit operand in palignr"
-      in
-      let result = Exp.Extract (high, low, shift) in
-      let im i = Exp.Int (int_of_mode mode i) in
-      let addresses = List.fold
-          ~f:(fun acc -> function Oaddr a -> a::acc | _ -> acc) ~init:[] [src;dst] in
-      (* Palignr seems to cause a CPU general protection exception if this fails.
-       * previously this code used the ast.ml Assert statement, which is gone,
-       * so it's been replaced with Bil's CpuExn *)
-      List.map ~f:(fun addr -> Stmt.If (Exp.((addr land im 15) = im 0),
-                                   [], [Cpu_exceptions.general_protection])) addresses
-      @ (match vsrc with
-          | None -> [assn t dst result]
-          | Some vdst -> [assn t vdst result])
-    | Pcmpstr(t,xmm1,xmm2m128,_imm,imm8cb,pcmpinfo) ->
-      (* All bytes and bits are numbered with zero being the least
-         significant. This includes strings! *)
-      (* NOTE: Strings are backwards, at least when they are in
-         registers.  This doesn't seem to be documented in the Intel
-         manual.  This means that the NULL byte comes before the
-         string. *)
-      let xmm1_e = op2e t xmm1 in
-      let xmm2m128_e = op2e t xmm2m128 in
-      let regm = type_of_mode mode in
-
-      let open Pcmpstr in
-      let nelem, _nbits, elemt = match imm8cb with
-        | {ssize=Bytes; _} -> 16, 8, Type.imm 8
-        | {ssize=Words; _} -> 8, 16, Type.imm 16
-      in
-      (* Get element index in e *)
-      let get_elem = extract_element !!elemt in
-      (* Get from xmm1/xmm2 *)
-      let get_xmm1 = get_elem xmm1_e in
-      let get_xmm2 = get_elem xmm2m128_e in
-      (* Build expressions that assigns the correct values to the
-         is_valid variables using implicit (NULL-based) string
-         length. *)
-      let build_implicit_valid_xmm_i is_valid_xmm_i get_xmm_i =
-        let f acc i =
-          (* Previous element is valid *)
-          let prev_valid = if i = 0 then exp_true else Exp.var (is_valid_xmm_i (i-1)) in
-          (* Current element is valid *)
-          let curr_valid = Exp.(get_xmm_i i <> (int_exp 0 !!elemt)) in
-          Exp.Let(is_valid_xmm_i i, Exp.(prev_valid land curr_valid), acc)
-        in (fun e -> List.fold_left ~f:f ~init:e (List.range ~stride:(-1) ~stop:`inclusive (nelem-1) 0))
-      in
-      (* Build expressions that assigns the correct values to the
-         is_valid variables using explicit string length. *)
-      let build_explicit_valid_xmm_i is_valid_xmm_i sizee =
-        (* Max size is nelem *)
-        let sizev = Var.create ~tmp:true "sz" regm in
-        let sizee = Exp.(Ite (BinOp (Binop.LT, int_exp nelem !!regm, sizee), int_exp nelem !!regm, sizee)) in
-        let f acc i =
-          (* Current element is valid *)
-          let curr_valid = Exp.(BinOp (Binop.LT, int_exp i !!regm, Var sizev)) in
-          Exp.Let(is_valid_xmm_i i, curr_valid, acc)
-        in (fun e -> Exp.Let(sizev, sizee, List.fold_left ~f:f ~init:e (List.range ~stride:(-1) ~stop:`inclusive (nelem-1) 0)))
-      in
-
-      (* Get var name indicating whether index in xmm num is a valid
-         byte (before NULL byte). *)
-      (* XXX more hashtable code *)
-      let is_valid =
-        let vh = Hashtbl.Poly.create () ~size:(2*nelem) in
-        (fun xmmnum index -> match Hashtbl.find vh (xmmnum,index) with
-           | Some v -> v
-           | None ->
-             let v = Var.create ~tmp:true ("is_valid_xmm"^string_of_int xmmnum^"_ele"^string_of_int index) bool_t in
-             Hashtbl.add_exn vh ~key:(xmmnum,index) ~data:v;
-             v)
-      in
-
-      let is_valid_xmm1 index = is_valid 1 index in
-      let is_valid_xmm2 index = is_valid 2 index in
-      let is_valid_xmm1_e index = Exp.Var(is_valid_xmm1 index) in
-      let is_valid_xmm2_e index = Exp.Var(is_valid_xmm2 index) in
-
-      let build_valid_xmm1,build_valid_xmm2 =
-        match pcmpinfo with
-        | {len=Implicit; _} ->
-          build_implicit_valid_xmm_i is_valid_xmm1 get_xmm1,
-          build_implicit_valid_xmm_i is_valid_xmm2 get_xmm2
-        | {len=Explicit; _} ->
-          build_explicit_valid_xmm_i is_valid_xmm1 rax_e,
-          build_explicit_valid_xmm_i is_valid_xmm2 rdx_e
-      in
-
-      let get_intres1_bit index =
-        let open Exp.Binop in
-        match imm8cb with
-        | {agg=EqualAny; _} ->
-          (* Is xmm2[index] at xmm1[j]? *)
-          let check_char acc j =
-            let eql = Exp.((get_xmm2 index) = (get_xmm1 j)) in
-            let valid = is_valid_xmm1_e j in
-            Exp.(Ite ((eql land valid), exp_true, acc))
-          in
-          Exp.BinOp (AND, is_valid_xmm2_e index,
-                 (* Is xmm2[index] included in xmm1[j] for any j? *)
-                 (List.fold ~f:check_char ~init:exp_false (List.range
-                                                             ~stride:(-1) ~stop:`inclusive (nelem-1) 0)))
-        | {agg=Ranges; _} ->
-          (* Is there an even j such that xmm1[j] <= xmm2[index] <=
-             xmm1[j+1]? *)
-          let check_char acc j =
-            (* XXX: Should this be AND? *)
-            let rangevalid = Exp.(is_valid_xmm1_e Pervasives.(2*j) land is_valid_xmm1_e Pervasives.(2*j+1)) in
-            let lte = match imm8cb with
-              | {ssign=Unsigned; _} -> LE
-              | {ssign=Signed; _} -> SLE
-            in
-            let inrange =
-              Exp.((BinOp (lte, (get_xmm1 Pervasives.(2*j)), (get_xmm2 index)))
-                   land (BinOp (lte, (get_xmm2 index), (get_xmm1 Pervasives.(2*j+1)))))
-            in
-            Exp.(Ite (UnOp (Unop.NOT, rangevalid), exp_false, Ite (inrange, exp_true, acc)))
-          in
-          Exp.(is_valid_xmm2_e index
-               (* Is xmm2[index] in the jth range pair? *)
-               land List.fold_left ~f:check_char ~init:exp_false (List.range ~stride:(-1) ~stop:`inclusive Pervasives.(nelem/2-1) 0))
-        | {agg=EqualEach; _} ->
-          (* Does xmm1[index] = xmm2[index]? *)
-          let xmm1_invalid = Exp.(UnOp (Unop.NOT, (is_valid_xmm1_e index))) in
-          let xmm2_invalid = Exp.(UnOp (Unop.NOT, (is_valid_xmm2_e index))) in
-          let bothinvalid = Exp.(xmm1_invalid land xmm2_invalid) in
-          let eitherinvalid = Exp.(xmm1_invalid lor xmm2_invalid) in
-          let eq = Exp.(get_xmm1 index = get_xmm2 index) in
-          (* both invalid -> true
-             one invalid -> false
-             both valid -> check same byte *)
-          Exp.Ite (bothinvalid, exp_true,
-               Exp.Ite (eitherinvalid, exp_false,
-                    Exp.Ite (eq, exp_true, exp_false)))
-        | {agg=EqualOrdered; _} ->
-          (* Does the substring xmm1 occur at xmm2[index]? *)
-          let check_char acc j =
-            let neq = Exp.(get_xmm1 j <> get_xmm2 Pervasives.(index+j)) in
-            let substrended = Exp.(UnOp (Unop.NOT, (is_valid_xmm1_e j))) in
-            let bigstrended = Exp.UnOp (Exp.Unop.NOT, (is_valid_xmm2_e (index+j))) in
-            (* substrended => true
-               bigstrended => false
-               byte diff => false
-               byte same => keep going  *)
-            Exp.Ite (substrended, exp_true,
-                 Exp.Ite (bigstrended, exp_false,
-                      Exp.Ite (neq, exp_false, acc)))
-          in
-          (* Is xmm1[j] equal to xmm2[index+j]? *)
-          List.fold_left ~f:check_char ~init:exp_true (List.range
-      ~stride:(-1) ~stop:`inclusive (nelem-index-1) 0)
-      in
-      let bits = List.map ~f:get_intres1_bit (List.range ~stride:(-1) ~stop:`inclusive (nelem-1) 0) in
-      let res_e = build_valid_xmm1 (build_valid_xmm2 (concat_explist bits)) in
-      let int_res_1 = Var.create ~tmp:true "IntRes1" reg16_t in
-      let int_res_2 = Var.create ~tmp:true "IntRes2" reg16_t in
-
-      let contains_null e =
-        List.fold_left ~f:(fun acc i ->
-            Exp.Ite (Exp.(get_elem e i = int_exp 0 !!elemt), exp_true, acc)) ~init:exp_false (List.init ~f:(fun x -> x) nelem)
-      in
-      (* For pcmpistri/pcmpestri *)
-      let sb e =
-        List.fold_left ~f:(fun acc i ->
-            Exp.Ite (Exp.(exp_true = Extract (i, i, e)),
-                 (int_exp i !!regm),
-                 acc))
-          ~init:(int_exp nelem !!regm)
-          (match imm8cb with
-           | {outselectsig=LSB; _} -> List.range ~stride:(-1) ~start:`exclusive ~stop:`inclusive nelem 0
-           | {outselectsig=MSB; _} -> List.init ~f:(fun x -> x) nelem)
-      in
-      (* For pcmpistrm/pcmpestrm *)
-      let mask e =
-        match imm8cb with
-        | {outselectmask=Bitmask; _} ->
-          Exp.(Cast (Cast.UNSIGNED, !!reg128_t, e))
-        | {outselectmask=Bytemask; _} ->
-          let get_element i =
-            Exp.(Cast (Cast.UNSIGNED, !!elemt, Extract (i, i, e)))
-          in
-          concat_explist (List.map ~f:get_element (List.range ~stride:(-1) ~start:`exclusive ~stop:`inclusive nelem 0))
-      in
-      (* comment crap from earlier *)
-      (*comment
-        ::*)
-      let open Stmt in
-      Move (int_res_1, Exp.(Cast (Cast.UNSIGNED, !!reg16_t, res_e)))
-      :: (match imm8cb with
-          | {negintres1=false; _} ->
-            Move (int_res_2, Exp.Var int_res_1)
-          | {negintres1=true; maskintres1=false; _} ->
-            (* int_res_1 is bitwise-notted *)
-            Move (int_res_2, Exp.(UnOp (Unop.NOT, (Var int_res_1))))
-          | {negintres1=true; maskintres1=true; _} ->
-            (* only the valid elements in xmm2 are bitwise-notted *)
-            (* XXX: Right now we duplicate the valid element computations
-               when negating the valid elements.  They are also used by the
-               aggregation functions.  A better way to implement this might
-               be to write the valid element information out as a temporary
-               bitvector.  The aggregation functions and this code would
-               then extract the relevant bit to see if an element is
-               valid. *)
-            let validvector =
-              let bits = List.map ~f:is_valid_xmm2_e (List.range ~stride:(-1) ~start:`exclusive ~stop:`inclusive nelem 0) in
-              build_valid_xmm2 (Exp.(Cast (Cast.UNSIGNED, !!reg16_t, concat_explist bits)))
-            in
-            Move (int_res_2, Exp.(validvector lxor Var int_res_1)))
-      :: (match pcmpinfo with
-          | {out=Index; _} -> Move (rcx, sb (Exp.Var int_res_2))
-          (* FIXME: ymms should be used instead of xmms here *)
-          | {out=Mask; _} -> Move (ymms.(0), mask (Exp.Var int_res_2)))
-      :: Move (cf, Exp.(Var int_res_2 <> int_exp 0 16))
-      :: Move (zf ,contains_null xmm2m128_e)
-      :: Move (sf, contains_null xmm1_e)
-      :: Move (oF, Exp.(Extract (0, 0, Var int_res_2)))
-      :: Move (af, int_exp 0 1)
-      :: Move (pf, int_exp 0 1)
-      :: []
-    | Pshufd (t, dst, src, vsrc, imm) ->
-      let src_e = op2e t src in
-      let imm_e = op2e t imm in
-      (* XXX: This would be more straight-forward if implemented using
-         map, instead of fold *)
-      let get_dword ndword =
-        let high_b = 2 * (ndword mod 4) + 1 in
-        let low_b = 2 * (ndword mod 4) in
-        let index = Exp.(Cast (Cast.UNSIGNED, !!t, Extract (high_b, low_b, imm_e))) in
-        let t' = !!t in
-        (* Use the same pattern for the top half of a ymm register *)
-        (* had to stop using extract_element_symbolic, since that calls
-         * Typecheck.infer_ast. I believe this captures the same
-         * "width logic", but this is a good place to check if things start
-         * going wrong later. *)
-        let (index, index_width) = if t' = 256 && ndword > 3 then
-            (Exp.(index + (Int (BV.of_int ~width:(!!t) 4))), 256)
-          else (index, t') in
-        extract_element_symbolic_with_width (Type.imm 32) src_e index index_width
-      in
-      let topdword = match t with Type.Imm 128 -> 3 | _ -> 7 in
-      let dwords = concat_explist (List.map ~f:get_dword (List.range ~stride:(-1) ~stop:`inclusive topdword 0)) in
-      (match vsrc with
-       | None -> [assn t dst dwords]
-       | Some vdst -> [assn t vdst dwords])
-    | Pshufb (t, dst, src, vsrc) ->
-      let order_e = op2e t src in
-      let dst_e = op2e t dst in
-      let get_bit i =
-        let highbit = Exp.Extract (((i*8)+7), ((i*8)+7), order_e) in
-        (* this part of the code previously also used Typecheck.infer_ast
-         * (indirectly, by calling Ast_convenience.extract_byte_symbolic with
-         * index as the last argument).
-         * I've read the relevant parts of infer_ast and extract_byte_symbolic
-         * and also the helpful comments below "3 bits" and "4 bits"
-         * and it seems those are the appropriate widths we get out of
-         * infer_ast, so I'm passing those in directly now.
-         * Imo, this is a lot less dubious than the thingy above. *)
-        let (index, index_width) = match t with
-          | Type.Imm 64 -> (Exp.Extract (((i*8)+2), ((i*8)+0), order_e), 64) (* 3 bits *)
-          | Type.Imm 128 -> (Exp.Extract (((i*8)+3), ((i*8)+0), order_e), 128) (* 4 bits *)
-          | Type.Imm 256 -> (Exp.Extract (((i*8)+3), ((i*8)+0), order_e), 256) (* 4 bits *)
-          | _ -> disfailwith "invalid size for pshufb"
+        [assn t op e]
+      | Retn (op, far_ret) when pref = [] || pref = [repz]  || pref = [repnz]->
+        let temp = Var.create ~tmp:true "ra" mt in
+        let load_stmt = if far_ret
+          then (* TODO Mess with segment selectors here *)
+            unimplemented "long retn not supported"
+          else Stmt.Move (temp, load_s mode seg_ss (size_of_typ mt) rsp_e)
         in
-        let index = Exp.(Cast (Cast.UNSIGNED, !!t, index)) in
-        let atindex = extract_byte_symbolic_with_width dst_e index index_width in
-        Exp.Ite (highbit, int_exp 0 8, atindex)
-      in
-      let n = !!t / 8 in
-      let e = concat_explist (List.map ~f:get_bit (List.range ~stride:(-1) ~start:`exclusive ~stop:`inclusive n 0)) in
-      (match vsrc with
-       | None -> [assn t dst e]
-       | Some vdst -> [assn t vdst e])
-    | Lea(t, r, a) when pref = [] ->
-      (* See Table 3-64 *)
-      (* previously, it checked whether addrbits > opbits before the cast_low.
-       * The conclusion we came to was that
-         - if they were equal, the cast is basically a nop
-         - if it was the other way round, you want to extend it anyway.
-       * (I may be remembering things wrongly) *)
-      [assn t r Exp.(Cast (Cast.LOW, !!t, a))]
-    | Call(o1, ra) when pref = [] ->
-      (* If o1 is an immediate, we should syntactically have Jump(imm)
-         so that the CFG algorithm knows where the jump goes.  Otherwise
-         it will point to BB_Indirect.
+        let rsp_stmts =
+          Stmt.Move (rsp, Exp.(rsp_e + (Int (mi (bytes_of_width mt)))))::
+          (match op with
+           | None -> []
+           | Some(t, src) ->
+             [Stmt.Move (rsp, Exp.(rsp_e + (op2e t src)))]
+          ) in
+        load_stmt::
+        rsp_stmts@
+        [Stmt.Jmp (Exp.Var temp)]
+      | Mov(t, dst, src, condition) ->
+        let c_src = (match condition with
+            | None -> op2e t src
+            | Some c -> Exp.Ite (c, op2e t src, op2e t dst))
+        in
+        (* Find base by looking at LDT or GDT *)
+        let base_e e =
+          (* 0 = GDT, 1 = LDT *)
+          let ti = Exp.Extract (3, 3, e) in
+          let base = Exp.Ite (ti, Exp.var ldt, Exp.var gdt) in
+          (* Extract index into table *)
+          let entry_size, entry_shift = match mode with
+            | X86 -> reg64_t, 6  (* "1<<6 = 64" *)
+            | X8664 -> reg128_t, 7 (* "1<<7 = 128" *)
+          in
+          let index = Exp.(Cast (Cast.UNSIGNED, !!mt, (Extract (15, 4, e)) lsl (Int (mi entry_shift)))) in
+          (* Load the table entry *)
+          let table_entry = load_s mode None (size_of_typ entry_size) (Exp.(base + index)) in
+          (* Extract the base *)
+          concat_explist
+            ((match mode with
+                | X86 -> []
+                | X8664 -> (Exp.Extract (95, 64, table_entry)) :: [])
+             @  (Exp.Extract (63, 56, table_entry))
+                :: (Exp.Extract (39, 32, table_entry))
+                :: (Exp.Extract (31, 16, table_entry))
+                :: [])
+        in
+        let bs =
+          let dst_e = op2e t dst in
+          if dst = o_fs && !compute_segment_bases then [Stmt.Move (fs_base, base_e dst_e)]
+          else if dst = o_gs && !compute_segment_bases then [Stmt.Move (gs_base, base_e dst_e)]
+          else []
+        in
+        assn t dst c_src :: bs
+      | Movs(Type.Imm _bits as t) ->
+        let stmts =
+          store_s mode seg_es t rdi_e (load_s mode seg_es (size_of_typ t) rsi_e)
+          :: string_incr mode t rsi
+          :: string_incr mode t rdi
+          :: []
+        in
+        if pref = [] then
+          stmts
+        else if List.mem pref repz || List.mem pref repnz then
+          (* movs has only rep instruction others just considered to be rep *)
+          rep_wrap ~mode ~addr ~next stmts
+        else
+          unimplemented "unsupported prefix for movs"
+      | Movzx(t, dst, ts, src) ->
+        [assn t dst Exp.(Cast (Cast.UNSIGNED, !!t, op2e ts src))]
+      | Movsx(t, dst, ts, src) ->
+        [assn t dst Exp.(Cast (Cast.SIGNED, !!t, op2e ts src))]
+      | Movdq(ts, s, td, d, align) ->
+        let (s, al) = match s with
+          | Ovec _ | Oreg _-> op2e ts s, []
+          | Oaddr a -> op2e ts s, [a]
+          | Oimm _ | Oseg _ -> disfailwith "invalid source operand for movdq"
+        in
+        let (d, al) = match d with
+          (* Behavior is to clear the xmm bits *)
+          | Ovec _ -> assn td d Exp.(Cast (Cast.UNSIGNED, !!td, s)), al
+          | Oreg _ -> assn td d s, al
+          | Oaddr a -> assn td d s, a::al
+          | Oimm _ | Oseg _ -> disfailwith "invalid dest operand for movdq"
+        in
+        (* sources tell me that movdqa raises a general protection exception
+         * if its operands aren't aligned on a 16-byte boundary *)
+        let im i = Exp.Int (int_of_mode mode i) in
+        let al =
+          if align then
+            List.map ~f:(fun a -> Stmt.If (Exp.((a land im 15) = im 0), [], [Cpu_exceptions.general_protection])) al
+          else []
+        in
+        d::al
+      | Movoffset((tdst, dst), offsets) ->
+        (* If a vex prefix is present, then extra space is filled with 0.
+           Otherwise, the bits are preserved. *)
+        let padding hi lo =
+          if hi < lo then []
+          else if has_vex then [int_exp 0 (hi - lo + 1)]
+          else [Exp.Extract (hi, lo, op2e tdst dst)]
+        in
+        let offsets = List.sort ~cmp:(fun {offdstoffset=o1; _} {offdstoffset=o2; _} -> Int.compare o1 o2) offsets in
+        let add_exp (elist,nextbit) {offlen; offtyp; offop; offsrcoffset; offdstoffset} =
+          Exp.Extract ((!!offlen + offsrcoffset - 1), offsrcoffset, (op2e offtyp offop))
+          :: padding (offdstoffset - 1) nextbit
+          @ elist, offdstoffset + !!offlen
+        in
+        let elist, nextbit = List.fold_left ~f:add_exp ~init:([],0) offsets in
+        let elist = padding (!!tdst - 1) nextbit @ elist in
+        [assn tdst dst (concat_explist elist)]
+      | Punpck(t, et, o, d, s, vs) ->
+        let nelem = match t, et with
+          | Type.Imm n, Type.Imm n' -> n / n'
+          | _ -> disfailwith "invalid"
+        in
+        assert (nelem mod 2 = 0);
+        let nelem_per_src = nelem / 2 in
+        let halft = Type.Imm (!!t / 2) in
+        let castf = match o with
+          | High -> fun e -> Exp.(Cast (Cast.HIGH, !!halft, e))
+          | Low -> fun e -> Exp.(Cast (Cast.LOW, !!halft, e))
+        in
+        let se, de = castf (op2e t s), castf (op2e t d) in
+        let st, dt = Var.create ~tmp:true "s" halft, Var.create ~tmp:true "d" halft in
+        let et' = !!et in
+        let mape i =
+          [extract_element et' (Exp.Var st) i; extract_element et' (Exp.Var dt) i]
+        in
+        let e = concat_explist (List.concat (List.map ~f:mape (List.range ~stride:(-1) ~stop:`inclusive (nelem_per_src-1) 0))) in
+        let dest = match vs with
+          | None -> d
+          | Some vdst -> vdst
+        in
+        [Stmt.Move (st, se);
+         Stmt.Move (dt, de);
+         assn t dest e]
+      | Ppackedbinop(t, et, fbop, _, d, s, vs) ->
+        let nelem = match t, et with
+          | Type.Imm n, Type.Imm n' -> n / n'
+          | _ -> disfailwith "invalid"
+        in
+        let getelement o i =
+          (* assumption: immediate operands are repeated for all vector
+             elements *)
+          match o with
+          | Oimm _ -> op2e et o
+          | _ -> extract_element !!et (op2e t o) i
+        in
+        let f i =
+          fbop (getelement d i) (getelement s i)
+        in
+        let e = concat_explist (List.map ~f:f (List.range ~stride:(-1) ~stop:`inclusive (nelem-1) 0)) in
+        (match vs with
+         | None -> [assn t d e]
+         | Some vdst -> [assn t vdst e])
+      | Pbinop(t, fbop, _s, o1, o2, vop) ->
+        (match vop with
+         | None -> [assn t o1 (fbop (op2e t o1) (op2e t o2))]
+         | Some vop -> [assn t o1 (fbop (op2e t vop) (op2e t o2))])
+      | Pcmp (t,elet,bop,_,dst,src,vsrc) ->
+        let elebits = !!elet in
+        let ncmps = !!t / elebits in
+        let src = match src with
+          | Ovec _ -> op2e t src
+          | Oaddr a -> load (size_of_typ t) a
+          | Oreg _ | Oimm _ | Oseg _ -> disfailwith "invalid"
+        in
+        let dst, vsrc = match vsrc with
+          | None -> dst, dst
+          | Some vsrc -> dst, vsrc
+        in
+        let compare_region i =
+          let byte1 = Exp.Extract(i*elebits-1, (i-1)*elebits, src) in
+          let byte2 = Exp.Extract(i*elebits-1, (i-1)*elebits, op2e t vsrc) in
+          let tmp = Var.create ~tmp:true ("t" ^ string_of_int i) elet in
+          let ltw n t = (BV.of_int64 n ~width:t) |> Exp.int in
+          Exp.Var tmp, Stmt.Move (tmp, Exp.(Ite (BinOp (bop, byte1, byte2), ltw (-1L) !!elet, ltw 0L !!elet)))
+        in
+        let indices = List.init ~f:(fun i -> i + 1) ncmps in (* list 1-nbytes *)
+        let comparisons = List.map ~f:compare_region indices in
+        let temps, cmps = List.unzip comparisons in
+        begin match List.rev temps with
+          | [] -> disfailwith "Pcmp element size mismatch" (* XXX what's actually going on in Pcmp? *)
+          | t_first::t_rest ->
+            (* could also be done with shifts *)
+            let store_back = List.fold_left ~f:(fun acc i -> Exp.Concat(acc,i)) ~init:t_first t_rest in
+            cmps @ [assn t dst store_back] end
+      | Pmov (t, dstet, srcet, dst, src, ext, _) ->
+        let nelem = match t, dstet with
+          | Type.Imm n, Type.Imm n' -> n / n'
+          | _ -> disfailwith "invalid"
+        in
+        let getelt op i = extract_element !!srcet (op2e t op) i in
+        let extcast =
+          let open Exp in
+          match ext with
+          | Cast.UNSIGNED | Cast.SIGNED -> fun e -> Exp.Cast (ext, !!dstet, e)
+          | _ -> disfailwith "invalid"
+        in
+        let extend i = extcast (getelt src i) in
+        let e = concat_explist (List.map ~f:extend (List.range ~stride:(-1) ~stop:`inclusive (nelem-1) 0)) in
+        [assn t dst e]
+      | Pmovmskb (t,dst,src) ->
+        let nbytes = bytes_of_width t in
+        let src = match src with
+          | Ovec _ -> op2e t src
+          | _ -> disfailwith "invalid operand"
+        in
+        let get_bit i = Exp.Extract(i*8-1, i*8-1, src) in
+        let byte_indices = List.init ~f:(fun i -> i + 1) nbytes in (* list 1-nbytes *)
+        let all_bits = List.rev (List.map ~f:get_bit byte_indices) in
+        (* could also be done with shifts *)
+        let padt = Type.Imm(32 - nbytes) in
+        let or_together_bits = List.fold_left ~f:(fun acc i -> Exp.Concat(acc,i)) ~init:(int_exp 0 (!!padt)) all_bits in
+        [assn reg32_t dst or_together_bits]
+      | Palignr (t,dst,src,vsrc,imm) ->
+        let (dst_e, t_concat) = op2e_keep_width t dst in
+        let (src_e, t_concat') = op2e_keep_width t src in
+        (* previously, this code called Typecheck.infer_ast.
+         * We're now just preserving the widths, so here we assert
+         * that our 2 "preserved widths" are the same. *)
+        assert (!!t_concat = !!t_concat');
+        let imm = op2e t imm in
+        let conct = Exp.(dst_e ^ src_e) in
+        let shift = Exp.(conct lsr (Cast (Cast.UNSIGNED, !!t_concat, imm lsl (int_exp 3 !!t)))) in
+        let high, low = match t with
+          | Type.Imm 256 -> 255, 0
+          | Type.Imm 128 -> 127, 0
+          | Type.Imm 64 -> 63, 0
+          | _ -> disfailwith "impossible: used non 64/128/256-bit operand in palignr"
+        in
+        let result = Exp.Extract (high, low, shift) in
+        let im i = Exp.Int (int_of_mode mode i) in
+        let addresses = List.fold
+            ~f:(fun acc -> function Oaddr a -> a::acc | _ -> acc) ~init:[] [src;dst] in
+        (* Palignr seems to cause a CPU general protection exception if this fails.
+         * previously this code used the ast.ml Assert statement, which is gone,
+         * so it's been replaced with Bil's CpuExn *)
+        List.map ~f:(fun addr -> Stmt.If (Exp.((addr land im 15) = im 0),
+                                          [], [Cpu_exceptions.general_protection])) addresses
+        @ (match vsrc with
+            | None -> [assn t dst result]
+            | Some vdst -> [assn t vdst result])
+      | Pcmpstr(t,xmm1,xmm2m128,_imm,imm8cb,pcmpinfo) ->
+        (* All bytes and bits are numbered with zero being the least
+           significant. This includes strings! *)
+        (* NOTE: Strings are backwards, at least when they are in
+           registers.  This doesn't seem to be documented in the Intel
+           manual.  This means that the NULL byte comes before the
+           string. *)
+        let xmm1_e = op2e t xmm1 in
+        let xmm2m128_e = op2e t xmm2m128 in
+        let regm = type_of_mode mode in
 
-         Otherwise, we should evaluate the operand before decrementing esp.
-         (This really only matters when esp is the base register of a memory
-         lookup. *)
-      let target = op2e mt o1 in
-      (match o1 with
-       | Oimm _ ->
-         [Stmt.Move (rsp, Exp.(rsp_e - (Int (mi (bytes_of_width mt)))));
-          store_s mode None mt rsp_e (Exp.Int ra);
-          Stmt.Jmp target]
-       | _ ->
-         let t = Var.create ~tmp:true "target" mt in
-         [Stmt.Move (t, target);
-          Stmt.Move (rsp, Exp.(rsp_e - (Int (mi (bytes_of_width mt)))));
-          store_s mode None mt rsp_e (Exp.Int ra);
-          Stmt.Jmp (Exp.Var t)])
-    | Jump(o) ->
-      [Stmt.Jmp (jump_target mode ss has_rex o)]
-    | Jcc(o, c) ->
-      [Stmt.If (c, [Stmt.Jmp (jump_target mode ss has_rex o)], [])]
-    | Setcc(t, o1, c) ->
-      [assn t o1 Exp.(Cast (Cast.UNSIGNED, !!t, c))]
-    | Shift(st, s, dst, shift) ->
-      let open Exp.Binop in
-      assert (List.mem [reg8_t; reg16_t; reg32_t; reg64_t] s);
-      let origCOUNT, origDEST = Var.create ~tmp:true "origCOUNT" s,
-                                Var.create ~tmp:true "origDEST" s in
-      let s' = !!s in
-      let size = int_exp s' s' in
-      let s_f = Exp.(match st with LSHIFT -> (lsl)  | RSHIFT -> (lsr)
-                                 | ARSHIFT -> (asr) | _ -> disfailwith
-         "invalid shift type") in
-      let dste = op2e s dst in
-      let count_mask = Exp.(size - (int_exp 1 s')) in
-      let count = Exp.((op2e s shift) land count_mask) in
-      let ifzero t e = Exp.(Ite ((Var origCOUNT = int_exp 0 s'), t, e)) in
-      let new_of = match st with
-        | LSHIFT -> Exp.((Cast (Cast.HIGH, !!bool_t, dste)) lxor cf_e)
-        | RSHIFT -> Exp.(Cast (Cast.HIGH, !!bool_t, Var origDEST))
-        | ARSHIFT -> exp_false
-        | _ -> disfailwith "impossible"
-      in
-      let unk_of = Exp.Unknown ("OF undefined after shift", bool_t) in
-      let new_cf =
-        (* undefined for SHL and SHR instructions where the count is greater than
-           or equal to the size (in bits) of the destination operand *)
-        match st with
-        | LSHIFT -> Exp.(Cast (Cast.LOW, !!bool_t, Var origDEST lsr (size - Var origCOUNT)))
-        | RSHIFT | ARSHIFT ->
-          Exp.(Cast (Cast.HIGH, !!bool_t, Var origDEST lsl (size - Var origCOUNT)))
-        | _ -> failwith "impossible"
-      in
-      [Stmt.Move (origDEST, dste);
-       Stmt.Move (origCOUNT, count);
-       assn s dst (s_f dste count);
-       Stmt.Move (cf, ifzero cf_e new_cf);
-       Stmt.Move (oF, Exp.(ifzero of_e (Ite (Var origCOUNT = int_exp 1 s', new_of, unk_of))));
-       Stmt.Move (sf, ifzero sf_e (compute_sf dste));
-       Stmt.Move (zf, ifzero zf_e (compute_zf s' dste));
-       Stmt.Move (pf, ifzero pf_e (compute_pf s dste));
-       Stmt.Move (af, ifzero af_e (Exp.Unknown ("AF undefined after shift", bool_t)))
-      ]
-    | Shiftd(st, s, dst, fill, count) ->
-      let open Exp.Binop in
-      let origDEST, origCOUNT = Var.create ~tmp:true "origDEST" s,
-                                Var.create ~tmp:true "origCOUNT" s in
-      let e_dst = op2e s dst in
-      let e_fill = op2e s fill in
-      let s' = !!s in
-      (* Check for 64-bit operand *)
-      let size = int_exp s' s' in
-      let count_mask = Exp.(size - int_exp 1 s') in
-      let e_count = Exp.((op2e s count) land count_mask) in
-      let new_cf =  match st with
-        | LSHIFT -> Exp.(Cast (Cast.LOW, !!bool_t, Var origDEST lsr (size - Var origCOUNT)))
-        | RSHIFT -> Exp.(Cast (Cast.HIGH, !!bool_t, Var origDEST lsl (size - Var origCOUNT)))
-        | _ -> disfailwith "impossible" in
-      let ifzero t e = Exp.(Ite ((Var origCOUNT = int_exp 0 s'), t, e)) in
-      let new_of = Exp.(Cast (Cast.HIGH, !!bool_t, (Var origDEST lxor e_dst))) in
-      let unk_of =
-        Exp.Unknown ("OF undefined after shiftd of more then 1 bit", bool_t) in
-      let ret1 = match st with
-        | LSHIFT -> Exp.(e_fill lsr (size - Var origCOUNT))
-        | RSHIFT -> Exp.(e_fill lsl (size - Var origCOUNT))
-        | _ -> disfailwith "impossible" in
-      let ret2 = match st with
-        | LSHIFT -> Exp.(e_dst lsl Var origCOUNT)
-        | RSHIFT -> Exp.(e_dst lsr Var origCOUNT)
-        | _ -> disfailwith "impossible" in
-      let result = Exp.(ret1 lor ret2) in
-      (* SWXXX If shift is greater than the operand size, dst and
-         flags are undefined *)
-      [ Stmt.Move (origDEST, e_dst);
-        Stmt.Move (origCOUNT, e_count);
-        assn s dst result;
-        Stmt.Move (cf, ifzero cf_e new_cf);
-        (* For a 1-bit shift, the OF flag is set if a sign change occurred;
-           otherwise, it is cleared. For shifts greater than 1 bit, the OF flag
-           is undefined. *)
-        Stmt.Move (oF, Exp.(ifzero of_e (Ite (Var origCOUNT = int_exp 1 s', new_of, unk_of))));
-        Stmt.Move (sf, ifzero sf_e (compute_sf e_dst));
-        Stmt.Move (zf, ifzero zf_e (compute_zf s' e_dst));
-        Stmt.Move (pf, ifzero pf_e (compute_pf s e_dst));
-        Stmt.Move (af, ifzero af_e (Exp.Unknown ("AF undefined after shiftd", bool_t)))
-      ]
-    | Rotate(rt, s, dst, shift, use_cf) ->
-      let open Exp.Binop in
-      (* SWXXX implement use_cf *)
-      if use_cf then unimplemented "rotate use_vf";
-      let origCOUNT = Var.create ~tmp:true "origCOUNT" s in
-      let e_dst = op2e s dst in
-      let shift_val = match s with
-        | Type.Imm 64 -> 63
-        | _ -> 31
-      in
-      let s' = !!s in
-      let e_shift = Exp.(op2e s shift land int_exp shift_val s') in
-      let size = int_exp !!s s' in
-      let new_cf = match rt with
-        | LSHIFT -> Exp.(Cast (Cast.LOW, !!bool_t, e_dst))
-        | RSHIFT -> Exp.(Cast (Cast.HIGH, !!bool_t, e_dst))
-        | _ -> disfailwith "impossible" in
-      let new_of = match rt with
-        | LSHIFT -> Exp.(cf_e lxor Cast (Cast.HIGH, !!bool_t, e_dst))
-        | RSHIFT -> Exp.(Cast (Cast.HIGH, !!bool_t, e_dst) lxor Cast (Cast.HIGH, !!bool_t, e_dst lsl int_exp 1 s'))
-        | _ -> disfailwith "impossible" in
-      let unk_of =
-        Exp.Unknown ("OF undefined after rotate of more then 1 bit", bool_t) in
-      (* this is repeated often enough in the cases perhaps
-       * we should bind it at the top of the function... *)
-      let ifzero t e = Exp.(Ite (Var origCOUNT = int_exp 0 s', t, e)) in
-      let ret1 = match rt with
-        | LSHIFT -> Exp.(e_dst lsl Var origCOUNT)
-        | RSHIFT -> Exp.(e_dst lsr Var origCOUNT)
-        | _ -> disfailwith "impossible" in
-      let ret2 = match rt with
-        | LSHIFT -> Exp.(e_dst lsr (size - Var origCOUNT))
-        | RSHIFT -> Exp.(e_dst lsl (size - Var origCOUNT))
-        | _ -> disfailwith "impossible" in
-      let result = Exp.(ret1 lor ret2) in
-      [
-        Stmt.Move (origCOUNT, e_shift);
-        assn s dst result;
-        (* cf must be set before of *)
-        Stmt.Move (cf, ifzero cf_e new_cf);
-        Stmt.Move (oF, ifzero of_e Exp.(Ite (Var origCOUNT = int_exp 1 s', new_of, unk_of)));
-      ]
-    | Bt(t, bitoffset, bitbase) ->
-      let t' = !!t in
-      let offset = op2e t bitoffset in
-      let value, shift = match bitbase with
-        | Oreg _ ->
-          let reg = op2e t bitbase in
-          let shift = Exp.(offset land int_exp Pervasives.(t' - 1) t') in
-          reg, shift
-        | Oaddr a ->
-          let byte = load (size_of_typ reg8_t) Exp.(a + (offset lsr int_exp 3 t')) in
-          let shift = Exp.(Cast (Cast.LOW, !!reg8_t, offset) land int_exp 7 8) in
-          byte, shift
-        | Ovec _ | Oseg _ | Oimm _ -> disfailwith "Invalid bt operand"
-      in
-      [
-        Stmt.Move (cf, Exp.(Cast (Cast.LOW, !!bool_t, value lsr shift)));
-        Stmt.Move (oF, Exp.Unknown ("OF undefined after bt", bool_t));
-        Stmt.Move (sf, Exp.Unknown ("SF undefined after bt", bool_t));
-        Stmt.Move (af, Exp.Unknown ("AF undefined after bt", bool_t));
-        Stmt.Move (pf, Exp.Unknown ("PF undefined after bt", bool_t))
-      ]
-    | Bs(t, dst, src, dir) ->
-      let t' = !!t in
-      let source_is_zero = Var.create ~tmp:true "t" bool_t in
-      let source_is_zero_v = Exp.Var source_is_zero in
-      let src_e = op2e t src in
-      let bits = !!t in
-      let check_bit bitindex next_value =
-        Exp.(Ite (Extract (bitindex,bitindex,src_e) = int_exp 1 1, int_exp bitindex t', next_value))
-      in
-      let bitlist = List.init ~f:(fun x -> x) bits in
-      (* We are folding from right to left *)
-      let bitlist = match dir with
-        | Forward -> (* least significant first *) bitlist
-        | Backward -> (* most significant *) List.rev bitlist
-      in
-      let first_one = List.fold_right ~f:check_bit bitlist
-          ~init:(Exp.Unknown("bs: destination undefined when source is zero", t)) in
-      [
-        Stmt.Move (source_is_zero, Exp.(src_e = int_exp 0 t'));
-        assn t dst first_one;
-        Stmt.Move (zf, Exp.Ite (source_is_zero_v, int_exp 1 1, int_exp 0 1));
-      ]
-      @
-      let undef r =
-        let (n,_,t) = Var.V1.serialize r in
-        Stmt.Move (r, Exp.Unknown (n^" undefined after bsf", t)) in
-      List.map ~f:undef [cf; oF; sf; af; pf]
-    | Hlt -> [] (* x86 Hlt is essentially a NOP *)
-    | Rdtsc ->
-      let undef reg = assn reg32_t reg (Exp.Unknown ("rdtsc", reg32_t)) in
-      List.map ~f:undef [o_rax; o_rdx]
-    | Cpuid ->
-      let undef reg = assn reg32_t reg (Exp.Unknown ("cpuid", reg32_t)) in
-      List.map ~f:undef [o_rax; o_rbx; o_rcx; o_rdx]
-    | Xgetbv ->
-      let undef reg = assn reg32_t reg (Exp.Unknown ("xgetbv", reg32_t)) in
-      List.map ~f:undef [o_rax; o_rdx]
-    | Stmxcsr (dst) ->
-      let dst = match dst with
-        | Oaddr addr -> addr
-        | _ -> disfailwith "stmxcsr argument cannot be non-memory"
-      in
-      [store reg32_t dst (Exp.Var mxcsr);(*(Unknown ("stmxcsr", reg32_t));*) ]
-    | Ldmxcsr (src) ->
-      let src = match src with
-        | Oaddr addr -> addr
-        | _ -> disfailwith "ldmxcsr argument cannot be non-memory"
-      in
-      [ Stmt.Move (mxcsr, load (size_of_typ reg32_t) src); ]
-    | Fnstcw (dst) ->
-      let dst = match dst with
-        | Oaddr addr -> addr
-        | _ -> disfailwith "fnstcw argument cannot be non-memory"
-      in
-      [store reg16_t dst (Exp.Var fpu_ctrl); ]
-    | Fldcw (src) ->
-      let src = match src with
-        | Oaddr addr -> addr
-        | _ -> disfailwith "fldcw argument cannot be non-memory"
-      in
-      [ Stmt.Move (fpu_ctrl, load (size_of_typ reg16_t) src); ]
-    | Fld _src ->
-      unimplemented "unsupported FPU register stack"
-    | Fst (_dst,_pop) ->
-      unimplemented "unsupported FPU flags"
-    | Cmps(Type.Imm _bits as t) ->
-      let t' = !!t in
-      let src1 = Var.create ~tmp:true "src1" t in
-      let src2 = Var.create ~tmp:true "src2" t in
-      let tmpres = Var.create ~tmp:true "tmp" t in
-      let stmts =
-        Stmt.Move (src1, op2e t (Oaddr rsi_e))
-        :: Stmt.Move (src2, op2e_s mode seg_es has_rex t (Oaddr rdi_e))
-        :: Stmt.Move (tmpres, Exp.(Var src1 - Var src2))
-        :: string_incr mode t rsi
-        :: string_incr mode t rdi
-        :: set_flags_sub t' (Exp.Var src1) (Exp.Var src2) (Exp.Var tmpres)
-      in
-      begin match pref with
-        | [] -> stmts
-        | [single] when single = repz || single = repnz ->
-          rep_wrap ~mode ~check_zf:single ~addr ~next stmts
-        | _ -> unimplemented "unsupported flags in cmps" end
-    | Scas(Type.Imm _bits as t) ->
-      let t' = !!t in
-      let src1 = Var.create ~tmp:true "src1" t in
-      let src2 = Var.create ~tmp:true "src2" t in
-      let tmpres = Var.create ~tmp:true "tmp" t in
-      let stmts =
+        let open Pcmpstr in
+        let nelem, _nbits, elemt = match imm8cb with
+          | {ssize=Bytes; _} -> 16, 8, Type.imm 8
+          | {ssize=Words; _} -> 8, 16, Type.imm 16
+        in
+        (* Get element index in e *)
+        let get_elem = extract_element !!elemt in
+        (* Get from xmm1/xmm2 *)
+        let get_xmm1 = get_elem xmm1_e in
+        let get_xmm2 = get_elem xmm2m128_e in
+        (* Build expressions that assigns the correct values to the
+           is_valid variables using implicit (NULL-based) string
+           length. *)
+        let build_implicit_valid_xmm_i is_valid_xmm_i get_xmm_i =
+          let f acc i =
+            (* Previous element is valid *)
+            let prev_valid = if i = 0 then exp_true else Exp.var (is_valid_xmm_i (i-1)) in
+            (* Current element is valid *)
+            let curr_valid = Exp.(get_xmm_i i <> (int_exp 0 !!elemt)) in
+            Exp.Let(is_valid_xmm_i i, Exp.(prev_valid land curr_valid), acc)
+          in (fun e -> List.fold_left ~f:f ~init:e (List.range ~stride:(-1) ~stop:`inclusive (nelem-1) 0))
+        in
+        (* Build expressions that assigns the correct values to the
+           is_valid variables using explicit string length. *)
+        let build_explicit_valid_xmm_i is_valid_xmm_i sizee =
+          (* Max size is nelem *)
+          let sizev = Var.create ~tmp:true "sz" regm in
+          let sizee = Exp.(Ite (BinOp (Binop.LT, int_exp nelem !!regm, sizee), int_exp nelem !!regm, sizee)) in
+          let f acc i =
+            (* Current element is valid *)
+            let curr_valid = Exp.(BinOp (Binop.LT, int_exp i !!regm, Var sizev)) in
+            Exp.Let(is_valid_xmm_i i, curr_valid, acc)
+          in (fun e -> Exp.Let(sizev, sizee, List.fold_left ~f:f ~init:e (List.range ~stride:(-1) ~stop:`inclusive (nelem-1) 0)))
+        in
+
+        (* Get var name indicating whether index in xmm num is a valid
+           byte (before NULL byte). *)
+        (* XXX more hashtable code *)
+        let is_valid =
+          let vh = Hashtbl.Poly.create () ~size:(2*nelem) in
+          (fun xmmnum index -> match Hashtbl.find vh (xmmnum,index) with
+             | Some v -> v
+             | None ->
+               let v = Var.create ~tmp:true ("is_valid_xmm"^string_of_int xmmnum^"_ele"^string_of_int index) bool_t in
+               Hashtbl.add_exn vh ~key:(xmmnum,index) ~data:v;
+               v)
+        in
+
+        let is_valid_xmm1 index = is_valid 1 index in
+        let is_valid_xmm2 index = is_valid 2 index in
+        let is_valid_xmm1_e index = Exp.Var(is_valid_xmm1 index) in
+        let is_valid_xmm2_e index = Exp.Var(is_valid_xmm2 index) in
+
+        let build_valid_xmm1,build_valid_xmm2 =
+          match pcmpinfo with
+          | {len=Implicit; _} ->
+            build_implicit_valid_xmm_i is_valid_xmm1 get_xmm1,
+            build_implicit_valid_xmm_i is_valid_xmm2 get_xmm2
+          | {len=Explicit; _} ->
+            build_explicit_valid_xmm_i is_valid_xmm1 rax_e,
+            build_explicit_valid_xmm_i is_valid_xmm2 rdx_e
+        in
+
+        let get_intres1_bit index =
+          let open Exp.Binop in
+          match imm8cb with
+          | {agg=EqualAny; _} ->
+            (* Is xmm2[index] at xmm1[j]? *)
+            let check_char acc j =
+              let eql = Exp.((get_xmm2 index) = (get_xmm1 j)) in
+              let valid = is_valid_xmm1_e j in
+              Exp.(Ite ((eql land valid), exp_true, acc))
+            in
+            Exp.BinOp (AND, is_valid_xmm2_e index,
+                       (* Is xmm2[index] included in xmm1[j] for any j? *)
+                       (List.fold ~f:check_char ~init:exp_false (List.range
+                                                                   ~stride:(-1) ~stop:`inclusive (nelem-1) 0)))
+          | {agg=Ranges; _} ->
+            (* Is there an even j such that xmm1[j] <= xmm2[index] <=
+               xmm1[j+1]? *)
+            let check_char acc j =
+              (* XXX: Should this be AND? *)
+              let rangevalid = Exp.(is_valid_xmm1_e Pervasives.(2*j) land is_valid_xmm1_e Pervasives.(2*j+1)) in
+              let lte = match imm8cb with
+                | {ssign=Unsigned; _} -> LE
+                | {ssign=Signed; _} -> SLE
+              in
+              let inrange =
+                Exp.((BinOp (lte, (get_xmm1 Pervasives.(2*j)), (get_xmm2 index)))
+                     land (BinOp (lte, (get_xmm2 index), (get_xmm1 Pervasives.(2*j+1)))))
+              in
+              Exp.(Ite (UnOp (Unop.NOT, rangevalid), exp_false, Ite (inrange, exp_true, acc)))
+            in
+            Exp.(is_valid_xmm2_e index
+                 (* Is xmm2[index] in the jth range pair? *)
+                 land List.fold_left ~f:check_char ~init:exp_false (List.range ~stride:(-1) ~stop:`inclusive Pervasives.(nelem/2-1) 0))
+          | {agg=EqualEach; _} ->
+            (* Does xmm1[index] = xmm2[index]? *)
+            let xmm1_invalid = Exp.(UnOp (Unop.NOT, (is_valid_xmm1_e index))) in
+            let xmm2_invalid = Exp.(UnOp (Unop.NOT, (is_valid_xmm2_e index))) in
+            let bothinvalid = Exp.(xmm1_invalid land xmm2_invalid) in
+            let eitherinvalid = Exp.(xmm1_invalid lor xmm2_invalid) in
+            let eq = Exp.(get_xmm1 index = get_xmm2 index) in
+            (* both invalid -> true
+               one invalid -> false
+               both valid -> check same byte *)
+            Exp.Ite (bothinvalid, exp_true,
+                     Exp.Ite (eitherinvalid, exp_false,
+                              Exp.Ite (eq, exp_true, exp_false)))
+          | {agg=EqualOrdered; _} ->
+            (* Does the substring xmm1 occur at xmm2[index]? *)
+            let check_char acc j =
+              let neq = Exp.(get_xmm1 j <> get_xmm2 Pervasives.(index+j)) in
+              let substrended = Exp.(UnOp (Unop.NOT, (is_valid_xmm1_e j))) in
+              let bigstrended = Exp.UnOp (Exp.Unop.NOT, (is_valid_xmm2_e (index+j))) in
+              (* substrended => true
+                 bigstrended => false
+                 byte diff => false
+                 byte same => keep going  *)
+              Exp.Ite (substrended, exp_true,
+                       Exp.Ite (bigstrended, exp_false,
+                                Exp.Ite (neq, exp_false, acc)))
+            in
+            (* Is xmm1[j] equal to xmm2[index+j]? *)
+            List.fold_left ~f:check_char ~init:exp_true (List.range
+                                                           ~stride:(-1) ~stop:`inclusive (nelem-index-1) 0)
+        in
+        let bits = List.map ~f:get_intres1_bit (List.range ~stride:(-1) ~stop:`inclusive (nelem-1) 0) in
+        let res_e = build_valid_xmm1 (build_valid_xmm2 (concat_explist bits)) in
+        let int_res_1 = Var.create ~tmp:true "IntRes1" reg16_t in
+        let int_res_2 = Var.create ~tmp:true "IntRes2" reg16_t in
+
+        let contains_null e =
+          List.fold_left ~f:(fun acc i ->
+              Exp.Ite (Exp.(get_elem e i = int_exp 0 !!elemt), exp_true, acc)) ~init:exp_false (List.init ~f:(fun x -> x) nelem)
+        in
+        (* For pcmpistri/pcmpestri *)
+        let sb e =
+          List.fold_left ~f:(fun acc i ->
+              Exp.Ite (Exp.(exp_true = Extract (i, i, e)),
+                       (int_exp i !!regm),
+                       acc))
+            ~init:(int_exp nelem !!regm)
+            (match imm8cb with
+             | {outselectsig=LSB; _} -> List.range ~stride:(-1) ~start:`exclusive ~stop:`inclusive nelem 0
+             | {outselectsig=MSB; _} -> List.init ~f:(fun x -> x) nelem)
+        in
+        (* For pcmpistrm/pcmpestrm *)
+        let mask e =
+          match imm8cb with
+          | {outselectmask=Bitmask; _} ->
+            Exp.(Cast (Cast.UNSIGNED, !!reg128_t, e))
+          | {outselectmask=Bytemask; _} ->
+            let get_element i =
+              Exp.(Cast (Cast.UNSIGNED, !!elemt, Extract (i, i, e)))
+            in
+            concat_explist (List.map ~f:get_element (List.range ~stride:(-1) ~start:`exclusive ~stop:`inclusive nelem 0))
+        in
+        (* comment crap from earlier *)
+        (*comment
+          ::*)
         let open Stmt in
-        Move (src1, Exp.(Cast (Cast.LOW, !!t, Var rax)))
-        :: Move (src2, op2e_s mode seg_es has_rex t (Oaddr rdi_e))
-        :: Move (tmpres, Exp.(Var src1 - Var src2))
-        :: string_incr mode t rdi
-        :: set_flags_sub t' (Exp.Var src1) (Exp.Var src2) (Exp.Var tmpres)
-      in
-      begin match pref with
-        | [] -> stmts
-        | [single] when single = repz || single = repnz ->
-          rep_wrap ~mode ~check_zf:single ~addr ~next stmts
-        | _ -> unimplemented "unsupported flags in scas" end
-    | Stos(Type.Imm _bits as t) ->
-      let stmts = [store_s mode seg_es t rdi_e (op2e t o_rax);
-                   string_incr mode t rdi]
-      in
-      begin match pref with
-        | [] -> stmts
-        | [single] when single = repz -> rep_wrap ~mode ~addr ~next stmts
-        | _ -> unimplemented "unsupported prefix for stos" end
-    | Push(t, o) ->
-      let tmp = Var.create ~tmp:true "t" t in (* only really needed when o involves esp *)
-      Stmt.Move (tmp, op2e t o)
-      :: Stmt.Move (rsp, Exp.(rsp_e - Int (mi (bytes_of_width t))))
-      :: store_s mode seg_ss t rsp_e (Exp.Var tmp) (* FIXME: can ss be overridden? *)
-      :: []
-    | Pop(t, o) ->
-      (* From the manual:
-
-         "The POP ESP instruction increments the stack pointer (ESP)
-         before data at the old top of stack is written into the
-         destination"
-
-         So, effectively there is no incrementation.
-      *)
-      assn t o (load_s mode seg_ss (size_of_typ t) rsp_e)
-      :: if o = o_rsp then []
-      else [Stmt.Move (rsp, Exp.(rsp_e + Int (mi (bytes_of_width t))))]
-    | Pushf(t) ->
-      (* Note that we currently treat these fields as unknowns, but the
-         manual says: When copying the entire EFLAGS register to the
-         stack, the VM and RF flags (bits 16 and 17) are not copied;
-         instead, the values for these flags are cleared in the EFLAGS
-         image stored on the stack. *)
-      let flags_e = match t with
-        | Type.Imm 16 -> flags_e
-        | Type.Imm 32 -> eflags_e
-        | Type.Imm 64 -> rflags_e
-        | _ -> failwith "impossible"
-      in
-      Stmt.Move (rsp, Exp.(rsp_e - Int (mi (bytes_of_width t))))
-      :: store_s mode seg_ss t rsp_e flags_e
-      :: []
-    | Popf t ->
-      let assnsf = match t with
-        | Type.Imm 16 -> assns_flags_to_bap
-        | Type.Imm 32 -> assns_eflags_to_bap
-        | Type.Imm 64 -> assns_rflags_to_bap
-        | _ -> failwith "impossible"
-      in
-      let tmp = Var.create ~tmp:true "t" t in
-      let extractlist =
-        List.map
-          ~f:(fun i ->
-              Exp.(Extract (i, i, Var tmp)))
-          (List.range ~stride:(-1) ~start:`exclusive ~stop:`inclusive !!t 0)
-      in
-      Stmt.Move (tmp, load_s mode seg_ss (size_of_typ t) rsp_e)
-      :: Stmt.Move (rsp, Exp.(rsp_e + Int (mi (bytes_of_width t))))
-      :: List.concat (List.map2_exn ~f:(fun f e -> f e) assnsf
-      extractlist)
-    | Popcnt(t, s, d) ->
-      let width = !!t in
-      let bits = op2e t s in
-      let bitvector = Array.to_list (Array.init width ~f:(fun i -> Exp.(Ite (Extract (i, i, bits), int_exp 1 width, int_exp 0 width)))) in
-      let count = List.reduce_exn ~f:Exp.(+) bitvector in
-      set_zf width bits
-      :: assn t d count
-      :: List.map ~f:(fun r -> Stmt.Move (r, int_exp 0 1)) [cf; oF; sf; af; pf]
-    | Sahf ->
-      let assnsf = assns_lflags_to_bap in
-      let tah = Var.create ~tmp:true "AH" reg8_t in
-      let extractlist =
-        List.map
-          ~f:(fun i ->
-              Exp.(Extract (i, i, Var tah)))
-          (List.range ~stride:(-1) ~stop:`inclusive 7 0)
-      in
-      Stmt.Move (tah, ah_e)
-      :: List.concat (List.map2_exn ~f:(fun f e -> f e) assnsf extractlist)
-    | Lahf ->
-      let o_ah = Oreg 4 in
-      [assn reg8_t o_ah lflags_e]
-    | Add(t, o1, o2) ->
-      let tmp = Var.create ~tmp:true "t1" t in
-      let tmp2 = Var.create ~tmp:true "t2" t in
-      Stmt.Move (tmp, op2e t o1)
-      :: Stmt.Move (tmp2, op2e t o2)
-      :: assn t o1 Exp.(op2e t o1 + Var tmp2)
-      :: let s1 = Exp.Var tmp in let s2 = Exp.Var tmp2 in let r = op2e t o1 in
-      set_flags_add !!t s1 s2 r
-    | Adc(t, o1, o2) ->
-      let orig1 = Var.create ~tmp:true "orig1" t in
-      let orig2 = Var.create ~tmp:true "orig2" t in
-      let bits = !!t in
-      let t' = Type.Imm (bits + 1) in
-      let c e = Exp.(Cast (Cast.UNSIGNED, !!t', e)) in
-      (* Literally compute the addition with an extra bit and see
-         what the value is for CF *)
-      let s1 = Exp.Var orig1 in let s2 = Exp.Var orig2 in let r = op2e t o1 in
-      let bige = Exp.(c s1 + c s2 + c (Cast (Cast.UNSIGNED, !!t, cf_e))) in
-      Stmt.Move (orig1, op2e t o1)
-      :: Stmt.Move (orig2, op2e t o2)
-      :: assn t o1 Exp.(s1 + s2 + Cast (Cast.UNSIGNED, !!t, cf_e))
-      :: Stmt.Move (cf, Exp.Extract (bits, bits, bige))
-      :: set_aopszf_add !!t s1 s2 r
-    | Inc(t, o) (* o = o + 1 *) ->
-      let t' = !!t in
-      let tmp = Var.create ~tmp:true "t" t in
-      Stmt.Move (tmp, op2e t o)
-      :: assn t o Exp.(op2e t o + int_exp 1 t')
-      :: set_aopszf_add t' (Exp.Var tmp) (int_exp 1 t') (op2e t o)
-    | Dec(t, o) (* o = o - 1 *) ->
-      let t' = !!t in
-      let tmp = Var.create ~tmp:true "t" t in
-      Stmt.Move (tmp, op2e t o)
-      :: assn t o Exp.(op2e t o - int_exp 1 t')
-      :: set_aopszf_sub t' (Exp.Var tmp) (int_exp 1 t') (op2e t o) (* CF is maintained *)
-    | Sub(t, o1, o2) (* o1 = o1 - o2 *) ->
-      let oldo1 = Var.create ~tmp:true "t" t in
-      Stmt.Move (oldo1, op2e t o1)
-      :: assn t o1 Exp.(op2e t o1 - op2e t o2)
-      :: set_flags_sub !!t (Exp.Var oldo1) (op2e t o2) (op2e t o1)
-    | Sbb(t, o1, o2) ->
-      let tmp_s = Var.create ~tmp:true "ts" t in
-      let tmp_d = Var.create ~tmp:true "td" t in
-      let orig_s = Exp.Var tmp_s in
-      let orig_d = Exp.Var tmp_d in
-      let sube = Exp.(orig_s + Cast (Cast.UNSIGNED, !!t, cf_e)) in
-      let d = op2e t o1 in
-      let s1 = op2e t o2 in
-      Stmt.Move (tmp_s, s1)
-      :: Stmt.Move (tmp_d, d)
-      :: assn t o1 Exp.(orig_d - sube)
-      :: Stmt.Move (oF, Exp.(Cast (Cast.HIGH, !!bool_t, (orig_s lxor orig_d) land (orig_d lxor d))))
-      (* When src = 0xffffffff and cf=1, the processor sets CF=1.
-
-         Note that we compute dest = dest - (0xffffffff + 1) = 0, so the
-         subtraction does not overflow.
-
-         So, I am guessing that CF is set if the subtraction overflows
-         or the addition overflows.
-
-         Maybe we should implement this by doing the actual computation,
-         like we do for adc.
-      *)
-      (* sub overflow | add overflow *)
-      :: Stmt.Move (cf, Exp.((sube > orig_d) lor (sube < orig_s)))
-      :: set_apszf !!t orig_s orig_d d
-    | Cmp(t, o1, o2) ->
-      let tmp = Var.create ~tmp:true "t" t in
-      Stmt.Move (tmp, Exp.(op2e t o1 - op2e t o2))
-      :: set_flags_sub !!t (op2e t o1) (op2e t o2) (Exp.Var tmp)
-    | Cmpxchg(t, src, dst) ->
-      let t' = !!t in
-      let eax_e = op2e t o_rax in
-      let dst_e = op2e t dst in
-      let src_e = op2e t src in
-      let tmp = Var.create ~tmp:true "t" t in
-      Stmt.Move (tmp, Exp.(eax_e - dst_e))
-      :: set_flags_sub t' eax_e dst_e (Exp.Var tmp)
-      @ assn t dst (Exp.Ite (zf_e, src_e, dst_e))
-        :: assn t o_rax (Exp.Ite (zf_e, eax_e, dst_e))
+        Move (int_res_1, Exp.(Cast (Cast.UNSIGNED, !!reg16_t, res_e)))
+        :: (match imm8cb with
+            | {negintres1=false; _} ->
+              Move (int_res_2, Exp.Var int_res_1)
+            | {negintres1=true; maskintres1=false; _} ->
+              (* int_res_1 is bitwise-notted *)
+              Move (int_res_2, Exp.(UnOp (Unop.NOT, (Var int_res_1))))
+            | {negintres1=true; maskintres1=true; _} ->
+              (* only the valid elements in xmm2 are bitwise-notted *)
+              (* XXX: Right now we duplicate the valid element computations
+                 when negating the valid elements.  They are also used by the
+                 aggregation functions.  A better way to implement this might
+                 be to write the valid element information out as a temporary
+                 bitvector.  The aggregation functions and this code would
+                 then extract the relevant bit to see if an element is
+                 valid. *)
+              let validvector =
+                let bits = List.map ~f:is_valid_xmm2_e (List.range ~stride:(-1) ~start:`exclusive ~stop:`inclusive nelem 0) in
+                build_valid_xmm2 (Exp.(Cast (Cast.UNSIGNED, !!reg16_t, concat_explist bits)))
+              in
+              Move (int_res_2, Exp.(validvector lxor Var int_res_1)))
+        :: (match pcmpinfo with
+            | {out=Index; _} -> Move (rcx, sb (Exp.Var int_res_2))
+            (* FIXME: ymms should be used instead of xmms here *)
+            | {out=Mask; _} -> Move (ymms.(0), mask (Exp.Var int_res_2)))
+        :: Move (cf, Exp.(Var int_res_2 <> int_exp 0 16))
+        :: Move (zf ,contains_null xmm2m128_e)
+        :: Move (sf, contains_null xmm1_e)
+        :: Move (oF, Exp.(Extract (0, 0, Var int_res_2)))
+        :: Move (af, int_exp 0 1)
+        :: Move (pf, int_exp 0 1)
         :: []
-    | Cmpxchg8b o -> (* only 32bit case *)
-      let accumulator = Exp.Concat((op2e reg32_t o_rdx),(op2e reg32_t o_rax)) in
-      let dst_e = op2e reg64_t o in
-      let src_e = Exp.Concat((op2e reg32_t o_rcx),(op2e reg32_t o_rbx)) in
-      let dst_low_e = Exp.Extract(63, 32, dst_e) in
-      let dst_hi_e = Exp.Extract(31, 0, dst_e) in
-      let eax_e = op2e reg32_t o_rax in
-      let edx_e = op2e reg32_t o_rdx in
-      let equal = Var.create ~tmp:true "t" bool_t in
-      let equal_v = Exp.Var equal in
-      [
-        Stmt.Move (equal, Exp.(accumulator = dst_e));
-        Stmt.Move (zf, equal_v);
-        assn reg64_t o (Exp.Ite (equal_v, src_e, dst_e));
-        assn reg32_t o_rax (Exp.Ite (equal_v, eax_e, dst_low_e));
-        assn reg32_t o_rdx (Exp.Ite (equal_v, edx_e, dst_hi_e))
-      ]
-    | Xadd(t, dst, src) ->
-      let tmp = Var.create ~tmp:true "t" t in
-      Stmt.Move (tmp, Exp.(op2e t dst + op2e t src))
-      :: assn t src (op2e t dst)
-      :: assn t dst (Exp.Var tmp)
-      :: let s = Exp.Var tmp in let src = op2e t src in let dst = op2e t dst in
-      set_flags_add !!t s src dst
-    | Xchg(t, src, dst) ->
-      let tmp = Var.create ~tmp:true "t" t in
-      [ Stmt.Move (tmp, op2e t src);
-        assn t src (op2e t dst);
-        assn t dst (Exp.Var tmp); ]
-    | And(t, o1, o2) ->
-      assn t o1 Exp.(op2e t o1 land op2e t o2)
-      :: Stmt.Move (oF, exp_false)
-      :: Stmt.Move (cf, exp_false)
-      :: Stmt.Move (af, Exp.Unknown ("AF is undefined after and", bool_t))
-      :: set_pszf t (op2e t o1)
-    | Or(t, o1, o2) ->
-      assn t o1 Exp.(op2e t o1 lor op2e t o2)
-      :: Stmt.Move (oF, exp_false)
-      :: Stmt.Move (cf, exp_false)
-      :: Stmt.Move (af, Exp.Unknown ("AF is undefined after or", bool_t))
-      :: set_pszf t (op2e t o1)
-    | Xor(t, o1, o2) when o1 = o2 ->
-      assn t o1 Exp.(Int (BV.of_int ~width:(!!t) 0))
-      :: Stmt.Move (af, Exp.Unknown ("AF is undefined after xor", bool_t))
-      :: List.map ~f:(fun v -> Stmt.Move (v, exp_true)) [zf; pf]
-      @  List.map ~f:(fun v -> Stmt.Move (v, exp_false)) [oF; cf; sf]
-    | Xor(t, o1, o2) ->
-      assn t o1 Exp.(op2e t o1 lxor op2e t o2)
-      :: Stmt.Move (oF, exp_false)
-      :: Stmt.Move (cf, exp_false)
-      :: Stmt.Move (af, Exp.Unknown ("AF is undefined after xor", bool_t))
-      :: set_pszf t (op2e t o1)
-    | Test(t, o1, o2) ->
-      let tmp = Var.create ~tmp:true "t" t in
-      Stmt.Move (tmp, Exp.(op2e t o1 land op2e t o2))
-      :: Stmt.Move (oF, exp_false)
-      :: Stmt.Move (cf, exp_false)
-      :: Stmt.Move (af, Exp.Unknown ("AF is undefined after and", bool_t))
-      :: set_pszf t (Exp.Var tmp)
-    | Ptest(t, o1, o2) ->
-      let open Stmt in
-      let t' = !!t in
-      let tmp1 = Var.create ~tmp:true "t1" t in
-      let tmp2 = Var.create ~tmp:true "t2" t in
-      Move (tmp1, Exp.(op2e t o2 land op2e t o1))
-      :: Move (tmp2, Exp.(op2e t o2 land (exp_not (op2e t o1))))
-      :: Move (af, exp_false)
-      :: Move (oF, exp_false)
-      :: Move (pf, exp_false)
-      :: Move (sf, exp_false)
-      :: Move (zf, Exp.(Var tmp1 = Int (BV.of_int ~width:t' 0)))
-      :: [Move (cf, Exp.(Var tmp2 = Int (BV.of_int ~width:t' 0)))]
-    | Not(t, o) ->
-      [assn t o (exp_not (op2e t o))]
-    | Neg(t, o) ->
-      let t' = !!t in
-      let tmp = Var.create ~tmp:true "t" t in
-      let min_int =
-        Exp.BinOp (Exp.Binop.LSHIFT, int_exp 1 t', int_exp (t'-1) t')
-      in
-      Stmt.Move (tmp, op2e t o)
-      ::assn t o Exp.(int_exp 0 t' - op2e t o)
-      ::Stmt.Move (cf, Exp.(Ite (Var tmp = int_exp 0 t', int_exp 0 1, int_exp 1 1)))
-      ::Stmt.Move (oF, Exp.(Ite (Var tmp = min_int, int_exp 1 1, int_exp 0 1)))
-      ::set_apszf_sub t' (Exp.Var tmp) (int_exp 0 t') (op2e t o)
-    | Mul (t, src) ->
-      (* Mul always multiplies EAX by src and stores the result in EDX:EAX
-         starting from the "right hand side" based on the type t of src *)
+      | Pshufd (t, dst, src, vsrc, imm) ->
+        let src_e = op2e t src in
+        let imm_e = op2e t imm in
+        (* XXX: This would be more straight-forward if implemented using
+           map, instead of fold *)
+        let get_dword ndword =
+          let high_b = 2 * (ndword mod 4) + 1 in
+          let low_b = 2 * (ndword mod 4) in
+          let index = Exp.(Cast (Cast.UNSIGNED, !!t, Extract (high_b, low_b, imm_e))) in
+          let t' = !!t in
+          (* Use the same pattern for the top half of a ymm register *)
+          (* had to stop using extract_element_symbolic, since that calls
+           * Typecheck.infer_ast. I believe this captures the same
+           * "width logic", but this is a good place to check if things start
+           * going wrong later. *)
+          let (index, index_width) = if t' = 256 && ndword > 3 then
+              (Exp.(index + (Int (BV.of_int ~width:(!!t) 4))), 256)
+            else (index, t') in
+          extract_element_symbolic_with_width (Type.imm 32) src_e index index_width
+        in
+        let topdword = match t with Type.Imm 128 -> 3 | _ -> 7 in
+        let dwords = concat_explist (List.map ~f:get_dword (List.range ~stride:(-1) ~stop:`inclusive topdword 0)) in
+        (match vsrc with
+         | None -> [assn t dst dwords]
+         | Some vdst -> [assn t vdst dwords])
+      | Pshufb (t, dst, src, vsrc) ->
+        let order_e = op2e t src in
+        let dst_e = op2e t dst in
+        let get_bit i =
+          let highbit = Exp.Extract (((i*8)+7), ((i*8)+7), order_e) in
+          (* this part of the code previously also used Typecheck.infer_ast
+           * (indirectly, by calling Ast_convenience.extract_byte_symbolic with
+           * index as the last argument).
+           * I've read the relevant parts of infer_ast and extract_byte_symbolic
+           * and also the helpful comments below "3 bits" and "4 bits"
+           * and it seems those are the appropriate widths we get out of
+           * infer_ast, so I'm passing those in directly now.
+           * Imo, this is a lot less dubious than the thingy above. *)
+          let (index, index_width) = match t with
+            | Type.Imm 64 -> (Exp.Extract (((i*8)+2), ((i*8)+0), order_e), 64) (* 3 bits *)
+            | Type.Imm 128 -> (Exp.Extract (((i*8)+3), ((i*8)+0), order_e), 128) (* 4 bits *)
+            | Type.Imm 256 -> (Exp.Extract (((i*8)+3), ((i*8)+0), order_e), 256) (* 4 bits *)
+            | _ -> disfailwith "invalid size for pshufb"
+          in
+          let index = Exp.(Cast (Cast.UNSIGNED, !!t, index)) in
+          let atindex = extract_byte_symbolic_with_width dst_e index index_width in
+          Exp.Ite (highbit, int_exp 0 8, atindex)
+        in
+        let n = !!t / 8 in
+        let e = concat_explist (List.map ~f:get_bit (List.range ~stride:(-1) ~start:`exclusive ~stop:`inclusive n 0)) in
+        (match vsrc with
+         | None -> [assn t dst e]
+         | Some vdst -> [assn t vdst e])
+      | Lea(t, r, a) when pref = [] ->
+        (* See Table 3-64 *)
+        (* previously, it checked whether addrbits > opbits before the cast_low.
+         * The conclusion we came to was that
+           - if they were equal, the cast is basically a nop
+           - if it was the other way round, you want to extend it anyway.
+         * (I may be remembering things wrongly) *)
+        [assn t r Exp.(Cast (Cast.LOW, !!t, a))]
+      | Call(o1, ra) when pref = [] ->
+        (* If o1 is an immediate, we should syntactically have Jump(imm)
+           so that the CFG algorithm knows where the jump goes.  Otherwise
+           it will point to BB_Indirect.
 
-      (* The OF and CF flags are set to 0 if the upper half of the result is 0;
-         otherwise, they are set to 1 *)
-      let new_t = Type.Imm (!!t * 2) in
-      let assnstmts, assne = Exp.(assn_dbl t ((Cast (Cast.UNSIGNED, !!new_t, op2e t o_rax)) * (Cast (Cast.UNSIGNED, !!new_t, op2e t src))))
-      in
-      let flag =
-        let highbit = !!new_t - 1 in
-        let lowbit = !!new_t / 2 in
-        Exp.((Extract (highbit, lowbit, assne)) <> int_exp 0 !!t)
-      in
-      assnstmts
-      @
-      [
-        Stmt.Move (oF, flag);
-        Stmt.Move (cf, flag);
-        Stmt.Move (sf, Exp.Unknown ("SF is undefined after Mul", bool_t));
-        Stmt.Move (zf, Exp.Unknown ("ZF is undefined after Mul", bool_t));
-        Stmt.Move (af, Exp.Unknown ("AF is undefined after Mul", bool_t));
-        Stmt.Move (pf, Exp.Unknown ("PF is undefined after Mul", bool_t))
-      ]
-    | Imul (t, (oneopform, dst), src1, src2) ->
-      let new_t = Type.Imm (!!t * 2) in
-      let mul_stmts =
-        (match oneopform with
-         | true ->
-           (* For one operand form, use assn_double *)
-           let assnstmts, assne =
-             assn_dbl t Exp.((Cast (Cast.SIGNED, !!new_t, op2e t src1)) * (Cast (Cast.SIGNED, !!new_t, op2e t src2))) in
-           let flag =
-             (* Intel checks if EAX == EDX:EAX.  Instead of doing this, we are just
-                going to check if the upper bits are != 0 *)
-             let highbit = !!new_t - 1 in
-             let lowbit = !!new_t / 2 in
-             Exp.((Extract (highbit, lowbit, assne)) <> int_exp 0 !!t)
+           Otherwise, we should evaluate the operand before decrementing esp.
+           (This really only matters when esp is the base register of a memory
+           lookup. *)
+        let target = op2e mt o1 in
+        (match o1 with
+         | Oimm _ ->
+           [Stmt.Move (rsp, Exp.(rsp_e - (Int (mi (bytes_of_width mt)))));
+            store_s mode None mt rsp_e (Exp.Int ra);
+            Stmt.Jmp target]
+         | _ ->
+           let t = Var.create ~tmp:true "target" mt in
+           [Stmt.Move (t, target);
+            Stmt.Move (rsp, Exp.(rsp_e - (Int (mi (bytes_of_width mt)))));
+            store_s mode None mt rsp_e (Exp.Int ra);
+            Stmt.Jmp (Exp.Var t)])
+      | Jump(o) ->
+        [Stmt.Jmp (jump_target mode ss has_rex o)]
+      | Jcc(o, c) ->
+        [Stmt.If (c, [Stmt.Jmp (jump_target mode ss has_rex o)], [])]
+      | Setcc(t, o1, c) ->
+        [assn t o1 Exp.(Cast (Cast.UNSIGNED, !!t, c))]
+      | Shift(st, s, dst, shift) ->
+        let open Exp.Binop in
+        assert (List.mem [reg8_t; reg16_t; reg32_t; reg64_t] s);
+        let origCOUNT, origDEST = Var.create ~tmp:true "origCOUNT" s,
+                                  Var.create ~tmp:true "origDEST" s in
+        let s' = !!s in
+        let size = int_exp s' s' in
+        let s_f = Exp.(match st with LSHIFT -> (lsl)  | RSHIFT -> (lsr)
+                                   | ARSHIFT -> (asr) | _ -> disfailwith
+                                                               "invalid shift type") in
+        let dste = op2e s dst in
+        let count_mask = Exp.(size - (int_exp 1 s')) in
+        let count = Exp.((op2e s shift) land count_mask) in
+        let ifzero t e = Exp.(Ite ((Var origCOUNT = int_exp 0 s'), t, e)) in
+        let new_of = match st with
+          | LSHIFT -> Exp.((Cast (Cast.HIGH, !!bool_t, dste)) lxor cf_e)
+          | RSHIFT -> Exp.(Cast (Cast.HIGH, !!bool_t, Var origDEST))
+          | ARSHIFT -> exp_false
+          | _ -> disfailwith "impossible"
+        in
+        let unk_of = Exp.Unknown ("OF undefined after shift", bool_t) in
+        let new_cf =
+          (* undefined for SHL and SHR instructions where the count is greater than
+             or equal to the size (in bits) of the destination operand *)
+          match st with
+          | LSHIFT -> Exp.(Cast (Cast.LOW, !!bool_t, Var origDEST lsr (size - Var origCOUNT)))
+          | RSHIFT | ARSHIFT ->
+            Exp.(Cast (Cast.HIGH, !!bool_t, Var origDEST lsl (size - Var origCOUNT)))
+          | _ -> failwith "impossible"
+        in
+        [Stmt.Move (origDEST, dste);
+         Stmt.Move (origCOUNT, count);
+         assn s dst (s_f dste count);
+         Stmt.Move (cf, ifzero cf_e new_cf);
+         Stmt.Move (oF, Exp.(ifzero of_e (Ite (Var origCOUNT = int_exp 1 s', new_of, unk_of))));
+         Stmt.Move (sf, ifzero sf_e (compute_sf dste));
+         Stmt.Move (zf, ifzero zf_e (compute_zf s' dste));
+         Stmt.Move (pf, ifzero pf_e (compute_pf s dste));
+         Stmt.Move (af, ifzero af_e (Exp.Unknown ("AF undefined after shift", bool_t)))
+        ]
+      | Shiftd(st, s, dst, fill, count) ->
+        let open Exp.Binop in
+        let origDEST, origCOUNT = Var.create ~tmp:true "origDEST" s,
+                                  Var.create ~tmp:true "origCOUNT" s in
+        let e_dst = op2e s dst in
+        let e_fill = op2e s fill in
+        let s' = !!s in
+        (* Check for 64-bit operand *)
+        let size = int_exp s' s' in
+        let count_mask = Exp.(size - int_exp 1 s') in
+        let e_count = Exp.((op2e s count) land count_mask) in
+        let new_cf =  match st with
+          | LSHIFT -> Exp.(Cast (Cast.LOW, !!bool_t, Var origDEST lsr (size - Var origCOUNT)))
+          | RSHIFT -> Exp.(Cast (Cast.HIGH, !!bool_t, Var origDEST lsl (size - Var origCOUNT)))
+          | _ -> disfailwith "impossible" in
+        let ifzero t e = Exp.(Ite ((Var origCOUNT = int_exp 0 s'), t, e)) in
+        let new_of = Exp.(Cast (Cast.HIGH, !!bool_t, (Var origDEST lxor e_dst))) in
+        let unk_of =
+          Exp.Unknown ("OF undefined after shiftd of more then 1 bit", bool_t) in
+        let ret1 = match st with
+          | LSHIFT -> Exp.(e_fill lsr (size - Var origCOUNT))
+          | RSHIFT -> Exp.(e_fill lsl (size - Var origCOUNT))
+          | _ -> disfailwith "impossible" in
+        let ret2 = match st with
+          | LSHIFT -> Exp.(e_dst lsl Var origCOUNT)
+          | RSHIFT -> Exp.(e_dst lsr Var origCOUNT)
+          | _ -> disfailwith "impossible" in
+        let result = Exp.(ret1 lor ret2) in
+        (* SWXXX If shift is greater than the operand size, dst and
+           flags are undefined *)
+        [ Stmt.Move (origDEST, e_dst);
+          Stmt.Move (origCOUNT, e_count);
+          assn s dst result;
+          Stmt.Move (cf, ifzero cf_e new_cf);
+          (* For a 1-bit shift, the OF flag is set if a sign change occurred;
+             otherwise, it is cleared. For shifts greater than 1 bit, the OF flag
+             is undefined. *)
+          Stmt.Move (oF, Exp.(ifzero of_e (Ite (Var origCOUNT = int_exp 1 s', new_of, unk_of))));
+          Stmt.Move (sf, ifzero sf_e (compute_sf e_dst));
+          Stmt.Move (zf, ifzero zf_e (compute_zf s' e_dst));
+          Stmt.Move (pf, ifzero pf_e (compute_pf s e_dst));
+          Stmt.Move (af, ifzero af_e (Exp.Unknown ("AF undefined after shiftd", bool_t)))
+        ]
+      | Rotate(rt, s, dst, shift, use_cf) ->
+        let open Exp.Binop in
+        (* SWXXX implement use_cf *)
+        if use_cf then unimplemented "rotate use_vf";
+        let origCOUNT = Var.create ~tmp:true "origCOUNT" s in
+        let e_dst = op2e s dst in
+        let shift_val = match s with
+          | Type.Imm 64 -> 63
+          | _ -> 31
+        in
+        let s' = !!s in
+        let e_shift = Exp.(op2e s shift land int_exp shift_val s') in
+        let size = int_exp !!s s' in
+        let new_cf = match rt with
+          | LSHIFT -> Exp.(Cast (Cast.LOW, !!bool_t, e_dst))
+          | RSHIFT -> Exp.(Cast (Cast.HIGH, !!bool_t, e_dst))
+          | _ -> disfailwith "impossible" in
+        let new_of = match rt with
+          | LSHIFT -> Exp.(cf_e lxor Cast (Cast.HIGH, !!bool_t, e_dst))
+          | RSHIFT -> Exp.(Cast (Cast.HIGH, !!bool_t, e_dst) lxor Cast (Cast.HIGH, !!bool_t, e_dst lsl int_exp 1 s'))
+          | _ -> disfailwith "impossible" in
+        let unk_of =
+          Exp.Unknown ("OF undefined after rotate of more then 1 bit", bool_t) in
+        (* this is repeated often enough in the cases perhaps
+         * we should bind it at the top of the function... *)
+        let ifzero t e = Exp.(Ite (Var origCOUNT = int_exp 0 s', t, e)) in
+        let ret1 = match rt with
+          | LSHIFT -> Exp.(e_dst lsl Var origCOUNT)
+          | RSHIFT -> Exp.(e_dst lsr Var origCOUNT)
+          | _ -> disfailwith "impossible" in
+        let ret2 = match rt with
+          | LSHIFT -> Exp.(e_dst lsr (size - Var origCOUNT))
+          | RSHIFT -> Exp.(e_dst lsl (size - Var origCOUNT))
+          | _ -> disfailwith "impossible" in
+        let result = Exp.(ret1 lor ret2) in
+        [
+          Stmt.Move (origCOUNT, e_shift);
+          assn s dst result;
+          (* cf must be set before of *)
+          Stmt.Move (cf, ifzero cf_e new_cf);
+          Stmt.Move (oF, ifzero of_e Exp.(Ite (Var origCOUNT = int_exp 1 s', new_of, unk_of)));
+        ]
+      | Bt(t, bitoffset, bitbase) ->
+        let t' = !!t in
+        let offset = op2e t bitoffset in
+        let value, shift = match bitbase with
+          | Oreg _ ->
+            let reg = op2e t bitbase in
+            let shift = Exp.(offset land int_exp Pervasives.(t' - 1) t') in
+            reg, shift
+          | Oaddr a ->
+            let byte = load (size_of_typ reg8_t) Exp.(a + (offset lsr int_exp 3 t')) in
+            let shift = Exp.(Cast (Cast.LOW, !!reg8_t, offset) land int_exp 7 8) in
+            byte, shift
+          | Ovec _ | Oseg _ | Oimm _ -> disfailwith "Invalid bt operand"
+        in
+        [
+          Stmt.Move (cf, Exp.(Cast (Cast.LOW, !!bool_t, value lsr shift)));
+          Stmt.Move (oF, Exp.Unknown ("OF undefined after bt", bool_t));
+          Stmt.Move (sf, Exp.Unknown ("SF undefined after bt", bool_t));
+          Stmt.Move (af, Exp.Unknown ("AF undefined after bt", bool_t));
+          Stmt.Move (pf, Exp.Unknown ("PF undefined after bt", bool_t))
+        ]
+      | Bs(t, dst, src, dir) ->
+        let t' = !!t in
+        let source_is_zero = Var.create ~tmp:true "t" bool_t in
+        let source_is_zero_v = Exp.Var source_is_zero in
+        let src_e = op2e t src in
+        let bits = !!t in
+        let check_bit bitindex next_value =
+          Exp.(Ite (Extract (bitindex,bitindex,src_e) = int_exp 1 1, int_exp bitindex t', next_value))
+        in
+        let bitlist = List.init ~f:(fun x -> x) bits in
+        (* We are folding from right to left *)
+        let bitlist = match dir with
+          | Forward -> (* least significant first *) bitlist
+          | Backward -> (* most significant *) List.rev bitlist
+        in
+        let first_one = List.fold_right ~f:check_bit bitlist
+            ~init:(Exp.Unknown("bs: destination undefined when source is zero", t)) in
+        [
+          Stmt.Move (source_is_zero, Exp.(src_e = int_exp 0 t'));
+          assn t dst first_one;
+          Stmt.Move (zf, Exp.Ite (source_is_zero_v, int_exp 1 1, int_exp 0 1));
+        ]
+        @
+        let undef r =
+          let (n,_,t) = Var.V1.serialize r in
+          Stmt.Move (r, Exp.Unknown (n^" undefined after bsf", t)) in
+        List.map ~f:undef [cf; oF; sf; af; pf]
+      | Hlt -> [] (* x86 Hlt is essentially a NOP *)
+      | Rdtsc ->
+        let undef reg = assn reg32_t reg (Exp.Unknown ("rdtsc", reg32_t)) in
+        List.map ~f:undef [o_rax; o_rdx]
+      | Cpuid ->
+        let undef reg = assn reg32_t reg (Exp.Unknown ("cpuid", reg32_t)) in
+        List.map ~f:undef [o_rax; o_rbx; o_rcx; o_rdx]
+      | Xgetbv ->
+        let undef reg = assn reg32_t reg (Exp.Unknown ("xgetbv", reg32_t)) in
+        List.map ~f:undef [o_rax; o_rdx]
+      | Stmxcsr (dst) ->
+        let dst = match dst with
+          | Oaddr addr -> addr
+          | _ -> disfailwith "stmxcsr argument cannot be non-memory"
+        in
+        [store reg32_t dst (Exp.Var mxcsr);(*(Unknown ("stmxcsr", reg32_t));*) ]
+      | Ldmxcsr (src) ->
+        let src = match src with
+          | Oaddr addr -> addr
+          | _ -> disfailwith "ldmxcsr argument cannot be non-memory"
+        in
+        [ Stmt.Move (mxcsr, load (size_of_typ reg32_t) src); ]
+      | Fnstcw (dst) ->
+        let dst = match dst with
+          | Oaddr addr -> addr
+          | _ -> disfailwith "fnstcw argument cannot be non-memory"
+        in
+        [store reg16_t dst (Exp.Var fpu_ctrl); ]
+      | Fldcw (src) ->
+        let src = match src with
+          | Oaddr addr -> addr
+          | _ -> disfailwith "fldcw argument cannot be non-memory"
+        in
+        [ Stmt.Move (fpu_ctrl, load (size_of_typ reg16_t) src); ]
+      | Fld _src ->
+        unimplemented "unsupported FPU register stack"
+      | Fst (_dst,_pop) ->
+        unimplemented "unsupported FPU flags"
+      | Cmps(Type.Imm _bits as t) ->
+        let t' = !!t in
+        let src1 = Var.create ~tmp:true "src1" t in
+        let src2 = Var.create ~tmp:true "src2" t in
+        let tmpres = Var.create ~tmp:true "tmp" t in
+        let stmts =
+          Stmt.Move (src1, op2e t (Oaddr rsi_e))
+          :: Stmt.Move (src2, op2e_s mode seg_es has_rex t (Oaddr rdi_e))
+          :: Stmt.Move (tmpres, Exp.(Var src1 - Var src2))
+          :: string_incr mode t rsi
+          :: string_incr mode t rdi
+          :: set_flags_sub t' (Exp.Var src1) (Exp.Var src2) (Exp.Var tmpres)
+        in
+        begin match pref with
+          | [] -> stmts
+          | [single] when single = repz || single = repnz ->
+            rep_wrap ~mode ~check_zf:single ~addr ~next stmts
+          | _ -> unimplemented "unsupported flags in cmps" end
+      | Scas(Type.Imm _bits as t) ->
+        let t' = !!t in
+        let src1 = Var.create ~tmp:true "src1" t in
+        let src2 = Var.create ~tmp:true "src2" t in
+        let tmpres = Var.create ~tmp:true "tmp" t in
+        let stmts =
+          let open Stmt in
+          Move (src1, Exp.(Cast (Cast.LOW, !!t, Var rax)))
+          :: Move (src2, op2e_s mode seg_es has_rex t (Oaddr rdi_e))
+          :: Move (tmpres, Exp.(Var src1 - Var src2))
+          :: string_incr mode t rdi
+          :: set_flags_sub t' (Exp.Var src1) (Exp.Var src2) (Exp.Var tmpres)
+        in
+        begin match pref with
+          | [] -> stmts
+          | [single] when single = repz || single = repnz ->
+            rep_wrap ~mode ~check_zf:single ~addr ~next stmts
+          | _ -> unimplemented "unsupported flags in scas" end
+      | Stos(Type.Imm _bits as t) ->
+        let stmts = [store_s mode seg_es t rdi_e (op2e t o_rax);
+                     string_incr mode t rdi]
+        in
+        begin match pref with
+          | [] -> stmts
+          | [single] when single = repz -> rep_wrap ~mode ~addr ~next stmts
+          | _ -> unimplemented "unsupported prefix for stos" end
+      | Push(t, o) ->
+        let tmp = Var.create ~tmp:true "t" t in (* only really needed when o involves esp *)
+        Stmt.Move (tmp, op2e t o)
+        :: Stmt.Move (rsp, Exp.(rsp_e - Int (mi (bytes_of_width t))))
+        :: store_s mode seg_ss t rsp_e (Exp.Var tmp) (* FIXME: can ss be overridden? *)
+        :: []
+      | Pop(t, o) ->
+        (* From the manual:
+
+           "The POP ESP instruction increments the stack pointer (ESP)
+           before data at the old top of stack is written into the
+           destination"
+
+           So, effectively there is no incrementation.
+        *)
+        assn t o (load_s mode seg_ss (size_of_typ t) rsp_e)
+        :: if o = o_rsp then []
+        else [Stmt.Move (rsp, Exp.(rsp_e + Int (mi (bytes_of_width t))))]
+      | Pushf(t) ->
+        (* Note that we currently treat these fields as unknowns, but the
+           manual says: When copying the entire EFLAGS register to the
+           stack, the VM and RF flags (bits 16 and 17) are not copied;
+           instead, the values for these flags are cleared in the EFLAGS
+           image stored on the stack. *)
+        let flags_e = match t with
+          | Type.Imm 16 -> flags_e
+          | Type.Imm 32 -> eflags_e
+          | Type.Imm 64 -> rflags_e
+          | _ -> failwith "impossible"
+        in
+        Stmt.Move (rsp, Exp.(rsp_e - Int (mi (bytes_of_width t))))
+        :: store_s mode seg_ss t rsp_e flags_e
+        :: []
+      | Popf t ->
+        let assnsf = match t with
+          | Type.Imm 16 -> assns_flags_to_bap
+          | Type.Imm 32 -> assns_eflags_to_bap
+          | Type.Imm 64 -> assns_rflags_to_bap
+          | _ -> failwith "impossible"
+        in
+        let tmp = Var.create ~tmp:true "t" t in
+        let extractlist =
+          List.map
+            ~f:(fun i ->
+                Exp.(Extract (i, i, Var tmp)))
+            (List.range ~stride:(-1) ~start:`exclusive ~stop:`inclusive !!t 0)
+        in
+        Stmt.Move (tmp, load_s mode seg_ss (size_of_typ t) rsp_e)
+        :: Stmt.Move (rsp, Exp.(rsp_e + Int (mi (bytes_of_width t))))
+        :: List.concat (List.map2_exn ~f:(fun f e -> f e) assnsf
+                          extractlist)
+      | Popcnt(t, s, d) ->
+        let width = !!t in
+        let bits = op2e t s in
+        let bitvector = Array.to_list (Array.init width ~f:(fun i -> Exp.(Ite (Extract (i, i, bits), int_exp 1 width, int_exp 0 width)))) in
+        let count = List.reduce_exn ~f:Exp.(+) bitvector in
+        set_zf width bits
+        :: assn t d count
+        :: List.map ~f:(fun r -> Stmt.Move (r, int_exp 0 1)) [cf; oF; sf; af; pf]
+      | Sahf ->
+        let assnsf = assns_lflags_to_bap in
+        let tah = Var.create ~tmp:true "AH" reg8_t in
+        let extractlist =
+          List.map
+            ~f:(fun i ->
+                Exp.(Extract (i, i, Var tah)))
+            (List.range ~stride:(-1) ~stop:`inclusive 7 0)
+        in
+        Stmt.Move (tah, ah_e)
+        :: List.concat (List.map2_exn ~f:(fun f e -> f e) assnsf extractlist)
+      | Lahf ->
+        let o_ah = Oreg 4 in
+        [assn reg8_t o_ah lflags_e]
+      | Add(t, o1, o2) ->
+        let tmp = Var.create ~tmp:true "t1" t in
+        let tmp2 = Var.create ~tmp:true "t2" t in
+        Stmt.Move (tmp, op2e t o1)
+        :: Stmt.Move (tmp2, op2e t o2)
+        :: assn t o1 Exp.(op2e t o1 + Var tmp2)
+        :: let s1 = Exp.Var tmp in let s2 = Exp.Var tmp2 in let r = op2e t o1 in
+        set_flags_add !!t s1 s2 r
+      | Adc(t, o1, o2) ->
+        let orig1 = Var.create ~tmp:true "orig1" t in
+        let orig2 = Var.create ~tmp:true "orig2" t in
+        let bits = !!t in
+        let t' = Type.Imm (bits + 1) in
+        let c e = Exp.(Cast (Cast.UNSIGNED, !!t', e)) in
+        (* Literally compute the addition with an extra bit and see
+           what the value is for CF *)
+        let s1 = Exp.Var orig1 in let s2 = Exp.Var orig2 in let r = op2e t o1 in
+        let bige = Exp.(c s1 + c s2 + c (Cast (Cast.UNSIGNED, !!t, cf_e))) in
+        Stmt.Move (orig1, op2e t o1)
+        :: Stmt.Move (orig2, op2e t o2)
+        :: assn t o1 Exp.(s1 + s2 + Cast (Cast.UNSIGNED, !!t, cf_e))
+        :: Stmt.Move (cf, Exp.Extract (bits, bits, bige))
+        :: set_aopszf_add !!t s1 s2 r
+      | Inc(t, o) (* o = o + 1 *) ->
+        let t' = !!t in
+        let tmp = Var.create ~tmp:true "t" t in
+        Stmt.Move (tmp, op2e t o)
+        :: assn t o Exp.(op2e t o + int_exp 1 t')
+        :: set_aopszf_add t' (Exp.Var tmp) (int_exp 1 t') (op2e t o)
+      | Dec(t, o) (* o = o - 1 *) ->
+        let t' = !!t in
+        let tmp = Var.create ~tmp:true "t" t in
+        Stmt.Move (tmp, op2e t o)
+        :: assn t o Exp.(op2e t o - int_exp 1 t')
+        :: set_aopszf_sub t' (Exp.Var tmp) (int_exp 1 t') (op2e t o) (* CF is maintained *)
+      | Sub(t, o1, o2) (* o1 = o1 - o2 *) ->
+        let oldo1 = Var.create ~tmp:true "t" t in
+        Stmt.Move (oldo1, op2e t o1)
+        :: assn t o1 Exp.(op2e t o1 - op2e t o2)
+        :: set_flags_sub !!t (Exp.Var oldo1) (op2e t o2) (op2e t o1)
+      | Sbb(t, o1, o2) ->
+        let tmp_s = Var.create ~tmp:true "ts" t in
+        let tmp_d = Var.create ~tmp:true "td" t in
+        let orig_s = Exp.Var tmp_s in
+        let orig_d = Exp.Var tmp_d in
+        let sube = Exp.(orig_s + Cast (Cast.UNSIGNED, !!t, cf_e)) in
+        let d = op2e t o1 in
+        let s1 = op2e t o2 in
+        Stmt.Move (tmp_s, s1)
+        :: Stmt.Move (tmp_d, d)
+        :: assn t o1 Exp.(orig_d - sube)
+        :: Stmt.Move (oF, Exp.(Cast (Cast.HIGH, !!bool_t, (orig_s lxor orig_d) land (orig_d lxor d))))
+        (* When src = 0xffffffff and cf=1, the processor sets CF=1.
+
+           Note that we compute dest = dest - (0xffffffff + 1) = 0, so the
+           subtraction does not overflow.
+
+           So, I am guessing that CF is set if the subtraction overflows
+           or the addition overflows.
+
+           Maybe we should implement this by doing the actual computation,
+           like we do for adc.
+        *)
+        (* sub overflow | add overflow *)
+        :: Stmt.Move (cf, Exp.((sube > orig_d) lor (sube < orig_s)))
+        :: set_apszf !!t orig_s orig_d d
+      | Cmp(t, o1, o2) ->
+        let tmp = Var.create ~tmp:true "t" t in
+        Stmt.Move (tmp, Exp.(op2e t o1 - op2e t o2))
+        :: set_flags_sub !!t (op2e t o1) (op2e t o2) (Exp.Var tmp)
+      | Cmpxchg(t, src, dst) ->
+        let t' = !!t in
+        let eax_e = op2e t o_rax in
+        let dst_e = op2e t dst in
+        let src_e = op2e t src in
+        let tmp = Var.create ~tmp:true "t" t in
+        Stmt.Move (tmp, Exp.(eax_e - dst_e))
+        :: set_flags_sub t' eax_e dst_e (Exp.Var tmp)
+        @ assn t dst (Exp.Ite (zf_e, src_e, dst_e))
+          :: assn t o_rax (Exp.Ite (zf_e, eax_e, dst_e))
+          :: []
+      | Cmpxchg8b o -> (* only 32bit case *)
+        let accumulator = Exp.Concat((op2e reg32_t o_rdx),(op2e reg32_t o_rax)) in
+        let dst_e = op2e reg64_t o in
+        let src_e = Exp.Concat((op2e reg32_t o_rcx),(op2e reg32_t o_rbx)) in
+        let dst_low_e = Exp.Extract(63, 32, dst_e) in
+        let dst_hi_e = Exp.Extract(31, 0, dst_e) in
+        let eax_e = op2e reg32_t o_rax in
+        let edx_e = op2e reg32_t o_rdx in
+        let equal = Var.create ~tmp:true "t" bool_t in
+        let equal_v = Exp.Var equal in
+        [
+          Stmt.Move (equal, Exp.(accumulator = dst_e));
+          Stmt.Move (zf, equal_v);
+          assn reg64_t o (Exp.Ite (equal_v, src_e, dst_e));
+          assn reg32_t o_rax (Exp.Ite (equal_v, eax_e, dst_low_e));
+          assn reg32_t o_rdx (Exp.Ite (equal_v, edx_e, dst_hi_e))
+        ]
+      | Xadd(t, dst, src) ->
+        let tmp = Var.create ~tmp:true "t" t in
+        Stmt.Move (tmp, Exp.(op2e t dst + op2e t src))
+        :: assn t src (op2e t dst)
+        :: assn t dst (Exp.Var tmp)
+        :: let s = Exp.Var tmp in let src = op2e t src in let dst = op2e t dst in
+        set_flags_add !!t s src dst
+      | Xchg(t, src, dst) ->
+        let tmp = Var.create ~tmp:true "t" t in
+        [ Stmt.Move (tmp, op2e t src);
+          assn t src (op2e t dst);
+          assn t dst (Exp.Var tmp); ]
+      | And(t, o1, o2) ->
+        assn t o1 Exp.(op2e t o1 land op2e t o2)
+        :: Stmt.Move (oF, exp_false)
+        :: Stmt.Move (cf, exp_false)
+        :: Stmt.Move (af, Exp.Unknown ("AF is undefined after and", bool_t))
+        :: set_pszf t (op2e t o1)
+      | Or(t, o1, o2) ->
+        assn t o1 Exp.(op2e t o1 lor op2e t o2)
+        :: Stmt.Move (oF, exp_false)
+        :: Stmt.Move (cf, exp_false)
+        :: Stmt.Move (af, Exp.Unknown ("AF is undefined after or", bool_t))
+        :: set_pszf t (op2e t o1)
+      | Xor(t, o1, o2) when o1 = o2 ->
+        assn t o1 Exp.(Int (BV.of_int ~width:(!!t) 0))
+        :: Stmt.Move (af, Exp.Unknown ("AF is undefined after xor", bool_t))
+        :: List.map ~f:(fun v -> Stmt.Move (v, exp_true)) [zf; pf]
+        @  List.map ~f:(fun v -> Stmt.Move (v, exp_false)) [oF; cf; sf]
+      | Xor(t, o1, o2) ->
+        assn t o1 Exp.(op2e t o1 lxor op2e t o2)
+        :: Stmt.Move (oF, exp_false)
+        :: Stmt.Move (cf, exp_false)
+        :: Stmt.Move (af, Exp.Unknown ("AF is undefined after xor", bool_t))
+        :: set_pszf t (op2e t o1)
+      | Test(t, o1, o2) ->
+        let tmp = Var.create ~tmp:true "t" t in
+        Stmt.Move (tmp, Exp.(op2e t o1 land op2e t o2))
+        :: Stmt.Move (oF, exp_false)
+        :: Stmt.Move (cf, exp_false)
+        :: Stmt.Move (af, Exp.Unknown ("AF is undefined after and", bool_t))
+        :: set_pszf t (Exp.Var tmp)
+      | Ptest(t, o1, o2) ->
+        let open Stmt in
+        let t' = !!t in
+        let tmp1 = Var.create ~tmp:true "t1" t in
+        let tmp2 = Var.create ~tmp:true "t2" t in
+        Move (tmp1, Exp.(op2e t o2 land op2e t o1))
+        :: Move (tmp2, Exp.(op2e t o2 land (exp_not (op2e t o1))))
+        :: Move (af, exp_false)
+        :: Move (oF, exp_false)
+        :: Move (pf, exp_false)
+        :: Move (sf, exp_false)
+        :: Move (zf, Exp.(Var tmp1 = Int (BV.of_int ~width:t' 0)))
+        :: [Move (cf, Exp.(Var tmp2 = Int (BV.of_int ~width:t' 0)))]
+      | Not(t, o) ->
+        [assn t o (exp_not (op2e t o))]
+      | Neg(t, o) ->
+        let t' = !!t in
+        let tmp = Var.create ~tmp:true "t" t in
+        let min_int =
+          Exp.BinOp (Exp.Binop.LSHIFT, int_exp 1 t', int_exp (t'-1) t')
+        in
+        Stmt.Move (tmp, op2e t o)
+        ::assn t o Exp.(int_exp 0 t' - op2e t o)
+        ::Stmt.Move (cf, Exp.(Ite (Var tmp = int_exp 0 t', int_exp 0 1, int_exp 1 1)))
+        ::Stmt.Move (oF, Exp.(Ite (Var tmp = min_int, int_exp 1 1, int_exp 0 1)))
+        ::set_apszf_sub t' (Exp.Var tmp) (int_exp 0 t') (op2e t o)
+      | Mul (t, src) ->
+        (* Mul always multiplies EAX by src and stores the result in EDX:EAX
+           starting from the "right hand side" based on the type t of src *)
+
+        (* The OF and CF flags are set to 0 if the upper half of the result is 0;
+           otherwise, they are set to 1 *)
+        let new_t = Type.Imm (!!t * 2) in
+        let assnstmts, assne = Exp.(assn_dbl t ((Cast (Cast.UNSIGNED, !!new_t, op2e t o_rax)) * (Cast (Cast.UNSIGNED, !!new_t, op2e t src))))
+        in
+        let flag =
+          let highbit = !!new_t - 1 in
+          let lowbit = !!new_t / 2 in
+          Exp.((Extract (highbit, lowbit, assne)) <> int_exp 0 !!t)
+        in
+        assnstmts
+        @
+        [
+          Stmt.Move (oF, flag);
+          Stmt.Move (cf, flag);
+          Stmt.Move (sf, Exp.Unknown ("SF is undefined after Mul", bool_t));
+          Stmt.Move (zf, Exp.Unknown ("ZF is undefined after Mul", bool_t));
+          Stmt.Move (af, Exp.Unknown ("AF is undefined after Mul", bool_t));
+          Stmt.Move (pf, Exp.Unknown ("PF is undefined after Mul", bool_t))
+        ]
+      | Imul (t, (oneopform, dst), src1, src2) ->
+        let new_t = Type.Imm (!!t * 2) in
+        let mul_stmts =
+          (match oneopform with
+           | true ->
+             (* For one operand form, use assn_double *)
+             let assnstmts, assne =
+               assn_dbl t Exp.((Cast (Cast.SIGNED, !!new_t, op2e t src1)) * (Cast (Cast.SIGNED, !!new_t, op2e t src2))) in
+             let flag =
+               (* Intel checks if EAX == EDX:EAX.  Instead of doing this, we are just
+                  going to check if the upper bits are != 0 *)
+               let highbit = !!new_t - 1 in
+               let lowbit = !!new_t / 2 in
+               Exp.((Extract (highbit, lowbit, assne)) <> int_exp 0 !!t)
+             in
+             assnstmts @
+             [Stmt.Move (oF, flag);
+              Stmt.Move (cf, flag)]
+           | false ->
+             (* Two and three operand forms *)
+             let tmp = Var.create ~tmp:true "t" new_t in
+             (* Flag is set when the result is truncated *)
+             let flag = Exp.(Var tmp <> Cast (Cast.SIGNED, !!new_t, op2e t dst)) in
+             [(Stmt.Move (tmp, Exp.((Cast (Cast.SIGNED, !!new_t, op2e t src1)) * (Cast (Cast.SIGNED, !!new_t, op2e t src2)))));
+              (assn t dst Exp.(Cast (Cast.LOW, !!t, Var tmp)));
+              Stmt.Move (oF, flag);
+              Stmt.Move (cf, flag)] )
+        in
+        mul_stmts@[
+          Stmt.Move (pf, Exp.Unknown ("PF is undefined after imul", bool_t));
+          Stmt.Move (sf, Exp.Unknown ("SF is undefined after imul", bool_t));
+          Stmt.Move (zf, Exp.Unknown ("ZF is undefined after imul", bool_t));
+          Stmt.Move (af, Exp.Unknown ("AF is undefined after imul", bool_t));]
+      | Div(t, src) ->
+        let dt' = !!t * 2 in
+        let dt = Type.Imm dt' in
+        let dividend = op2e_dbl t in
+        let divisor = Exp.(Cast (Cast.UNSIGNED, !!dt, op2e t src)) in
+        let tdiv = Var.create ~tmp:true "div" dt in
+        let trem = Var.create ~tmp:true "rem" dt in
+        let assne = Exp.((Cast (Cast.LOW, !!t, Exp.Var trem)) ^ (Cast (Cast.LOW, !!t, Var tdiv))) in
+        Stmt.If (Exp.(divisor = int_exp 0 dt'), [Cpu_exceptions.divide_by_zero], [])
+        :: Stmt.Move (tdiv, Exp.(dividend / divisor))
+        :: Stmt.Move (trem, Exp.(dividend mod divisor))
+        (* Overflow is indicated with the #DE (divide error) exception
+           rather than with the CF flag. *)
+        :: Stmt.If (Exp.((Cast (Cast.HIGH, !!t, Var tdiv)) = int_exp 0 !!t), [], [Cpu_exceptions.divide_by_zero])
+        :: fst (assn_dbl t assne)
+        @ (let undef r =
+             let n,_,t = Var.V1.serialize r in
+             Stmt.Move (r, Exp.Unknown ((n^" undefined after div"), t))
            in
-           assnstmts @
-           [Stmt.Move (oF, flag);
-            Stmt.Move (cf, flag)]
-         | false ->
-           (* Two and three operand forms *)
-           let tmp = Var.create ~tmp:true "t" new_t in
-           (* Flag is set when the result is truncated *)
-           let flag = Exp.(Var tmp <> Cast (Cast.SIGNED, !!new_t, op2e t dst)) in
-           [(Stmt.Move (tmp, Exp.((Cast (Cast.SIGNED, !!new_t, op2e t src1)) * (Cast (Cast.SIGNED, !!new_t, op2e t src2)))));
-            (assn t dst Exp.(Cast (Cast.LOW, !!t, Var tmp)));
-            Stmt.Move (oF, flag);
-            Stmt.Move (cf, flag)] )
-      in
-      mul_stmts@[
-        Stmt.Move (pf, Exp.Unknown ("PF is undefined after imul", bool_t));
-        Stmt.Move (sf, Exp.Unknown ("SF is undefined after imul", bool_t));
-        Stmt.Move (zf, Exp.Unknown ("ZF is undefined after imul", bool_t));
-        Stmt.Move (af, Exp.Unknown ("AF is undefined after imul", bool_t));]
-    | Div(t, src) ->
-      let dt' = !!t * 2 in
-      let dt = Type.Imm dt' in
-      let dividend = op2e_dbl t in
-      let divisor = Exp.(Cast (Cast.UNSIGNED, !!dt, op2e t src)) in
-      let tdiv = Var.create ~tmp:true "div" dt in
-      let trem = Var.create ~tmp:true "rem" dt in
-      let assne = Exp.((Cast (Cast.LOW, !!t, Exp.Var trem)) ^ (Cast (Cast.LOW, !!t, Var tdiv))) in
-      Stmt.If (Exp.(divisor = int_exp 0 dt'), [Cpu_exceptions.divide_by_zero], [])
-      :: Stmt.Move (tdiv, Exp.(dividend / divisor))
-      :: Stmt.Move (trem, Exp.(dividend mod divisor))
-      (* Overflow is indicated with the #DE (divide error) exception
-         rather than with the CF flag. *)
-      :: Stmt.If (Exp.((Cast (Cast.HIGH, !!t, Var tdiv)) = int_exp 0 !!t), [], [Cpu_exceptions.divide_by_zero])
-      :: fst (assn_dbl t assne)
-      @ (let undef r =
-          let n,_,t = Var.V1.serialize r in
-          Stmt.Move (r, Exp.Unknown ((n^" undefined after div"), t))
-         in
-         List.map ~f:undef [cf; oF; sf; zf; af; pf])
-    | Idiv(t, src) ->
-      let dt' = !!t * 2 in
-      let dt = Type.Imm dt' in
-      let dividend = op2e_dbl t in
-      let divisor = Exp.(Cast (Cast.SIGNED, !!dt, op2e t src)) in
-      let tdiv = Var.create ~tmp:true "div" dt in
-      let trem = Var.create ~tmp:true "rem" dt in
-      let assne = Exp.((Cast (Cast.LOW, !!t, Var trem)) ^ (Cast (Cast.LOW, !!t, Var tdiv))) in
-      Stmt.If (Exp.(divisor = int_exp 0 dt'), [Cpu_exceptions.divide_by_zero], [])
-      :: Stmt.Move (tdiv, Exp.(dividend /$ divisor))
-      :: Stmt.Move (trem, Exp.(dividend %$ divisor))
-      (* Overflow is indicated with the #DE (divide error) exception
-         rather than with the CF flag. *)
-      (* SWXXX For signed division make sure quotient is between smallest and
-         largest values.  For type t, this would be -2^(t/2) to (2^(t/2) - 1). *)
-      :: Stmt.If (Exp.((Cast (Cast.HIGH, !!t, Var tdiv)) = int_exp 0 !!t), [], [Cpu_exceptions.divide_by_zero])
-      :: fst (assn_dbl t assne)
-      @ (let undef r =
-          let n,_,t = Var.V1.serialize r in
-          Stmt.Move (r, Exp.Unknown (n^" undefined after div", t)) in
-         List.map ~f:undef [cf; oF; sf; zf; af; pf])
-    | Cld ->
-      [Stmt.Move (df, exp_false)]
-    | Leave t when pref = [] -> (* #UD if Lock prefix is used *)
-      Stmt.Move (rsp, rbp_e)
-      ::to_ir mode addr next ss pref has_rex has_vex (Pop(t, o_rbp))
-    | Interrupt3 -> [Stmt.Special "int3"]
-    | Interrupt(Oimm i) ->
-      (** use [BV.string_of_value ~hex:true] here *)
-      [Stmt.Special ("int " ^ Addr.string_of_value i)]
-    | Sysenter | Syscall -> [Stmt.Special "syscall"]
-    (* Match everything exhaustively *)
-    | Leave _ ->  unimplemented "to_ir: Leave"
-    | Call _ ->  unimplemented "to_ir: Call"
-    | Lea _ ->  unimplemented "to_ir: Lea"
-    | Movs _ ->  unimplemented "to_ir: Movs"
-    | Cmps _ ->  unimplemented "to_ir: Cmps"
-    | Scas _ ->  unimplemented "to_ir: Scas"
-    | Stos _ ->  unimplemented "to_ir: Stos"
-    | Retn _ ->  unimplemented "to_ir: Retn"
-    | Interrupt _ ->  unimplemented "to_ir: Interrupt"
+           List.map ~f:undef [cf; oF; sf; zf; af; pf])
+      | Idiv(t, src) ->
+        let dt' = !!t * 2 in
+        let dt = Type.Imm dt' in
+        let dividend = op2e_dbl t in
+        let divisor = Exp.(Cast (Cast.SIGNED, !!dt, op2e t src)) in
+        let tdiv = Var.create ~tmp:true "div" dt in
+        let trem = Var.create ~tmp:true "rem" dt in
+        let assne = Exp.((Cast (Cast.LOW, !!t, Var trem)) ^ (Cast (Cast.LOW, !!t, Var tdiv))) in
+        Stmt.If (Exp.(divisor = int_exp 0 dt'), [Cpu_exceptions.divide_by_zero], [])
+        :: Stmt.Move (tdiv, Exp.(dividend /$ divisor))
+        :: Stmt.Move (trem, Exp.(dividend %$ divisor))
+        (* Overflow is indicated with the #DE (divide error) exception
+           rather than with the CF flag. *)
+        (* SWXXX For signed division make sure quotient is between smallest and
+           largest values.  For type t, this would be -2^(t/2) to (2^(t/2) - 1). *)
+        :: Stmt.If (Exp.((Cast (Cast.HIGH, !!t, Var tdiv)) = int_exp 0 !!t), [], [Cpu_exceptions.divide_by_zero])
+        :: fst (assn_dbl t assne)
+        @ (let undef r =
+             let n,_,t = Var.V1.serialize r in
+             Stmt.Move (r, Exp.Unknown (n^" undefined after div", t)) in
+           List.map ~f:undef [cf; oF; sf; zf; af; pf])
+      | Cld ->
+        [Stmt.Move (df, exp_false)]
+      | Leave t when pref = [] -> (* #UD if Lock prefix is used *)
+        Stmt.Move (rsp, rbp_e)
+        ::to_ir mode addr next ss pref has_rex has_vex (Pop(t, o_rbp))
+      | Interrupt3 -> [Stmt.Special "int3"]
+      | Interrupt(Oimm i) ->
+        (** use [BV.string_of_value ~hex:true] here *)
+        [Stmt.Special ("int " ^ Addr.string_of_value i)]
+      | Sysenter | Syscall -> [Stmt.Special "syscall"]
+      (* Match everything exhaustively *)
+      | Leave _ ->  unimplemented "to_ir: Leave"
+      | Call _ ->  unimplemented "to_ir: Call"
+      | Lea _ ->  unimplemented "to_ir: Lea"
+      | Movs _ ->  unimplemented "to_ir: Movs"
+      | Cmps _ ->  unimplemented "to_ir: Cmps"
+      | Scas _ ->  unimplemented "to_ir: Scas"
+      | Stos _ ->  unimplemented "to_ir: Stos"
+      | Retn _ ->  unimplemented "to_ir: Retn"
+      | Interrupt _ ->  unimplemented "to_ir: Interrupt"
 
 end (* ToIR *)
 
@@ -1465,3 +1467,57 @@ let insn arch mem insn =
   let addr = Memory.min_addr mem in
   Or_error.try_with (fun () ->
       let stmts, _ = disasm_instr mode mem addr in stmts)
+
+
+module Make_CPU(Env : ModeVars) : CPU = struct
+  open Env
+  (* we do not include pc into a set of gpr *)
+  let gpr = Var.Set.of_list @@ [
+      rax; rcx; rdx; rsi; rdi;
+      rbx; rbp; rsp;
+    ] @ Array.to_list nums
+
+  let flags = Var.Set.of_list [
+      cf; pf; af; zf; sf; oF; df
+    ]
+
+  let pc = rip
+  let sp = rsp
+  let bp = rbp
+  let mem = mem
+  let zf = zf
+  let cf = cf
+  let vf = oF
+  let nf = sf
+
+  let addr_of_pc = Memory.max_addr
+
+  let is = Var.equal
+  let is_reg r = is pc r || Set.mem gpr r
+  let is_flag = Set.mem flags
+  let is_zf = is zf
+  let is_cf = is cf
+  let is_vf = is oF
+  let is_nf = is sf
+  let is_mem = is mem
+  let is_sp = is sp
+  let is_bp = is bp
+  let is_pc = is pc
+end
+
+
+module AMD64 = struct
+  module CPU = Make_CPU(R64)
+  let registered = ref []
+  let register_abi abi = registered := abi :: !registered
+  let get_abi = create_abi_getter registered
+  let lift mem i = insn `x86_64 mem i
+end
+
+module IA32 = struct
+  module CPU = Make_CPU(R32)
+  let registered = ref []
+  let register_abi abi = registered := abi :: !registered
+  let get_abi = create_abi_getter registered
+  let lift mem i = insn `x86 mem i
+end

--- a/lib/bap_disasm/bap_disasm_x86_lifter.mli
+++ b/lib/bap_disasm/bap_disasm_x86_lifter.mli
@@ -1,6 +1,25 @@
 open Core_kernel.Std
 open Bap_types.Std
+open Bap_image_std
+open Bap_disasm_types
+open Bap_disasm_abi
 
-(** [insn mem basic] takes a basic instruction and a memory and
-    returns a sequence of BIL statements. *)
-val insn : Arch.x86 -> Bap_memory.t -> ('a,'k) Bap_disasm_basic.insn -> stmt list Or_error.t
+module IA32 : sig
+  module CPU : CPU
+  val register_abi : abi_constructor -> unit
+  val get_abi :
+    ?all:bool -> (** defaults to false  *)
+    ?image:image ->
+    ?sym:string -> mem -> Bap_disasm_block.t -> abi list
+  val lift : mem -> ('a,'k) Basic.insn -> stmt list Or_error.t
+end
+
+module AMD64 : sig
+  module CPU : CPU
+  val register_abi : abi_constructor -> unit
+  val get_abi :
+    ?all:bool -> (** defaults to false  *)
+    ?image:image ->
+    ?sym:string -> mem -> Bap_disasm_block.t -> abi list
+  val lift : mem -> ('a,'k) Basic.insn -> stmt list Or_error.t
+end

--- a/lib/bap_types/bap_helpers.mli
+++ b/lib/bap_types/bap_helpers.mli
@@ -48,8 +48,9 @@ val fold_consts : bil -> bil
 class constant_folder : mapper
 
 (** [fixpoint f] applies transformation [f] until fixpoint is
-    reached. If the transformation orbit contains non-trivial
-    cycles, then a arbitrary point of cycle will be returned. *)
+    reached. If the transformation orbit contains non-trivial cycles,
+    then the transformation will stop at an arbitrary point of a
+    cycle. *)
 val fixpoint : (bil -> bil) -> (bil -> bil)
 
 (** Bil provides two prefix tries trees.

--- a/lib_test/bap_disasm/test_disasm.ml
+++ b/lib_test/bap_disasm/test_disasm.ml
@@ -234,7 +234,7 @@ let blocks = [|
 
 let run_rec () =
   let mem = create_block 0x840Cl strlen in
-  let lifter = Arm.Lift.insn in
+  let lifter = ARM.lift in
   Rec.run ~lifter `armv7 mem
 
 let test_cfg test ctxt =
@@ -292,7 +292,7 @@ let test_micro_cfg insn ctxt =
   let mem = Bigstring.of_string insn |>
             Memory.create LittleEndian (Addr.of_int64 0L) |>
             ok_exn in
-  let lifter = Bap_disasm_x86_lifter.insn `x86_64 in
+  let lifter = AMD64.lift in
   let dis = Rec.run ~lifter `x86_64 mem |> ok_exn in
   assert_bool "No errors" (Rec.errors dis = []);
   assert_bool "One block" (Rec.blocks dis |> Table.length = 1);
@@ -342,7 +342,7 @@ let has_dest src dst kind =
 let call1_3ret ctxt =
   let mem = String.concat [call1; ret; ret; ret] |>
             memory_of_string in
-  let lifter = Bap_disasm_x86_lifter.insn `x86_64 in
+  let lifter = AMD64.lift in
   let dis = Rec.run ~lifter `x86_64 mem |> Or_error.ok_exn in
   assert_bool "No errors" (Rec.errors dis = []);
   assert_bool "Three block" (Rec.blocks dis |> Table.length = 3);

--- a/src/readbin/printing.ml
+++ b/src/readbin/printing.ml
@@ -11,6 +11,7 @@ module type Env = sig
   val syms : string table
   val cfg  : block table
   val arch : arch
+  module Target : Target
 end
 
 module Make(Env : Env) = struct

--- a/src/readbin/printing.mli
+++ b/src/readbin/printing.mli
@@ -14,6 +14,8 @@ module type Env = sig
   val cfg  : block table
   (** target architecture  *)
   val arch : arch
+
+  module Target : Target
 end
 (** Create a set of pretty printers for a given program
     environment.

--- a/src/readbin/readbin.ml
+++ b/src/readbin/readbin.ml
@@ -141,6 +141,7 @@ module Program(Conf : Options.Provider) = struct
     let project =
       List.fold ~init:project (Program_visitor.registered ())
         ~f:(fun project visit -> visit project) in
+    let module Target = (val target_of_arch arch) in
 
     let module Env = struct
       let options = options
@@ -148,6 +149,7 @@ module Program(Conf : Options.Provider) = struct
       let base = project.memory
       let syms = project.symbols
       let arch = project.arch
+      module Target = Target
     end in
     let module Printing = Printing.Make(Env) in
     let module Helpers = Helpers.Make(Env) in

--- a/src/server/adt.ml
+++ b/src/server/adt.ml
@@ -83,8 +83,8 @@ end
 module Arm = struct
   open Disasm
   let pp_op ch = function
-    | Arm.Op.Imm imm -> pr ch "Imm(%a)" pp_word imm
-    | Arm.Op.Reg reg -> pr ch "Reg(%a())" Arm.Reg.pp reg
+    | ARM.Op.Imm imm -> pr ch "Imm(%a)" pp_word imm
+    | ARM.Op.Reg reg -> pr ch "Reg(%a())" ARM.Reg.pp reg
 
   let rec pp_ops ch = function
     | [] -> ()
@@ -92,7 +92,7 @@ module Arm = struct
     | x :: xs -> pr ch "%a, %a" pp_op x pp_ops xs
 
   let pp_insn ch (insn,ops) =
-    pr ch "%a(%a)" (pp_sexp Arm.Insn.sexp_of_t) insn pp_ops ops
+    pr ch "%a(%a)" (pp_sexp ARM.Insn.sexp_of_t) insn pp_ops ops
 end
 
 let to_string pp x = Format.asprintf "%a" pp x

--- a/src/server/adt.mli
+++ b/src/server/adt.mli
@@ -6,7 +6,7 @@ val strings_of_bil   : stmt list -> string list
 val strings_of_ops   : Basic.op list -> string list
 val strings_of_kinds : Basic.kind list -> string list
 val strings_of_preds : Basic.pred list -> string list
-val string_of_arm    : Arm.Insn.t -> Arm.Op.t list -> string
+val string_of_arm    : ARM.Insn.t -> ARM.Op.t list -> string
 val string_of_endian : endian -> string
 
 module Parse : sig

--- a/src/server/rpc.mli
+++ b/src/server/rpc.mli
@@ -17,7 +17,7 @@ module Id : Identifiable with type t := id
 module Target : sig
   type t = target
 
-  val arm :  Arm.Insn.t -> Arm.Op.t list -> t
+  val arm :  ARM.Insn.t -> ARM.Op.t list -> t
 
 end
 


### PR DESCRIPTION
This PR unifies all lifter targets under the common interface, named
Target. Also disasm library is cleaned and more unified. As a
consequence bap-server now also should give back a bil for x86 family.

Two new main data structures under the Target module:

- CPU defines CPU specific BIL expressions, allowing one to figure out
  what variable is PC, and what is register or flag. It also abstracts
  the process of resolving PC to addresses.

- ABI this one abstracts application binary interface, including calling
  convention, stack frame and data representation, and maybe more

Given this new structures, I've added a new optimization to the BIL
printer that will resolve PC-relative addresses to its values.

With this the following:

```ocaml
  begin(sub_ad5c_0x160) {
    R3 := mem[PC + 0x65C:32, el]:u32
    mem := mem with [SP, el]:u32 <- R3
    R0 := 0x1E:32
    R1 := 0x0:32
    R2 := mem[PC + 0x650:32, el]:u32
    R3 := mem[PC + 0x650:32, el]:u32
    LR := sub_ad5c + 0x17C:32
    jmp hash_initialize
  }
```
is transformed to

```ocaml
begin(sub_ad5c_0x160) {
    R3 := dev_ino_free
    mem := mem with [SP, el]:u32 <- R3
    R0 := 0x1E:32
    R1 := 0x0:32
    R2 := dev_ino_hash
    R3 := dev_ino_compare
    LR := sub_ad5c + 0x17C:32
    jmp hash_initialize
  }
```