### PR TITLE
Makes bap-server emit full variable names

### DIFF
--- a/src/server/adt.ml
+++ b/src/server/adt.ml
@@ -24,7 +24,7 @@ module Var = struct
     | Type.Mem (n,m) -> pr ch "Mem(%a,%a)" pp_size n pp_size m
 
   let pp_var ch v =
-    pr ch "Var(\"%s\",%a)" Var.(name v) pp_ty Var.(typ v)
+    pr ch "Var(\"%a\",%a)" Var.pp v  pp_ty Var.(typ v)
 
 end
 


### PR DESCRIPTION
This change will make temporary variables have their unique names in the BIL output from `bap-server`.