### PR TITLE
Propagate BIL transformations though plugins.

### DIFF
--- a/lib/bap/bap_program_visitor.ml
+++ b/lib/bap/bap_program_visitor.ml
@@ -8,8 +8,10 @@ type project = {
   symbols : string table;
   memory  : mem;
   annots  : (string * string) memmap;
+  bil_of_insns : (mem * insn) list -> bil;
 }
 
 let visitors = ref []
 let register v = visitors := v :: !visitors
+let register' v = register (fun p -> v p; p)
 let registered () = List.rev !visitors

--- a/lib/bap/bap_program_visitor.mli
+++ b/lib/bap/bap_program_visitor.mli
@@ -8,8 +8,9 @@ type project = {
   symbols : string table;
   memory  : mem;
   annots  : (string * string) memmap;
+  bil_of_insns : (mem * insn) list -> bil;
 }
 
 val register : (project -> project) -> unit
-
+val register': (project -> unit) -> unit
 val registered : unit -> (project -> project) list

--- a/src/readbin/helpers.ml
+++ b/src/readbin/helpers.ml
@@ -95,10 +95,13 @@ module Make(Env : Printing.Env) = struct
     |> disable_if no_optimizations
     |> fun optimize -> optimize bil
 
+  let bil_of_insn insn = optimizations (Tuple2.map2 ~f:Insn.bil insn)
+
+
   let bil_of_insns insns =
-    List.(insns >>| Tuple2.map2 ~f:Insn.bil >>| optimizations |> concat)
+    List.(insns >>| bil_of_insn |> concat)
 
 
   let bil_of_block blk : bil =
-    bil_of_insns List.(Block.insns blk)
+    bil_of_insns (Block.insns blk)
 end

--- a/src/readbin/helpers.mli
+++ b/src/readbin/helpers.mli
@@ -5,4 +5,6 @@ open Bap.Std
 
 module Make(Env : Printing.Env) : sig
   val bil_of_block : block -> bil
+  val bil_of_insns : (mem * insn) list -> bil
+  val bil_of_insn  : mem * insn -> bil
 end

--- a/src/readbin/readbin.ml
+++ b/src/readbin/readbin.ml
@@ -124,12 +124,7 @@ module Program(Conf : Options.Provider) = struct
       annotate_symbols "ida-symbol" ida_syms |>
       annotate_symbols "image-symbol" img_syms |>
       annotate_symbols "user-symbol" usr_syms in
-    let project = {
-      arch; memory = mem;
-      annots;
-      program = disasm;
-      symbols = syms;
-    } in
+
     List.iter options.plugins ~f:(fun name ->
         let name = if Filename.check_suffix name ".plugin" then
             name else (name ^ ".plugin") in
@@ -138,10 +133,28 @@ module Program(Conf : Options.Provider) = struct
         with Ok () -> ()
            | Error err -> eprintf "Failed to load plugin %s: %a@."
                             (Filename.basename name) Error.pp err);
-    let project =
-      List.fold ~init:project (Program_visitor.registered ())
-        ~f:(fun project visit -> visit project) in
     let module Target = (val target_of_arch arch) in
+
+    let make_project annots symbols =
+      let module H = Helpers.Make(struct
+          let options = options
+          let cfg = Disasm.blocks disasm
+          let base = mem
+          let syms = syms
+          let arch = arch
+          module Target = Target
+        end) in {
+        annots;
+        symbols;
+        arch; memory = mem;
+        program = disasm;
+        bil_of_insns = H.bil_of_insns;
+      } in
+
+    let project =
+      List.fold ~init:(make_project annots syms)
+        (Program_visitor.registered ())
+        ~f:(fun p visit -> visit (make_project p.annots p.symbols)) in
 
     let module Env = struct
       let options = options
@@ -154,7 +167,7 @@ module Program(Conf : Options.Provider) = struct
     let module Printing = Printing.Make(Env) in
     let module Helpers = Helpers.Make(Env) in
     let open Printing in
-    let open Helpers in
+    let bil_of_block blk = project.bil_of_insns (Block.insns blk) in
 
     let pp_sym = List.map options.print_symbols ~f:(function
         | `with_name -> pp_name


### PR DESCRIPTION
This PR provides a new field in a project record: a function that will
transform instruction list to a BIL program. Initially this
transformation includes all optimizations that were requested from the
command line. Plugin, can rebind this optimization.

There is one issue, that should be qualified, the call
`project.bil_of_insns` is statically bound to the `project`, so there is
no open recursion here or any late binding. So all your changes to the
project will not affect this function, until the next plugin, where it
will be rebound to the new state of project.

I'm considering to switch project type to the object type.