### PR TITLE
Introduce arm-gnueabi and some fixes.

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -221,6 +221,7 @@ Library disasm
                  Bap_disasm_abi,
                  Bap_disasm_abi_helpers,
                  Bap_disasm_arm,
+                 Bap_disasm_arm_abi,
                  Bap_disasm_arm_bit,
                  Bap_disasm_arm_branch,
                  Bap_disasm_arm_env,
@@ -233,6 +234,8 @@ Library disasm
                  Bap_disasm_arm_shift,
                  Bap_disasm_arm_types,
                  Bap_disasm_arm_utils,
+                 Bap_disasm_amd64_abi,
+                 Bap_disasm_ia32_abi,
                  Bap_disasm_stub_lifter,
                  Bap_disasm_x86,
                  Bap_disasm_x86_lifter,
@@ -250,6 +253,7 @@ Library disasm
                  Bap_insn_kind,
                  Bap_byteweight,
                  Bap_signatures
+
 
   CCOpt:         $cc_optimization
   CCLib:         $cxxlibs

--- a/lib/bap_disasm/bap_disasm_abi.ml
+++ b/lib/bap_disasm/bap_disasm_abi.ml
@@ -52,7 +52,7 @@ class type abi = object
       A good start whould be to use:
       [specific; compiler; os; vendor]
 
-      Example: ["unknown; ""linux"; "gnueabi"; "*exit"].
+      Example: ["*exit"; "gnueabi"; "linux"; "unknown"]
 
       Will encode an ABI of [exit] family of functions for ARM linux
       gnueabi. The recommended printing format for the ABI is to
@@ -91,8 +91,7 @@ class type abi = object
   (** [return_value] returns an expression, that can be used to return
       a value from a function. Use [Bil.concat] to represent return
       value that doesn't fit into one register  *)
-  method return_value : exp
-
+  method return_value : exp option
 
   (** [args] returns a list of expressions that represents
       arguments of the given function. Each expression can be
@@ -110,4 +109,4 @@ end
 (** symbol name may be provided if known. Also an access
     to the whole binary image is provided if there is one. *)
 type abi_constructor =
-  ?image:image -> ?sym:string -> mem -> Bap_disasm_block.t -> abi option
+  ?image:image -> ?sym:string -> mem -> Bap_disasm_block.t -> abi

--- a/lib/bap_disasm/bap_disasm_abi_helpers.mli
+++ b/lib/bap_disasm/bap_disasm_abi_helpers.mli
@@ -19,6 +19,6 @@ val to_string : arch -> string list -> string
 (**/**)
 val create_abi_getter :
   abi_constructor list ref ->
-  ?all:bool -> (** defaults to false  *)
+  ?merge:(abi list -> abi) -> (** defaults to [merge]  *)
   ?image:image ->
-  ?sym:string -> mem -> Bap_disasm_block.t -> abi list
+  ?sym:string -> mem -> Bap_disasm_block.t -> abi

--- a/lib/bap_disasm/bap_disasm_amd64_abi.ml
+++ b/lib/bap_disasm/bap_disasm_amd64_abi.ml
@@ -1,0 +1,9 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_image_std
+open Bap_disasm_abi
+open Bap_disasm_abi_helpers
+
+let registered = ref []
+let register abi = registered := abi :: !registered
+let create = create_abi_getter registered

--- a/lib/bap_disasm/bap_disasm_amd64_abi.mli
+++ b/lib/bap_disasm/bap_disasm_amd64_abi.mli
@@ -1,0 +1,9 @@
+open Bap_image_std
+open Bap_disasm_abi
+
+val register : abi_constructor -> unit
+
+val create :
+  ?merge:(abi list -> abi) ->
+  ?image:image ->
+  ?sym:string -> mem -> Bap_disasm_block.t -> abi

--- a/lib/bap_disasm/bap_disasm_arm.mli
+++ b/lib/bap_disasm/bap_disasm_arm.mli
@@ -1,7 +1,7 @@
 (** Types for ARM instructions.
-    The type definitions itself can be viewed in a
-    [Bap_disasm_arm_types] module. This one extends them with a
-    [Regular] functions.
+     The type definitions itself can be viewed in a
+     [Bap_disasm_arm_types] module. This one extends them with a
+     [Regular] functions.
 *)
 open Core_kernel.Std
 open Bap_types.Std

--- a/lib/bap_disasm/bap_disasm_arm_abi.ml
+++ b/lib/bap_disasm/bap_disasm_arm_abi.ml
@@ -1,0 +1,77 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_image_std
+open Bap_disasm_types
+open Bap_disasm_abi
+open Bap_disasm_abi_helpers
+open Bap_disasm_arm_env
+
+module Block = Bap_disasm_block
+module Insn = Bap_disasm_insn
+
+let registered = ref []
+
+let register abi = registered := abi :: !registered
+
+let create =
+  create_abi_getter registered
+
+
+class gnueabi_basic ?image ?sym mem blk = object(self)
+  inherit stub
+  method! id = ["gnueabi"; "linux"; "unknown"]
+  method! specific = false
+  method! choose other =
+    if List.mem other#id "gnueabi" then
+      Int.compare (List.length self#id) (List.length other#id)
+    else 0
+
+  method! return_value = Some (Bil.var r0)
+  method! args = [r0; r1; r2; r3] |>
+                 List.map ~f:(fun r -> None, Bil.var r)
+end
+
+module Cfg = Block.Cfg.Imperative
+
+let bil_of_block blk =
+  Block.Cfg.Block.insns blk |> List.concat_map ~f:(fun (_,insn) -> Insn.bil insn)
+
+let is_used_before_assigned v bil =
+  Bil.is_referenced v bil &&
+  Bil.find (object(self) inherit [unit] Bil.finder
+    method! visit_move u e goto =
+      if compare_var v u = 0
+      then goto.return None;
+      self#visit_exp e goto
+    method! enter_var u goto =
+      if compare_var v u = 0
+      then goto.return (Some ());
+      goto
+  end) bil
+
+let is_assigned_before cfg blk var =
+  with_return (fun {return} -> Cfg.iter_pred (fun blk ->
+      if Bil.is_assigned var (bil_of_block blk)
+      then return true) cfg blk;
+      false)
+
+let is_parameter cfg var =
+  with_return (fun {return} ->
+      Cfg.iter_vertex (fun blk ->
+          let bil = bil_of_block blk in
+          if is_used_before_assigned var bil &&
+             not (is_assigned_before cfg blk var)
+          then return true) cfg;
+      false)
+
+class gnueabi ?image ?sym mem blk =
+  let _,cfg = Block.to_imperative_graph ~bound:mem blk in
+  let args = List.take_while [r0;r1;r2;r3] ~f:(is_parameter cfg) in
+  object(self)
+    inherit gnueabi_basic ?image ?sym mem blk
+    method! args = List.map args ~f:(fun r -> None, Bil.var r)
+  end
+
+
+
+let () = register (new gnueabi)

--- a/lib/bap_disasm/bap_disasm_arm_abi.mli
+++ b/lib/bap_disasm/bap_disasm_arm_abi.mli
@@ -1,0 +1,12 @@
+open Bap_image_std
+open Bap_disasm_abi
+
+class gnueabi : ?image:image ->
+  ?sym:string -> mem -> Bap_disasm_block.t -> abi
+
+val register : abi_constructor -> unit
+
+val create :
+  ?merge:(abi list -> abi) ->
+  ?image:image ->
+  ?sym:string -> mem -> Bap_disasm_block.t -> abi

--- a/lib/bap_disasm/bap_disasm_arm_lifter.ml
+++ b/lib/bap_disasm/bap_disasm_arm_lifter.ml
@@ -1068,8 +1068,8 @@ let lift mem insn =
   | exn -> of_exn exn
 
 
-module CPU : CPU = struct
-  open Bap_disasm_arm_env
+module CPU = struct
+  include Bap_disasm_arm_env
 
   let mem = mem
   let pc = pc
@@ -1128,10 +1128,3 @@ module CPU : CPU = struct
   let is_permanent = Set.mem perms
   let is_mem = is mem
 end
-
-
-let registered = ref []
-
-let register_abi abi = registered := abi :: !registered
-
-let get_abi = create_abi_getter registered

--- a/lib/bap_disasm/bap_disasm_arm_lifter.mli
+++ b/lib/bap_disasm/bap_disasm_arm_lifter.mli
@@ -9,11 +9,7 @@ open Bap_disasm_abi
 val lift : mem -> ('a,'k) Basic.insn -> stmt list Or_error.t
 
 
-module CPU : CPU
-
-val register_abi : abi_constructor -> unit
-
-val get_abi :
-  ?all:bool -> (** defaults to false  *)
-  ?image:image ->
-  ?sym:string -> mem -> Bap_disasm_block.t -> abi list
+module CPU : sig
+  include module type of Bap_disasm_arm_env
+  include CPU
+end

--- a/lib/bap_disasm/bap_disasm_block.ml
+++ b/lib/bap_disasm/bap_disasm_block.ml
@@ -59,7 +59,8 @@ module Build(G : Graph.Builder.S with type G.E.t = t * edge * t
       Vis.mem visited addr || not (bounded addr) in
     let rec build gr vis src =
       if skip vis src then (gr,vis)
-      else Seq.fold ~init:(gr,Vis.add vis (addr src)) (dests src)
+      else Seq.fold (dests src)
+          ~init:(G.add_vertex gr src,Vis.add vis (addr src))
           ~f:(fun (gr,vis) -> function
               | `Unresolved kind -> (gr,vis)
               | `Block (dst,kind) ->

--- a/lib/bap_disasm/bap_disasm_ia32_abi.ml
+++ b/lib/bap_disasm/bap_disasm_ia32_abi.ml
@@ -1,0 +1,9 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_image_std
+open Bap_disasm_abi
+open Bap_disasm_abi_helpers
+
+let registered = ref []
+let register abi = registered := abi :: !registered
+let create = create_abi_getter registered

--- a/lib/bap_disasm/bap_disasm_ia32_abi.mli
+++ b/lib/bap_disasm/bap_disasm_ia32_abi.mli
@@ -1,0 +1,9 @@
+open Bap_image_std
+open Bap_disasm_abi
+
+val register : abi_constructor -> unit
+
+val create :
+  ?merge:(abi list -> abi) ->
+  ?image:image ->
+  ?sym:string -> mem -> Bap_disasm_block.t -> abi

--- a/lib/bap_disasm/bap_disasm_stub_lifter.ml
+++ b/lib/bap_disasm/bap_disasm_stub_lifter.ml
@@ -1,11 +1,14 @@
 open Core_kernel.Std
 open Bap_types.Std
 open Bap_image_std
+open Bap_disasm_abi_helpers
 
 let lift _ _ = Or_error.error_string "not implemented"
-
-let register_abi _ = ()
-let get_abi ?all ?image ?sym mem blk = []
+module ABI = struct
+  let register _ = ()
+  let create ?merge ?image ?sym mem blk = new stub
+  include Bap_disasm_abi_helpers
+end
 
 module CPU = struct
   let gpr = Var.Set.empty

--- a/lib/bap_disasm/bap_disasm_stub_lifter.mli
+++ b/lib/bap_disasm/bap_disasm_stub_lifter.mli
@@ -4,16 +4,17 @@ open Bap_image_std
 open Bap_disasm_types
 open Bap_disasm_abi
 
-
-
 val lift : mem -> ('a,'k) Basic.insn -> stmt list Or_error.t
-
 
 module CPU : CPU
 
-val register_abi : abi_constructor -> unit
+module ABI : sig
+  val register : abi_constructor -> unit
 
-val get_abi :
-  ?all:bool -> (** defaults to false  *)
-  ?image:image ->
-  ?sym:string -> mem -> Bap_disasm_block.t -> abi list
+  val create :
+    ?merge:(abi list -> abi) ->
+    ?image:image ->
+    ?sym:string -> mem -> Bap_disasm_block.t -> abi
+
+  include module type of Bap_disasm_abi_helpers
+end

--- a/lib/bap_disasm/bap_disasm_x86_lifter.ml
+++ b/lib/bap_disasm/bap_disasm_x86_lifter.ml
@@ -1469,8 +1469,9 @@ let insn arch mem insn =
       let stmts, _ = disasm_instr mode mem addr in stmts)
 
 
-module Make_CPU(Env : ModeVars) : CPU = struct
-  open Env
+module Make_CPU(Env : ModeVars) = struct
+  include Bap_disasm_x86_env
+  include Env
   (* we do not include pc into a set of gpr *)
   let gpr = Var.Set.of_list @@ [
       rax; rcx; rdx; rsi; rdi;
@@ -1508,16 +1509,10 @@ end
 
 module AMD64 = struct
   module CPU = Make_CPU(R64)
-  let registered = ref []
-  let register_abi abi = registered := abi :: !registered
-  let get_abi = create_abi_getter registered
   let lift mem i = insn `x86_64 mem i
 end
 
 module IA32 = struct
   module CPU = Make_CPU(R32)
-  let registered = ref []
-  let register_abi abi = registered := abi :: !registered
-  let get_abi = create_abi_getter registered
   let lift mem i = insn `x86 mem i
 end

--- a/lib/bap_disasm/bap_disasm_x86_lifter.mli
+++ b/lib/bap_disasm/bap_disasm_x86_lifter.mli
@@ -5,21 +5,19 @@ open Bap_disasm_types
 open Bap_disasm_abi
 
 module IA32 : sig
-  module CPU : CPU
-  val register_abi : abi_constructor -> unit
-  val get_abi :
-    ?all:bool -> (** defaults to false  *)
-    ?image:image ->
-    ?sym:string -> mem -> Bap_disasm_block.t -> abi list
+  module CPU : sig
+    include module type of Bap_disasm_x86_env
+    include Bap_disasm_x86_env.ModeVars
+    include CPU
+  end
   val lift : mem -> ('a,'k) Basic.insn -> stmt list Or_error.t
 end
 
 module AMD64 : sig
-  module CPU : CPU
-  val register_abi : abi_constructor -> unit
-  val get_abi :
-    ?all:bool -> (** defaults to false  *)
-    ?image:image ->
-    ?sym:string -> mem -> Bap_disasm_block.t -> abi list
+  module CPU : sig
+    include module type of Bap_disasm_x86_env
+    include Bap_disasm_x86_env.ModeVars
+    include CPU
+  end
   val lift : mem -> ('a,'k) Basic.insn -> stmt list Or_error.t
 end

--- a/lib/bap_disasm/bap_program_visitor.ml
+++ b/lib/bap_disasm/bap_program_visitor.ml
@@ -1,0 +1,14 @@
+open Bap_types.Std
+open Image_internal_std
+open Bap_disasm
+
+type project = {
+  arch    : arch;
+  program : disasm;
+  symbols : string table;
+  memory  : mem;
+  annots  : tags table;
+}
+let visitors = ref []
+let register v = visitors := v :: !visitors
+let registered () = List.rev !visitors

--- a/lib/bap_disasm/bap_program_visitor.mli
+++ b/lib/bap_disasm/bap_program_visitor.mli
@@ -1,0 +1,15 @@
+open Bap_types.Std
+open Image_internal_std
+open Bap_disasm
+
+type project = {
+  arch    : arch;
+  program : disasm;
+  symbols : string table;
+  memory  : mem;
+  annots  : tags table;
+}
+
+val register : (project -> project) -> unit
+
+val registered : unit -> (project -> project) list

--- a/lib/bap_types/bap_helpers.ml
+++ b/lib/bap_types/bap_helpers.ml
@@ -25,12 +25,6 @@ let is_referenced x = find (object(self)
       if Bap_var.(x = y) then cc.return (Some ()); cc
   end)
 
-let is_modified x = find (object inherit [unit] finder
-    method! enter_move y _ ctrl =
-      if Bap_var.(x = y) then ctrl.return (Some ());
-      ctrl
-  end)
-
 let prune_unreferenced stmt =
   let rec loop ss = function
     | [] -> List.rev ss

--- a/lib/bap_types/bap_helpers.mli
+++ b/lib/bap_types/bap_helpers.mli
@@ -13,9 +13,6 @@ val map : #mapper -> bil -> bil
     statement in program [p] *)
 val is_referenced : var -> bil -> bool
 
-(** [is_modified x p] is [true] is [x] is assigned in [p]  *)
-val is_modified : var -> bil -> bool
-
 (** [is_assigned x p] is [true] if there exists such [Move]
     statement, that [x] occures on the left side of it. If [strict]
     is true, then only unconditional assignments. By default,


### PR DESCRIPTION
This PR adds preliminary support for ARM gnueabi. Currently only
parameters passed via registers are recognized. The `return_value` is
set to always return `Some r0`, as type inference is needed for a more
correct heuristics, since may functions finishes with
`jmp another_function`.

The abi interface is little bit refined. First of all the `return_value`
now returns an option type, to handle functions returning `void`. ABI
modules are moved into the corresponding targets. So to create an
instance of abi one should call to `Target.ABI.create` function. In
general one should use module `Target` as returned by
`target_of_arch` function to access cross-platform
abstractions. Platform specific abstractions are still available, under
corresponding modules, e.g., `ARM.CPU.r0` will refer to the `r0`
register.

This PR will also fix a bug in functions that create a graph from a
block in a `Block` module. In case of function consisting of only one
block, this functions returned empty graph.