### PR TITLE
Adds a newline to the bap-objdump error message.

### DIFF
--- a/src/readbin/cmdline.ml
+++ b/src/readbin/cmdline.ml
@@ -173,4 +173,4 @@ let program =
 
 let parse () = match Term.eval program with
   | `Ok opts -> Ok opts
-  | _ -> Or_error.errorf "no cmdline options provided"
+  | _ -> Or_error.errorf "no cmdline options provided\n"


### PR DESCRIPTION
Previously the error message did not have a newline
when no options were provided, which was unaesthic and
offset the next command prompt.