### PR TITLE
Extended integration with IDA.

### DIFF
--- a/src/readbin/cmdline.ml
+++ b/src/readbin/cmdline.ml
@@ -131,6 +131,11 @@ let sigsfile : string option Term.t =
              usually it is enough to run `bap-byteweight update'." in
   Arg.(value & opt (some non_dir_file) None & info ["sigs"] ~doc)
 
+let emit_ida_script : string option Term.t =
+  let doc = "Emit annotations to IDA based on project annotations to \
+             the specified filename." in
+  Arg.(value & opt (some string) None & info ["emit-ida-script"] ~doc)
+
 let load : string list Term.t =
   let doc = "Load the specified plugin. Plugin must be compiled with \
              `bapbuild $(docv).plugin'. This option can be specified \
@@ -139,9 +144,17 @@ let load : string list Term.t =
   Arg.(value & opt_all string [] &
        info ["load"; "l"] ~doc ~docv:"NAME")
 
+let load_path : string list Term.t =
+  let doc = "Add $(docv) to a set of search paths. Plugins specified \
+             with `-l` flag will be searched in this paths, if they \
+             are not found in the current folder or in a folder \
+             specified by a `BAP_PLUGIN_PATH' environment variable" in
+  Arg.(value & opt_all string [] &
+       info ["load-path"; "L"] ~doc ~docv:"PATH")
+
 let create
-    a b c d e f g h i k l m n o p q r s t u = Options.Fields.create
-    a b c d e f g h i k l m n o p q r s t u
+    a b c d e f g h i k l m n o p q r s t u v x = Options.Fields.create
+    a b c d e f g h i k l m n o p q r s t u v x
 let program =
   let doc = "Disassemble binary" in
   let man = [
@@ -167,7 +180,8 @@ let program =
         $no_resolve $keep_alive
         $no_inline $keep_consts $no_optimizations
         $binaryarch $verbose $bw_disable $bw_length $bw_threshold
-        $print_symbols $use_ida $sigsfile $load),
+        $print_symbols $use_ida $sigsfile $load
+        $emit_ida_script $load_path),
   Term.info "bap-objdump"
     ~version:Config.pkg_version ~doc ~man
 

--- a/src/readbin/idapy.ml
+++ b/src/readbin/idapy.ml
@@ -1,0 +1,33 @@
+open Core_kernel.Std
+open Bap.Std
+open Program_visitor
+
+let extract_symbols output = sprintf "
+from idautils import *
+with open('%s', 'w+') as out:
+    for ea in Segments():
+        fs = Functions(SegStart(ea), SegEnd(ea))
+        for f in fs:
+            out.write ('(%%s 0x%%x 0x%%x)\\n' %% (
+                GetFunctionName(f),
+                GetFunctionAttr(f, FUNCATTR_START),
+                GetFunctionAttr(f, FUNCATTR_END)))
+
+idc.Exit(0)" output
+
+let addr take mem =
+  sprintf "0x%s" @@ Addr.string_of_value (take mem)
+
+let annotate_ida p =
+  let buf = Buffer.create 64 in
+  Buffer.add_string buf "from idautils import *\n";
+  Memmap.to_sequence p.annots |> Seq.iter ~f:(fun (mem,(tag,script)) ->
+      if tag = "idapy" then
+        Buffer.add_substitute buf (function
+            | "min_addr" -> addr Memory.min_addr mem
+            | "max_addr" -> addr Memory.max_addr mem
+            | "mem_size" -> Int.to_string (Memory.length mem)
+            | s -> sprintf
+                     "raise RuntimeError('bad substitution: %s')" s)
+          script);
+  Buffer.contents buf

--- a/src/readbin/idapy.mli
+++ b/src/readbin/idapy.mli
@@ -1,0 +1,21 @@
+open Bap.Std
+open Program_visitor
+
+(** [extract_symbols output_path] will emit a script, that will
+    extract symbols from IDA database and store it [output_path] *)
+val extract_symbols : string -> string
+
+
+(** for each (tag,script) pair attached to memory region [mem],
+    if [tag] is equal to [idapy], then the [script] is added to the
+    output program. The following substitution are avaliable in the
+    script:
+
+    $min_addr  - starting address of the [mem]
+    $max_addr  - the addres of the last byte of [mem]
+    $mem_size  - the size of memory [mem] in bytes
+
+    all defintions from [idautils] modules are brought to the environment.
+
+*)
+val annotate_ida : project -> string

--- a/src/readbin/options.ml
+++ b/src/readbin/options.ml
@@ -25,6 +25,8 @@ type t = {
   use_ida : string option option;
   sigfile : string option;
   plugins : string list;
+  emit_ida_script : string option;
+  load_path : string list;
 } with sexp, fields
 
 module type Provider = sig


### PR DESCRIPTION
This PR will add two new command line options, and (hopefully) fix
issues with locating IDA.

1. added -L option.
   This option allows to specify search paths for BAP plugins. The
   option can be specified several times. Moreover, one can specify
   search path using `BAP_PLUGIN_PATH` environment variable, that
   accepts a set of paths separated by `:`.

2. added --emit-ida-script option, that will dump an IDA script,
   using new function `Idapy.annotate_ida`. This function allow plugins
   to smoothly talk to IDA, by annotating code segments with python
   commands.

3. fixed location issue. Only those entries of the locatedb are
   considered that ends with the specified string.