### PR TITLE
bap-mc enhancing.

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -118,6 +118,7 @@ Library types
                    Bap_addr,
                    Bap_arch,
                    Bap_bil,
+                   Bap_bil_adt,
                    Bap_bitvector,
                    Bap_common,
                    Bap_config,

--- a/lib/bap_disasm/bap_disasm_basic.ml
+++ b/lib/bap_disasm/bap_disasm_basic.ml
@@ -186,10 +186,17 @@ module Op = struct
       | Fmm of fmm
     with bin_io, compare, sexp
 
+    let pr fmt = Format.fprintf fmt
     let pp fmt = function
-      | Reg reg -> Format.fprintf fmt "%a" Reg.pp reg
-      | Imm imm -> Format.fprintf fmt "%a" Imm.pp imm
-      | Fmm fmm -> Format.fprintf fmt "%a" Fmm.pp fmm
+      | Reg reg -> pr fmt "%a" Reg.pp reg
+      | Imm imm -> pr fmt "%a" Imm.pp imm
+      | Fmm fmm -> pr fmt "%a" Fmm.pp fmm
+
+    let pp_adt ch = function
+      | Imm imm -> pr ch "Imm(0x%Lx)" (Imm.to_int64 imm)
+      | Fmm fmm -> pr ch "Fmm(%g)" (Fmm.to_float fmm)
+      | Reg reg -> pr ch "Reg(\"%a\")" Reg.pp reg
+
 
     let module_name = "Bap_disasm_basic.Op"
 

--- a/lib/bap_disasm/bap_disasm_basic.mli
+++ b/lib/bap_disasm/bap_disasm_basic.mli
@@ -202,6 +202,7 @@ module Op : sig
     val compare_ops : t array -> t array -> int
   end
 
+  val pp_adt : Format.formatter -> t -> unit
   include Regular with type t := t
 end
 

--- a/lib/bap_disasm/bap_disasm_block.mli
+++ b/lib/bap_disasm/bap_disasm_block.mli
@@ -27,6 +27,17 @@ type insn = Bap_disasm_insn.t with compare,bin_io,sexp
 include Block_accessors with type t := t and type insn := insn
 include Block_traverse  with type t := t
 
+
+(** [dfs ?next ?bound blk] searches from the [blk] using DFS.
+
+    Search can be bound with [bound], i.e., the search will not continue
+    on block that has no intersections with the specified bound. By
+    default the search is unbound. Search direction can be also
+    specified by the [next] parameter. By default search is performed
+    in a forward direction, using [succs] function. To search in a
+    reverse direction, use [preds] function. The search result is
+    returned as a lazy sequence.
+*)
 val dfs : ?next:(t -> t seq) -> ?bound:mem -> t -> t seq
 
 

--- a/lib/bap_disasm/bap_disasm_insn.ml
+++ b/lib/bap_disasm/bap_disasm_insn.ml
@@ -84,6 +84,21 @@ let has_side_effect insn = may_store insn || may_load insn
 let is_unconditional_jump insn =
   is_jump insn || not (is_conditional_jump insn)
 
+module Adt = struct
+  let pr fmt = Format.fprintf fmt
+
+  let rec pp_ops ch = function
+    | [] -> ()
+    | [x] -> pr ch "%a" Op.pp_adt x
+    | x :: xs -> pr ch "%a, %a" Op.pp_adt x pp_ops xs
+
+  let pp ch insn = pr ch "%s(%a)"
+      (String.capitalize insn.name)
+      pp_ops (Array.to_list insn.ops)
+end
+
+let pp_adt = Adt.pp
+
 module Trie = struct
   module Key = struct
     type token = int * Op.t array with bin_io, compare, sexp

--- a/lib/bap_disasm/bap_disasm_insn.mli
+++ b/lib/bap_disasm/bap_disasm_insn.mli
@@ -64,6 +64,10 @@ val may_load : t -> bool
 val may_store : t -> bool
 
 
+(** [pp_adt] prints instruction in ADT format, suitable for reading
+    by evaluating in many languages, e.g. Python, Js, etc *)
+val pp_adt : Format.formatter -> t -> unit
+
 (** {3 Prefix Tree}
     This module provides a trie data structure where a sequence of
     instructions is used as a key (and an individual instruction

--- a/lib/bap_types/bap_bil_adt.ml
+++ b/lib/bap_types/bap_bil_adt.ml
@@ -1,0 +1,76 @@
+open Core_kernel.Std
+open Bap_common
+open Bap_bil
+module Word = Bitvector
+
+
+let pr ch fms = Format.fprintf ch fms
+
+let pp_word ch word =
+  pr ch "Int(%s,%d)"
+    (Word.string_of_value ~hex:false word)
+    (Word.bitwidth word)
+
+let pp_endian ch = function
+  | BigEndian -> pr ch "BigEndian()"
+  | LittleEndian -> pr ch "LittleEndian()"
+
+let pp_size ch size =
+  pr ch "%d" (Bap_size.to_bits size)
+
+let pp_sexp sexp ch x =
+  pr ch "%a" Sexp.pp (sexp x)
+
+module Var = struct
+  let pp_ty ch = function
+    | Type.Imm n -> pr ch "Imm(%d)" n
+    | Type.Mem (n,m) -> pr ch "Mem(%a,%a)" pp_size n pp_size m
+
+  let pp_var ch v =
+    pr ch "Var(\"%a\",%a)" Bap_var.pp v  pp_ty Bap_var.(typ v)
+
+end
+
+module Exp = struct
+  open Exp
+  open Var
+
+  let rec pp ch = function
+    | Load (x,y,e,s) ->
+      pr ch "Load(%a,%a,%a,%a)" pp x pp y pp_endian e pp_size s
+    | Store (x,y,z,e,s) ->
+      pr ch "Store(%a,%a,%a,%a,%a)" pp x pp y pp z pp_endian e pp_size s
+    | BinOp (op,x,y) ->
+      pr ch "%a(%a,%a)" (pp_sexp sexp_of_binop) op pp x pp y
+    | UnOp (op,x) ->
+      pr ch "%a(%a)" (pp_sexp sexp_of_unop) op pp x
+    | Var v -> pp_var ch v
+    | Int w -> pp_word ch w
+    | Cast (ct,sz,ex) ->
+      pr ch "%a(%d,%a)" (pp_sexp sexp_of_cast) ct sz pp ex
+    | Let (v,e1,e2) -> pr ch "Let(%a,%a,%a)" pp_var v pp e1 pp e2
+    | Unknown (s,t) -> pr ch "Unknown(%S,%a)" s pp_ty t
+    | Ite (e1,e2,e3) -> pr ch "Ite(%a,%a,%a)" pp e1 pp e2 pp e3
+    | Extract (n,m,e) -> pr ch "Extract(%d,%d,%a)" n m pp e
+    | Concat (e1,e2) -> pr ch "Concat(%a,%a)" pp e1 pp e2
+end
+
+module Stmt = struct
+  open Stmt
+  open Var
+  let rec pp ch = function
+    | Move (v,e) -> pr ch "Move(%a,%a)" pp_var v Exp.pp e
+    | Jmp e -> pr ch "Jmp(%a)" Exp.pp e
+    | Special s -> pr ch "Special(%S)" s
+    | While (e,ss) -> pr ch "While(%a, (%a))" Exp.pp e pps ss
+    | If (e,xs,ys) -> pr ch "If(%a, (%a), (%a))" Exp.pp e pps xs pps ys
+    | CpuExn n -> pr ch "CpuExn(%d)" n
+  and pps ch = function
+    | []  -> ()
+    | [s] -> pp ch s
+    | s :: ss -> pr ch "%a, %a" pp s pps ss
+end
+
+
+let pp_stmt = Stmt.pp
+let pp_exp = Exp.pp

--- a/lib/bap_types/bap_bil_adt.mli
+++ b/lib/bap_types/bap_bil_adt.mli
@@ -1,0 +1,7 @@
+open Core_kernel.Std
+open Bap_common
+open Bap_bil
+open Format
+
+val pp_exp : formatter -> exp -> unit
+val pp_stmt : formatter -> stmt -> unit

--- a/lib/bap_types/bap_types.ml
+++ b/lib/bap_types/bap_types.ml
@@ -168,6 +168,7 @@ module Std = struct
     module Unop = Bap_bil.Unop
     module Binop = Bap_bil.Binop
     module Cast = Bap_bil.Cast
+    let pp_adt = Bap_bil_adt.pp_exp
   end
 
   (** Bil statements  *)
@@ -177,6 +178,7 @@ module Std = struct
     include Bap_stmt.Stmt
     include Bap_stmt
     include Bap_stmt.Infix
+    let pp_adt = Bap_bil_adt.pp_stmt
   end
 
   module Bil = struct

--- a/src/bap_mc/bap_mc.ml
+++ b/src/bap_mc/bap_mc.ml
@@ -1,257 +1,228 @@
 open Core_kernel.Std
 open Or_error
-open OUnit2
+open Format
 open Bap.Std
 open Bap_plugins.Std
 
-module Disasm = Disasm_expert.Basic
-module Insn = Disasm.Insn
+module Dis = Disasm_expert.Basic
 
 exception Bad_user_input
-exception No_disassembly of mem * int * int
-exception Convert_imm_exn of string
-exception Create_mem_exn
-exception Stdin_exn
+exception Bad_insn of mem * int * int
+exception Convert_imm of string
+exception Create_mem
+exception No_input
+exception Unknown_arch
+exception Can't_lift of Error.t
+exception Trailing_data of int
 
 let no_disassembly state boff =
-  let mem = Disasm.memory state in
-  let addr = Disasm.addr state in
+  let mem = Dis.memory state in
+  let addr = Dis.addr state in
   let stop = Addr.to_int addr |> ok_exn in
-  raise (No_disassembly (mem, boff, stop))
+  raise (Bad_insn (mem, boff, stop))
 
-let create_memory arch addr s =
-  let width = match Arch.of_string arch with
-    | Some arch -> Arch.addr_size arch |> Size.to_bits
-    | None -> eprintf "Warning: unknown arch, assuming 32 bitness\n";
-      32 in
-  Memory.create LittleEndian Addr.(of_int64 ~width addr) @@
-  Bigstring.of_string s |> function
-  | Ok r -> r
-  | Error _ -> raise Create_mem_exn
+let escape_0x =
+  String.substr_replace_all ~pattern:"0x" ~with_:"\\x"
 
-let print_kinds insn =
-  let output = Insn.kinds insn
-               |> List.map ~f:(fun kind ->
-                   Sexp.to_string_hum (Disasm.sexp_of_kind kind))
-               |> String.concat ~sep:", " in
-  printf "%-4s;; %s\n" " " output
+let prepend_slash_x x = "\\x" ^ x
 
-let print_insn insn width o_reg_format o_imm_format =
-  let open Disasm.Op in
-  let init = [Sexp.Atom (Insn.name insn)] in
-  let res =
-    Insn.ops insn
-    |> Array.fold ~init ~f:(fun l x -> match x with
-        | Reg reg ->
-          if String.(o_reg_format = "code") then
-            Sexp.Atom ("r:" ^ Int.to_string (Reg.code reg)) :: l else
-            Sexp.Atom (Reg.name reg) :: l
-        | Imm imm ->
-          if String.(o_imm_format = "dec") then
-            let v = match Imm.to_int imm with
-              | Some x -> x
-              | None -> raise @@ Convert_imm_exn (Imm.to_string imm) in
-            Sexp.Atom (Printf.sprintf "%d" v) :: l else
-            Sexp.Atom (Imm.to_string imm) :: l
-        | Fmm fmm ->
-          Sexp.Atom (Fmm.to_string fmm) :: l) in
-  let s = Sexp.to_string @@ Sexp.List (List.rev res) in
-  printf "%-4s%-*s" " " width s
-
-let rec dinsns_to_insn_list = function
-  | [(_, None)] 
-  | [] -> []
-  | (_, None) :: restInsns -> dinsns_to_insn_list restInsns
-  | (_, Some insn) :: restInsns -> insn :: (dinsns_to_insn_list restInsns)
-
-let insns_to_bil_list insns = 
-  let insns = (dinsns_to_insn_list insns) in
-  (List.map insns Bap.Std.Insn.bil) 
-
-let print_bilsexp_of_insns insns =
-  let bil_list = insns_to_bil_list insns in
-  let f x= Sexp.to_string_hum (sexp_of_bil x) in
-  let string_list = (List.map bil_list f) in
-  List.iter string_list print_string;;
-
-let print_pb_of_insns insns =
-  let bil_list = insns_to_bil_list insns in
-  let f x = (Bil_piqi.pb_of_stmts (Bap.Std.Insn.bil x)) in
-  List.iter (List.map (dinsns_to_insn_list insns) ~f:f) ~f:print_string
-
-let print_json_of_insns insns =
-  let bil_list = insns_to_bil_list insns in
-  let f x = (Bil_piqi.json_of_stmts (Bap.Std.Insn.bil x)) in
-  List.iter (List.map (dinsns_to_insn_list insns) ~f:f) print_string
-
-let print_xml_of_insns insns =
-  let bil_list = insns_to_bil_list insns in
-  let f x = Bil_piqi.xml_of_stmts (Bap.Std.Insn.bil x) in
-  List.iter (List.map (dinsns_to_insn_list insns) ~f:f) print_string
-
-(* Note: Insn.asm returns string with 8 character padding, Strip it to keep
- * things consistent *)
-let print_asm insn f_inst =
-  let s = String.strip @@ Insn.asm insn in
-  if f_inst
-  then printf "; %s" s
-  else printf "%-4s%s" " " s
-
-let print_disasm arch width f_asm f_inst f_bil f_bil_to_pb f_bil_to_json f_bil_to_xml f_kinds o_reg_format o_imm_format
-    state mem insn off =
-  if f_kinds then print_kinds insn;
-  if f_inst then print_insn insn width o_reg_format o_imm_format;
-  if f_bil then print_bilsexp_of_insns (linear_sweep_exn arch mem);
-  if f_bil_to_pb then print_pb_of_insns (linear_sweep_exn arch mem);
-  if f_bil_to_json then print_json_of_insns (linear_sweep_exn arch mem);
-  if f_bil_to_xml then print_xml_of_insns (linear_sweep_exn arch mem);
-  if f_asm then print_asm insn f_inst;
-  if (f_asm || f_inst) then print_newline ();
-  Disasm.step state (Disasm.addr state |> Addr.to_int |> ok_exn)
-
-(* Convert strings to binary string representation "\x01\x02..." *)
-let to_bin_str s f =
+(** [to_binary ?escape s] make a binary string from ascii
+    representation, (e.g., "\x01\x02..."). Apply optional
+    escape function for each byte *)
+let to_binary ?(escape=ident) s =
   let seps = [' '; ','; ';'] in
   let separated = List.exists seps ~f:(String.mem s) in
   let bytes = if separated
     then String.split_on_chars ~on:seps s
     else List.init (String.length s / 2) ~f:(fun n ->
         String.slice s (n*2) (n*2+2)) in
-  try bytes |> List.map ~f |> String.concat |> Scanf.unescaped
+  try bytes |> List.map ~f:escape |> String.concat |> Scanf.unescaped
   with Scanf.Scan_failure _ -> raise Bad_user_input
 
-let disasm s o_arch f_asm f_inst
-	   f_bil f_bil_to_pb f_bil_to_json f_bil_to_xml
-	   f_kinds o_reg_format o_imm_format =
-  let input_src =
-    match s with
-    | "" -> In_channel.input_line In_channel.stdin
-    | _ -> Some s in
-  Disasm.create ~backend:"llvm" o_arch >>= fun dis ->
-  let input = match input_src with
-    | Some input ->
-      begin match String.prefix input 2 with
-        | "" | "\n" -> exit 0
-        | "\\x" -> let f = ident in to_bin_str input f
-        | "0x" -> let f = String.substr_replace_all ~pattern:"0x" ~with_:"\\x"
-          in to_bin_str input f
-        | _ -> let f x = "\\x" ^ x in to_bin_str input f
-      end
-    | None -> raise Stdin_exn in
-  (* arm instructions tend to be longer, so increase the printed width *)
-  let width = if o_arch = "arm" then 65 else 50 in
-  let arch = if o_arch="arm" then `arm
-	     else if o_arch="x86" then `x86
-	     else if o_arch="x86_64" || o_arch="x86-64" then `x86_64
-	     else `x86 in
-  let hit =
-    print_disasm arch width f_asm f_inst f_bil
-		 f_bil_to_pb f_bil_to_json f_bil_to_xml
-		 f_kinds o_reg_format o_imm_format in
+let read_input input =
+  let input = match input with
+    | None -> In_channel.input_line In_channel.stdin
+    | Some s -> Some s in
+  match input with
+  | None -> raise No_input
+  | Some input -> match String.prefix input 2 with
+    | "" | "\n" -> exit 0
+    | "\\x" -> to_binary input
+    | "0x" ->  to_binary ~escape:escape_0x input
+    | x -> to_binary ~escape:prepend_slash_x input
+
+let create_memory arch s =
+  let width = Arch.addr_size arch |> Size.to_bits in
+  let endian = Arch.endian arch in
+  Memory.create endian Addr.(of_int ~width 0) @@
+  Bigstring.of_string s |> function
+  | Ok r -> r
+  | Error _ -> raise Create_mem
+
+let print_kinds insn =
+  Dis.Insn.kinds insn |>
+  List.map ~f:sexp_of_kind |>
+  List.iter ~f:(printf "%a@." Sexp.pp)
+
+let print_insn insn_formats insn =
+  let insn = Insn.of_basic insn in
+  List.iter insn_formats ~f:(function
+      | `asm -> printf "%s@." @@ Insn.asm insn
+      | `adt -> printf "%a@." Insn.pp_adt insn
+      | `sexp ->
+        printf "(%s %s)@."
+          (Insn.name insn)
+          List.(Insn.ops insn |> Array.to_list >>| Op.to_string |>
+                String.concat ~sep:" "))
+
+let bil_of_insn lift mem insn =
+  match lift mem insn with
+  | Error e -> raise (Can't_lift e)
+  | Ok bil -> bil
+
+let pp_sexp fmt x =
+  Sexp.pp fmt (sexp_of_bil x)
+
+let string_of_list pp bil =
+  List.iter bil ~f:(fun stmt ->
+      pp str_formatter stmt;
+      pp_print_newline str_formatter ());
+  flush_str_formatter ()
+
+let string_of_bil = function
+  | `pb -> Bil_piqi.pb_of_stmts
+  | `json -> Bil_piqi.json_of_stmts
+  | `xml -> Bil_piqi.xml_of_stmts
+  | `bil -> asprintf "%a" Stmt.pp_stmts
+  | `adt -> string_of_list Stmt.pp_adt
+  | `sexp -> asprintf "%a" pp_sexp
+  | `binprot -> Binable.to_string
+                  (module struct type t = bil with bin_io end)
+
+let print_bil lift bil_formats mem insn =
+  let bil = bil_of_insn lift mem in
+  List.iter bil_formats ~f:(fun fmt ->
+      printf "%s@." (string_of_bil fmt (bil insn)))
+
+let make_print lift insn_fmt bil_fmt show_kinds mem insn =
+  print_insn insn_fmt insn;
+  print_bil lift bil_fmt mem insn;
+  if show_kinds then print_kinds insn
+
+let step print state mem insn _ =
+  print mem insn;
+  Dis.step state (Dis.addr state |> Addr.to_int |> ok_exn)
+
+let disasm src arch show_insn show_bil show_kinds =
+  let arch = match Arch.of_string arch with
+    | None -> raise Unknown_arch
+    | Some arch -> arch in
+  let module Target = (val target_of_arch arch) in
+  let print = make_print Target.lift show_insn show_bil show_kinds in
+  let input = read_input src in
+  Dis.create ~backend:"llvm" (Arch.to_string arch) >>= fun dis ->
   let invalid state mem off = no_disassembly state off in
-  let mem = create_memory o_arch 0x0L input in
-  let _pos : int =
-    Disasm.run dis ~return:ident ~stop_on:[`Valid] ~invalid ~hit ~init:0
-      mem in
+  let pos =
+    Dis.run dis ~return:ident
+      ~stop_on:[`Valid] ~invalid ~hit:(step print) ~init:0
+      (create_memory arch input) in
+  if pos <> String.length input then
+    raise (Trailing_data (String.length input - pos));
   return ()
 
-open Cmdliner
+module Cmdline = struct
+  open Cmdliner
 
-let o_arch =
-  let doc = "Target architecture (x86_64 or arm)." in
-  Arg.(value & opt string "x86_64" & info ["arch"] ~docv:"ARCH" ~doc)
+  let arch =
+    let doc = "Target architecture" in
+    Arg.(value & opt string "x86_64" & info ["arch"] ~docv:"ARCH" ~doc)
 
-let o_reg_format =
-  let doc = "Register format (code or name)." in
-  Arg.(value & opt string "name" & info ["reg-format"] ~docv:"REG_FORMAT" ~doc)
+  let show_kinds =
+    let doc = "Output instruction kinds." in
+    Arg.(value & flag & info ["show-kinds"] ~doc)
 
-let o_imm_format =
-  let doc = "Imm format (hex or dec)." in
-  Arg.(value & opt string "hex" & info ["imm-format"] ~docv:"IMM_FORMAT" ~doc)
+  let show_insn =
+    let formats = [
+      "asm", `asm;
+      "adt", `adt;
+      "sexp", `sexp;
+    ] in
+    let doc = sprintf
+        "Print instructions, using specified format $(docv). \
+         $(docv) can be %s. Defaults to `asm'." @@
+      Arg.doc_alts_enum formats in
+    Arg.(value & opt_all ~vopt:`asm (enum formats) [] &
+         info ["show-inst"; "show-insn"] ~doc)
 
-let f_kinds =
-  let doc = "Output instruction kinds." in
-  Arg.(value & flag & info ["show-kinds"] ~doc)
+  let show_bil =
+    let formats = [
+      "bil", `bil;
+      "pb", `pb;
+      "json", `json;
+      "xml", `xml;
+      "sexp", `sexp;
+      "binprot", `binprot;
+      "adt", `adt;
+    ] in
+    let doc = sprintf
+        "Output BIL code. Optional value specifies format \
+         and can be %s. Defaults to `bil`, i.e., in a BIL \
+         concrete syntax" @@ Arg.doc_alts_enum formats in
+    Arg.(value & opt_all ~vopt:`bil (enum formats) [] &
+         info ["show-bil"] ~doc)
 
-let f_inst =
-  let doc = "Output BAP instruction disassembly." in
-  Arg.(value & flag & info ["show-inst"] ~doc)
+  let src =
+    let doc = "String to disassemble. If not specified read stdin" in
+    Arg.(value & pos 0 (some string) None & info [] ~docv:"STRING" ~doc)
 
-let f_bil = 
-  let doc = "Output unadulterated BIL for given hex." in
-  Arg.(value & flag & info ["show-bil"] ~doc)
+  let cmd main =
+    let doc = "manual page for bap-mc 1.0" in
+    let man = [
+      `S "DESCRIPTION";
+      `I ("OVERVIEW",
+          " Disassemble a string of bytes. This is the BAP machine \
+           code playground. It is intended to mimic a subset of \
+           llvm-mc  functionality using the BAP disassembly backend.");
+      `S "EXAMPLES";
+      `P "Three hex representations are supported:"; `Noblank;
+      `I (".BR", " 0x31 0xd2 0x48 0xf7 0xf3"); `Noblank;
+      `I (".BR", " \\\\x31\\\\xd2\\\\x48\\\\xf7\\\\xf3"); `Noblank;
+      `I (".BR", " 31 d2 48 f7 f3");
+      `I (".BR", " 31d248f7f3");
+      `I ("INPUT: Supplied via stdin or on the command-line",
+          "echo \"0x31 0xd2 0x48 0xf7 0xf3\" | \
+           bap-mc  --show-inst --show-asm");
+      `S "SEE ALSO";
+      `P "$(llvm-mc)"] in
+    Term.(pure main $src $arch $show_insn $show_bil $show_kinds),
+    Term.info "bap-mc" ~doc ~man ~version:Config.pkg_version
 
-let f_bil_pb =
-  let doc = "Output protobuf of BIL for given hex." in
-  Arg.(value & flag & info ["show-pb"] ~doc)
+  let parse main = Term.eval (cmd main) ~catch:false
+end
 
-let f_bil_json =
-  let doc = "Output json of BIL for given hex." in
-  Arg.(value & flag & info ["show-json"] ~doc)
-
-let f_bil_xml =
-  let doc = "Output xml of BIL for given hex." in
-  Arg.(value & flag & info ["show-xml"] ~doc)
-
-let f_asm =
-  let doc = "Output disassembly." in
-  Arg.(value & flag & info ["show-asm"] ~doc)
-
-let hex_str =
-  let doc = "String to disassemble (if not specified on stdin)." in
-  Arg.(value & pos 0 string "" & info [] ~docv:"STRING" ~doc)
-
-let cmd =
-  let doc = "manual page for bap-mc 1.0" in
-  let man = [
-    `S "DESCRIPTION";
-    `I ("OVERVIEW: Disassemble a string of hex bytes",
-        "This is the BAP machine code playground. It is intended to mimic a
-        subset of llvm-mc functionality using the BAP disassembly backend.");
-    `S "EXAMPLES";
-    `P "Three hex representations are supported:"; `Noblank;
-    `I (".BR", " 0x31 0xd2 0x48 0xf7 0xf3"); `Noblank;
-    `I (".BR", " \\\\x31\\\\xd2\\\\x48\\\\xf7\\\\xf3"); `Noblank;
-    `I (".BR", " 31 d2 48 f7 f3");
-    `I (".BR", " 31d248f7f3");
-    `I ("INPUT: Supplied via stdin or on the command-line",
-        "echo \"0x31 0xd2 0x48 0xf7 0xf3\" | bap-mc  --show-inst --show-asm");
-    `S "SEE ALSO";
-    `P "$(llvm-mc)"] in
-  Term.(pure disasm $ hex_str $ o_arch $ f_asm $ f_inst
-	$ f_bil $ f_bil_pb $ f_bil_json $ f_bil_xml
-	$ f_kinds $ o_reg_format $ o_imm_format),
-  Term.info "bap-mc" ~doc ~man ~version:"1.0"
+let exitf n = ksprintf (fun s -> eprintf "%s\n" s; exit n)
 
 let () =
   Plugins.load ();
-  let err = Format.std_formatter in
-  try match Term.eval cmd ~catch:false ~err with
+  try match Cmdline.parse disasm with
     | `Ok Ok () -> exit 0
-    | `Ok Error err ->
-      eprintf "%s\n" Error.(to_string_hum err); exit 2
+    | `Ok Error err -> exitf 12 "%s\n" Error.(to_string_hum err)
     | `Error `Parse -> exit 64
     | `Error _ -> exit 2
     | _ -> exit 1
-
-  with e ->
-    let fin n s = eprintf "%s\n" s; exit n in
-    match e with
-    | Bad_user_input ->
-      fin 65 "Could not parse: malformed input"
-    | Convert_imm_exn imm ->
-      sprintf "Unable to convert Imm hex value [%s] to int" imm |>
-      fin 1
-    | Create_mem_exn ->
-      fin 1 "Internal error: cannot create memory for dissasembly backend"
-    | Stdin_exn ->
-      fin 1 "Could not read from stdin"
-    | No_disassembly (mem,boff,stop)->
-      let dump = Memory.hexdump mem in
-      let line = boff / 16 in
-      let pos off = line * 77 + (off mod 16) * 3 + 9 in
-      dump.[pos boff] <- '(';
-      dump.[pos stop] <- ')';
-      sprintf "Invalid instruction at offset %d:\n%s" boff dump |>
-      fin 1
-    | _ -> fin 1 "Could not disassemble input"
+  with
+  | Bad_user_input | Create_mem ->
+    exitf 65 "Could not parse: malformed input"
+  | No_input -> exitf 1 "Could not read from stdin"
+  | Unknown_arch ->
+    exitf 64 "Unknown architecture. Supported architectures:\n%s\n" @@
+    String.concat ~sep:"\n" @@ List.map Arch.all ~f:Arch.to_string
+  | Trailing_data left ->
+    exitf 1 "%d bytes were left non disassembled@." left
+  | Bad_insn (mem,boff,stop)->
+    let dump = Memory.hexdump mem in
+    let line = boff / 16 in
+    let pos off = line * 77 + (off mod 16) * 3 + 9 in
+    dump.[pos boff] <- '(';
+    dump.[pos stop] <- ')';
+    exitf 1 "Invalid instruction at offset %d:\n%s" boff dump

--- a/src/readbin/readbin.ml
+++ b/src/readbin/readbin.ml
@@ -221,9 +221,6 @@ module Program(Conf : Options.Provider) = struct
     | None ->
       Image.create options.filename >>= fun (img,warns) ->
       List.iter warns ~f:(eprintf "Warning: %a@." Error.pp);
-      (* printf "%-20s: %s@." "File" options.filename; *)
-      (* printf "%-20s: %a@." "Arch" Arch.pp (Image.arch img); *)
-      (* printf "%-20s: %a@." "Entry" Addr.pp (Image.entry_point img); *)
       Table.iteri (Image.sections img) ~f:(fun mem s ->
           if Section.is_executable s then
             disassemble ~img (Image.arch img) mem);


### PR DESCRIPTION
Now bap-mc supports 7 formats for outputting BIL and three formats for
printing assembly. The command line interface is refactored.