### PR TITLE
ARM now defaults to ARMv7

### DIFF
--- a/lib/bap_types/bap_arch.ml
+++ b/lib/bap_types/bap_arch.ml
@@ -21,6 +21,7 @@ module T = struct
     | "i386"| "i486" | "i586" | "i686" -> "x86"
     | "x86-64" | "x86_64" | "amd64" | "x64" | "x86_64h" -> "x86_64"
     | "powerpc" -> "ppc"
+    | "arm" -> "armv7"
     | "xscale"  -> "arm"
     | "thumbv4t" -> "armv4t"
     | "armv5t" | "armv5e" | "thumbv5" | "thumbv5e" -> "armv5"


### PR DESCRIPTION
This is a little bit a hack, since it breaks tradition. But now, when
one says ARM we understand it like ARMv7. I didn't like it...