### PR TITLE
Cleaned BIL module.

### DIFF
--- a/lib/bap/bap.ml
+++ b/lib/bap/bap.ml
@@ -4,7 +4,7 @@
     find a list of modules, as well as redirection to other subparts
     of the library. This module can be viewed as library index.
 
-    BAP has a layered architecture currently consisting of three
+    BAP has a layered architecture currently consisting of four
     layers:
     [Types] - an extension of standard library, adding some types
               specific to binary analysis.
@@ -13,6 +13,7 @@
     [Disasm] - a first step of program structure reconstruction,
               representing a program as a graph of blocks of
               instructions.
+    [Sema]  - provides semantic analysis.
 
     Each library resides in each own subfolder, named correspondingly.
 
@@ -88,24 +89,23 @@ module Std = struct
   *)
   include Bap_disasm_std
 
-
-
   (** {3 Sematic analysis}   *)
   include Bap_sema.Std
 
   (** {3 Auxiliary libraries} *)
 
-  (** {3 Program visitor}  *)
+  (** {3 Program visitor}
+      An extension point for program visiting plugins.  *)
   module Program_visitor = Bap_program_visitor
 
   (** {4 Dwarf library}
       This library gives an access to debugging information stored
       in a binary program.  *)
-  module Dwarf   = Bap_dwarf
+  module Dwarf = Bap_dwarf
 
   (** {4 Elf library}
       Provides an access to [ELF] information.  *)
-  module Elf     = Bap_elf
+  module Elf = Bap_elf
   type elf = Elf.t
 
   (** {4 Binary Signatures Storage}  *)

--- a/lib/bap/bap_program_visitor.mli
+++ b/lib/bap/bap_program_visitor.mli
@@ -1,16 +1,30 @@
+(** Interface for the BAP program visitor plugins.
+
+    Plugin is applied to a value of a project type, that can be
+    optionally transformed. For example, a plugin can add new
+    annotations, symbols or even change re-disassemble program and
+    provide their own lifters.
+*)
 open Bap_types.Std
 open Image_internal_std
-open Bap_disasm
+open Bap_disasm_std
 
+(** The result of Binary analysis.  *)
 type project = {
-  arch    : arch;
-  program : disasm;
-  symbols : string table;
-  memory  : mem;
-  annots  : (string * string) memmap;
-  bil_of_insns : (mem * insn) list -> bil;
+  arch    : arch;               (** architecture  *)
+  program : disasm;             (** disassembled memory  *)
+  symbols : string table;       (** symbol table  *)
+  memory  : mem;                (** base memory *)
+  annots  : (string * string) memmap; (** annotations  *)
+  bil_of_insns : (mem * insn) list -> bil; (** lifting  *)
 }
 
+(** [register plugin] registers [plugin] in the system  *)
 val register : (project -> project) -> unit
+
+(** [register' plugin] registers a [plugin] that will be
+    evaluated only for side effect. *)
 val register': (project -> unit) -> unit
+
+(** A list of registered plugins in the order of registration  *)
 val registered : unit -> (project -> project) list

--- a/lib/bap_disasm/bap_disasm_arm_branch.ml
+++ b/lib/bap_disasm/bap_disasm_arm_branch.ml
@@ -17,20 +17,20 @@ let word = Word.of_int ~width:32
 let lift operand ?link ?x:_ ?cond addr =
   let target =
     match operand with
-    | Op.Reg r -> Exp.var (Env.of_reg r)
+    | Op.Reg r -> Bil.var (Env.of_reg r)
     | Op.Imm offset ->
       let width = Word.bitwidth offset in
       let _1 = Word.one 32 in
       let min_32 = Word.Int_exn.(_1 lsl Word.of_int 31 ~width) in
       let offset = if offset = min_32 then Word.zero 32 else offset in
       let r = Word.Int_exn.(addr + pc_offset + offset) in
-      Exp.int r in
+      Bil.int r in
   (* TODO detect change to thumb in `x` *)
-  let jump_instr = [Stmt.jmp target] in
+  let jump_instr = [Bil.jmp target] in
   let link_instr =
     let next_addr = Word.Int_exn.(addr + pc_offset - word 4) in
     match link with
-    | Some true -> [Stmt.move Env.lr Exp.(int next_addr)]
+    | Some true -> [Bil.move Env.lr Bil.(int next_addr)]
     | _         -> [] in
   let stmts = link_instr @ jump_instr in
   match cond with

--- a/lib/bap_disasm/bap_disasm_arm_flags.ml
+++ b/lib/bap_disasm/bap_disasm_arm_flags.ml
@@ -11,31 +11,31 @@ module Shift = Bap_disasm_arm_shift
 
 
 let set_nzf r t = [
-  Stmt.move Env.nf (msb r);
-  Stmt.move Env.zf Exp.(r = zero t);
+  Bil.move Env.nf (msb r);
+  Bil.move Env.zf Bil.(r = zero t);
 ]
 
 let set_vnzf_add s1 s2 r t =
-  Stmt.move Env.vf (msb Exp.((lnot (s1 lxor s2)) land (s1 lxor r)))
+  Bil.move Env.vf (msb Bil.((lnot (s1 lxor s2)) land (s1 lxor r)))
   :: set_nzf r t
 
 let set_add s1 s2 r t =
-  Stmt.move Env.cf Exp.(r < s1) :: set_vnzf_add s1 s2 r t
+  Bil.move Env.cf Bil.(r < s1) :: set_vnzf_add s1 s2 r t
 
 let set_vnzf_sub s1 s2 r t =
-  Stmt.move Env.vf (msb Exp.((s1 lxor s2) land (s1 lxor r))) ::
+  Bil.move Env.vf (msb Bil.((s1 lxor s2) land (s1 lxor r))) ::
   set_nzf r t
 
 let set_sub s1 s2 r t =
-  Stmt.move Env.cf Exp.(s2 <= s1) :: set_vnzf_sub s1 s2 r t
+  Bil.move Env.cf Bil.(s2 <= s1) :: set_vnzf_sub s1 s2 r t
 
 let set_adc s1 s2 r t =
   let sum_with_carry =
     let extend = Bil.(cast unsigned) (bitlen t + 1) in
-    Exp.(extend s1 + extend s2 + extend (var Env.cf)) in
-  Stmt.move Env.cf (msb sum_with_carry) :: set_vnzf_add s1 s2 r t
+    Bil.(extend s1 + extend s2 + extend (var Env.cf)) in
+  Bil.move Env.cf (msb sum_with_carry) :: set_vnzf_add s1 s2 r t
 
-let set_sbc s1 s2 r t = set_adc s1 Exp.(lnot s2) r t
+let set_sbc s1 s2 r t = set_adc s1 Bil.(lnot s2) r t
 
 let set_cf_data ~imm ~data =
   let value =
@@ -43,7 +43,7 @@ let set_cf_data ~imm ~data =
     if Word.(of_int ~width 255 >= imm && imm >= zero width) then
       let width = Word.bitwidth data in
       if Word.(Int_exn.(data land of_int ~width 0xf00) = zero width)
-      then Exp.var Env.cf
-      else Exp.int Word.b0
-    else msb Exp.(int imm) in
-  Stmt.move Env.cf value
+      then Bil.var Env.cf
+      else Bil.int Word.b0
+    else msb Bil.(int imm) in
+  Bil.move Env.cf value

--- a/lib/bap_disasm/bap_disasm_arm_mem.ml
+++ b/lib/bap_disasm/bap_disasm_arm_mem.ml
@@ -20,20 +20,20 @@ let lift_r  ~(dst1 : Var.t) ?(dst2 : Var.t option) ~(base : Var.t)
    * Use the originals
    **)
   let address = match mode, operation, size, dst1 with
-    | PostIndex, Ld, W, d when d = Env.pc -> Exp.var o_base
-    | PreIndex, Ld, W, d when d = Env.pc  -> Exp.(var o_base + offset)
-    | PostIndex, _,  _, _               -> Exp.var base
-    | PreIndex, _, _, _ | Offset, _, _, _ -> Exp.(var base + offset) in
+    | PostIndex, Ld, W, d when d = Env.pc -> Bil.var o_base
+    | PreIndex, Ld, W, d when d = Env.pc  -> Bil.(var o_base + offset)
+    | PostIndex, _,  _, _               -> Bil.var base
+    | PreIndex, _, _, _ | Offset, _, _, _ -> Bil.(var base + offset) in
 
   (* Create temps for original if this is a jump *)
   let pre_write_back = match mode, operation, size, dst1 with
     | PreIndex,  Ld, W, d when d = Env.pc -> [
-        Stmt.move o_base Exp.(var base);
-        Stmt.move base  Exp.(var base + offset)
+        Bil.move o_base Bil.(var base);
+        Bil.move base  Bil.(var base + offset)
       ]
     | PostIndex, Ld, W, d when d = Env.pc -> [
-        Stmt.move o_base  Exp.(var base);
-        Stmt.move base Exp.(var base + offset)
+        Bil.move o_base  Bil.(var base);
+        Bil.move base Bil.(var base + offset)
       ]
     | Offset, _, _, _ -> []
     | _ -> [] in
@@ -42,33 +42,33 @@ let lift_r  ~(dst1 : Var.t) ?(dst2 : Var.t option) ~(base : Var.t)
     | PreIndex,  Ld, W, d when d = Env.pc -> []
     | PostIndex, Ld, W, d when d = Env.pc -> []
     | Offset,    _,  _, _               -> []
-    | _ -> [Stmt.move base Exp.(var base + offset)] in
+    | _ -> [Bil.move base Bil.(var base + offset)] in
 
   let typ = match size with
     | B -> `r8
     | H -> `r16
     | W | D -> `r32 in
 
-  let store m n v = Exp.(store m n v LittleEndian typ) in
-  let load  m n   = Exp.(load  m n LittleEndian typ) in
+  let store m n v = Bil.(store m n v LittleEndian typ) in
+  let load  m n   = Bil.(load  m n LittleEndian typ) in
 
   let temp = match size with
     | B | H -> Env.new_tmp "t"
     | _ -> dst1 in
 
-  let four = Exp.int (Word.of_int 4 ~width:32) in
+  let four = Bil.int (Word.of_int 4 ~width:32) in
 
   match operation with
   | Ld ->
-    let rhs = cast_of_sign sign 32 Exp.(var temp) in
+    let rhs = cast_of_sign sign 32 Bil.(var temp) in
     let extend = match size with
-      | B | H -> [Stmt.move dst1 rhs]
+      | B | H -> [Bil.move dst1 rhs]
       | W | D -> [] in
     let loads =
-      let mem = Exp.var (Env.mem) in
+      let mem = Bil.var (Env.mem) in
       if size = D then [
-        Stmt.move dst1 (load mem address);
-        Stmt.move (uw dst2) (load mem Exp.(address + four));
+        Bil.move dst1 (load mem address);
+        Bil.move (uw dst2) (load mem Bil.(address + four));
       ] else [
         assn temp (load mem address);
       ] in
@@ -83,19 +83,19 @@ let lift_r  ~(dst1 : Var.t) ?(dst2 : Var.t option) ~(base : Var.t)
     let trunc = match size with
       | B | H ->
         let n = if size = B then 8 else 16 in
-        [Stmt.move temp Exp.(cast low n (var dst1))]
+        [Bil.move temp Bil.(cast low n (var dst1))]
       | W | D -> [] in
     let stores =
       let m = Env.mem in
-      let v = Exp.var m in
+      let v = Bil.var m in
       match size with
       | D -> [
-          Stmt.move m (store v address Exp.(var dst1));
-          Stmt.move m (store v
-                         Exp.(address + four) Exp.(var (uw dst2)));
+          Bil.move m (store v address Bil.(var dst1));
+          Bil.move m (store v
+                        Bil.(address + four) Bil.(var (uw dst2)));
         ]
       | B | H | W -> [
-          Stmt.move m (store v address Exp.(var temp));
+          Bil.move m (store v address Bil.(var temp));
         ] in
     List.concat [
       trunc;                   (* truncate the value if necessary *)
@@ -117,27 +117,27 @@ let lift_m dest_list base mode update operation =
     | NoUpdate -> []
     | Update ->
       let (+-) = match mode with
-        | IB | IA -> Exp.(+)
-        | DB | DA -> Exp.(-)
-      in [Stmt.move base Exp.(var base +-  int dest_len)] in
+        | IB | IA -> Bil.(+)
+        | DB | DA -> Bil.(-)
+      in [Bil.move base Bil.(var base +-  int dest_len)] in
   let create_access i dest =
     let offset_e = Word.of_int ~width:32 (calc_offset i) in
-    let mem = Exp.var Env.mem in
-    let addr = Exp.(var o_base + int offset_e) in
+    let mem = Bil.var Env.mem in
+    let addr = Bil.(var o_base + int offset_e) in
     match operation with
-    | Ld -> assn dest Exp.(load mem addr LittleEndian `r32)
-    | St -> Stmt.move Env.mem
-              Exp.(store Env.(var mem) addr (var dest) LittleEndian `r32) in
+    | Ld -> assn dest Bil.(load mem addr LittleEndian `r32)
+    | St -> Bil.move Env.mem
+              Bil.(store Env.(var mem) addr (var dest) LittleEndian `r32) in
   (* Jmps should always be the last statement *)
   let rec move_jump_to_end l =
     match l with
       [] -> []
     | (stmt :: stmts) ->
       match stmt with
-      | (Stmt.Jmp exp) -> stmts @ [Stmt.Jmp exp]
+      | (Bil.Jmp exp) -> stmts @ [Bil.Jmp exp]
       |   _  -> stmt :: move_jump_to_end stmts in
   move_jump_to_end (List.concat [
-      [Stmt.move o_base Exp.(var base)];
+      Bil.([o_base := var base]);
       List.mapi ~f:create_access dest_list;
       writeback
     ])

--- a/lib/bap_disasm/bap_disasm_arm_mem_shift.ml
+++ b/lib/bap_disasm/bap_disasm_arm_mem_shift.ml
@@ -28,7 +28,7 @@ let repair_imm (src : word) ~sign_mask ~imm_mask rtype : exp =
     (bit_set && rtype = `NEG) ||
     (not bit_set && rtype = `POS) in
   let offset = Z.(src land word imm_mask) in
-  Exp.int (if negate then Z.neg offset else offset)
+  Bil.int (if negate then Z.neg offset else offset)
 
 let repair_reg reg imm ~sign_mask rtype =
   let bit_set =
@@ -37,7 +37,7 @@ let repair_reg reg imm ~sign_mask rtype =
     (bit_set && rtype = `NEG) || (not bit_set && rtype = `POS)
   in
   let m_one = Word.(ones (bitwidth imm))  in
-  if negate then Exp.(int m_one * reg) else reg
+  if negate then Bil.(int m_one * reg) else reg
 
 
 
@@ -46,14 +46,14 @@ let lift_r_op ~dest1 ?dest2 ?shift ~base ~offset mode sign size operation =
   let base = assert_reg _here_ base |> Env.of_reg in
   let (offset : exp) =
     match offset with
-    | Op.Reg r -> Exp.(var (Env.of_reg r))
+    | Op.Reg r -> Bil.(var (Env.of_reg r))
     | Op.Imm w ->
       let width = Word.bitwidth w in
       let _1 = Word.one 32 in
       let min_32 = Word.Int_exn.(_1 lsl Word.of_int 31 ~width) in
       if Word.(w = min_32)
-      then Exp.(int Word.(zero width))
-      else Exp.(int w) in
+      then Bil.(int Word.(zero width))
+      else Bil.(int w) in
 
   let offset = match shift with
     | Some s -> Shift.lift_mem ~src:offset s reg32_t
@@ -99,7 +99,7 @@ let mem_offset_reg_or_imm_neg reg_off imm_off =
   | Op.Reg #Reg.nil ->
     repair_imm imm_off ~sign_mask:0x100 ~imm_mask:0xff `NEG
   | Op.Reg (#Reg.gpr as reg) ->
-    repair_reg Exp.(var (Env.of_reg reg)) imm_off ~sign_mask:0x100 `NEG
+    repair_reg Bil.(var (Env.of_reg reg)) imm_off ~sign_mask:0x100 `NEG
   | op -> fail _here_ "unexpected operand: %s" (Arm.Op.to_string op)
 
 let mem_offset_reg_or_imm_pos reg_off imm_off =
@@ -107,5 +107,5 @@ let mem_offset_reg_or_imm_pos reg_off imm_off =
   | Op.Reg #Reg.nil ->
     repair_imm imm_off ~sign_mask:0x100 ~imm_mask:0xff `POS
   | Op.Reg (#Reg.gpr as reg) ->
-    repair_reg Exp.(var (Env.of_reg reg)) imm_off ~sign_mask:0x1 `POS
+    repair_reg Bil.(var (Env.of_reg reg)) imm_off ~sign_mask:0x1 `POS
   | op -> fail _here_ "unexpected operand: %s" (Arm.Op.to_string op)

--- a/lib/bap_disasm/bap_disasm_arm_mov.ml
+++ b/lib/bap_disasm/bap_disasm_arm_mov.ml
@@ -27,24 +27,24 @@ let lift ?dest src1 ?src2 (itype ) ?sreg ?simm raw ~wflag cond =
     | `MOV, Some sreg, Some simm
     | `MVN, Some sreg, Some simm ->
       let shifted, carry = Shift.lift_r
-          ~src:Exp.(var unshifted) simm
+          ~src:Bil.(var unshifted) simm
           ~shift:(exp_of_op sreg) reg32_t in
-      shifted, s2, [Stmt.move unshifted s1], carry
+      shifted, s2, [Bil.move unshifted s1], carry
     | _, Some sreg, Some simm ->
       let shifted, carry = Shift.lift_r
-          ~src:Exp.(var unshifted) simm
+          ~src:Bil.(var unshifted) simm
           ~shift:(exp_of_op sreg) reg32_t in
-      s1, shifted, [Stmt.move unshifted s2], carry
+      s1, shifted, [Bil.move unshifted s2], carry
     | `MOV, None, Some simm
     | `MVN, None, Some simm ->
       let shifted, carry = Shift.lift_i
-          ~src:Exp.(var unshifted) simm reg32_t in
-      shifted, s2, [Stmt.move unshifted s1], carry
+          ~src:Bil.(var unshifted) simm reg32_t in
+      shifted, s2, [Bil.move unshifted s1], carry
     | _, None, Some simm ->
       let shifted, carry = Shift.lift_i
-          ~src:Exp.(var unshifted) simm reg32_t in
-      s1, shifted, [Stmt.move unshifted s2], carry
-    | _ -> s1, s2, [], Exp.var Env.cf in
+          ~src:Bil.(var unshifted) simm reg32_t in
+      s1, shifted, [Bil.move unshifted s2], carry
+    | _ -> s1, s2, [], Bil.var Env.cf in
 
   let stmts, flags = match itype, src1, src2 with
     | `MOV, Op.Imm i64, _
@@ -53,13 +53,13 @@ let lift ?dest src1 ?src2 (itype ) ?sreg ?simm raw ~wflag cond =
     | `BIC, _,         Some (Op.Imm i64)
     | `EOR, _,         Some (Op.Imm i64)
     | `ORR, _,         Some (Op.Imm i64) ->
-      stmts, set_cf_data i64 raw :: set_nzf Exp.(var dest) reg32_t
+      stmts, set_cf_data i64 raw :: set_nzf Bil.(var dest) reg32_t
     | #move, _, _ ->
-      stmts, Stmt.move Env.cf carry :: set_nzf Exp.(var dest) reg32_t
+      stmts, Bil.move Env.cf carry :: set_nzf Bil.(var dest) reg32_t
     | #arth as itype1, _, _ ->
       let orig1 = Env.new_tmp "s" in
       let orig2 = Env.new_tmp "t" in
-      let v1,v2,vd = Exp.(var orig1, var orig2, var dest) in
+      let v1,v2,vd = Bil.(var orig1, var orig2, var dest) in
       let flags = match itype1 with
         | `SUB -> set_sub v1 v2 vd reg32_t
         | `RSB -> set_sub v2 v1 vd reg32_t
@@ -67,19 +67,19 @@ let lift ?dest src1 ?src2 (itype ) ?sreg ?simm raw ~wflag cond =
         | `ADC -> set_adc v1 v2 vd reg32_t
         | `SBC -> set_sbc v1 v2 vd reg32_t
         | `RSC -> set_sbc v2 v1 vd reg32_t in
-      stmts @ [Stmt.move orig1 s1; Stmt.move orig2 s2], flags in
-  let vcf = Exp.var Env.cf in
+      stmts @ [Bil.move orig1 s1; Bil.move orig2 s2], flags in
+  let vcf = Bil.var Env.cf in
   let oper = match itype with
-    | `AND -> Exp.(s1 land s2)
-    | `BIC -> Exp.(s1 land lnot s2)
-    | `EOR -> Exp.(s1 lxor s2)
+    | `AND -> Bil.(s1 land s2)
+    | `BIC -> Bil.(s1 land lnot s2)
+    | `EOR -> Bil.(s1 lxor s2)
     | `MOV -> s1
-    | `MVN -> Exp.(lnot s1)
-    | `ORR -> Exp.(s1 lor s2)
-    | `SUB -> Exp.(s1 - s2)
-    | `RSB -> Exp.(s2 - s1)
-    | `ADD -> Exp.(s1 + s2)
-    | `ADC -> Exp.(s1 + s2 + cast unsigned 32 vcf)
-    | `SBC -> Exp.(s1 + lnot s2 + cast unsigned 32 vcf)
-    | `RSC -> Exp.(lnot s1 + s2 + cast unsigned 32 vcf) in
+    | `MVN -> Bil.(lnot s1)
+    | `ORR -> Bil.(s1 lor s2)
+    | `SUB -> Bil.(s1 - s2)
+    | `RSB -> Bil.(s2 - s1)
+    | `ADD -> Bil.(s1 + s2)
+    | `ADC -> Bil.(s1 + s2 + cast unsigned 32 vcf)
+    | `SBC -> Bil.(s1 + lnot s2 + cast unsigned 32 vcf)
+    | `RSC -> Bil.(lnot s1 + s2 + cast unsigned 32 vcf) in
   exec (stmts @ [assn dest oper]) ~flags ~wflag cond

--- a/lib/bap_disasm/bap_disasm_arm_mul.ml
+++ b/lib/bap_disasm/bap_disasm_arm_mul.ml
@@ -19,16 +19,16 @@ let lift_mull ~lodest ~hidest ~src1 ~src2 sign ?addend ~wflag cond =
     let cast src = cast_of_sign sign 64 (exp_of_op src) in
     cast src1, cast src2 in
   let result = new_tmp "r" in
-  let eres  = Exp.var result in
+  let eres  = Bil.var result in
   let flags = Flags.set_nzf eres reg64_t in
   let opn = match addend with
-    | Some _ -> Exp.(s1_64 * s2_64 +
+    | Some _ -> Bil.(s1_64 * s2_64 +
                      concat (exp_of_reg hidest) (exp_of_reg lodest))
-    | None   -> Exp.(s1_64 * s2_64) in
+    | None   -> Bil.(s1_64 * s2_64) in
   let insns = [
-    Stmt.move result opn;
-    Stmt.move (Env.of_reg lodest) Exp.(extract 31 0 eres);
-    Stmt.move (Env.of_reg hidest) Exp.(extract 63 32 eres);
+    Bil.move result opn;
+    Bil.move (Env.of_reg lodest) Bil.(extract 31 0 eres);
+    Bil.move (Env.of_reg hidest) Bil.(extract 63 32 eres);
   ] in
   exec insns ~flags ~wflag cond
 
@@ -36,13 +36,13 @@ let lift_smul ~dest ?hidest ~src1 ~src2 ?accum ?hiaccum ?q size cond =
   let dest = assert_reg _here_ dest in
   let src1 = exp_of_op src1 in
   let src2 = exp_of_op src2 in
-  let excast hi lo s = Exp.(cast signed 64 (extract hi lo s)) in
+  let excast hi lo s = Bil.(cast signed 64 (extract hi lo s)) in
   let top  = excast 31 16 in
   let bot  = excast 15 0 in
   let top32 = excast 47 16 in
   let res = new_tmp "r" in
   let result =
-    let open Exp in
+    let open Bil in
     match size with
     | BB -> bot src1 * bot src2
     | BT -> bot src1 * top src2
@@ -53,7 +53,7 @@ let lift_smul ~dest ?hidest ~src1 ~src2 ?accum ?hiaccum ?q size cond =
     | WB -> top32 (cast signed 64 (src1 * bot src2))
     | WT -> top32 (cast signed 64 (src1 * top src2))  in
   let result =
-    let open Exp in
+    let open Bil in
     match accum, hiaccum with
     | None,   None     -> result
     | Some a, None     -> result + cast signed 64 (exp_of_op a)
@@ -62,18 +62,18 @@ let lift_smul ~dest ?hidest ~src1 ~src2 ?accum ?hiaccum ?q size cond =
   let qflag =
     match q with
     | Some true ->
-      [Stmt.move Env.qf Exp.(excast 31 0 (var res) <> (var res))]
+      [Bil.move Env.qf Bil.(excast 31 0 (var res) <> (var res))]
     | _ -> [] in
   let instr =
     match hidest with
     | Some (Op.Reg hid) -> [
-        Stmt.move res result;
-        Stmt.move (Env.of_reg hid)  Exp.(extract 63 32 (var res));
-        Stmt.move (Env.of_reg dest) Exp.(extract 31 0  (var res));
+        Bil.move res result;
+        Bil.move (Env.of_reg hid)  Bil.(extract 63 32 (var res));
+        Bil.move (Env.of_reg dest) Bil.(extract 31 0  (var res));
       ]
     | None -> [
-        Stmt.move res result;
-        Stmt.move (Env.of_reg dest) Exp.(extract 31 0 (var res));
+        Bil.move res result;
+        Bil.move (Env.of_reg dest) Bil.(extract 31 0 (var res));
       ]
     | _ -> fail _here_ "unexpected operand type" in
   exec (instr @ qflag) cond

--- a/lib/bap_disasm/bap_disasm_arm_utils.ml
+++ b/lib/bap_disasm/bap_disasm_arm_utils.ml
@@ -28,7 +28,7 @@ let assert_cond loc op =
 
 
 let assn d s =
-  if d = Env.pc then Stmt.jmp s else Stmt.move d s
+  if d = Env.pc then Bil.jmp s else Bil.move d s
 
 let bitlen = function
   | Type.Imm len -> len
@@ -46,47 +46,47 @@ let exec
     | _ -> stmts in
   (* generates an expression for the given McCond *)
   let set_cond mccond =
-    let z = Exp.var Env.zf in
-    let c = Exp.var Env.cf in
-    let v = Exp.var Env.vf in
-    let n = Exp.var Env.nf in
-    let f = Exp.int (Word.of_bool false) in
-    let t = Exp.int (Word.of_bool true) in
+    let z = Bil.var Env.zf in
+    let c = Bil.var Env.cf in
+    let v = Bil.var Env.vf in
+    let n = Bil.var Env.nf in
+    let f = Bil.int (Word.of_bool false) in
+    let t = Bil.int (Word.of_bool true) in
     match cond with
-    | `EQ -> Exp.(z = t)
-    | `NE -> Exp.(z = f)
-    | `CS -> Exp.(c = t)
-    | `CC -> Exp.(c = f)
-    | `MI -> Exp.(n = t)
-    | `PL -> Exp.(n = f)
-    | `VS -> Exp.(v = t)
-    | `VC -> Exp.(v = f)
-    | `HI -> Exp.((c = t) land (z = f))
-    | `LS -> Exp.((c = f) lor  (z = t))
-    | `GE -> Exp.(n = v)
-    | `LT -> Exp.(n <> v)
-    | `GT -> Exp.((z = f) land (n =  v))
-    | `LE -> Exp.((z = t) lor  (n <> v))
+    | `EQ -> Bil.(z = t)
+    | `NE -> Bil.(z = f)
+    | `CS -> Bil.(c = t)
+    | `CC -> Bil.(c = f)
+    | `MI -> Bil.(n = t)
+    | `PL -> Bil.(n = f)
+    | `VS -> Bil.(v = t)
+    | `VC -> Bil.(v = f)
+    | `HI -> Bil.((c = t) land (z = f))
+    | `LS -> Bil.((c = f) lor  (z = t))
+    | `GE -> Bil.(n = v)
+    | `LT -> Bil.(n <> v)
+    | `GT -> Bil.((z = f) land (n =  v))
+    | `LE -> Bil.((z = t) lor  (n <> v))
     | `AL -> t in
   (* We shortcut if the condition = all *)
   match cond with
   | `AL -> stmts
-  | _ -> [Stmt.If (set_cond cond, stmts, [])]
+  | _ -> [Bil.If (set_cond cond, stmts, [])]
 
 
-let exp_of_reg reg = Exp.var (Env.of_reg reg)
+let exp_of_reg reg = Bil.var (Env.of_reg reg)
 
 let exp_of_op = function
   | Op.Reg reg -> exp_of_reg reg
-  | Op.Imm word -> Exp.int word
+  | Op.Imm word -> Bil.int word
 
 let cast_type = function
-  | Signed -> Exp.signed
-  | Unsigned -> Exp.unsigned
+  | Signed -> Bil.signed
+  | Unsigned -> Bil.unsigned
 
-let cast_of_sign sign size exp = Exp.cast (cast_type sign) size exp
+let cast_of_sign sign size exp = Bil.cast (cast_type sign) size exp
 
 
 
-let msb r = Exp.(cast high 1 r)
-let zero ty = Exp.int (Word.zero (bitlen ty))
+let msb r = Bil.(cast high 1 r)
+let zero ty = Bil.int (Word.zero (bitlen ty))

--- a/lib/bap_disasm/bap_disasm_rec.ml
+++ b/lib/bap_disasm/bap_disasm_rec.ml
@@ -1,5 +1,6 @@
 open Core_kernel.Std
 open Bap_types.Std
+open Bil.Types
 open Or_error
 open Image_internal_std
 module Dis = Bap_disasm_basic
@@ -201,10 +202,10 @@ let fold_consts = Bil.(fixpoint fold_consts)
 let rec dests_of_bil bil =
   fold_consts bil |> List.concat_map ~f:dests_of_stmt
 and dests_of_stmt = function
-  | Stmt.Jmp (Exp.Int addr) -> [Some addr,`Jump]
-  | Stmt.Jmp (_) -> [None, `Jump]
-  | Stmt.If (_,yes,no) -> merge_branches yes no
-  | Stmt.While (_,ss) -> dests_of_bil ss
+  | Jmp (Int addr) -> [Some addr,`Jump]
+  | Jmp (_) -> [None, `Jump]
+  | If (_,yes,no) -> merge_branches yes no
+  | While (_,ss) -> dests_of_bil ss
   | _ -> []
 and merge_branches yes no =
   let x = dests_of_bil yes and y = dests_of_bil no in

--- a/lib/bap_types/bap_helpers.mli
+++ b/lib/bap_types/bap_helpers.mli
@@ -1,3 +1,4 @@
+(** BIL high level functions.   *)
 open Core_kernel.Std
 open Bap_common
 open Bap_bil

--- a/lib/bap_types/bap_regular.mli
+++ b/lib/bap_types/bap_regular.mli
@@ -48,13 +48,13 @@ module type S = sig
 end
 
 module Make(M : sig
-              type t with bin_io, sexp, compare
-              include Pretty_printer.S with type t := t
-              val hash : t -> int
-              val module_name : string
-            end ) : S with type t := M.t
+    type t with bin_io, sexp, compare
+    include Pretty_printer.S with type t := t
+    val hash : t -> int
+    val module_name : string
+  end ) : S with type t := M.t
 
 module Printable(M : sig
-                   include Pretty_printer.S
-                   val module_name : string
-                 end) : Printable with type t := M.t
+    include Pretty_printer.S
+    val module_name : string
+  end) : Printable with type t := M.t

--- a/lib/bap_types/bap_stmt.ml
+++ b/lib/bap_types/bap_stmt.ml
@@ -53,3 +53,12 @@ include Regular.Make(struct
     let module_name = "Bap_stmt"
     let pp = pp
   end)
+
+module Stmts_pp = struct
+  type t = stmt list
+  include Printable(struct
+      type nonrec t = t
+      let pp = pp_stmts
+      let module_name = "Bil"
+    end)
+end

--- a/lib/bap_types/bap_stmt.mli
+++ b/lib/bap_types/bap_stmt.mli
@@ -20,3 +20,5 @@ end
 module Infix : sig
   val (:=) : var -> exp -> stmt
 end
+
+module Stmts_pp : Printable with type t = stmt list

--- a/src/readbin/printing.ml
+++ b/src/readbin/printing.ml
@@ -39,7 +39,7 @@ module Make(Env : Env) = struct
       sep ppf ();
       pp_list ~sep pp_v ppf vs
 
-  let pp_bil : bil pp = Stmt.pp_stmts
+  let pp_bil : bil pp = Bil.pp
 
   let pp_err fmt err = fprintf fmt "%a: %a" Memory.pp (fst err) Disasm.Error.pp (snd err)
 


### PR DESCRIPTION
Now `Bil` is for writing BIL programs. `Stmt` and `Expr`
modules are for using them as an OCaml values, i.e.,
they expose `Regular` interface.

`Bil` module also exposes `Printable`, `Sexpable` and `Binable`
interfaces.