### PR TITLE
Add command line arguments for plugins

### DIFF
--- a/lib/bap/bap_program_visitor.ml
+++ b/lib/bap/bap_program_visitor.ml
@@ -4,6 +4,7 @@ open Bap_disasm
 
 type project = {
   arch    : arch;
+  argv    : string array;
   program : disasm;
   symbols : string table;
   memory  : mem;

--- a/lib/bap/bap_program_visitor.mli
+++ b/lib/bap/bap_program_visitor.mli
@@ -12,7 +12,8 @@ open Bap_disasm_std
 (** The result of Binary analysis.  *)
 type project = {
   arch    : arch;               (** architecture  *)
-  program : disasm;             (** disassembled memory  *)
+  argv    : string array;       (** command line arguments *)
+  program : disasm;             (** disassembled memory *)
   symbols : string table;       (** symbol table  *)
   memory  : mem;                (** base memory *)
   annots  : (string * string) memmap; (** annotations  *)

--- a/src/bap_mc/bap_mc.ml
+++ b/src/bap_mc/bap_mc.ml
@@ -175,13 +175,13 @@ module Cmdline = struct
     Arg.(value & pos 0 (some string) None & info [] ~docv:"STRING" ~doc)
 
   let cmd main =
-    let doc = "manual page for $(tname)" in
+    let doc = "BAP machine instruction playground" in
     let man = [
       `S "DESCRIPTION";
       `I ("OVERVIEW",
           " Disassemble a string of bytes. This is the BAP machine \
            code playground. It is intended to mimic a subset of \
-           llvm-mc  functionality using the BAP disassembly backend.");
+           llvm-mc functionality using the BAP disassembly backend.");
       `S "EXAMPLES";
       `P "Four hex representations are supported:"; `Noblank;
       `I (".BR", " 0x31 0xd2 0x48 0xf7 0xf3"); `Noblank;
@@ -192,7 +192,7 @@ module Cmdline = struct
           "echo \"0x31 0xd2 0x48 0xf7 0xf3\" | \
            bap-mc  --show-inst --show-asm");
       `S "SEE ALSO";
-      `P "$(llvm-mc)"] in
+      `P "llvm-mc"] in
     Term.(pure main $src $arch $show_insn $show_bil $show_kinds),
     Term.info "bap-mc" ~doc ~man ~version:Config.pkg_version
 

--- a/src/readbin/cmdline.ml
+++ b/src/readbin/cmdline.ml
@@ -157,9 +157,11 @@ let load_path : string list Term.t =
        info ["load-path"; "L"] ~doc ~docv:"PATH")
 
 let create
-    a b c d e f g h i k l m n o p q r s t u v x y =
+    a b c d e f g h i j k l m n o p q r s t u v x =
   Options.Fields.create
-    a b c d e f g h i k l m n o p q r s t u v x y
+    a b c d e f g h i j k l m n o p q r s t u v x
+
+
 let program =
   let doc = "Disassemble binary" in
   let man = [
@@ -179,6 +181,7 @@ let program =
         https://github.com/BinaryAnalysisPlatform/bap/issues";
     `S "SEE ALSO"; `P "$(b,bap-mc)(1)"
   ] in
+
   Term.(pure create
         $filename $loader $symsfile $cfg_format
         $output_phoenix $output_dump $demangle
@@ -190,6 +193,15 @@ let program =
   Term.info "bap-objdump"
     ~version:Config.pkg_version ~doc ~man
 
-let parse () = match Term.eval program with
+let parse () =
+  let plugins = match Term.eval_peek_opts load with
+    | Some ps,_ -> ps | _ -> eprintf "no plugins\n"; [] in
+
+  let argv = Array.filter ~f:(fun opt ->
+      not(List.exists plugins ~f:(fun plugin ->
+          let prefix = "--"^plugin^"-" in
+          String.is_prefix opt ~prefix))) Sys.argv in
+
+  match Term.eval ~argv program with
   | `Ok opts -> Ok opts
   | _ -> Or_error.errorf "no cmdline options provided\n"


### PR DESCRIPTION
This PR makes available command line arguments in the plugin.

Only a restricted subset of command line language is allowed, as all
arguments must be non-positional with long name option (i.e., start with
`--`), and values (if any) must be provided with `=` sign,
e.g. `--callstrings-interesting=st.cpy`. Parameters must be prefixed
with the name of plugin to which they should be passed, e.g.,

```
bap-objdump /bin/ls -lstaticstore --staticstore-help
```
A set of parameters is passed to a plugin in a `argv` field of a project
record with removed prefixes, e.g., `--staticstore-help` is transformed
to `--help`;  `--staticstore-print` is transformed to `--print`; etc.