### PR TITLE
Switch to LLVM backend by default.

### DIFF
--- a/lib/bap_image/bap_image.ml
+++ b/lib/bap_image/bap_image.ml
@@ -243,10 +243,9 @@ let autoload data path =
   | [] -> errorf "Autoloader: no suitable backend found"
   | _  -> errorf "Autoloader: can't resolve proper backend"
 
-let create_image path ?backend data : result =
-  match backend with
-  | None -> autoload data path
-  | Some backend -> of_backend backend data path
+let create_image path ?(backend="llvm") data : result =
+  if backend = "auto" then autoload data path
+  else of_backend backend data path
 
 let of_bigstring ?backend data =
   create_image None ?backend data

--- a/lib/bap_image/bap_image.mli
+++ b/lib/bap_image/bap_image.mli
@@ -25,11 +25,11 @@ type path = string
     this information messages can be considered as warnings. *)
 type result = (t * Error.t list) Or_error.t
 
-(** [create ?backend filename] creates an image of the file
-    specified specified by the [filename]. If [backend] is not specfied,
-    then all backends are tried in order. If only one backend can read
-    this file (i.e., there is no ambiguity), then image is
-    returned. *)
+(** [create ?backend filename] creates an image of the file specified
+    specified by the [filename]. If [backend] is equal to "auto", then
+    all backends are tried in order. If only one backend can read this
+    file (i.e., there is no ambiguity), then image is returned. If
+    [backend] is not specifed, then the LLVM backend is used. *)
 val create : ?backend:string -> path -> result
 
 (** [of_string ?backend ~data] creates an image from the specified

--- a/src/readbin/cmdline.ml
+++ b/src/readbin/cmdline.ml
@@ -15,7 +15,7 @@ let symsfile : string option Term.t =
 
 let loader : string Term.t =
   let doc = "Backend name for an image loader" in
-  Arg.(value & opt string "bap-elf" & info ["loader"] ~doc)
+  Arg.(value & opt string "llvm" & info ["loader"] ~doc)
 
 let cfg_format : 'a list Term.t =
   Arg.(value & vflag_all [`with_name] [


### PR DESCRIPTION
This will switch BAP to use LLVM as a default loader.
Also, this change the behavior of the `Image.create` function.
Previously, if backend wasn't specified it started the autoresolution
process. Now, it will default "llvm" also. But, if "auto" is provided
as a backend name, then the autoresolution will be started.