### PR TITLE
Type safe memory annotations.

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -132,6 +132,7 @@ Library types
                    Bap_seq,
                    Bap_size,
                    Bap_stmt,
+                   Bap_tag,
                    Bap_trie,
                    Bap_type,
                    Bap_var,

--- a/bapbuild
+++ b/bapbuild
@@ -28,10 +28,13 @@ source="_build/$name.cmxa"
 if [ -f "$source" ]; then
     CMD=`grep -A1 "Target: $name.cmxa" _build/_log | grep -v "Target" | sed 's/.cmxa/.cmxs/' | sed 's/-a/-shared/'`
     cd _build
-    $CMD
-    cp "$name.cmxs" "../$target"
-    cd ..
-    chmod a-x $target
+    echo $CMD | grep '#' > /dev/null
+    if [ $? -ne 0 ]; then
+        $CMD
+        cp "$name.cmxs" "../$target"
+        cd ..
+        chmod a-x $target
+    fi
 fi
 
 exit $result

--- a/lib/bap/bap_install_printers.ml
+++ b/lib/bap/bap_install_printers.ml
@@ -4,9 +4,12 @@ open Or_error
 
 let install_printers () =
   List.map (Pretty_printer.all ()) ~f:(fun printer ->
-      let printer = String.substr_replace_first printer
-          ~pattern:"Core"
-          ~with_:"Core_kernel" in
+      let printer =
+        if String.is_prefix printer ~prefix:"Core."
+        then String.substr_replace_first printer
+            ~pattern:"Core"
+            ~with_:"Core_kernel"
+        else printer in
       let cmd = sprintf "#install_printer %s;;" printer in
       Bap_toplevel.eval cmd) |>
   Or_error.all >>| List.for_all ~f:ident

--- a/lib/bap/bap_program_visitor.ml
+++ b/lib/bap/bap_program_visitor.ml
@@ -1,3 +1,4 @@
+open Core_kernel.Std
 open Bap_types.Std
 open Image_internal_std
 open Bap_disasm
@@ -8,9 +9,29 @@ type project = {
   program : disasm;
   symbols : string table;
   memory  : mem;
-  annots  : (string * string) memmap;
+  annots  : value memmap;
   bil_of_insns : (mem * insn) list -> bil;
 }
+
+type color = [
+  | `black
+  | `red
+  | `green
+  | `yellow
+  | `blue
+  | `magenta
+  | `cyan
+  | `white
+] with sexp
+
+let text = Tag.register "text" sexp_of_string
+let html = Tag.register "html" sexp_of_string
+let comment = Tag.register "comment" sexp_of_string
+let python = Tag.register "python" sexp_of_string
+let shell = Tag.register "shell" sexp_of_string
+let mark = Tag.register "mark" sexp_of_unit
+let color = Tag.register "color" sexp_of_color
+let weight = Tag.register "weight" sexp_of_float
 
 let visitors = ref []
 let register v = visitors := v :: !visitors

--- a/lib/bap/bap_program_visitor.mli
+++ b/lib/bap/bap_program_visitor.mli
@@ -16,9 +16,66 @@ type project = {
   program : disasm;             (** disassembled memory *)
   symbols : string table;       (** symbol table  *)
   memory  : mem;                (** base memory *)
-  annots  : (string * string) memmap; (** annotations  *)
+  annots  : value memmap;       (** annotations  *)
   bil_of_insns : (mem * insn) list -> bil; (** lifting  *)
 }
+
+type color = [
+  | `black
+  | `red
+  | `green
+  | `yellow
+  | `blue
+  | `magenta
+  | `cyan
+  | `white
+] with sexp
+
+(** all string tags supports the following substitutions:
+
+    - $region_{name,addr,min_addr,max_addr} - name of region of file
+      to which it belongs. For example, in ELF this name will
+      correspond to the section name
+
+    - $symbol_{name,addr} - name or address of the symbol to which this
+      memory belongs
+
+    - $asm - assembler listing of the memory region
+
+    - $bil - BIL code of the tagged memory region
+
+    - $block_{name,addr} - name or address of a basic block to which
+      this region belongs
+
+    - $min_addr, $addr - starting address of a memory region
+
+    - $max_addr - address of the last byte of a memory region.
+*)
+
+
+(** an arbitrary text *)
+val text : string tag
+
+(** the associated data is an html markup *)
+val html : string tag
+
+(** associate a comment string with a memory region  *)
+val comment : string tag
+
+(** to assosiate a python command with a region *)
+val python : string tag
+
+(** to assosiate a shell command with a region  *)
+val shell : string tag
+
+(** just mark a region  *)
+val mark : unit tag
+
+(** attach a color  *)
+val color : color tag
+
+(** attach a weight to a memory  *)
+val weight : float tag
 
 (** [register plugin] registers [plugin] in the system  *)
 val register : (project -> project) -> unit

--- a/lib/bap_disasm/bap_disasm.ml
+++ b/lib/bap_disasm/bap_disasm.ml
@@ -211,6 +211,10 @@ module Disasm = struct
     | `Failed_to_lift of mem * insn * Error.t
   ] with sexp_of
 
+  let insn  = Tag.register "insn" sexp_of_insn
+  let block = Tag.register "block" sexp_of_block
+  let error = Tag.register "error" sexp_of_error
+
   module Error = Printable(struct
       open Format
       type t = error

--- a/lib/bap_disasm/bap_disasm.mli
+++ b/lib/bap_disasm/bap_disasm.mli
@@ -93,7 +93,6 @@ module Disasm : sig
       starting address only.  *)
   val insn_at_addr : t -> addr -> (mem * insn) option
 
-
   (** returns a blocks of memory that was visited during the
       disassembly. The regions are merged with [Memory.merge] if
       possible. So it returns the least possible amount of contiguous
@@ -111,4 +110,9 @@ module Disasm : sig
   (** returns a list of all errors and warnings that occurred during
       the disassembling *)
   val errors : t -> (mem * error) seq
+
+  (** Tags to annotate memory  *)
+  val insn : insn tag
+  val block : block tag
+  val error : error tag
 end

--- a/lib/bap_image/bap_image.mli
+++ b/lib/bap_image/bap_image.mli
@@ -56,8 +56,13 @@ val words : t -> size -> word table
 val sections : t -> sec table
 val symbols : t -> sym table
 
+
+val section : sec tag
+val symbol  : sym tag
+val region  : string tag
+
 (** returns memory tagged with arbitrary [(name,data)] tags  *)
-val tags : t -> (string * string) memmap
+val memory : t -> value memmap
 
 (** {2 Mappings }  *)
 val memory_of_section  : t -> sec -> mem
@@ -65,6 +70,8 @@ val memory_of_section  : t -> sec -> mem
 val memory_of_symbol   : t -> sym -> mem * mem seq
 val symbols_of_section : t -> sec -> sym seq
 val section_of_symbol  : t -> sym -> sec
+
+
 
 module Sec : sig
   type t = sec

--- a/lib/bap_image/image_backend.ml
+++ b/lib/bap_image/image_backend.ml
@@ -26,10 +26,9 @@ module Sym = struct
   } with bin_io, compare, fields, sexp
 end
 
-module Tag = struct
+module Region = struct
   type t = {
     name : string;
-    data : string;
     location : location;
   } with bin_io, compare, fields, sexp
 end
@@ -40,7 +39,7 @@ module Img = struct
     entry    : addr;
     sections : Section.t * Section.t list;
     symbols  : Sym.t list;
-    tags     : Tag.t list;
+    regions  : Region.t list;
   } with bin_io, compare, fields, sexp
 end
 

--- a/lib/bap_image/image_elf.ml
+++ b/lib/bap_image/image_elf.ml
@@ -146,13 +146,12 @@ let img_of_elf data elf : Img.t Or_error.t =
     | Error err ->
       [], Error.tag err "failed to read symbols" :: errors in
   arch >>= fun arch ->
-  let tags = Seq.filter_map elf.e_sections ~f:(fun s ->
+  let regions = Seq.filter_map elf.e_sections ~f:(fun s ->
       match Elf.section_name data elf s with
       | Error _ -> None
       | Ok name -> Some {
-          Tag.name = "section";
-          Tag.data = name;
-          Tag.location = {
+          Region.name;
+          Region.location = {
             Location.addr = addr s.sh_addr;
             Location.len  = Int64.to_int_exn s.sh_size;
           }
@@ -160,9 +159,8 @@ let img_of_elf data elf : Img.t Or_error.t =
   match sections with
   | [] -> errorf "failed to read sections"
   | s::ss ->
-    let img =
-      Img.Fields.create ~arch ~entry ~sections:(s,ss) ~symbols ~tags in
-    Ok img
+    return @@
+    Img.Fields.create ~arch ~entry ~sections:(s,ss) ~symbols ~regions
 
 let of_data_err (data : bigstring) : Img.t Or_error.t =
   Elf.Parse.from_bigstring data >>= img_of_elf data

--- a/lib/bap_image/llvm_loader.mli
+++ b/lib/bap_image/llvm_loader.mli
@@ -3,5 +3,3 @@ open Bap_types.Std
 open Image_backend
 
 val from_data : Bigstring.t -> Img.t option
-
-val from_file : string -> Img.t option

--- a/lib/bap_types/bap_stmt.ml
+++ b/lib/bap_types/bap_stmt.ml
@@ -59,6 +59,6 @@ module Stmts_pp = struct
   include Printable(struct
       type nonrec t = t
       let pp = pp_stmts
-      let module_name = "Bil"
+      let module_name = "Bap_stmt.Stmts_pp"
     end)
 end

--- a/lib/bap_types/bap_tag.ml
+++ b/lib/bap_types/bap_tag.ml
@@ -1,0 +1,27 @@
+open Core_kernel.Std
+open Bap_common
+
+type 'a t = 'a Type_equal.Id.t with sexp_of
+type value = Univ.t with sexp_of
+
+let register name sexp = Type_equal.Id.create ~name sexp
+
+let is t v = Univ.does_match v t
+let value t v = Univ.match_ v t
+let create t v = Univ.create t v
+let tagname = Univ.type_id_name
+let name = Type_equal.Id.name
+
+include Printable(struct
+    type t = value with sexp_of
+
+    let rec ppstring_of_sexp = function
+      | Sexp.List ss -> sprintf "(%s)" @@
+        String.concat ~sep:", " (List.map ss ~f:ppstring_of_sexp)
+      | Sexp.Atom x -> x
+
+    let pp ppf v = Format.fprintf ppf "%s %s"
+        (String.capitalize (tagname v))
+        (ppstring_of_sexp (sexp_of_value v))
+    let module_name = "Bap_tag"
+  end)

--- a/lib/bap_types/bap_tag.mli
+++ b/lib/bap_types/bap_tag.mli
@@ -1,0 +1,57 @@
+(** Extensible variant.
+
+    This module creates an extensible variant type, that resembles
+    extensible variant types, introduced in 4.02, but even more safe.
+
+    To extend variant type with a new constructor, use
+
+    [Tag.register constructor_name sexp_of_constructor], where
+
+    constructor name can be any name, and can even clash with previous
+    definitions it is guaranteed, that you will receive a new
+    representation of the constructor, every time you're calling this
+    function even if parameters are the same. The returned value is
+    supposed to be exposed in a module, for later use in other
+    modules, c.f., [Image] module defines three constructors:
+    - [Image.symbol] for Image symbols, that basically can be seen as
+      [Image.Symbol of sym]
+    - [Image.section] for image sections;
+    - [Image.region] for other named image memory regions.
+
+*)
+open Core_kernel.Std
+open Bap_common
+
+(** Tag constructor of type ['a]  *)
+type 'a t   with sexp_of
+
+(** a value injected into extensible variant  *)
+type value with sexp_of
+
+(** [register name sexp] creates a new variant constructor, i.e.,
+    a new branch in a variant type. This function has no side-effects,
+    it just returns a witness of a new constructor, that can be later
+    used for storing into [value] and extracting from it. This
+    witness should be shared between user and creator of the value *)
+val register : string -> ('a -> Sexp.t) -> 'a t
+
+(** [create cons x] creates a value using constructor [cons] and
+    argument [x] *)
+val create : 'a t -> 'a -> value
+
+(** [value cons] extracts a value associated with a constructor [cons]
+    (Essentially, performs a pattern match on the specified variant
+    branch) *)
+val value : 'a t -> value -> 'a option
+
+(** [is cons v] true if value [v] was constructed with constructor
+    [cons] *)
+val is  : 'a t -> value -> bool
+
+(** [tagname value] returns a constructor name of the [value]  *)
+val tagname : value -> string
+
+(** [name cons] returns a name of a constructor.  *)
+val name : 'a t -> string
+
+include Printable with type t := value

--- a/lib/bap_types/bap_types.ml
+++ b/lib/bap_types/bap_types.ml
@@ -297,8 +297,10 @@ module Std = struct
        represent data *)
   module Word = Bitvector
 
+  module Tag = Bap_tag
+
   (** Byte endian. This is the only not first class type in a bap-types.
-      Sorry, no mapping and tables for this type.
+      Sorry, no maps and tables for this type.
   *)
   type endian = Bap_common.endian = LittleEndian | BigEndian
   with sexp,bin_io,compare
@@ -319,18 +321,20 @@ module Std = struct
   type nonrec addr_size = addr_size
   with bin_io, compare, sexp
 
-  type addr      = Addr.t      with bin_io, compare, sexp
-  type arch      = Arch.t      with bin_io, compare, sexp
-  type bil       = Bap_bil.bil with bin_io, compare, sexp
-  type binop     = Bil.binop   with bin_io, compare, sexp
-  type cast      = Bil.cast    with bin_io, compare, sexp
-  type exp       = Exp.t       with bin_io, compare, sexp
-  type size      = Size.t      with bin_io, compare, sexp
-  type stmt      = Stmt.t      with bin_io, compare, sexp
-  type typ       = Type.t      with bin_io, compare, sexp
-  type unop      = Bil.unop    with bin_io, compare, sexp
-  type var       = Var.t       with bin_io, compare, sexp
-  type word      = Word.t      with bin_io, compare, sexp
+  type addr  = Addr.t      with bin_io, compare, sexp
+  type arch  = Arch.t      with bin_io, compare, sexp
+  type bil   = Bap_bil.bil with bin_io, compare, sexp
+  type binop = Bil.binop   with bin_io, compare, sexp
+  type cast  = Bil.cast    with bin_io, compare, sexp
+  type exp   = Exp.t       with bin_io, compare, sexp
+  type size  = Size.t      with bin_io, compare, sexp
+  type stmt  = Stmt.t      with bin_io, compare, sexp
+  type typ   = Type.t      with bin_io, compare, sexp
+  type unop  = Bil.unop    with bin_io, compare, sexp
+  type var   = Var.t       with bin_io, compare, sexp
+  type word  = Word.t      with bin_io, compare, sexp
+  type value = Tag.value   with sexp_of
+  type 'a tag = 'a Tag.t     with sexp_of
 
   class ['a] bil_visitor = ['a] Bap_visitor.visitor
 

--- a/lib_test/bap_image/test_image.ml
+++ b/lib_test/bap_image/test_image.ml
@@ -62,9 +62,9 @@ let create ?(addr_size=`r32) ?(endian=LittleEndian) ~syms ss name =
     | `r64,LittleEndian -> `mips64el
     | `r64,BigEndian    -> `mips64 in
   let entry = create_addr addr_size 0 in
-  let tags = [] in
+  let regions = [] in
   let load _ =
-    Some (Img.Fields.create ~arch ~entry ~sections ~symbols ~tags) in
+    Some (Img.Fields.create ~arch ~entry ~sections ~symbols ~regions) in
   load
 
 let backends =

--- a/src/readbin/cmdline.ml
+++ b/src/readbin/cmdline.ml
@@ -202,6 +202,6 @@ let parse () =
           let prefix = "--"^plugin^"-" in
           String.is_prefix opt ~prefix))) Sys.argv in
 
-  match Term.eval ~argv program with
+  match Term.eval ~argv ~catch:false program with
   | `Ok opts -> Ok opts
   | _ -> Or_error.errorf "no cmdline options provided\n"

--- a/src/readbin/idapy.mli
+++ b/src/readbin/idapy.mli
@@ -18,4 +18,5 @@ val extract_symbols : string -> string
     all defintions from [idautils] modules are brought to the environment.
 
 *)
-val annotate_ida : project -> string
+
+val extract_script : value memmap -> string


### PR DESCRIPTION
This PR moves from previous stringly typed `(string * string)` tags,
to a new typesafe extensible variant types, based on universal types,
aka existentials.

This allows plugin writers to speak with each other in a type-safe
manner, using BAP library as a mediator.

Also this PR fixes few small issues, like errors when installing
pretty-printers from core library, and the necessity to clean before
calling to `bapbuild`.

Also this PR fixes #60.