### PR TITLE
Fix building documentation.

### DIFF
--- a/lib/bap/bap_project.mli
+++ b/lib/bap/bap_project.mli
@@ -34,7 +34,12 @@
 
     - [Image.section] -- if the binary data was loaded from a binary
       format that contains sections (aka segments), then corresponding
-      memory regions would be marked. Sections gives you access
+      memory regions would be marked. Sections gives you access to
+      permission information.
+
+    - [Image.symbol] -- with this tag we annotate each memory regions
+      that belongs to a particular symbol. Currently, the type of tag
+      is just a string.
 
 *)
 open Core_kernel.Std
@@ -50,8 +55,8 @@ type t = {
   storage : value String.Map.t; (** arbitrary data storage *)
 
   (** Deprecated fields, the will be removed in a next release. *)
-  symbols : string table;       (** symbol table  @deprecated *)
-  base    : mem;                (** base memory   @deprecated *)
+  symbols : string table;       (** @deprecated symbol table  *)
+  base    : mem;                (** @deprecated base memory  *)
 }
 
 type color = [

--- a/opam
+++ b/opam
@@ -14,7 +14,6 @@ build: [
                  "--docdir=%{doc}%/bap"
                  "--mandir=%{man}%"]
   [make]
-  [make "doc"]
 ]
 install: [
   [make "install"]

--- a/postinstall.ml.ab
+++ b/postinstall.ml.ab
@@ -8,7 +8,7 @@ let (/) = Filename.concat
 
 let tools = [
   "bap-mc";
-  "bap-objdump";
+  "bap";
   "bap-byteweight";
 ]
 


### PR DESCRIPTION
Releasing revealed a bug in documentation, that wasn't caught by CI,
since we're not compiling documentation on Travis. I've fixed this
bug in opam file, that is in the official repository, and bumped changes
back here. Also, I fixed the source of the error.

Since, that time we no longer build documentation as a part of
installation, since it takes too much time, very faulty (this is not a
first time), and worthless (the output is of very low quality). When
codoc will mature, we will return to this issue.