### PR TITLE
Ordered block destinations.

### DIFF
--- a/lib/bap_disasm/bap_disasm_block.mli
+++ b/lib/bap_disasm/bap_disasm_block.mli
@@ -36,7 +36,11 @@ include Block_traverse  with type t := t
     specified by the [next] parameter. By default search is performed
     in a forward direction, using [succs] function. To search in a
     reverse direction, use [preds] function. The search result is
-    returned as a lazy sequence.
+    returned as a lazy sequence. Destinations of the block are visited
+    in the order of execution, e.g., taken branch is visited before
+    non taken. No such guarantee is made for the predecessors or any
+    other function provided as a [next] arguments, since it is a
+    property of a [next] function, not the algorithm itsef.
 *)
 val dfs : ?next:(t -> t seq) -> ?bound:mem -> t -> t seq
 

--- a/lib/bap_disasm/bap_disasm_block_intf.ml
+++ b/lib/bap_disasm/bap_disasm_block_intf.ml
@@ -42,11 +42,13 @@ module type Block_traverse = sig
   ] with compare, sexp_of
 
   (** [dests blk] block immediate destinations including unresolved
-      one *)
+      one. Successors are returned in the order of execution, e.g.,
+      taken branch comes before the implicit one. *)
   val dests : t -> dest seq
 
-  (** [succs blk] block immediate successors  *)
+  (** [succs blk] block immediate successors in the order of
+      execution, @see dests.  *)
   val succs : t -> t seq
-  (** [preds blk] block immediate predecessors  *)
+  (** [preds blk] block immediate predecessors in unspecified order. *)
   val preds : t -> t seq
 end

--- a/lib/bap_disasm/bap_disasm_rec.ml
+++ b/lib/bap_disasm/bap_disasm_rec.ml
@@ -434,6 +434,12 @@ module Block = struct
        instructions.
   *)
 
+
+  let sort_dests =
+    List.sort ~cmp:(fun x y -> match x,y with
+        | (_,`Fall), _ -> 1
+        | _,_ -> 0)
+
   let rec create t addr =
     let nabes inj side =
       Seq.of_list (side addr) |> Seq.unfold_with ~init:()
@@ -449,7 +455,7 @@ module Block = struct
       | None,`Jump -> Yield (`Unresolved `Jump, ())
       | None,`Cond -> Yield (`Unresolved `Cond, ()) in
     let with_nil f a = Option.value ~default:[] (f a) in
-    let succs a = with_nil (Addrs.find t.succs) a in
+    let succs a = sort_dests (with_nil (Addrs.find t.succs) a) in
     let preds a = with_nil (Addrs.find t.preds) a in
     let get_mem () = Addrs.find_exn t.addrs addr  in
     let mem = Lazy.from_fun get_mem in


### PR DESCRIPTION
Now `succs` and `dests` functions returns successors in the order of
execution. As a result, dfs algorithm will visit blocks in the execution
order.