### PR TITLE
Fix possible double linking in bapbuild.

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -390,6 +390,7 @@ Executable "bap"
   MainIs:         readbin.ml
   Install:        true
   CompiledObject: best
+  # XXX: Update bapbuild.ml bap_packages if you add something here
   BuildDepends:   bap,
                   bap.plugins,
                   ocamlgraph,

--- a/bapbuild.ml
+++ b/bapbuild.ml
@@ -11,7 +11,20 @@ let syntax_packages = List.map [
 
 let default_pkgs = ["bap"; "bap.plugins"; "core_kernel"]
 
-let packages = default_pkgs @ syntax_packages
+(* there is no way to figure out what libraries were linked into
+   the bap executable in the runtime. Later we can try to figure
+   this out from the _oasis file for example, but right now I will
+   hardcode the dependencies here.
+*)
+let bap_packages = [
+  "ocamlgraph";
+  "ezjsonm";
+  "cmdliner";
+  "fileutils";
+  "re.posix";
+]
+
+let packages = default_pkgs @ syntax_packages @ bap_packages
 
 let default_tags = [
   "linkall";
@@ -37,8 +50,8 @@ let extern_deps_link_flags () =
                 Findlib.topological_closure in
   !Options.ocaml_pkgs |>
   List.map ~f:Findlib.query |>
-  List.filter ~f:(fun pkg -> not (List.mem interns pkg)) |>
   Findlib.topological_closure |>
+  List.filter ~f:(fun pkg -> not (List.mem interns pkg)) |>
   Findlib.link_flags_native
 
 let symlink env =


### PR DESCRIPTION
On a linking phase, we're excluding from the plugin all bap library
dependencies, but not the dependencies of the bap executable. As a
result we can link the same library twice, and if it has some kind
of state it can lead to undefined behavior, aka segmentation fault.

Since it is impossible to figure out what libraries are linked into
the bap binary in runtime, the only way it to hardcode this information
in the bapbuild itself. As a side effect, there is no need to define
`-pkg cmdliner,re.posix` to compile a plugin. In fact, all bap binary
dependencies are now automatically available.