### PR TITLE
Fix #181 and Block.dfs.

### DIFF
--- a/lib/bap_disasm/bap_disasm_block.mli
+++ b/lib/bap_disasm/bap_disasm_block.mli
@@ -42,7 +42,10 @@ include Block_traverse  with type t := t
     other function provided as a [next] arguments, since it is a
     property of a [next] function, not the algorithm itsef.
 *)
-val dfs : ?next:(t -> t seq) -> ?bound:mem -> t -> t seq
+val dfs :
+  ?order:[`post | `pre] ->        (** defaults to pre *)
+  ?next:(t -> t seq) ->           (** defaults to succs  *)
+  ?bound:mem -> t -> t seq
 
 
 (** A classic control flow graph using OCamlgraph library.


### PR DESCRIPTION
There was a bug in `Block.dfs` that results in that
dsf sequence of blocks was consumed after first run.

In the nature of an apology for this I also provided
an extra optional parameter `order` that allows you
to specify whether you would like visit blocks in
pre-order or post-order.

Also I fixed #181.