### PR TITLE
As per discussion, grammar names conflict with cpp vernacular keywords, and some options were needed in bap-mc

### DIFF
--- a/lib/bap_types/bil_piqi.ml
+++ b/lib/bap_types/bil_piqi.ml
@@ -41,7 +41,7 @@ let binop_to_piqi : 'a -> Stmt_piqi.binop_type = function
   | ARSHIFT -> `arshift
   | AND -> `andbop
   | OR -> `orbop
-  | XOR -> `xor
+  | XOR -> `x_or
   | EQ -> `eq
   | NEQ -> `neq
   | LT -> `lt
@@ -62,7 +62,7 @@ let binop_of_piqi = function
   | `arshift -> ARSHIFT
   | `andbop -> AND
   | `orbop -> OR
-  | `xor -> XOR
+  | `x_or -> XOR
   | `eq -> EQ
   | `neq -> NEQ
   | `lt -> LT
@@ -101,7 +101,7 @@ let endianness_of_piqi = function
   | `little_endian -> LittleEndian
   | `big_endian -> BigEndian
 
-let rec exp_to_piqi : exp -> Stmt_piqi.exp =
+let rec exp_to_piqi : exp -> Stmt_piqi.expr =
   function
   | Load (m, i, e, s) ->
     let m = exp_to_piqi m in
@@ -220,7 +220,7 @@ let rec stmt_to_piqi : stmt -> Stmt_piqi.stmt = function
     let then_branch = stmts_to_piqi then_branch in
     let else_branch = stmts_to_piqi else_branch in
     `if_stmt {P.If_stmt.cond=e; true_branch=then_branch; false_branch=else_branch}
-  | CpuExn n -> `cpuexn {P.Cpuexn.errno=n}
+  | CpuExn n -> `cpuexn {P.Cpuexn.errnum=n}
 
 and stmts_to_piqi l = List.map ~f:stmt_to_piqi l
 
@@ -242,7 +242,7 @@ let rec stmt_of_piqi = function
     let then_branch = stmts_of_piqi true_branch in
     let else_branch = stmts_of_piqi false_branch in
     If (e, then_branch, else_branch)
-  | `cpuexn {P.Cpuexn.errno} -> CpuExn errno
+  | `cpuexn {P.Cpuexn.errnum} -> CpuExn errnum
 
 and stmts_of_piqi l = List.map ~f:stmt_of_piqi l
 

--- a/lib/bap_types/exp.piqi
+++ b/lib/bap_types/exp.piqi
@@ -9,7 +9,7 @@
 ]
 
 .variant [
-  .name exp
+  .name expr
   .option [.type var    ]
   .option [.type inte   ]
   .option [.type load   ]
@@ -28,11 +28,11 @@
   .name load
   .field [
     .name memory
-    .type exp
+    .type expr
   ]
   .field [
     .name address
-    .type exp
+    .type expr
   ]
   .field [
     .name endian
@@ -48,15 +48,15 @@
   .name store
   .field [
     .name memory
-    .type exp
+    .type expr
   ]
   .field [
     .name address
-    .type exp
+    .type expr
   ]
   .field [
     .name value
-    .type exp
+    .type expr
   ]
   .field [
     .name endian
@@ -76,11 +76,11 @@
   ]
   .field [
     .name lexp
-    .type exp
+    .type expr
   ]
   .field [
     .name rexp
-    .type exp
+    .type expr
   ]
 ]
 
@@ -92,7 +92,7 @@
   ]
   .field [
     .name exp
-    .type exp
+    .type expr
   ]
 ]
 
@@ -116,7 +116,7 @@
   ]
   .field [
     .name exp
-    .type exp
+    .type expr
   ]
 ]
 
@@ -128,11 +128,11 @@
   ]
   .field [
     .name definition
-    .type exp
+    .type expr
   ]
   .field [
     .name open-exp
-    .type exp
+    .type expr
   ]
 ]
 
@@ -152,15 +152,15 @@
   .name ite
   .field [
     .name condition
-    .type exp
+    .type expr
   ]
   .field [
     .name iftrue
-    .type exp
+    .type expr
   ]
   .field [
     .name iffalse
-    .type exp
+    .type expr
   ]
 ]
 
@@ -176,7 +176,7 @@
   ]
   .field [
     .name exp
-    .type exp
+    .type expr
   ]
 ]
 
@@ -184,10 +184,10 @@
   .name concat
   .field [
     .name lexp
-    .type exp
+    .type expr
   ]
   .field [
     .name rexp
-    .type exp
+    .type expr
   ]
 ]

--- a/lib/bap_types/stmt.piqi
+++ b/lib/bap_types/stmt.piqi
@@ -25,7 +25,7 @@
   ]
   .field [
     .name rexp
-    .type exp
+    .type expr
   ]
 ]
 
@@ -33,7 +33,7 @@
   .name jmp
   .field [
     .name target
-    .type exp
+    .type expr
   ]
 ]
 
@@ -46,7 +46,7 @@
   .name while-stmt
   .field [
     .name cond
-    .type exp
+    .type expr
   ]
   .field [
     .name loop-body
@@ -58,7 +58,7 @@
   .name if-stmt
   .field [
     .name cond
-    .type exp
+    .type expr
   ]
   .field [
     .name true-branch
@@ -73,7 +73,7 @@
 .record [
   .name cpuexn
   .field [
-    .name errno
+    .name errnum
     .type int
   ]
 ]

--- a/lib/bap_types/type.piqi
+++ b/lib/bap_types/type.piqi
@@ -57,7 +57,7 @@
   .option [.name arshift]
   .option [.name andbop ]
   .option [.name orbop  ]
-  .option [.name xor    ]
+  .option [.name x-or   ]
   .option [.name eq     ]
   .option [.name neq    ]
   .option [.name lt     ]


### PR DESCRIPTION
For our specific use cases, we needed to be able to know the opcode length, stop disassembling after some number of instructions and lastly specify a memory offset in order that certain BIL semantics be generated correctly.

Additionally, we would like to be able to deserialize via any method supported, so I went about changing the BIL spec to rename only what had forced keyword conflicts, I then propagated those changes throughout related ml code, and it compiles