### PR TITLE
Integrate bapdoc with build system.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -15,8 +15,11 @@ The BAP Library and BAP Toolkit are distributed under the terms of the
 MIT Licence (included below).
 
 The bap.top library and bapbuild executable are distributed under ther
-terms of the Q Public License version 1.0 (included below)
+terms of the Q Public License version 1.0 (included below).
 
+The `doc/style.css' file was taken from Cubicle Project, copyrighted
+by Sylvain Conchon and Alain Mebsout, Universite Paris-Sud 11, under
+Apache Software License version 2.0. See `doc/COPYING` file.
 
 
 --------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@ OCI=ocp-indent
 build: setup.data setup.ml
 	$(SETUP) -build $(BAPBUILDFLAGS)
 
-doc: setup.data build
-	$(SETUP) -doc $(BAPDOCFLAGS)
+.PHONY: doc
+doc:
+	ocaml bapdoc.ml
 
 test: setup.data build
 	$(SETUP) -test $(BAPTESTFLAGS)

--- a/_oasis
+++ b/_oasis
@@ -30,15 +30,6 @@ PostInstallCommand: ocaml postinstall.ml
 PostUninstallCommand: $rm $bindir/baptop
 PostDistcleanCommand: $rm  _tags myocamlbuild.ml setup.ml setup.data
 
-Document bap
-  Type: ocamlbuild (0.4)
-  BuildTools: ocamlbuild, ocamldoc
-  Title:      API documentation for bap
-  XOCamlbuildPath: lib/bap
-  XOCamlbuildExtraArgs:
-    "-docflags '-colorize-code -short-functors -charset utf-8'"
-  XOCamlbuildModules: Bap
-
 Flag serialization
   Description: Build serialization library
   Default: true

--- a/bapdoc.ml
+++ b/bapdoc.ml
@@ -104,10 +104,11 @@ let generate () =
      not (Sys.is_directory outdir) then
     raise No_out_dir;
   Sys.chdir tmp;
-  compile ~options:("-d " ^ outdir ^ " -html") on
-
+  let options = String.concat " " ["-d"; outdir; "-html"] in
+  compile ~options on
 
 let () =
   try generate () with
   | No_out_dir ->
     prerr_string ("Please, create the `" ^ outdir ^ "' folder");
+    exit 1

--- a/doc/COPYING
+++ b/doc/COPYING
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/doc/style.css
+++ b/doc/style.css
@@ -1,0 +1,109 @@
+table { font-size: 11pt; }
+.keyword { font-weight : bold ; color : #e74c3c }
+.keywordsign { color : #8e44ad }
+.superscript { font-size : 4 }
+.subscript { font-size : 4 }
+.comment { color : #27ae60 }
+.constructor { color : #c0392b }
+.type { color : #2980b9 }
+.string { color : #e67e22 }
+.warning { color : Red ; font-weight : bold }
+.info { margin-left : 3em; margin-right: 3em }
+.param_info { margin-top: 4px; margin-left : 3em; margin-right : 3em }
+.code { color : #465F91 ; }
+.typetable { border-style : hidden; font-size: 10.5pt }
+.paramstable { border-style : hidden ; padding: 5pt 5pt}
+tr { background-color : White }
+td.typefieldcomment { background-color : #FFFFFF ; font-size: 10pt ;}
+div.sig_block {margin-left: 2em}
+*:target { background: #f1c40f; border-radius:3px}
+
+
+a {color: #3498db;
+   text-decoration: none;
+   border-radius: 3px;}
+
+a:hover, a:hover code
+{
+ color:white;
+ background-color: #1abc9c;
+ -webkit-transition: all 0.15s linear;
+ transition: all 0.15s linear;
+}
+
+pre { margin-bottom: 4px;
+      font-family: monospace;
+    }
+pre.verbatim, pre.codepre { }
+.indextable {
+             background-color: #ecf0f1;
+             border-collapse: collapse;
+             border-radius:6px;
+             overflow:hidden;
+             /* margin-left:auto;  */
+             /* margin-right:auto; */
+            }
+.indextable td, .indextable th {
+    /* font-size: 12pt; */
+    background-color: #ecf0f1;
+    padding:4px;
+    padding-left:8px;
+    padding-right:8px;
+    min-width: 80px}
+.indextable td.module {
+    font-size: 13pt;
+    background-color: #dbdfe0;
+    padding-left:10px; }
+.indextable td.module a {color:#2c3e50;  }
+.indextable td.module a:hover { color: #1abc9c; background:none }
+.deprecated {color: #888; font-style: italic}
+.indextable tr td div.info { margin-left: 2px; margin-right: 2px }
+ul.indexlist { margin-left: 0; padding-left: 0;}
+ul.indexlist li { list-style-type: none ; margin-left: 0; padding-left: 0; }
+
+
+body{
+    font-family:  'Open Sans', Helvetica, Arial, sans-serif, Verdana; 
+    /* font-size: 1.1em; */
+    color: #2c3e50;
+    margin:0 auto;
+    max-width:900px;
+    font-size: 11pt;
+    padding: 5px;
+}
+
+
+.navbar { background-color: #2c3e50;
+          color:#ecf0f1;
+          text-align:right;
+          border-top-left-radius: 6px;
+          border-top-right-radius: 6px;
+          padding:0;
+          margin:8pt;
+          position:absolute;
+          top:0;
+        }
+
+.navbar a { color:white }
+.navbar a:hover {color: #1abc9c; background:none}
+
+h1 { background-color: #2c3e50;
+     color:white;
+     font-size : 20pt ;
+     text-align: center;
+     margin-top:0;
+     margin-bottom:20pt;
+     padding:15pt;
+     border-radius: 6px;
+     -webkit-font-smoothing: antialiased;
+   }
+
+h1 a { color:white }
+h1 a:hover {color: #1abc9c; background:none }
+
+h2 { 
+    font-size : 20pt ; margin-top: 20pt; margin-bottom: 2px ;padding: 2px;
+    border:0;
+    border-bottom:1px; border-style:solid; border-color:#2c3e50;
+}
+h3 { font-size : 16pt ; margin-top: 20pt; margin-bottom: 2px ;padding: 2px; }

--- a/opam
+++ b/opam
@@ -11,25 +11,26 @@ build: [
   ["./configure"
                  "--prefix=%{prefix}%"
                  "--with-cxx=`which clang++`"
-                 "--docdir=%{doc}%/bap"
                  "--mandir=%{man}%"]
   [make]
+  [make "doc"]
 ]
 install: [
   [make "install"]
   ["bap-byteweight" "update"]
+  ["cp" "-r" "doc" bap:doc]
 ]
 
 remove: [
   ["ocamlfind" "remove" "bap"]
   ["ocamlfind" "remove" "core_lwt"]
   ["rm" "-rf" bap:doc]
-  ["rm" "-f" "%{prefix}%/share/bap/sigs.zip"]
+  ["rm" "-rf" "%{prefix}%/share/bap"]
   ["rm" "-f" "%{man}%/man1/bap-mc.1"]
-  ["rm" "-f" "%{man}%/man1/bap-objdump.1"]
+  ["rm" "-f" "%{man}%/man1/bap.1"]
   ["rm" "-f" "%{man}%/man1/bap-byteweight.1"]
   ["rm" "-f" "%{bin}%/bap-mc"]
-  ["rm" "-f" "%{bin}%/bap-objdump"]
+  ["rm" "-f" "%{bin}%/bap"]
   ["rm" "-f" "%{bin}%/bap-byteweight"]
   ["rm" "-f" "%{bin}%/bap-server"]
   ["rm" "-f" "%{bin}%/bapbuild"]
@@ -37,35 +38,45 @@ remove: [
 ]
 
 depends: [
- 	"base-unix"
- 	"bitstring"
+    "base-unix"
+    "bitstring"
     "camlzip"
-	"cmdliner" {>= "0.9.6"}
-	"cohttp" {>= "0.15.0"}
-	"core_kernel" {>= "111.28.0"}
-	"ezjsonm" {>= "0.4.0"}
-	"faillib"
+    "cmdliner" {>= "0.9.6"}
+    "cohttp" {>= "0.15.0"}
+    "core_kernel" {>= "111.28.0"}
+    "ezjsonm" {>= "0.4.0"}
+    "faillib"
     "fileutils"
-	"lwt"
-	"oasis" {build & >= "0.4.0"}
+    "lwt"
+    "oasis" {build & >= "0.4.0"}
     "ocamlgraph"
     "ocurl"
-	"re"
-	"uri"
+    "re"
+    "uri"
     "utop"
-	"zarith"
+    "zarith"
     "piqi" {>= "0.7.4"}
 ]
 
 depexts: [
     [["ubuntu"] [
-                "libgmp-dev"
-                "libzip-dev"
-                "libcurl4-gnutls-dev"
-                "llvm-3.4-dev"
-                "time" "clang"
-                "llvm" "m4"
-                ]]
+        "libgmp-dev"
+        "libzip-dev"
+        "libcurl4-gnutls-dev"
+        "llvm-3.4-dev"
+        "time"
+        "clang"
+        "llvm"
+        "m4"
+     ]]
+     [["osx" "macports"] [
+        "gmp"
+        "llvm-3.4"
+        "graphviz"
+        "curl"
+        "libzip"
+     ]
+    ]
 ]
 
-available: [ocaml-version >= "4.01"]
+available: [ocaml-version >= "4.01.0"]


### PR DESCRIPTION
This will remove old documentation generator, and
integrate new `bapdoc` tool with the build system.

The target `doc` will now build documentation. Installation is left on
behalf of opam.

Also, small fixes to opam and a tentative addition of external
dependencies on mac os x.