### PR TITLE
bap-fsi-benchmark implementation

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -392,6 +392,20 @@ Executable "bap"
                   fileutils,
                   re.posix
 
+Executable "bap-byteweight"
+  Path:           src/readbin
+  MainIs:         bap-byteweight.ml
+  Install:        true
+  CompiledObject: best
+  BuildDepends:   bap, bap.plugins, cmdliner, fileutils, curl, re.posix
+
+Executable "bap-fsi-benchmark"
+  Path:           src/readbin
+  MainIs:         fsi_benchmark.ml
+  Install:        true
+  CompiledObject: best
+  BuildDepends:   bap, bap.plugins, cmdliner, re.posix, fileutils
+
 Executable "bap-mc"
   Path:           src/bap_mc
   MainIs:         bap_mc.ml
@@ -399,12 +413,6 @@ Executable "bap-mc"
   CompiledObject: best
   BuildDepends:   bap, bap.plugins, cmdliner, bap.serialization
 
-Executable "bap-byteweight"
-  Path:           src/byteweight
-  MainIs:         byteweight.ml
-  Install:        true
-  CompiledObject: best
-  BuildDepends:   bap, bap.plugins, cmdliner, fileutils, curl, re.posix
 
 Executable "bapbuild"
   Path:           .

--- a/src/readbin/find_starts.ml
+++ b/src/readbin/find_starts.ml
@@ -1,0 +1,23 @@
+open Bap.Std
+open Core_kernel.Std
+open Or_error
+
+let with_byteweight bin : Addr.Set.t t =
+  let tmp = Filename.temp_file "bw_" ".output" in
+  let cmd = sprintf "bap-byteweight dump -i byteweight %S > %S" bin tmp in
+  if Sys.command cmd = 0
+  then return (In_channel.with_file tmp ~f:Symbols.read_addrset)
+  else error_string cmd
+
+
+let with_ida ~which_ida bin : Addr.Set.t t =
+  Image.create bin >>= fun (img, _warns) ->
+  let arch = Image.arch img in
+  Ida.create ?ida:(Some which_ida) bin >>| fun ida ->
+  Table.foldi (Image.sections img) ~init:Addr.Set.empty ~f:(fun mem sec ida_syms ->
+      if Image.Sec.is_executable sec then
+        let sym_tbl = Ida.(get_symbols ida arch mem) in
+        Seq.fold Seq.(Table.regions sym_tbl >>| Memory.min_addr)
+          ~init:ida_syms
+          ~f:(fun s sym -> Addr.Set.add s sym)
+      else ida_syms)

--- a/src/readbin/find_starts.mli
+++ b/src/readbin/find_starts.mli
@@ -1,0 +1,12 @@
+open Bap.Std
+open Core_kernel.Std
+
+
+(** [with_ida ~which_ida testbin] evaluates the IDA from [which_ida]
+    on the binary [testbin], and returns the function start address
+    set *)
+val with_ida: which_ida:string -> string -> Addr.Set.t Or_error.t
+
+(** [with_byteweight testbin] evaluates bap-byteweight on the binary
+    [testbin], and returns the function start address set *)
+val with_byteweight: string -> Addr.Set.t Or_error.t

--- a/src/readbin/fsi_benchmark.ml
+++ b/src/readbin/fsi_benchmark.ml
@@ -1,0 +1,120 @@
+open Core_kernel.Std
+open Cmdliner
+open Bap.Std
+open Bap_plugins.Std
+open Format
+
+type metrics = [
+  | `with_F
+  | `with_FN
+  | `with_FP
+  | `with_TP
+  | `with_prec
+  | `with_recl
+]
+
+type evaluation = {
+  true_positive: int;
+  false_negative: int;
+  false_positive: int;
+  prec: float;
+  recl: float;
+  f_05: float}
+
+let tool : string Term.t =
+  let doc = "The tool of the function start result that we are going to
+  evaluate. If user wants to evaluate bap-byteweight, one can use
+  \"bap-byteweight\". If user want to evaluate IDA, one can use
+  \"idaq\", \"idal\", \"idaq64\" or the specific path of IDA." in
+  Arg.(required & pos 0 (some string) (Some "bap-byteweight") & info [] ~docv:"tool" ~doc)
+
+let bin : string Term.t =
+  let doc = "The testing stripped binary." in
+  Arg.(required & pos 1 (some non_dir_file) None & info [] ~docv:"binary" ~doc)
+
+let truth : string Term.t =
+  let doc =
+    "The ground truth. The ground truth can be an unstripped
+  binary, or a .scm file with symbol information. In .scm file, each symbol should
+  be in format of:
+  (<symbol name> <symbol start address> <symbol end address>), e.g.
+  (malloc@@GLIBC_2.4 0x11034 0x11038)" in
+  Arg.(required & pos 2 (some non_dir_file) None
+       & info [] ~docv:"ground-truth" ~doc)
+
+let print_metrics : metrics list Term.t =
+  let opts = [
+    "precision", `with_prec;
+    "recall", `with_recl;
+    "F_measure", `with_F;
+    "TP", `with_TP;
+    "FP", `with_FP;
+    "FN", `with_FN;
+  ] in
+  let doc = "Print metrics. User can choose to print -cprecision, -crecall,
+  -cF_measure, -cTP, -cFP and -cFN." in
+  Arg.(value & opt_all (enum opts) (List.map ~f:snd opts) &
+       info ["with-metrics"; "c"] ~doc)
+
+let output_metric_value formatter r metrics : unit =
+  let output_ratio = fprintf formatter "\t%.2g" in
+  let output_int = fprintf formatter "\t%d" in
+  List.iter metrics ~f:(function
+      | `with_prec -> output_ratio r.prec
+      | `with_recl -> output_ratio r.recl
+      | `with_F -> output_ratio r.f_05
+      | `with_TP -> output_int r.true_positive
+      | `with_FN -> output_int r.false_negative
+      | `with_FP -> output_int r.false_positive);
+  fprintf formatter "\n"
+
+let string_of_metric = function
+  | `with_prec -> "Prcs"
+  | `with_recl -> "Rcll"
+  | `with_F -> "F_05"
+  | `with_TP -> "TP"
+  | `with_FN -> "FN"
+  | `with_FP -> "FP"
+
+let print formatter tool result print_metrics : unit =
+  let tool_name = if tool = "bap-byteweight" then "BW" else "IDA" in
+  fprintf formatter "Tool";
+  List.iter print_metrics ~f:(fun m -> fprintf formatter "\t%s"
+                               @@ string_of_metric m);
+  fprintf formatter "\n%s" tool_name;
+  output_metric_value formatter result print_metrics
+
+let compare_against tool_name bin truth_name print_metrics : unit =
+  let open Or_error in
+  match (Func_start.of_tool tool_name ~testbin:bin >>| fun tool ->
+         Func_start.of_truth truth_name ~testbin:bin >>| fun truth ->
+         let result =
+           let false_positive = Set.(length (diff tool truth)) in
+           let false_negative = Set.(length (diff truth tool)) in
+           let true_positive = Set.length truth - false_negative in
+           let ratio x = Float.(of_int true_positive / (of_int true_positive + of_int x)) in
+           let prec = ratio false_positive in
+           let recl = ratio false_negative in
+           let f_05 = 1.5 *. prec *. recl /. (0.5 *. prec +. recl) in
+           {false_positive;false_negative;true_positive;prec;recl;f_05} in
+         print std_formatter tool_name result print_metrics) with
+  | Ok _ -> ()
+  | Error err ->
+    printf "Function start is not recognized properly due to
+  the following error:\n %a" Error.pp err
+
+
+let compare_against_t = Term.(pure compare_against $tool $bin $truth $print_metrics)
+
+let info =
+  let doc = "to compare the functions start identification result to the ground
+  truth" in
+  let man = [] in
+  Term.info "bap-fsi-benchmark" ~doc ~man
+
+let () =
+  Printexc.record_backtrace true;
+  Plugins.load ();
+  match Term.eval ~catch:false (compare_against_t, info) with
+  | `Error _ -> exit 1
+  | _ -> exit 0

--- a/src/readbin/fsi_benchmark.mli
+++ b/src/readbin/fsi_benchmark.mli
@@ -1,0 +1,1 @@
+(*fsi-benchmark*)

--- a/src/readbin/func_start.ml
+++ b/src/readbin/func_start.ml
@@ -1,0 +1,22 @@
+open Bap.Std
+open Core_kernel.Std
+
+type truth_format = [
+  | `unstripped_bin
+  | `symbol_file ]
+
+
+let format_of_filename f =
+  if Filename.check_suffix f ".scm" then `symbol_file
+  else `unstripped_bin
+
+let of_truth truth ~testbin : Addr.Set.t Or_error.t =
+  match format_of_filename truth with
+  | `unstripped_bin -> Ground_truth.from_unstripped_bin truth
+  | `symbol_file -> Ground_truth.from_symbol_file truth ~testbin
+
+
+let of_tool tool ~testbin : Addr.Set.t Or_error.t =
+  if tool = "bap-byteweight"
+  then Find_starts.with_byteweight testbin
+  else Find_starts.with_ida ~which_ida:tool testbin

--- a/src/readbin/func_start.mli
+++ b/src/readbin/func_start.mli
@@ -1,0 +1,10 @@
+open Bap.Std
+open Core_kernel.Std
+open Cmdliner
+
+(** [of_truth truth ~testbin] given the test binary [testbin], returns
+    the function start address from ground truth [truth] *)
+val of_truth: string -> testbin:string -> Addr.Set.t Or_error.t
+
+(** [of_tool tool] returns the function start address from [tool] *)
+val of_tool: string -> testbin:string -> Addr.Set.t Or_error.t

--- a/src/readbin/ground_truth.ml
+++ b/src/readbin/ground_truth.ml
@@ -1,0 +1,28 @@
+open Bap.Std
+open Core_kernel.Std
+open Or_error
+
+
+let from_unstripped_bin bin : Addr.Set.t t =
+  let tmp = Filename.temp_file "bw_" ".symbol" in
+  let cmd = sprintf "bap-byteweight dump -i %s %S > %S" "symbols"
+      bin tmp in
+  if Sys.command cmd = 0
+  then return (In_channel.with_file tmp ~f:Symbols.read_addrset)
+  else errorf
+      "failed to fetch symbols from unstripped binary, command `%s'
+  failed" cmd
+
+
+let from_symbol_file filename ~testbin : Addr.Set.t t =
+  Image.create testbin >>| (fun (img, _errors) ->
+      let arch = Image.arch img in
+      Table.foldi (Image.sections img) ~init:Addr.Set.empty
+        ~f:(fun mem sec t_fs ->
+            if Image.Sec.is_executable sec then
+              let sym_tbl = In_channel.with_file filename
+                  ~f:(fun ic -> Symbols.read ic arch mem) in
+              Seq.fold ~init:t_fs (Table.regions sym_tbl)
+                ~f:(fun accum mem -> Addr.Set.add accum @@ Memory.min_addr mem)
+            else t_fs))
+

--- a/src/readbin/ground_truth.mli
+++ b/src/readbin/ground_truth.mli
@@ -1,0 +1,11 @@
+open Bap.Std
+open Core_kernel.Std
+
+(** [from_unstripped_bin bin] returns the function start address set
+    from the symbols in unstripped binary [bin] *)
+val from_unstripped_bin : string -> Addr.Set.t Or_error.t
+
+(** [from_symbol_file symbolfile ~testbin] gets the architecture and
+    memory information from [testbin], and returns the function start
+    address set from the symbols in [symbolfile] *)
+val from_symbol_file : string -> testbin:string -> Addr.Set.t Or_error.t

--- a/src/readbin/ida.mli
+++ b/src/readbin/ida.mli
@@ -9,19 +9,24 @@
 open Bap.Std
 open Core_kernel.Std
 
-(** IDA instance  *)
+(** exception External_command_failed occurs when the external IDA
+    command is not executed successfully *)
+exception External_command_failed of string
+
+(** IDA instance *)
 type t
 
 (** [create ?ida target] create an IDA instance that will work with
-     [target] executable. [ida] is an optional hint, that can be
-     either a full path to [ida] executable, or just an executable
-     name *)
+    [target] executable. [ida] is an optional hint, that can be
+    either a full path to [ida] executable, or just an executable
+    name *)
 val create : ?ida:string -> string -> t Or_error.t
 
-(** [get_symbols ?demangle ida mem] extract symbols from binary, using IDA *)
+(** [get_symbols ?demangle ida mem] extract symbols from binary, using
+    IDA with specific path [ida] *)
 val get_symbols : ?demangle:Options.demangle -> t -> arch -> mem -> string table
 
-(** [close ida] finish interaction with IDA and clean all resources  *)
+(** [close ida] finish interaction with IDA and clean all resources *)
 val close : t -> unit
 
 

--- a/src/readbin/readbin.ml
+++ b/src/readbin/readbin.ml
@@ -214,7 +214,8 @@ module Program(Conf : Options.Provider) = struct
     let demangle = options.demangle in
     let usr_syms = match options.symsfile with
       | Some filename ->
-        Symbols.read ?demangle ~filename arch mem
+        In_channel.with_file filename
+          ~f:(fun ic -> Symbols.read ?demangle ic arch mem)
       | None -> Table.empty in
     let ida_syms = match options.use_ida with
       | None -> Table.empty

--- a/src/readbin/symbols.mli
+++ b/src/readbin/symbols.mli
@@ -26,4 +26,18 @@ open Bap.Std
 
 *)
 
-val read : ?demangle:Options.demangle -> filename:string -> arch -> mem -> string table
+(** [read ?demangle ic arch mem] reads symbol table from input channel
+    [ic] *)
+val read : ?demangle:Options.demangle -> in_channel -> arch -> mem -> string table
+
+(** [read_addrset ic] reads function start address set from input
+    channel [ic] *)
+val read_addrset : in_channel -> Addr.Set.t
+
+(** [write oc sym] writes function start address set from symbol table
+    [sym] to output channel [oc] *)
+val write : out_channel -> Image.sym table -> unit
+
+(** [write oc addrset] writes function start addresses [addrset] to
+    output channel [oc] *)
+val write_addrset : out_channel -> Addr.Set.t -> unit


### PR DESCRIPTION
This is the new implementation of the original `bap-compare`, which we rename it to `bap-fsi-benchmark`. The code is improved from the following points: 1. change io interfaces of symbols.ml to input and output channels. 2. more helper information. 3. redesign the command argument. 4. sync with latest bap (0.9.7). 5. process the abnormal command exit.