### PR TITLE
Minor change for bap-byteweight and bap-fsi-benchmark

### DIFF
--- a/src/readbin/bap-byteweight.ml
+++ b/src/readbin/bap-byteweight.ml
@@ -97,7 +97,7 @@ let symbols print_name print_size input : unit t =
       printf "%a %s%s\n" Addr.pp addr size name);
   printf "Outputted %d symbols\n" (Table.length syms)
 
-let dump _output_format info length threshold path (input : string) : unit t =
+let dump info length threshold path (input : string) : unit t =
   Image.create input >>= fun (img, _warns) ->
   match info with
   | `BW ->
@@ -231,11 +231,6 @@ module Cmdline = struct
     let doc = "Print symbol's size." in
     Arg.(value & flag & info ["print-size"; "s"] ~doc)
 
-  let output_format : [`text | `sexp] Term.t =
-    let enums = ["text", `text; "sexp", `sexp] in
-    let doc = sprintf "The output format. %s" @@ Arg.doc_alts_enum enums in
-    Arg.(value & opt (enum enums) `sexp & info ["output_format"; "f"] ~doc)
-
   let tool : [`BW | `SymTbl] Term.t =
     let enums = ["byteweight", `BW; "symbols", `SymTbl] in
     let doc = sprintf "The info to be dumped. %s" @@ Arg.doc_alts_enum enums in
@@ -243,8 +238,7 @@ module Cmdline = struct
 
   let dump =
     let doc = "Dump the function starts in a given executable by given tool" in
-    Term.(pure dump $output_format $tool $length $threshold $database_in
-          $filename),
+    Term.(pure dump $tool $length $threshold $database_in $filename),
     Term.info "dump" ~doc
 
   let train =

--- a/src/readbin/find_starts.ml
+++ b/src/readbin/find_starts.ml
@@ -18,6 +18,5 @@ let with_ida ~which_ida bin : Addr.Set.t t =
       if Image.Sec.is_executable sec then
         let sym_tbl = Ida.(get_symbols ida arch mem) in
         Seq.fold Seq.(Table.regions sym_tbl >>| Memory.min_addr)
-          ~init:ida_syms
-          ~f:(fun s sym -> Addr.Set.add s sym)
+          ~init:ida_syms ~f:Addr.Set.add
       else ida_syms)


### PR DESCRIPTION
Remove redundant argument from bap-byteweight, and change a closure in `find_starts.ml`