### PR TITLE
IR lifter

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -304,6 +304,7 @@ Library sema
   InternalModules:
                  Bap_sema,
                  Bap_sema_symtab,
+                 Bap_sema_lift,
                  Bap_ir,
                  Bap_lnf
 

--- a/_tags.in
+++ b/_tags.in
@@ -1,2 +1,3 @@
 true: short_paths
 true: annot, bin_annot
+true: debug

--- a/lib/bap/bap_project.mli
+++ b/lib/bap/bap_project.mli
@@ -63,7 +63,7 @@ val python : string tag
 (** to assosiate a shell command with a region  *)
 val shell : string tag
 
-(** just mark a region  *)
+(** just mark a region *)
 val mark : unit tag
 
 (** attach a color  *)

--- a/lib/bap_disasm/bap_disasm_block_intf.ml
+++ b/lib/bap_disasm/bap_disasm_block_intf.ml
@@ -38,7 +38,7 @@ module type Block_traverse = sig
   type t
   type dest = [
     | `Block of t * edge
-    | `Unresolved of    jump
+    | `Unresolved of jump
   ] with compare, sexp_of
 
   (** [dests blk] block immediate destinations including unresolved

--- a/lib/bap_sema/bap_sema.ml
+++ b/lib/bap_sema/bap_sema.ml
@@ -4,4 +4,23 @@ module Std = struct
   module Lnf = Bap_lnf
   include Bap_ir
 
+  module Ir_lift = Bap_sema_lift
+
+  module Program = struct
+    include Ir_program
+    let lift = Ir_lift.program
+  end
+
+  module Arg = Ir_arg
+  module Phi = Ir_phi
+  module Jmp = Ir_jmp
+  module Def = Ir_def
+  module Blk = struct
+    include Ir_blk
+    let lift = Ir_lift.blk
+  end
+  module Sub = struct
+    include Ir_sub
+    let lift = Ir_lift.sub
+  end
 end

--- a/lib/bap_sema/bap_sema_lift.ml
+++ b/lib/bap_sema/bap_sema_lift.ml
@@ -1,0 +1,201 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_image_std
+open Bap_disasm_std
+open Bap_ir
+
+(* A note about lifting call instructions.
+
+   We're labeling calls with an expected continuation, that should be
+   derived from the BIL. But instead we lift calls in a rather
+   speculative way, thus breaking the abstraction of the BIL, that
+   desugars calls into two pseudo instructions:
+
+   <update return address to next instruction>
+   <jump to target>
+
+   A correct way of doing things would be to find a live write to the
+   place that is used to store return address (ABI specific), and put
+   this expression as an expected return address (aka continuation).
+
+   But a short survey into existing instruction sets shows, that call
+   instructions doesn't allow to store something other then next
+   instruction, e.g., `call` in x86, `bl` in ARM, `jal` in MIPS,
+   `call` and `jumpl` in SPARC (althought the latter allows to choose
+   arbitrary register to store return address). That's all is not to
+   say, that it is impossible to encode a call with return address
+   different from a next instruction, that's why it is called a
+   speculation.
+*)
+
+type linear =
+  | Label of tid
+  | Instr of Ir_blk.elt
+
+let fall_of_block block =
+  Seq.find_map (Block.dests block) ~f:(function
+      | `Block (b,`Fall) -> Some b
+      | _ -> None)
+
+let label_of_fall block =
+  Option.map (fall_of_block block) ~f:(fun blk ->
+      Label.indirect Bil.(int (Block.addr blk)))
+
+let linear_of_stmt block insn stmt : linear list =
+  let goto ?cond id =
+    Ir_blk.Jmp (Ir_jmp.create_goto ?cond (Label.direct id)) in
+  let jump ?cond exp =
+    let target = Label.indirect exp in
+    let fall = lazy (label_of_fall block) in
+    let tail = if cond = None then [] else
+        match Lazy.force fall with
+        | None -> []
+        | Some fall -> [Ir_jmp.create_goto fall] in
+    if Insn.is_return insn
+    then Ir_jmp.create_ret ?cond target :: tail
+    else if Insn.is_call insn
+    then [
+      Ir_jmp.create_call ?cond
+        (Call.create ?return:(Lazy.force fall) ~target ())
+    ] else Ir_jmp.create_goto ?cond target :: tail in
+  let jump ?cond exp =
+    List.map (jump ?cond exp) ~f:(fun j -> Instr (Ir_blk.Jmp j)) in
+  let cpuexn ?cond n =
+    let next = Tid.create () in [
+      Instr (Ir_blk.Jmp (Ir_jmp.create_int ?cond n next));
+      Label next] in
+
+  let rec linearize = function
+    | Bil.Move (lhs,rhs) -> [Instr (Ir_blk.Def (Ir_def.create lhs rhs))]
+    | Bil.If (cond, [],[]) -> []
+    | Bil.If (cond,[],no) -> linearize Bil.(If (lnot cond, no,[]))
+    | Bil.If (cond,[Bil.CpuExn n],[]) -> cpuexn ~cond n
+    | Bil.If (cond,[Bil.Jmp exp],[]) -> jump ~cond exp
+    | Bil.If (cond,yes,[]) ->
+      let yes_label = Tid.create () in
+      let tail = Tid.create () in
+      Instr (goto ~cond yes_label) ::
+      Instr (goto tail) ::
+      Label yes_label ::
+      List.concat_map yes ~f:linearize @
+      Instr (goto tail) ::
+      Label tail :: []
+    | Bil.If (cond,yes,no) ->
+      let yes_label = Tid.create () in
+      let no_label = Tid.create () in
+      let tail = Tid.create () in
+      Instr (goto ~cond yes_label) ::
+      Instr (goto no_label) ::
+      Label yes_label ::
+      List.concat_map yes ~f:linearize @
+      Instr (goto tail) ::
+      Label no_label ::
+      List.concat_map no ~f:linearize @
+      Instr (goto tail) ::
+      Label tail :: []
+    | Bil.Jmp exp -> jump exp
+    | Bil.CpuExn n -> cpuexn n
+    | Bil.Special _ -> []
+    | Bil.While (cond,body) ->
+      let header = Tid.create () in
+      let tail = Tid.create () in
+      let finish = Tid.create () in
+      Instr (goto tail) ::
+      Label header ::
+      List.concat_map body ~f:linearize @
+      Instr (goto tail) ::
+      Label tail ::
+      Instr (goto ~cond header) ::
+      Instr (goto finish) ::
+      Label finish :: [] in
+  linearize stmt
+
+let blk block : blk term list =
+  List.fold (Block.insns block) ~init:([],Ir_blk.Builder.create ())
+    ~f:(fun init (_mem,insn)->
+        List.fold (Insn.bil insn) ~init ~f:(fun init stmt ->
+            List.fold (linear_of_stmt block insn stmt) ~init
+              ~f:( fun (bs,b) -> function
+                  | Label lab ->
+                    Ir_blk.Builder.result b :: bs,
+                    Ir_blk.Builder.create ~tid:lab ()
+                  | Instr elt -> Ir_blk.Builder.add_elt b elt; bs,b))) |>
+  fun (bs,b) -> List.rev (Ir_blk.Builder.result b :: bs)
+
+(* extracts resolved calls from the blk *)
+let call_of_blk blk =
+  Term.to_sequence jmp_t blk |>
+  Seq.find_map ~f:(fun jmp -> match Ir_jmp.kind jmp with
+      | Int _ | Goto _ | Ret _ -> None
+      | Call call -> match Call.target call with
+        | Direct _ -> None
+        | Indirect (Bil.Int addr) -> Some addr
+        | Indirect _ -> None)
+
+let resolve_jmp addrs jmp =
+  let update_kind jmp addr make_kind =
+    Option.value_map ~default:jmp
+      (Hashtbl.find addrs addr)
+      ~f:(fun id -> Ir_jmp.with_kind jmp (make_kind id)) in
+  match Ir_jmp.kind jmp with
+  | Ret _ | Int _ -> jmp
+  | Goto (Indirect (Bil.Int addr)) ->
+    update_kind jmp addr (fun id -> Goto (Direct id))
+  | Goto _ -> jmp
+  | Call call ->
+    let jmp,call = match Call.target call with
+      | Indirect (Bil.Int addr) ->
+        let new_call = ref call in
+        let jmp = update_kind jmp addr
+            (fun id ->
+               new_call := Call.with_target call (Direct id);
+               Call !new_call) in
+        jmp, !new_call
+      | _ -> jmp,call in
+    match Call.return call with
+    | Some (Indirect (Bil.Int addr)) ->
+      update_kind jmp addr
+        (fun id -> Call (Call.with_return call (Direct id)))
+    | _ -> jmp
+
+let sub entry =
+  let addrs = Addr.Table.create () in
+  let calls = Addr.Hash_set.create () in
+  let rec recons acc b =
+    let addr = Block.addr b in
+    if Hashtbl.mem addrs addr || Hash_set.mem calls addr
+    then acc
+    else
+      let bls = blk b in
+      Option.iter (List.hd bls) ~f:(fun blk ->
+          Hashtbl.add_exn addrs ~key:addr ~data:(Term.tid blk));
+      Option.iter (List.find_map bls ~f:call_of_blk)
+        ~f:(Hash_set.add calls);
+      Seq.fold (Block.succs b) ~init:(acc @ bls) ~f:recons in
+  let blks = recons [] entry in
+  let sub = Ir_sub.Builder.create ~blks:(List.length blks) () in
+  List.iter blks ~f:(fun blk ->
+      Ir_sub.Builder.add_blk sub
+        (Term.map jmp_t blk ~f:(resolve_jmp addrs)));
+  Ir_sub.Builder.result sub
+
+let ok_duplicate = function
+  | `Ok | `Duplicate -> ()
+
+let program roots cfg =
+  let b = Ir_program.Builder.create () in
+  let roots = Bap_sema_symtab.create_roots_table roots cfg in
+  let addrs = Addr.Table.create () in
+  Hashtbl.iter roots ~f:(fun ~key:root ~data:name ->
+      if not (Hashtbl.mem addrs root) then
+        match Table.find_addr cfg root with
+        | Some (mem,blk)
+          when Addr.(Memory.min_addr mem = root) ->
+          let sub = sub blk in
+          Ir_program.Builder.add_sub b (Ir_sub.with_name sub name);
+          Hashtbl.add_exn addrs ~key:root ~data:(Term.tid sub)
+        | _ -> ());
+  let program = Ir_program.Builder.result b in
+  Term.map sub_t program ~f:(fun sub ->
+      Term.map blk_t sub ~f:(fun blk ->
+          Term.map jmp_t blk ~f:(resolve_jmp addrs)))

--- a/lib/bap_sema/bap_sema_lift.mli
+++ b/lib/bap_sema/bap_sema_lift.mli
@@ -1,0 +1,10 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_image_std
+open Bap_disasm_std
+open Bap_ir
+
+
+val program : addr list -> block table -> program term
+val sub : block -> sub term
+val blk : block -> blk term list

--- a/lib/bap_sema/bap_sema_symtab.ml
+++ b/lib/bap_sema/bap_sema_symtab.ml
@@ -46,6 +46,7 @@ let dest_of_insn insn =
   | _ :: _ as bil -> dest_of_bil bil
   | [] -> None
 
+
 let create_roots_table roots cfg =
   let table = Addr.Table.create () in
   let name addr =
@@ -58,7 +59,7 @@ let create_roots_table roots cfg =
       if Insn.is_call term then match dest_of_insn term with
         | None -> ()
         | Some w ->
-          let _ : string =
+          let (_ : string) =
             Addr.Table.find_or_add table w ~default:(fun () -> name w) in
           ());
   table

--- a/lib/bap_sema/bap_sema_symtab.mli
+++ b/lib/bap_sema/bap_sema_symtab.mli
@@ -10,6 +10,8 @@ type t = string table
 *)
 val create : addr list -> mem -> block table -> t
 
+val create_roots_table : addr list -> block table -> string Addr.Table.t
+
 module Graph : Graph.Sig.P
   with type V.label = mem * string (** function body *)
    and type E.label = addr         (** callsite  *)

--- a/lib/bap_types/bap_exp.ml
+++ b/lib/bap_types/bap_exp.ml
@@ -157,10 +157,10 @@ module PP = struct
     | Load (mem, idx, edn, s) ->
       pr "(%a)[%a, %a]:%a" pp mem pp idx pp_edn edn Bap_size.pp s
     | Store (mem, idx, exp, edn, s) ->
-      pr "@[<v2>%a@;with [%a, %a]:%a <- %a@]"
+      pr "@[<2>%a@;with [%a, %a]:%a <- %a@]"
         pp mem pp idx pp_edn edn Bap_size.pp s pp exp
     | Ite (ce, te, fe) ->
-      pr "@[<v2>if %a@;then %a@;else %a@]" pp ce pp te pp fe
+      pr "@[<2>if %a@;then %a@;else %a@]" pp ce pp te pp fe
     | Extract (hi, lo, exp) ->
       pr "extract: %d:%d[%a]" hi lo pp exp
     | Concat (le, re) ->

--- a/lib_test/bap_sema/test_ir.ml
+++ b/lib_test/bap_sema/test_ir.ml
@@ -68,12 +68,12 @@ let make_sub name args blks : sub term =
   Sub.Builder.result b
 
 let abc = Term.append jmp_t abc
-    (Jmp.create_goto (Label.indirect Bil.(var ARM.CPU.lr)))
+    (Jmp.create_ret (Label.indirect Bil.(var ARM.CPU.lr)))
 
 let sub1 = make_sub "f" [arg_1;arg_2] [abc]
 let sub1_label = Label.direct Term.(tid sub1)
 let goto_xyz =
-  Jmp.create_goto ~cond:Bil.(var s = var @@ Arg.to_var arg_1) xyz_label
+  Jmp.create_goto ~cond:Bil.(var s = var @@ Arg.var arg_1) xyz_label
 let call_sub1 =
   let call = Call.create ~return:pqr_label ~target:sub1_label () in
   Jmp.create_call call

--- a/src/readbin/cmdline.ml
+++ b/src/readbin/cmdline.ml
@@ -40,6 +40,7 @@ let output_dump : _ list Term.t =
   let values = [
     "asm", `with_asm;
     "bil", `with_bil;
+    "bir", `with_bir;
   ] in
   let doc = sprintf
       "Print dump to standard output. Optional value \

--- a/src/readbin/options.ml
+++ b/src/readbin/options.ml
@@ -1,7 +1,8 @@
 open Core_kernel.Std
 
 type demangle = [`program of string | `internal] with sexp
-type insn_format = [ `with_asm | `with_bil ] with sexp
+type insn_format = [ `with_asm | `with_bil  ] with sexp
+type dump_format = [insn_format | `with_bir] with sexp
 type label_format = [`with_name | insn_format] with sexp
 
 type t = {
@@ -10,7 +11,7 @@ type t = {
   symsfile : string sexp_option;
   cfg_format : label_format sexp_list;
   output_phoenix : string option;
-  output_dump : insn_format sexp_list;
+  output_dump : dump_format sexp_list;
   demangle : demangle sexp_option;
   no_resolve : bool;
   keep_alive : bool;


### PR DESCRIPTION
This PR adds a lifter to IR. Namely, three new functions were added:

  - Program.lift - lifts the whole program
  - Sub.lift - lifts a subroutine
  - Blk.lift - lifts a basic block.

Also, there is a bunch of fixes to the IR, like:

  - add Interrupt as a new kind of jump
  - add Return as a new kind of jump
  - add intent field to arguments

Some other fixes, like adding missed functions, etc.

 Also, this PR adds new variant to the `--dump` (aka `-d`) command line
 option: `bir`. With this option the IR representation of a program will
 be printed to standard output.

 Note: this is still a work in progress.