### PR TITLE
Extend Value module and added attributes to terms.

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -11,6 +11,7 @@ PKG jsonm
 PKG ocamlgraph
 PKG camlzip
 PKG fileutils
+PKG uuidm
 
 B _build
 B _build/lib/bap

--- a/_oasis
+++ b/_oasis
@@ -101,10 +101,11 @@ Library types
   FindlibParent:   bap
   FindlibName:     types
   CompiledObject:  best
-  BuildDepends:    zarith
+  BuildDepends:    zarith, uuidm
   InternalModules:
                    Bap_addr,
                    Bap_arch,
+                   Bap_attributes,
                    Bap_bil,
                    Bap_bil_adt,
                    Bap_bitvector,
@@ -124,6 +125,7 @@ Library types
                    Bap_types,
                    Bap_value,
                    Bap_var,
+                   Bap_vector,
                    Bap_visitor
 
 Library conceval

--- a/lib/bap/bap_project.mli
+++ b/lib/bap/bap_project.mli
@@ -2,29 +2,19 @@ open Core_kernel.Std
 open Bap_types.Std
 open Image_internal_std
 open Bap_disasm_std
+open Bap_sema.Std
 
 (** The result of Binary analysis.  *)
 type t = {
   arch    : arch;               (** architecture  *)
   disasm  : disasm;             (** disassembly of a program *)
   memory  : value memmap;       (** annotations  *)
-  storage : value String.Map.t; (** arbitrary data storage *)
-
+  storage : dict;               (** arbitrary data storage *)
+  program : program term;       (** program lifted to BAP IR *)
   (** Deprecated fields, the will be removed in a next release. *)
   symbols : string table;       (** @deprecated symbol table  *)
   base    : mem;                (** @deprecated base memory  *)
 }
-
-type color = [
-  | `black
-  | `red
-  | `green
-  | `yellow
-  | `blue
-  | `magenta
-  | `cyan
-  | `white
-] with sexp
 
 (** all string tags supports the following substitutions:
 
@@ -46,31 +36,8 @@ type color = [
 
     - $max_addr - address of the last byte of a memory region.
 *)
-val substitute : t -> t
+val substitute : ?tags:string tag list -> t -> t
 
-(** an arbitrary text *)
-val text : string tag
-
-(** the associated data is an html markup *)
-val html : string tag
-
-(** associate a comment string with a memory region  *)
-val comment : string tag
-
-(** to assosiate a python command with a region *)
-val python : string tag
-
-(** to assosiate a shell command with a region  *)
-val shell : string tag
-
-(** just mark a region *)
-val mark : unit tag
-
-(** attach a color  *)
-val color : color tag
-
-(** attach a weight to a memory  *)
-val weight : float tag
 
 (** [register plugin] registers [plugin] in the system  *)
 val register_plugin : (t -> t) -> unit

--- a/lib/bap_disasm/bap_disasm.ml
+++ b/lib/bap_disasm/bap_disasm.ml
@@ -211,9 +211,13 @@ module Disasm = struct
     | `Failed_to_lift of mem * insn * Error.t
   ] with sexp_of
 
-  let insn  = Value.Tag.register "insn" sexp_of_insn
-  let block = Value.Tag.register "block" sexp_of_block
-  let error = Value.Tag.register "error" sexp_of_error
+  let insn  = Value.Tag.register (module Insn)
+      ~name:"insn"
+      ~uuid:"8e2a3998-bf07-4a52-a791-f74ea190630a"
+
+  let block = Value.Tag.register (module Addr)
+      ~name:"disasm_block"
+      ~uuid:"d261d12c-23b9-4bc0-9d0b-a6700bf59377"
 
   module Error = Printable(struct
       open Format

--- a/lib/bap_disasm/bap_disasm.mli
+++ b/lib/bap_disasm/bap_disasm.mli
@@ -19,7 +19,7 @@ type disasm
 
 (** values of type [insn] represents machine instructions decoded
     from the given piece of memory *)
-type insn = Bap_disasm_insn.t with bin_io, compare, sexp_of
+type insn = Bap_disasm_insn.t with bin_io, compare, sexp
 type op = Op.t with bin_io, compare, sexp_of
 
 (** [block] is a region of memory that is believed to be a basic block
@@ -111,8 +111,7 @@ module Disasm : sig
       the disassembling *)
   val errors : t -> (mem * error) seq
 
-  (** Tags to annotate memory  *)
+  (** Tags  *)
   val insn : insn tag
-  val block : block tag
-  val error : error tag
+  val block : addr tag
 end

--- a/lib/bap_image/bap_image.ml
+++ b/lib/bap_image/bap_image.ml
@@ -62,10 +62,21 @@ end
 type sec = Sec.t with bin_io, compare, sexp
 type sym = Sym.t with bin_io, compare, sexp
 
-let section = Value.Tag.register "section" sexp_of_sec
-let symbol  = Value.Tag.register "symbol" sexp_of_string
-let region  = Value.Tag.register "region" sexp_of_string
-let file    = Value.Tag.register "file"   sexp_of_string
+let section = Value.Tag.register (module Sec)
+    ~name:"section"
+    ~uuid:"a0eec123-5937-4283-b141-58d579a9b0df"
+
+let symbol  = Value.Tag.register (module String)
+    ~name:"symbol"
+    ~uuid:"768bc13d-d4be-43fc-9f7a-c369ebab9c7e"
+
+let region  = Value.Tag.register (module String)
+    ~name:"region"
+    ~uuid:"4014408d-a3af-488f-865b-5413beaf198e"
+
+let file = Value.Tag.register (module String)
+    ~name:"file"
+    ~uuid:"c119f700-4069-47ad-ba99-fc29791e0d47"
 
 type words = {
   r8  : word table Lazy.t;

--- a/lib/bap_sema/bap_ir.mli
+++ b/lib/bap_sema/bap_ir.mli
@@ -68,6 +68,11 @@ module Term : sig
   val before : ('a,'b) cls -> ?rev:bool -> 'a t -> tid -> 'b t seq
   val append : ('a,'b) cls -> ?after:tid -> 'a t -> 'b t -> 'a t
   val prepend : ('a,'b) cls -> ?before:tid -> 'a t -> 'b t -> 'a t
+  val length : ('a,'b) cls -> 'a t -> int
+  val set_attr : 'a t -> 'b tag -> 'b -> 'a t
+  val get_attr : 'a t -> 'b tag -> 'b option
+  val del_attr : 'a t -> 'b tag -> 'a t
+  val has_attr : 'a t -> 'b tag -> bool
 end
 
 module Ir_program : sig
@@ -141,6 +146,7 @@ end
 
 module Ir_jmp : sig
   type t = jmp term
+  val create : ?cond:exp -> jmp_kind -> t
   val create_call : ?cond:exp -> call -> t
   val create_goto : ?cond:exp -> label -> t
   val create_ret  : ?cond:exp -> label -> t

--- a/lib/bap_types/bap_attributes.ml
+++ b/lib/bap_types/bap_attributes.ml
@@ -1,0 +1,64 @@
+open Core_kernel.Std
+
+open Bap_value.Tag
+
+module Color = struct
+  type t = [
+    | `black
+    | `red
+    | `green
+    | `yellow
+    | `blue
+    | `magenta
+    | `cyan
+    | `white
+  ] with bin_io, compare, sexp
+  let pp ppf color =
+    Format.fprintf ppf "%a" Sexp.pp (sexp_of_t color)
+end
+
+type color = Color.t with bin_io, compare, sexp
+
+let comment = register (module String)
+    ~name:"comment"
+    ~uuid:"4b974ab3-bf3b-4a83-8c62-299bca70f02a"
+
+let python = register (module String)
+    ~name:"python"
+    ~uuid:"831a6268-0ca8-4c1b-b4d6-076995f49d84"
+
+let shell = register (module String)
+    ~name:"shell"
+    ~uuid:"8c2c459d-6f3e-42f7-bce7-bf5cfa280f24"
+
+let mark = register (module Unit)
+    ~name:"mark"
+    ~uuid:"8e9801dc-0c64-4943-acf4-bfd02347af91"
+
+let color = register (module Color)
+    ~name:"color"
+    ~uuid:"1938c44a-149d-4c71-832a-7f484be800cc"
+
+let weight = register (module Float)
+    ~name:"weight"
+    ~uuid:"657366ea-9a28-4e5e-8341-c545d861732b"
+
+let target_addr = register (module Bap_bitvector)
+    ~name:"target_addr"
+    ~uuid:"7bcef7c0-0b37-4167-887a-eba0d68891fe"
+
+let target_name = register (module String)
+    ~name:"target_name"
+    ~uuid:"35d9334f-7c17-46f7-8ff9-9430aa1293ac"
+
+let subroutine_addr = register (module Bap_bitvector)
+    ~name:"subroutine_addr"
+    ~uuid:"76bfd31c-05fb-48af-bfc1-721720710f0f"
+
+let subroutine_name = register (module String)
+    ~name:"subroutine_name"
+    ~uuid:"86fe023d-2637-4d92-baac-a420f518f250"
+
+let filename = register (module String)
+    ~name:"filename"
+    ~uuid:"9701d189-24e3-4348-8610-0dedf780d06b"

--- a/lib/bap_types/bap_types.ml
+++ b/lib/bap_types/bap_types.ml
@@ -209,6 +209,7 @@ module Std = struct
   module Word = Bitvector
 
   module Value = Bap_value
+  module Dict = Value.Dict
 
   (** Byte endian. This is the only not first class type in a bap-types.
       Sorry, no maps and tables for this type.
@@ -245,8 +246,9 @@ module Std = struct
   type var   = Var.t       with bin_io, compare, sexp
   type word  = Word.t      with bin_io, compare, sexp
   type nat1  = int         with bin_io, compare, sexp
-  type value = Value.t     with sexp_of
-  type 'a tag = 'a Value.tag with sexp_of
+  type value = Value.t     with bin_io, compare, sexp
+  type dict  = Value.dict  with bin_io, compare, sexp
+  type 'a tag = 'a Value.tag
 
   class ['a] bil_visitor = ['a] Bap_visitor.visitor
 
@@ -258,11 +260,17 @@ module Std = struct
   end
   include Seq.Export
 
+
+  module Vector = Bap_vector
+
+  type 'a vector = 'a Vector.t with bin_io, compare, sexp
+
   (** {2 Common type abbreviations}  *)
   type 'a seq = 'a Seq.seq with sexp
   type bigstring = Bigstring.t
 
   include Bap_int_conversions
+  include Bap_attributes
 
   (** Library configuration, version, and other constants  *)
   module Config = Bap_config

--- a/lib/bap_types/bap_value.ml
+++ b/lib/bap_types/bap_value.ml
@@ -1,32 +1,209 @@
 open Core_kernel.Std
 open Bap_common
 
-type 'a tag = 'a Type_equal.Id.t with sexp_of
-type t = Univ.t with sexp_of
+module Vector = Bap_vector
 
-let is t v = Univ.does_match v t
-let get t v = Univ.match_ v t
-let create t v = Univ.create t v
-let tagname = Univ.type_id_name
+type void
+type literal = (void,void,void) format
 
-module Tag = struct
-  type 'a t = 'a tag with sexp_of
-  let to_string = Type_equal.Id.name
-  let register name sexp = Type_equal.Id.create ~name sexp
+module type S = sig
+  type t with bin_io, compare, sexp
+  val pp : Format.formatter -> t -> unit
 end
 
-module Map = Univ_map
+type 'a tag = 'a Type_equal.Id.t
+type t = Univ.t
 
-include Printable(struct
-    type nonrec t = t with sexp_of
+(* The only shared
+*)
 
-    let rec ppstring_of_sexp = function
-      | Sexp.List ss -> sprintf "(%s)" @@
-        String.concat ~sep:", " (List.map ss ~f:ppstring_of_sexp)
-      | Sexp.Atom x -> x
+(* uuid simultaneously has three representations:
+   int as an interned string
+   string as human readable identifier
+   bytes as compact string of bytes.
 
-    let pp ppf v = Format.fprintf ppf "%s %s"
-        (String.capitalize (tagname v))
-        (ppstring_of_sexp (sexp_of_t v))
+   string and bytes representations are persistent, i.e.,
+   they do not change in time and space. Integer representation
+   is fast but online, i.e., is valid only for the run of the
+   program.
+*)
+
+module Typeid = struct
+
+  module Bin = Bin_prot.Utils.Make_binable(struct
+      module Binable = String
+      type t = Uuidm.t
+      let to_binable = Uuidm.to_bytes
+      let of_binable s = match Uuidm.of_bytes s with
+        | None -> invalid_arg "Bad UUID format"
+        | Some uuid -> uuid
+    end)
+
+  module Stringable = struct
+    type t = Uuidm.t
+    let of_string s = match Uuidm.of_string s with
+      | None -> invalid_arg "Bad UUID format"
+      | Some uuid -> uuid
+    let to_string s = Uuidm.to_string s
+  end
+
+  module Sexp = Sexpable.Of_stringable(Stringable)
+
+  include Regular.Make(struct
+      let compare = Uuidm.compare
+      include Bin
+      include Sexp
+      include Stringable
+      let hash = Hashtbl.hash
+      let module_name = "Bap.Std.Value.Typeid"
+      let pp ppf t = Uuidm.print ppf t
+    end)
+  include Uuidm
+  let of_string = Stringable.of_string
+  let to_string = Stringable.to_string
+end
+
+type typeid = Typeid.t with bin_io, compare, sexp
+
+
+type type_info = {
+  uuid : Typeid.t;
+  pp   : Format.formatter -> Univ.t -> unit;
+  of_string : string -> Univ.t;
+  to_string : Univ.t -> string;
+  compare : Univ.t -> Univ.t -> int;
+}
+
+let types : type_info Type_equal.Id.Uid.Table.t  =
+  Type_equal.Id.Uid.Table.create ~size:128 ()
+
+let info_of_uuid uuid =
+  Hashtbl.to_alist types |> List.find ~f:(fun (k,i) -> i.uuid = uuid)
+
+let register (type a) ~name ~uuid
+    (typ : (module S with type t = a)) : a tag =
+  let module S = (val typ) in
+  if info_of_uuid uuid <> None then
+    invalid_argf "UUID %s is already in use" (Uuidm.to_string uuid) ();
+  let tag = Type_equal.Id.create name S.sexp_of_t in
+  let pp ppf univ = S.pp ppf (Univ.match_exn univ tag) in
+  let of_string str =
+    Univ.create tag (Binable.of_string (module S) str) in
+  let to_string x =
+    Binable.to_string (module S) (Univ.match_exn x tag) in
+  let compare x y = match Univ.match_ x tag, Univ.match_ y tag with
+    | Some x, Some y -> S.compare x y
+    | _,_ -> Type_equal.Id.Uid.compare
+               (Univ.type_id_uid x) (Univ.type_id_uid y) in
+  let info = {
+    uuid; pp;
+    of_string;
+    to_string;
+    compare;
+  } in
+  Hashtbl.add_exn types ~key:(Type_equal.Id.uid tag) ~data:info;
+  tag
+
+module Nil = struct
+  type t = Typeid.t * string with sexp_of
+  let t = Type_equal.Id.create "nil" sexp_of_t
+end
+
+let typeof v = Hashtbl.find types (Univ.type_id_uid v)
+
+include Bin_prot.Utils.Make_binable(struct
+    module Binable = struct
+      type t = Typeid.t * string with bin_io
+    end
+    type nonrec t = t
+    let of_binable (uuid,data) = match info_of_uuid uuid with
+      | Some (_,t) -> t.of_string data
+      | None -> Univ.create Nil.t (uuid,data)
+
+    let to_binable v = match typeof v with
+      | Some t -> t.uuid, t.to_string v
+      | None -> Univ.match_exn v Nil.t
+  end)
+
+include Sexpable.Of_sexpable
+    (struct type t = Typeid.t * string with sexp end)
+    (struct
+      type nonrec t = t
+
+      let of_sexpable (uuid,data) = match info_of_uuid uuid with
+        | Some (_,t) -> t.of_string data
+        | None -> Univ.create Nil.t (uuid,data)
+
+      let to_sexpable v = match typeof v with
+        | Some t -> t.uuid, t.to_string v
+        | None -> Univ.match_exn v Nil.t
+    end)
+
+type value = t with bin_io, sexp
+
+let compare_value x y =
+  match typeof x, typeof y with
+  | None,_ | _,None -> Pervasives.compare x y
+  | Some t,_ -> t.compare x y
+
+
+let compare = compare_value
+
+let create = Univ.create
+let get t x = Univ.match_ x t
+let get_exn t x = Univ.match_exn x t
+let is t x = Univ.does_match x t
+let tagname t = Univ.type_id_name t
+let typeid x = match typeof x with
+  | Some t -> t.uuid
+  | None -> fst (Univ.match_exn x Nil.t)
+
+module Tag = struct
+  type 'a t = 'a tag
+  let to_string = Type_equal.Id.name
+
+  let register (type a) ~name ~uuid
+      (typ : (module S with type t = a)) : a tag =
+    let uuid = Typeid.of_string (string_of_format uuid) in
+    register ~name:(string_of_format name) ~uuid typ
+end
+
+module Dict = struct
+
+  type t = value Typeid.Map.t with bin_io, compare, sexp
+
+  let uuid tag =
+    (Hashtbl.find_exn types (Type_equal.Id.uid tag)).uuid
+
+  let empty = Typeid.Map.empty
+  let set t key data = Map.add t ~key:(uuid key) ~data:(create key data)
+  let mem t key = Map.mem t (uuid key)
+  let remove t key = Map.remove t (uuid key)
+  let is_empty = Map.is_empty
+  let find t key = match Map.find t (uuid key) with
+    | None -> None
+    | Some x -> get key x
+  let add t key data =
+    if mem t key then `Duplicate else `Ok (set t key data)
+  let change t key update =
+    let orig = find t key in
+    let next = update orig in
+    match next with
+    | Some data -> set t key data
+    | None -> if Option.is_none orig then t else remove t key
+
+  let data t : value Sequence.t =
+    Map.to_sequence t |> Sequence.map ~f:snd
+end
+
+type dict = Dict.t with bin_io, compare,sexp
+
+include Regular.Make(struct
+    type nonrec t = t with bin_io, compare, sexp
+    let hash = Hashtbl.hash
+
+    let pp ppf v = match typeof v with
+      | Some t -> t.pp ppf v
+      | None -> Format.fprintf ppf "<poly>"
     let module_name = "Bap.Std.Value"
   end)

--- a/lib/bap_types/bap_value.mli
+++ b/lib/bap_types/bap_value.mli
@@ -1,29 +1,46 @@
 open Core_kernel.Std
 open Bap_common
 
-type t with sexp_of
-type 'a tag with sexp_of
+type t with bin_io, compare, sexp
+type value = t with bin_io, compare, sexp
+type typeid with bin_io, compare, sexp
+type 'a tag
+type dict with bin_io, compare, sexp
+type void
+type literal = (void,void,void) format
 
 val create : 'a tag -> 'a -> t
 val get : 'a tag -> t -> 'a option
+val get_exn : 'a tag -> t -> 'a
 val is  : 'a tag -> t -> bool
 val tagname : t -> string
+val typeid : t -> typeid
 
-module Map : sig
-  type t
+module Dict : sig
+  type t = dict with bin_io, compare, sexp
   val empty : t
   val is_empty : t -> bool
   val set : t -> 'a tag -> 'a -> t
+  val remove : t -> 'a tag -> t
   val mem : t -> 'a tag -> bool
   val find : t -> 'a tag -> 'a option
   val add : t -> 'a tag -> 'a -> [`Ok of t | `Duplicate]
   val change : t -> 'a tag -> ('a option -> 'a option) -> t
+  val data : t -> value Sequence.t
+end
+
+module type S = sig
+  type t with bin_io, compare, sexp
+  val pp : Format.formatter -> t -> unit
 end
 
 module Tag : sig
-  type 'a t = 'a tag with sexp_of
+  type 'a t = 'a tag
   val to_string : 'a tag -> string
-  val register : string -> ('a -> Sexp.t) -> 'a tag
+  val register : name:literal -> uuid:literal ->
+    (module S with type t = 'a) -> 'a tag
 end
 
-include Printable with type t := t
+module Typeid : Regular with type t = typeid
+
+include Regular with type t := t

--- a/lib/bap_types/bap_vector.ml
+++ b/lib/bap_types/bap_vector.ml
@@ -1,0 +1,120 @@
+open Core_kernel.Std
+type 'a t = {
+  mutable size : int;
+  mutable data : 'a array;
+  default : 'a;
+} with bin_io, compare, sexp
+
+let create ?(capacity=16) default =
+  if capacity <= 0
+  then invalid_arg "capacity must be positive";
+  {
+    size = 0;
+    data = Array.create ~len:capacity default;
+    default;
+  }
+
+let resize vec =
+  let n = Array.length vec.data in
+  let data = Array.init (vec.size * 2)
+      ~f:(fun i -> if i < n
+           then Array.unsafe_get vec.data i
+           else vec.default) in
+  vec.data <- data
+
+let append vec x =
+  if Array.length vec.data = vec.size
+  then resize vec;
+  Array.unsafe_set vec.data vec.size x;
+  vec.size <- vec.size + 1
+
+let to_array vec =
+  Array.sub vec.data ~pos:0 ~len:vec.size
+
+let map_to_array vec ~f =
+  Array.init vec.size ~f:(fun i ->
+      f (Array.unsafe_get vec.data i))
+
+let get vec n =
+  if n < vec.size then Array.unsafe_get vec.data n
+  else invalid_arg "Index out of bounds"
+
+let set vec n x =
+  if n < vec.size then Array.unsafe_set vec.data n x
+  else invalid_arg "Index out of bounds"
+
+let nth vec n =
+  if n < vec.size then Some (Array.unsafe_get vec.data n)
+  else None
+
+let foldi vec ~init ~f =
+  let rec loop i init =
+    if i < vec.size
+    then loop (i+1) (f i init (Array.unsafe_get vec.data i))
+    else init in
+  loop 0 init
+
+let fold vec ~init ~f =
+  foldi vec ~init ~f:(fun _ acc x -> f acc x)
+
+let iteri vec ~f =
+  let rec loop i =
+    if i < vec.size
+    then
+      let () = f i (Array.unsafe_get vec.data i) in
+      loop (i+1)  in
+  loop 0
+
+
+let iter vec ~f = iteri vec ~f:(fun _ x -> f x)
+
+let find_mapi vec ~f =
+  with_return (fun {return} ->
+      iteri vec ~f:(fun i x -> match f i x with
+          | None -> ()
+          | hay -> return hay);
+      None)
+
+let findi vec ~f =
+  with_return (fun {return} ->
+      iteri vec ~f:(fun i x ->
+          if f i x then return (Some (i,x)));
+      None)
+
+let peq = Polymorphic_compare.equal
+
+let index_with ?(equal=peq) ~default vec x : int =
+  with_return (fun {return} ->
+      iteri vec ~f:(fun i y -> if equal x y then return i);
+      default)
+
+let index ?equal vec x : int option =
+  let n = index_with ~default:(-1) ?equal vec x in
+  if n < 0 then None else Some n
+
+let index_exn ?equal vec x : int =
+  let n = index_with ~default:(-1) ?equal vec x in
+  if n < 0 then raise Not_found else n
+
+module C = Container.Make(struct
+    type nonrec 'a t = 'a t
+    let fold = fold
+    let iter = `Custom iter
+  end)
+
+let mem = C.mem
+let length vec = vec.size
+let is_empty vec = length vec = 0
+let exists = C.exists
+let for_all = C.for_all
+let count = C.count
+let sum = C.sum
+let find = C.find
+let find_map = C.find_map
+
+let to_list vec =
+  List.init vec.size (fun i ->
+      Array.unsafe_get vec.data i)
+
+let min_elt = C.min_elt
+let max_elt = C.max_elt

--- a/lib/bap_types/bap_vector.mli
+++ b/lib/bap_types/bap_vector.mli
@@ -1,0 +1,17 @@
+open Core_kernel.Std
+type 'a t with bin_io, compare, sexp
+val create : ?capacity:int -> 'a -> 'a t
+val append : 'a t -> 'a -> unit
+val nth : 'a t -> int -> 'a option
+val get : 'a t -> int -> 'a
+val set : 'a t -> int -> 'a -> unit
+val map_to_array : 'a t -> f:('a -> 'b) -> 'b array
+val findi : 'a t -> f:(int -> 'a -> bool) -> (int * 'a) option
+val iteri : 'a t -> f:(int -> 'a -> unit) -> unit
+val foldi : 'a t -> init:'b -> f:(int -> 'b -> 'a -> 'b) -> 'b
+
+val index : ?equal:('a -> 'a -> bool) -> 'a t -> 'a -> int option
+val index_exn : ?equal:('a -> 'a -> bool) -> 'a t -> 'a -> int
+val index_with : ?equal:('a -> 'a -> bool) -> default:int -> 'a t -> 'a -> int
+
+include Container.S1 with type 'a t := 'a t

--- a/lib_test/bap_project/test_project.ml
+++ b/lib_test/bap_project/test_project.ml
@@ -29,16 +29,17 @@ let create_project architecture =
     disassemble architecture mem in
   let symtab = Table.add Table.empty mem ".text" |> ok_exn in
   {arch = architecture; disasm = dis; memory = Memmap.empty;
-   storage = String.Map.empty; symbols = symtab;
+   program = Program.create ();
+   storage = Dict.empty; symbols = symtab;
    base = mem }
 
 let substitute project ~kind ~hexstring =
   let memory =
-    let tag = Value.create text kind in
+    let tag = Value.create comment kind in
     Memmap.add project.memory (create_mem ~hexstring ()) tag in
   let project_result = Project.substitute {project with memory} in
   Memmap.fold ~init:[] project_result.memory ~f:(fun acc tag ->
-      match Value.get text tag with
+      match Value.get comment tag with
       | None -> acc
       | Some text -> text :: acc)
 

--- a/opam
+++ b/opam
@@ -56,6 +56,7 @@ depends: [
     "utop"
     "zarith"
     "piqi" {>= "0.7.4"}
+    "uuidm"
 ]
 
 depexts: [

--- a/opam.deps
+++ b/opam.deps
@@ -15,3 +15,4 @@ re
 uri
 zarith
 piqi
+uuidm

--- a/src/bap_mc/bap_mc.ml
+++ b/src/bap_mc/bap_mc.ml
@@ -201,16 +201,16 @@ module Cmdline = struct
 
   let addr =
     let doc = "Specify an address of first byte, as though \
-	           the instructions occur at a certain address, \
-	           and accordingly interpreted. Be careful that \
-	           you appropriately use 0x prefix for hex and \
-	           leave it without for decimal." in
+	       the instructions occur at a certain address, \
+	       and accordingly interpreted. Be careful that \
+	       you appropriately use 0x prefix for hex and \
+	       leave it without for decimal." in
     Arg.(value & opt  string "0x0" &  info ["addr"] ~doc)
 
   let max_insns =
     let doc = "Specify a number of instructions to disassemble.\
-	           Good for ensuring that only one instruction is ever\
-	           lifted or disassembled from a byte blob. Default is all" in
+	       Good for ensuring that only one instruction is ever\
+	       lifted or disassembled from a byte blob. Default is all" in
     Arg.(value & opt (some int) None & info ["max-insns"] ~doc)
 
 


### PR DESCRIPTION
Values of type value are now serializable, pretty-printable and
comparable (in short they are now first class). That allows us
to add them as attributes to IR terms. Now we can attach to terms
arbitrary values.