### PR TITLE
Update docs, fix bapdoc, add type equality witness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-[![Join the chat at https://gitter.im/BinaryAnalysisPlatform/bap](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/BinaryAnalysisPlatform/bap?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://travis-ci.org/BinaryAnalysisPlatform/bap.svg?branch=master)](https://travis-ci.org/BinaryAnalysisPlatform/bap) [![docs](https://img.shields.io/badge/doc-v0.9.7-green.svg)](http://binaryanalysisplatform.github.io/bap/api/v0.9.7/Bap.Std.html)[![docs](https://img.shields.io/badge/doc-master-green.svg)](http://binaryanalysisplatform.github.io/bap/api/master/Bap.Std.html)
+[![Join the chat at https://gitter.im/BinaryAnalysisPlatform/bap](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/BinaryAnalysisPlatform/bap?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://travis-ci.org/BinaryAnalysisPlatform/bap.svg?branch=master)](https://travis-ci.org/BinaryAnalysisPlatform/bap) [![docs](https://img.shields.io/badge/doc-v0.9.7-green.svg)](http://binaryanalysisplatform.github.io/bap/api/v0.9.7/Bap.Std.html) [![docs](https://img.shields.io/badge/doc-master-green.svg)](http://binaryanalysisplatform.github.io/bap/api/master/Bap.Std.html)
 
 BAP is a platform for binary analysis. It is written in OCaml, but can
 be used from other languages, for example, from Python.

--- a/bapdoc.ml
+++ b/bapdoc.ml
@@ -3,6 +3,7 @@
 
 let target = "lib/bap/bap.mli"
 let outdir = "doc"
+
 let deps = [
   "core_kernel";
   "ocamlgraph";
@@ -46,11 +47,11 @@ let find_p4_with s =
 let preprocess_with oc s = match find_p4_with s with
   | None -> output_string oc s
   | Some i -> match find_comments s with
-    | None, None -> output_substring oc s 0 i
+    | None, None -> output oc s 0 i
     | Some j,_ when j > i ->
-      output_substring oc s 0 i;
-      output_substring oc s j (String.length s - j)
-    | _, Some j -> if j < i then output_substring oc s 0 i
+      output oc s 0 i;
+      output oc s j (String.length s - j)
+    | _, Some j -> if j < i then output oc s 0 i
     | _ -> output_string oc s
 
 
@@ -104,7 +105,13 @@ let generate () =
      not (Sys.is_directory outdir) then
     raise No_out_dir;
   Sys.chdir tmp;
-  let options = String.concat " " ["-d"; outdir; "-html"] in
+  let options = String.concat " " [
+      "-d"; outdir;
+      "-html";
+      "-colorize-code";
+      "-short-functors";
+      "-hide Bap.Std,Core_kernel.Std"
+    ] in
   compile ~options on
 
 let () =

--- a/lib/bap_types/bap_value.ml
+++ b/lib/bap_types/bap_value.ml
@@ -160,12 +160,24 @@ let typeid x = match typeof x with
 
 module Tag = struct
   type 'a t = 'a tag
-  let to_string = Type_equal.Id.name
+  let name = Type_equal.Id.name
 
   let register (type a) ~name ~uuid
       (typ : (module S with type t = a)) : a tag =
     let uuid = Typeid.of_string (string_of_format uuid) in
     register ~name:(string_of_format name) ~uuid typ
+
+
+
+  (* core changed the type of same_witness in transition from 111 to
+     112, so we can't use more efficient [same_witness]. When we drop,
+     4.01 support we can rewrite it to more efficient functions.  *)
+  let same_witness t1 t2 =
+    Option.try_with (fun () -> Type_equal.Id.same_witness_exn t1 t2)
+
+  let same_witness_exn = Type_equal.Id.same_witness_exn
+  let same = Type_equal.Id.same
+
 end
 
 module Dict = struct

--- a/lib/bap_types/bap_value.mli
+++ b/lib/bap_types/bap_value.mli
@@ -36,9 +36,13 @@ end
 
 module Tag : sig
   type 'a t = 'a tag
-  val to_string : 'a tag -> string
   val register : name:literal -> uuid:literal ->
     (module S with type t = 'a) -> 'a tag
+
+  val name : 'a tag -> string
+  val same : 'a t -> 'b t -> bool
+  val same_witness : 'a t -> 'b t -> ('a,'b) Type_equal.t option
+  val same_witness_exn : 'a t -> 'b t -> ('a,'b) Type_equal.t
 end
 
 module Typeid : Regular with type t = typeid


### PR DESCRIPTION
This PR extends documentation of IR.

It also fixes `bapdoc` compatibility issues, turns on code highlighting
and removes ubiquitous `Bap.Std.` in generated documentation.

And it also exposes type equality witness for the `'a tag`.