### PR TITLE
Adding --dump-symbols option for `bap`, and changing the interfaces in Module symbols

### DIFF
--- a/src/readbin/.merlin
+++ b/src/readbin/.merlin
@@ -2,5 +2,6 @@ REC
 PKG ezjsonm
 PKG fileutils
 PKG re.posix
+PKG curl
 B ../../_build/src/readbin
 S .

--- a/src/readbin/byteweight_main.ml
+++ b/src/readbin/byteweight_main.ml
@@ -108,11 +108,12 @@ let dump info length threshold path (input : string) : unit t =
               let new_fs_s = BW.find bw ~length ~threshold mem in
               Addr.Set.union fs_s @@ Addr.Set.of_list new_fs_s
             else fs_s) in
-    Symbols.write_addrset stdout fs_set;
+    Symbols.write_addrs stdout @@ Addr.Set.to_list fs_set;
     Ok ()
   | `SymTbl ->
     let syms = Image.symbols img in
-    Symbols.write stdout syms;
+    let mems = Table.regions syms in
+    Symbols.write_addrs stdout @@ Seq.to_list (Seq.map mems Memory.min_addr);
     Ok ()
 
 let create_parent_dir dst =

--- a/src/readbin/cmdline.ml
+++ b/src/readbin/cmdline.ml
@@ -51,6 +51,15 @@ let output_dump : _ list Term.t =
   Arg.(value & opt_all ~vopt:`with_asm (enum values) [] &
        info ["dump"; "d"] ~doc)
 
+let dump_symbols : string option option Term.t =
+  let doc = "Output symbol information. In the output file, each symbol is in format of:
+  (<symbol name> <symbol start address> <symbol end address>), e.g.,
+  (malloc@@GLIBC_2.4 0x11034 0x11038)" in
+  Arg.(value & opt ~vopt:(Some None) (some (some string)) None & info
+         ["dump-symbols"] ~doc)
+
+
+
 let demangle : 'a option Term.t =
   let doc = "Demangle C++ symbols, using either internal \
              algorithm or a specified external tool, e.g. \
@@ -158,10 +167,9 @@ let load_path : string list Term.t =
        info ["load-path"; "L"] ~doc ~docv:"PATH")
 
 let create
-    a b c d e f g h i j k l m n o p q r s t u v x =
+    a b c d e f g h i j k l m n o p q r s t u v x y =
   Options.Fields.create
-    a b c d e f g h i j k l m n o p q r s t u v x
-
+    a b c d e f g h i j k l m n o p q r s t u v x y
 
 let program =
   let doc = "Binary Analysis Platform" in
@@ -211,7 +219,7 @@ let program =
 
   Term.(pure create
         $filename $loader $symsfile $cfg_format
-        $output_phoenix $output_dump $demangle
+        $output_phoenix $output_dump $dump_symbols $demangle
         $no_resolve $keep_alive
         $no_inline $keep_consts $no_optimizations
         $binaryarch $verbose $bw_disable $bw_length $bw_threshold

--- a/src/readbin/find_starts.ml
+++ b/src/readbin/find_starts.ml
@@ -2,21 +2,17 @@ open Bap.Std
 open Core_kernel.Std
 open Or_error
 
-let with_byteweight bin : Addr.Set.t t =
+let with_byteweight bin : addr seq Or_error.t =
   let tmp = Filename.temp_file "bw_" ".output" in
   let cmd = sprintf "bap-byteweight dump -i byteweight %S > %S" bin tmp in
   if Sys.command cmd = 0
-  then return (In_channel.with_file tmp ~f:Symbols.read_addrset)
+  then return (Seq.of_list @@ In_channel.with_file tmp ~f:Symbols.read_addrs)
   else error_string cmd
 
 
-let with_ida ~which_ida bin : Addr.Set.t t =
+let with_ida ~which_ida bin : addr seq Or_error.t =
   Image.create bin >>= fun (img, _warns) ->
   let arch = Image.arch img in
   Ida.create ?ida:(Some which_ida) bin >>| fun ida ->
-  Table.foldi (Image.sections img) ~init:Addr.Set.empty ~f:(fun mem sec ida_syms ->
-      if Image.Sec.is_executable sec then
-        let sym_tbl = Ida.(get_symbols ida arch mem) in
-        Seq.fold Seq.(Table.regions sym_tbl >>| Memory.min_addr)
-          ~init:ida_syms ~f:Addr.Set.add
-      else ida_syms)
+  let syms = Ida.get_symbols ida arch in
+  Seq.of_list @@ List.map syms ~f:(fun (_, es, _) -> es)

--- a/src/readbin/find_starts.mli
+++ b/src/readbin/find_starts.mli
@@ -4,9 +4,9 @@ open Core_kernel.Std
 
 (** [with_ida ~which_ida testbin] evaluates the IDA from [which_ida]
     on the binary [testbin], and returns the function start address
-    set *)
-val with_ida: which_ida:string -> string -> Addr.Set.t Or_error.t
+    sequence *)
+val with_ida: which_ida:string -> string -> addr seq Or_error.t
 
 (** [with_byteweight testbin] evaluates bap-byteweight on the binary
-    [testbin], and returns the function start address set *)
-val with_byteweight: string -> Addr.Set.t Or_error.t
+    [testbin], and returns the function start address sequence *)
+val with_byteweight: string -> addr seq Or_error.t

--- a/src/readbin/func_start.ml
+++ b/src/readbin/func_start.ml
@@ -10,13 +10,12 @@ let format_of_filename f =
   if Filename.check_suffix f ".scm" then `symbol_file
   else `unstripped_bin
 
-let of_truth truth ~testbin : Addr.Set.t Or_error.t =
+let of_truth truth ~testbin : addr seq Or_error.t =
   match format_of_filename truth with
   | `unstripped_bin -> Ground_truth.from_unstripped_bin truth
   | `symbol_file -> Ground_truth.from_symbol_file truth ~testbin
 
-
-let of_tool tool ~testbin : Addr.Set.t Or_error.t =
+let of_tool tool ~testbin : addr seq Or_error.t =
   if tool = "bap-byteweight"
   then Find_starts.with_byteweight testbin
   else Find_starts.with_ida ~which_ida:tool testbin

--- a/src/readbin/func_start.mli
+++ b/src/readbin/func_start.mli
@@ -3,8 +3,9 @@ open Core_kernel.Std
 open Cmdliner
 
 (** [of_truth truth ~testbin] given the test binary [testbin], returns
-    the function start address from ground truth [truth] *)
-val of_truth: string -> testbin:string -> Addr.Set.t Or_error.t
+    the function start address sequence from ground truth [truth] *)
+val of_truth: string -> testbin:string -> addr seq Or_error.t
 
-(** [of_tool tool] returns the function start address from [tool] *)
-val of_tool: string -> testbin:string -> Addr.Set.t Or_error.t
+(** [of_tool tool] returns the function start address sequence from
+    [tool] *)
+val of_tool: string -> testbin:string -> addr seq Or_error.t

--- a/src/readbin/ground_truth.ml
+++ b/src/readbin/ground_truth.ml
@@ -3,26 +3,19 @@ open Core_kernel.Std
 open Or_error
 
 
-let from_unstripped_bin bin : Addr.Set.t t =
+let from_unstripped_bin bin : addr seq Or_error.t =
   let tmp = Filename.temp_file "bw_" ".symbol" in
   let cmd = sprintf "bap-byteweight dump -i %s %S > %S" "symbols"
       bin tmp in
   if Sys.command cmd = 0
-  then return (In_channel.with_file tmp ~f:Symbols.read_addrset)
+  then return (Seq.of_list @@ In_channel.with_file tmp ~f:Symbols.read_addrs)
   else errorf
       "failed to fetch symbols from unstripped binary, command `%s'
   failed" cmd
 
-
-let from_symbol_file filename ~testbin : Addr.Set.t t =
+let from_symbol_file filename ~testbin : addr seq Or_error.t =
   Image.create testbin >>| (fun (img, _errors) ->
       let arch = Image.arch img in
-      Table.foldi (Image.sections img) ~init:Addr.Set.empty
-        ~f:(fun mem sec t_fs ->
-            if Image.Sec.is_executable sec then
-              let sym_tbl = In_channel.with_file filename
-                  ~f:(fun ic -> Symbols.read ic arch mem) in
-              Seq.fold ~init:t_fs (Table.regions sym_tbl)
-                ~f:(fun accum mem -> Addr.Set.add accum @@ Memory.min_addr mem)
-            else t_fs))
-
+      let syms = In_channel.with_file filename ~f:(Symbols.read arch)
+      in
+      Seq.of_list @@ List.map syms ~f:(fun (_, es, _) -> es))

--- a/src/readbin/ground_truth.mli
+++ b/src/readbin/ground_truth.mli
@@ -1,11 +1,11 @@
 open Bap.Std
 open Core_kernel.Std
 
-(** [from_unstripped_bin bin] returns the function start address set
+(** [from_unstripped_bin bin] returns the function start address sequence
     from the symbols in unstripped binary [bin] *)
-val from_unstripped_bin : string -> Addr.Set.t Or_error.t
+val from_unstripped_bin : string -> addr seq Or_error.t
 
 (** [from_symbol_file symbolfile ~testbin] gets the architecture and
     memory information from [testbin], and returns the function start
-    address set from the symbols in [symbolfile] *)
-val from_symbol_file : string -> testbin:string -> Addr.Set.t Or_error.t
+    address sequence from the symbols in [symbolfile] *)
+val from_symbol_file : string -> testbin:string -> addr seq Or_error.t

--- a/src/readbin/ida.ml
+++ b/src/readbin/ida.ml
@@ -141,10 +141,9 @@ let run_script self script_to =
       FileUtil.rm [script; result]);
   result
 
-let get_symbols ?demangle t arch mem =
+let get_symbols t arch =
   let result = run_script t Idapy.extract_symbols in
-  In_channel.with_file result ~f:(fun ic ->
-    Symbols.read ?demangle ic arch mem)
+  In_channel.with_file result ~f:(Symbols.read arch)
 
 let close self = self.close ()
 

--- a/src/readbin/ida.mli
+++ b/src/readbin/ida.mli
@@ -22,9 +22,9 @@ type t
     name *)
 val create : ?ida:string -> string -> t Or_error.t
 
-(** [get_symbols ?demangle ida mem] extract symbols from binary, using
-    IDA with specific path [ida] *)
-val get_symbols : ?demangle:Options.demangle -> t -> arch -> mem -> string table
+(** [get_symbols ida arch] extract symbols from binary, using IDA with
+    specific path [ida] *)
+val get_symbols : t -> arch -> (string * addr * addr) list
 
 (** [close ida] finish interaction with IDA and clean all resources *)
 val close : t -> unit

--- a/src/readbin/options.ml
+++ b/src/readbin/options.ml
@@ -12,6 +12,7 @@ type t = {
   cfg_format : label_format sexp_list;
   output_phoenix : string option;
   output_dump : dump_format sexp_list;
+  dump_symbols : string option option;
   demangle : demangle sexp_option;
   no_resolve : bool;
   keep_alive : bool;

--- a/src/readbin/symbols.mli
+++ b/src/readbin/symbols.mli
@@ -26,18 +26,18 @@ open Bap.Std
 
 *)
 
-(** [read ?demangle ic arch mem] reads symbol table from input channel
-    [ic] *)
-val read : ?demangle:Options.demangle -> in_channel -> arch -> mem -> string table
 
-(** [read_addrset ic] reads function start address set from input
+(** [read arch ic] reads (symbol, start, end) from input channel [ic] *)
+val read : arch -> in_channel -> (string * addr * addr) list
+
+(** [read_addrs ic] reads function start address list from input
     channel [ic] *)
-val read_addrset : in_channel -> Addr.Set.t
+val read_addrs : in_channel -> addr list
 
-(** [write oc sym] writes function start address set from symbol table
-    [sym] to output channel [oc] *)
-val write : out_channel -> Image.sym table -> unit
-
-(** [write oc addrset] writes function start addresses [addrset] to
+(** [write oc syms] writes the [syms] in format of (name, start, end) to
     output channel [oc] *)
-val write_addrset : out_channel -> Addr.Set.t -> unit
+val write : out_channel -> (string * addr * addr) list -> unit
+
+(** [write oc addrs] writes function start addresses list [addrs] to
+    output channel [oc] *)
+val write_addrs : out_channel -> addr list -> unit


### PR DESCRIPTION
This pull request aims to resolve issue #132 by adding --dump-symbols option for bap_main, and changing the interfaces in Module `symbols`.