### PR TITLE
Introduce pass dependencies and autoloading.

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -69,6 +69,7 @@ Library bap
                    bap.image,
                    bap.llvm,
                    bap.llvm_loader,
+                   bap.plugins,
                    bap.sema,
                    bap.types
   Modules:         Bap

--- a/lib/bap/bap_project.mli
+++ b/lib/bap/bap_project.mli
@@ -48,11 +48,11 @@ val set : t -> 'a tag -> 'a -> t
 val get : t -> 'a tag -> 'a option
 val has : t -> 'a tag -> bool
 
-val register_pass : string -> (t -> t) -> unit
-val register_pass': string -> (t -> unit) -> unit
-val register_pass_with_args : string -> (string array -> t -> t) -> unit
-val register_pass_with_args' : string -> (string array -> t -> unit) -> unit
+type 'a register = ?deps:string list -> string -> 'a -> unit
 
-val run_passes : ?argv:string array -> t -> t
-val run_pass : ?argv:string array -> string -> t -> t option
-val has_pass : string -> bool
+val register_pass : (t -> t) register
+val register_pass': (t -> unit) register
+val register_pass_with_args : (string array -> t -> t) register
+val register_pass_with_args' : (string array -> t -> unit) register
+
+val run_passes : ?library:string list -> ?argv:string array -> t -> t Or_error.t

--- a/src/readbin/bap_main.ml
+++ b/src/readbin/bap_main.ml
@@ -34,8 +34,9 @@ module Program(Conf : Options.Provider) = struct
 
   let run project =
     let system = "bap.pass" in
+    let library = options.load_path in
     List.iter options.plugins ~f:(fun name ->
-        Plugin.create ~library:options.load_path ~system name |>
+        Plugin.create ~library ~system name |>
         function
         | None ->
           invalid_argf "Failed to find plugin with name '%s'" name ()
@@ -45,7 +46,7 @@ module Program(Conf : Options.Provider) = struct
             invalid_argf "Failed to load plugin `%s': %s" name
               (Error.to_string_hum err) ());
 
-    let project = Project.run_passes project in
+    let project = Project.run_passes ~library project |> ok_exn in
 
     Option.iter options.emit_ida_script (fun dst ->
         Out_channel.write_all dst


### PR DESCRIPTION
This PR provides two new features (and revokes one).

1. Passes can now specify dependencies as list of names.
The dependencies will be run before the pass.

2. [run_passes] now will auto-load plugins. I.e., now it is sufficient
just to specify the sink pass, all dependencies will be properly
resolved and loaded.

3. Now it is not possible to register the same plugin (or different
plugins with the same name).