### PR TITLE
Renaming things.

### DIFF
--- a/lib/bap_disasm/bap_disasm.ml
+++ b/lib/bap_disasm/bap_disasm.ml
@@ -137,9 +137,9 @@ let disassemble ?roots arch mem =
   | Error err -> fail (`Failed err) mem
   | Ok r -> of_rec r
 
-(* merges the results of disassembling of different sections,
+(* merges the results of disassembling of different segments,
    table entries mustn't overlap. *)
-let merge_different_sections d1 d2 =
+let merge_different_segments d1 d2 =
   let add mem x tab = Table.add tab mem x |> ok_exn in
   let merge t1 t2 = Table.foldi t1 ~init:t2 ~f:add in
   let memmap = merge d1.memmap d2.memmap in
@@ -153,9 +153,9 @@ let disassemble_image ?roots image =
     | Some roots -> roots
     | None -> Image.symbols image |> Table.regions |>
               Seq.map ~f:Memory.min_addr |> Seq.to_list in
-  Table.foldi ~init:empty (Image.sections image) ~f:(fun mem sec dis ->
-      if Image.Sec.is_executable sec then
-        merge_different_sections dis (disassemble ~roots arch mem)
+  Table.foldi ~init:empty (Image.segments image) ~f:(fun mem sec dis ->
+      if Image.Segment.is_executable sec then
+        merge_different_segments dis (disassemble ~roots arch mem)
       else dis)
 
 let disassemble_file ?roots filename =

--- a/lib/bap_image/bap_image.mli
+++ b/lib/bap_image/bap_image.mli
@@ -10,10 +10,10 @@ open Image_internal_std
 
 type t with sexp_of            (** image   *)
 
-(** section *)
-type sec with bin_io, compare, sexp
+(** segment *)
+type segment with bin_io, compare, sexp
 (** symbol  *)
-type sym with bin_io, compare, sexp
+type symbol with bin_io, compare, sexp
 
 type path = string
 
@@ -53,30 +53,30 @@ val data : t -> Bigstring.t
 
 (** {2 Tables }  *)
 val words : t -> size -> word table
-val sections : t -> sec table
+val segments : t -> segment table
 
 (** @deprecated: this will be removed in a next release  *)
-val symbols : t -> sym table
+val symbols : t -> symbol table
 
 
-val section : sec tag
+val segment : segment tag
 val symbol  : string tag
-val region  : string tag
+val section : string tag
 
 (** returns memory  *)
 val memory : t -> value memmap
 
 (** {2 Mappings }  *)
-val memory_of_section  : t -> sec -> mem
-(** [memory_of_symbol sym]: returns the memory of symbol in acending order. *)
-val memory_of_symbol   : t -> sym -> mem * mem seq
-val symbols_of_section : t -> sec -> sym seq
-val section_of_symbol  : t -> sym -> sec
+val memory_of_segment  : t -> segment -> mem
+(** [memory_of_symbol symbol]: returns the memory of symbol in acending order. *)
+val memory_of_symbol   : t -> symbol -> mem * mem seq
+val symbols_of_segment : t -> segment -> symbol seq
+val segment_of_symbol  : t -> symbol -> segment
 
 
 
-module Sec : sig
-  type t = sec
+module Segment : sig
+  type t = segment
   include Regular with type t := t
   val name : t -> string
   val is_writable   : t -> bool
@@ -84,8 +84,8 @@ module Sec : sig
   val is_executable : t -> bool
 end
 
-module Sym : sig
-  type t = sym
+module Symbol : sig
+  type t = symbol
   include Regular with type t := t
   val name : t -> string
   val is_function : t -> bool

--- a/lib/bap_image/bap_image_std.ml
+++ b/lib/bap_image/bap_image_std.ml
@@ -2,9 +2,9 @@
 include Image_internal_std
 
 module Image   = Bap_image
-module Section = Image.Sec
-module Symbol  = Image.Sym
+module Segment = Image.Segment
+module Symbol  = Image.Symbol
 
 type image = Image.t
 type symbol  = Symbol.t with bin_io, compare, sexp
-type section = Section.t with bin_io, compare, sexp
+type segment = Segment.t with bin_io, compare, sexp

--- a/lib/bap_image/image_backend.ml
+++ b/lib/bap_image/image_backend.ml
@@ -6,10 +6,10 @@ type perm = R | W | X | Or of perm * perm
 with bin_io, compare, sexp
 
 (** A named contiguous part of file with permissions.  *)
-module Section = struct
+module Segment = struct
   type t = {
     name: string;
-    perm: perm;         (** section's permissions  *)
+    perm: perm;         (** segment's permissions  *)
     off: int;
     location : location;
   } with bin_io, compare, fields, sexp
@@ -17,7 +17,7 @@ end
 
 (** Symbol definition, that can span several non-contiguous parts of
     memory *)
-module Sym = struct
+module Symbol = struct
   type t = {
     name : string;
     is_function : bool;
@@ -26,7 +26,7 @@ module Sym = struct
   } with bin_io, compare, fields, sexp
 end
 
-module Region = struct
+module Section = struct
   type t = {
     name : string;
     location : location;
@@ -37,9 +37,9 @@ module Img = struct
   type t = {
     arch     : arch;
     entry    : addr;
-    sections : Section.t * Section.t list;
-    symbols  : Sym.t list;
-    regions  : Region.t list;
+    segments : Segment.t * Segment.t list;
+    symbols  : Symbol.t list;
+    sections : Section.t list;
   } with bin_io, compare, fields, sexp
 end
 

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -27,7 +27,7 @@ Disassembling things
 
 ``disasm`` is a swiss knife for disassembling things. It takes either a
 string object, or something returned by an ``image`` function, e.g.,
-images, sections and symbols.
+images, segments and symbols.
 
 ``disasm`` function returns a generator yielding instances of class
 ``Insn`` defined in module :mod:`asm`. It has the following attributes:
@@ -69,9 +69,9 @@ file by name, and the following set of attributes (self describing):
 * addr_size
 * endian
 * file (file name)
-* sections
+* segments
 
-Sections is a list of instances of ``Section`` class, that also has a
+Segments is a list of instances of ``Segment`` class, that also has a
 ``get_symbol`` function and the following attributes:
 
 * name

--- a/python/bap.py
+++ b/python/bap.py
@@ -123,27 +123,27 @@ class Image(Resource):
     def __init__(self, ident, bap):
         super(Image,self).__init__('image', ident, bap)
 
-    def load_sections(self):
-        ss = self.get('sections')
-        self.sections = [Section(s, self) for s in ss]
+    def load_segments(self):
+        ss = self.get('segments')
+        self.segments = [Segment(s, self) for s in ss]
 
     def get_symbol(self, name, d=None):
-        for sec in self.sections:
+        for sec in self.segments:
             sym = sec.get_symbol(name, d)
             if sym is not d:
                 return sym
         return d
 
     def __getattr__(self, name):
-        if name == 'sections':
-            self.load_sections()
-            return self.sections
+        if name == 'segments':
+            self.load_segments()
+            return self.segments
         else:
             return self.get(name)
 
-class Section(Resource):
+class Segment(Resource):
     def __init__(self, ident, parent):
-        super(Section, self).__init__('section', ident, parent.bap)
+        super(Segment, self).__init__('segment', ident, parent.bap)
         self.parent = parent
 
     def load_symbols(self):
@@ -362,8 +362,8 @@ def demo_chunk():
 def demo_image():
     img = image("coreutils_O0_ls")
     print "Arch: {1}".format(img.name, img.arch)
-    print "Sections:"
-    for sec in img.sections:
+    print "Segments:"
+    for sec in img.segments:
         print "\t{0}\t{1}".format(sec.name, "".join(sec.perm))
         print "\t\tSymbols:"
         for sym in sec.symbols:

--- a/src/readbin/bap_main.ml
+++ b/src/readbin/bap_main.ml
@@ -159,8 +159,12 @@ module Program(Conf : Options.Provider) = struct
         List.iter warns ~f:(eprintf "Warning: %a@." Error.pp);
       let arch = Image.arch img in
       let symbols = symbols arch in
-      let roots = Map.keys symbols in
       let name = Map.find symbols in
+      let roots = Table.foldi (Image.segments img)
+          ~init:(Map.keys symbols) ~f:(fun mem sec roots ->
+              if Image.Segment.is_executable sec
+              then find_roots arch mem @ roots
+              else roots) in
       Project.from_image ~name ~roots img >>= fun proj ->
       run proj;
       return 0

--- a/src/server/manager.ml
+++ b/src/server/manager.ml
@@ -42,14 +42,14 @@ type 'a resource = {
 type context = {
   images : image resource Ids.t;
   chunks : mem   resource Ids.t;
-  sections : Image.Sec.t Ids.t;
-  symbols  : Image.Sym.t  Ids.t;
-  sections_of_image  : id list Ids.t;
-  symbols_of_section : id list Ids.t;
+  segments : Image.Segment.t Ids.t;
+  symbols  : Image.Symbol.t  Ids.t;
+  segments_of_image  : id list Ids.t;
+  symbols_of_segment : id list Ids.t;
   memory_of_symbol   : id list Ids.t;
   symbol_of_memory   : id Ids.t;
-  section_of_symbol  : id Ids.t;
-  image_of_section   : id Ids.t;
+  segment_of_symbol  : id Ids.t;
+  image_of_segment   : id Ids.t;
 } with fields
 
 
@@ -59,14 +59,14 @@ let t =
   {
     images = empty ();
     chunks = empty ();
-    sections = empty ();
+    segments = empty ();
     symbols = empty ();
-    sections_of_image = empty ();
-    symbols_of_section = empty ();
+    segments_of_image = empty ();
+    symbols_of_segment = empty ();
     memory_of_symbol = empty ();
     symbol_of_memory = empty ();
-    section_of_symbol = empty ();
-    image_of_section = empty ();
+    segment_of_symbol = empty ();
+    image_of_segment = empty ();
   }
 
 
@@ -97,21 +97,21 @@ let add_image ?file img =
   let img_id = next_id () in
   let file = Option.first_some file (Image.filename img) in
   let arch = Image.arch img in
-  let sections = Image.sections img |> Table.to_sequence in
-  Lwt.Or_error.Seq.iter sections ~f:(fun (mem,sec) ->
+  let segments = Image.segments img |> Table.to_sequence in
+  Lwt.Or_error.Seq.iter segments ~f:(fun (mem,sec) ->
       let sec_id = next_id () in
-      Ids.add_multi t.sections_of_image ~key:img_id ~data:sec_id;
-      Ids.add_exn t.image_of_section ~key:sec_id ~data:img_id;
-      provide_memory arch ?file sec_id mem >>=? fun section ->
-      Ids.add_exn t.chunks ~key:sec_id ~data:section;
-      Ids.add_exn t.sections ~key:sec_id ~data:sec;
-      let syms = Image.symbols_of_section img sec  in
+      Ids.add_multi t.segments_of_image ~key:img_id ~data:sec_id;
+      Ids.add_exn t.image_of_segment ~key:sec_id ~data:img_id;
+      provide_memory arch ?file sec_id mem >>=? fun segment ->
+      Ids.add_exn t.chunks ~key:sec_id ~data:segment;
+      Ids.add_exn t.segments ~key:sec_id ~data:sec;
+      let syms = Image.symbols_of_segment img sec  in
       Lwt.Or_error.Seq.iter syms ~f:(fun sym ->
           let sym_id = next_id () in
           let (mem,mems) = Image.memory_of_symbol img sym in
           Ids.add_exn t.symbols ~key:sym_id ~data:sym;
-          Ids.add_multi t.symbols_of_section ~key:sec_id ~data:sym_id;
-          Ids.add_exn t.section_of_symbol ~key:sym_id ~data:sec_id;
+          Ids.add_multi t.symbols_of_segment ~key:sec_id ~data:sym_id;
+          Ids.add_exn t.segment_of_symbol ~key:sym_id ~data:sec_id;
           let all_mems = mem :: Seq.to_list mems in
           Lwt.Or_error.List.iter all_mems ~f:(fun mem ->
               let mem_id = next_id () in
@@ -157,21 +157,21 @@ let id_of_string s =
   let open Or_error in
   Id.of_string s >>= fun id ->
   let f = Ids.mem in
-  let tables = [f t.images; f t.chunks; f t.symbols; f t.sections] in
+  let tables = [f t.images; f t.chunks; f t.symbols; f t.segments] in
   match List.exists tables ~f:(fun f -> f id) with
   | true -> Ok id
   | false -> errorf "Id %s is not known"  s
 
 let symbol_of_memory = Ids.find t.symbol_of_memory
-let section_of_symbol = Ids.find t.section_of_symbol
-let image_of_section = Ids.find t.image_of_section
+let segment_of_symbol = Ids.find t.segment_of_symbol
+let image_of_segment = Ids.find t.image_of_segment
 
 let find_list tab id = match Ids.find tab id with
   | Some lst -> lst
   | None -> []
 
-let sections_of_image = find_list t.sections_of_image
-let symbols_of_section = find_list t.symbols_of_section
+let segments_of_image = find_list t.segments_of_image
+let symbols_of_segment = find_list t.symbols_of_segment
 let memory_of_symbol = find_list t.memory_of_symbol
 
 type 'a served = {
@@ -181,8 +181,8 @@ type 'a served = {
 
 type nil = Nil
 type mem = Memory.t served
-type sym = Image.Sym.t             (** symbol  *)
-type sec = Image.Sec.t            (** section  *)
+type sym = Image.Symbol.t             (** symbol  *)
+type seg = Image.Segment.t            (** segment  *)
 type img = Image.t served
 
 type ('mem, 'img, 'sec, 'sym) res = {
@@ -198,7 +198,7 @@ type ('mem,'img,'sec,'sym,'a) visitor =
 
 let memory  r = r.mem
 let image   r = r.img
-let section r = r.sec
+let segment r = r.sec
 let symbol  r = r.sym
 let endian  r = r.res.endian
 let addr    r = r.res.addr
@@ -279,10 +279,10 @@ let fetch_image r = r.fetch ()
 let of_image res : (nil,img,nil,nil) res =
   { (init res) with img = serve res; }
 
-let of_section sec id : (mem,img,sec,nil) res Or_error.t =
+let of_segment sec id : (mem,img,seg,nil) res Or_error.t =
   let open Or_error in
   let open Fields_of_context in
-  find_in image_of_section id >>= fun img_id ->
+  find_in image_of_segment id >>= fun img_id ->
   find_in images img_id >>= fun img ->
   find_in chunks id >>= fun mem ->
   let r = init mem in
@@ -291,12 +291,12 @@ let of_section sec id : (mem,img,sec,nil) res Or_error.t =
            mem = serve mem;
            sec}
 
-let of_symbol sym id : (mem list1,img,sec,sym) res Or_error.t =
+let of_symbol sym id : (mem list1,img,seg,sym) res Or_error.t =
   let open Fields_of_context in
   let open Or_error in
-  find_in section_of_symbol id    >>= fun sec_id ->
-  find_in sections sec_id         >>= fun sec    ->
-  find_in image_of_section sec_id >>= fun img_id ->
+  find_in segment_of_symbol id    >>= fun sec_id ->
+  find_in segments sec_id         >>= fun sec    ->
+  find_in image_of_segment sec_id >>= fun img_id ->
   find_in images img_id           >>= fun img ->
   find_in memory_of_symbol id     >>= fun mems ->
   List.map mems ~f:(find_in chunks) |> all >>= function
@@ -318,12 +318,12 @@ module Return = struct
   let error msg data sexp _res = Lwt.Or_error.error msg data sexp
 end
 
-let with_resource ~chunk ~symbol ~section ~image (id : id) =
+let with_resource ~chunk ~symbol ~segment ~image (id : id) =
   let open Fields_of_context in
   match Ids.find t.images id with
   | Some img -> image (of_image img)
-  | None -> match Ids.find t.sections id with
-    | Some sec -> return (of_section sec id) >>=? section
+  | None -> match Ids.find t.segments id with
+    | Some sec -> return (of_segment sec id) >>=? segment
     | None -> match Ids.find t.symbols id with
       | Some sym -> return (of_symbol sym id) >>=? symbol
       | None -> match Ids.find t.chunks id with
@@ -345,7 +345,7 @@ include struct
   open Fields_of_context
 
   let images = export images
-  let sections = export sections
+  let segments = export segments
   let symbols = export symbols
   let chunks = export chunks
 end

--- a/src/server/manager.mli
+++ b/src/server/manager.mli
@@ -23,8 +23,8 @@ type ('mem,'img,'sec,'sym) res
 (** Types of resource data  *)
 type nil                        (** data not available  *)
 type mem
-type sym = Image.Sym.t             (** symbol  *)
-type sec = Image.Sec.t            (** section  *)
+type sym = Image.Symbol.t             (** symbol  *)
+type seg = Image.Segment.t            (** segment  *)
 type img
 
 (** Unique Identifer  *)
@@ -47,15 +47,15 @@ val string_of_id : id -> string
 val id_of_string : string -> id Or_error.t
 
 val symbol_of_memory  : id -> id option
-val section_of_symbol : id -> id option
-val image_of_section  : id -> id option
+val segment_of_symbol : id -> id option
+val image_of_segment  : id -> id option
 
-val sections_of_image  : id -> id list
-val symbols_of_section : id -> id list
+val segments_of_image  : id -> id list
+val symbols_of_segment : id -> id list
 val memory_of_symbol   : id -> id list
 
 val images : id list
-val sections : id list
+val segments : id list
 val symbols : id list
 val chunks : id list
 
@@ -63,7 +63,7 @@ val chunks : id list
 
 val memory  : ('a,_,_,_) res -> 'a
 val image   : (_,'a,_,_) res -> 'a
-val section : (_,_,'a,_) res -> 'a
+val segment : (_,_,'a,_) res -> 'a
 val symbol  : (_,_,_,'a) res -> 'a
 val endian  : (_,_,_,_) res -> endian
 val arch    : (_,_,_,_) res -> arch
@@ -110,7 +110,7 @@ end
 *)
 val with_resource :
   chunk:(mem,nil,nil,nil,'a) visitor ->
-  symbol:(mem list1, img,sec,sym,'a) visitor ->
-  section:(mem,img,sec,nil,'a) visitor ->
+  symbol:(mem list1, img,seg,sym,'a) visitor ->
+  segment:(mem,img,seg,nil,'a) visitor ->
   image:(nil,img,nil,nil,'a) visitor ->
   id -> 'a Lwt.Or_error.t

--- a/src/server/rpc.ml
+++ b/src/server/rpc.ml
@@ -148,7 +148,7 @@ module Response = struct
 
   let list_of_perm sec =
     let (:=) v f = Option.some_if (f sec) v in
-    List.filter_opt Image.Sec.([
+    List.filter_opt Image.Segment.([
         "r" := is_readable;
         "w" := is_writable;
         "x" := is_executable;
@@ -165,13 +165,13 @@ module Response = struct
       "addr_size", string / Int.to_string / Size.to_bits / addr_size;
       "endian", string / Adt.string_of_endian / endian;
     ] @ optional_field "file" string (filename image) @ [
-      "sections", strings secs;
+      "segments", strings secs;
     ]
 
 
 
   let symbol s mems : msg =
-    let open Image.Sym in [
+    let open Image.Symbol in [
       "symbol", dict @@ [
         "name", string @@ name s;
         "is_function", bool @@ is_function s;
@@ -183,16 +183,16 @@ module Response = struct
       ]
     ]
 
-  let section ~syms s mem : msg = [
-    "section", dict @@ [
-      "name", string @@ Image.Sec.name s;
+  let segment ~syms s mem : msg = [
+    "segment", dict @@ [
+      "name", string @@ Image.Segment.name s;
       "perm", strings @@ list_of_perm s;
       "symbols", strings syms;
     ] @ memory mem
   ]
 
   let resources name rs : msg = [name, strings rs]
-  let sections = resources "sections"
+  let segments = resources "segments"
   let symbols = resources "symbols"
   let images = resources "images"
   let chunks = resources "chunks"

--- a/src/server/rpc.mli
+++ b/src/server/rpc.mli
@@ -57,9 +57,9 @@ module Response : sig
 
   val image : secs:res_ids -> Image.t resource -> msg
 
-  val section : syms:res_ids -> Image.Sec.t -> mem resource -> msg
+  val segment : syms:res_ids -> Image.Segment.t -> mem resource -> msg
 
-  val symbol : Image.Sym.t -> mem resource List1.t -> msg
+  val symbol : Image.Symbol.t -> mem resource List1.t -> msg
 
   val memory : mem resource -> msg
 
@@ -69,7 +69,7 @@ module Response : sig
   val insns : insn list -> msg
 
   val images   : res_id list -> msg
-  val sections : res_id list -> msg
+  val segments : res_id list -> msg
   val symbols  : res_id list -> msg
   val chunks   : res_id list -> msg
   val added    : res_id -> msg


### PR DESCRIPTION
This PR forfeits our previous awkward naming scheme, where segments
were sections, sections were segments and regions were sections. No need
to understand the above anymore.

Now segments are segments.
Sections are sections.
Symbols are symbols.

For those who adopted the previous scheme, this renaming will do the
following:
```
s/section/segment
s/region/section
s/sym/symbol
```