### PR TITLE
Extend and fix BIL helpers.

### DIFF
--- a/lib/bap_disasm/bap_disasm_arm_abi.ml
+++ b/lib/bap_disasm/bap_disasm_arm_abi.ml
@@ -35,17 +35,7 @@ let bil_of_block blk =
   Block.insns blk |> List.concat_map ~f:(fun (_,insn) -> Insn.bil insn)
 
 let is_used_before_assigned v bil =
-  Bil.is_referenced v bil &&
-  Bil.find (object(self) inherit [unit] Bil.finder
-    method! visit_move u e goto =
-      if compare_var v u = 0
-      then goto.return None;
-      self#visit_exp e goto
-    method! enter_var u goto =
-      if compare_var v u = 0
-      then goto.return (Some ());
-      goto
-  end) bil
+  Bil.is_referenced v bil
 
 let is_assigned_before bound blk var =
   Seq.exists (Block.preds blk) ~f:(fun blk ->

--- a/lib/bap_disasm/bap_disasm_symtab.ml
+++ b/lib/bap_disasm/bap_disasm_symtab.ml
@@ -41,10 +41,10 @@ let recons_symbol starts ((name,entry) as fn) table : fn memmap =
 
 let dest_of_bil bil =
   (object inherit [word] Bil.finder
-    method! enter_int dst goto =
-      if in_jmp then goto.return (Some dst);
-      goto
-  end)#find bil
+    method! enter_jmp dst goto = match dst with
+      | Bil.Int dst -> goto.return (Some dst)
+      | _ -> goto
+  end)#find_in_bil bil
 
 let dest_of_insn insn =
   match Insn.bil insn with

--- a/lib/bap_types/bap_helpers.mli
+++ b/lib/bap_types/bap_helpers.mli
@@ -4,8 +4,8 @@ open Bap_common
 open Bap_bil
 open Bap_visitor
 
-val find_map : 'a #finder -> bil -> 'a option
-val find : unit #finder -> bil -> bool
+val find : 'a #finder -> bil -> 'a option
+val exists : unit #finder -> bil -> bool
 val iter : unit #visitor -> bil -> unit
 val fold : 'a #visitor -> init:'a -> bil -> 'a
 val map : #mapper -> bil -> bil
@@ -20,8 +20,6 @@ val is_referenced : var -> bil -> bool
     [strict] is [false] *)
 val is_assigned : ?strict:bool -> var -> bil -> bool
 
-(** [prune_unreferenced p] remove all assignments to variables that
-    are not used in the program [p] *)
 val prune_unreferenced : bil -> bil
 
 (** [normalize_negatives p] transform [x + y] to [x - abs(y)] if [y < 0] *)
@@ -50,6 +48,27 @@ class constant_folder : mapper
     then the transformation will stop at an arbitrary point of a
     cycle. *)
 val fixpoint : (bil -> bil) -> (bil -> bil)
+
+module Exp : sig
+  val fold : 'a #visitor -> init:'a -> exp -> 'a
+  val iter : unit #visitor -> exp -> unit
+  val find : 'a #finder -> exp -> 'a option
+  val map  : #mapper -> exp -> exp
+  val exists : unit #finder -> exp -> bool
+  val is_referenced : var -> exp -> bool
+  val normalize_negatives : exp -> exp
+  val fold_constants : exp -> exp
+  val fixpoint : (exp -> exp) -> (exp -> exp)
+end
+
+module Stmt : sig
+  val fold : 'a #visitor -> init:'a -> stmt -> 'a
+  val iter : unit #visitor -> stmt -> unit
+  val find : 'a #finder -> stmt -> 'a option
+  val exists : unit #finder -> stmt -> bool
+  val is_referenced : var -> stmt -> bool
+  val fixpoint : (stmt -> stmt) -> (stmt -> stmt)
+end
 
 (** Bil provides two prefix tries trees.
 

--- a/lib/bap_types/bap_types.ml
+++ b/lib/bap_types/bap_types.ml
@@ -173,6 +173,7 @@ module Std = struct
   (** [Regular] interface for BIL expressions *)
   module Exp = struct
     type t = Bap_bil.exp with bin_io, compare, sexp
+    include Bap_helpers.Exp
     include (Bap_exp : Regular with type t := t)
     let pp_adt = Bap_bil_adt.pp_exp
   end
@@ -180,6 +181,7 @@ module Std = struct
   (** [Regular] interface for BIL statements  *)
   module Stmt = struct
     type t = Bap_bil.stmt with bin_io, compare, sexp
+    include Bap_helpers.Stmt
     include (Bap_stmt : Regular with type t := t)
     let pp_adt = Bap_bil_adt.pp_stmt
   end

--- a/lib/bap_types/bap_visitor.ml
+++ b/lib/bap_types/bap_visitor.ml
@@ -186,9 +186,13 @@ exception Found
 
 class ['a] finder = object(self)
   inherit ['a option return] visitor
-  method find stmts : 'a option =
+  method find_in_bil stmts : 'a option =
     with_return (fun cc ->
         ignore (self#run stmts cc);
+        None)
+  method find_in_exp exp : 'a option =
+    with_return (fun cc ->
+        ignore (self#visit_exp exp cc);
         None)
 end
 

--- a/lib/bap_types/bap_visitor.mli
+++ b/lib/bap_types/bap_visitor.mli
@@ -208,7 +208,8 @@ end
 *)
 class ['a] finder : object
   inherit ['a option return] visitor
-  method find : bil -> 'a option
+  method find_in_bil : bil -> 'a option
+  method find_in_exp : exp -> 'a option
 end
 
 (** AST transformation.


### PR DESCRIPTION
This PR adds some helpers, that previously can be found only in `Bil`
module to `Stmt` and `Exp` module. For example, there are now three
`fixpoint` operators: `Bil.fixpoint`, `Stmt.fixpoint` and
`Exp.fixpoint`. The same is with `fold`, `iter`, `find`, etc.

It also fixes the wrong naming, `find` is renamed to `exists` and
`find_map` to `find`.

Also some nasty bugs were fixed.