### PR TITLE
Cleaner error handling and some bug fixes.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,72 @@
+0.9.8
+=====
+
+1. BAP IR is introduced
+
+   BAP Intermediate Representation is based on BAP Instruction
+   Language and is a semigraphical representation of a program.
+
+   See documentation and following PR's for more information.
+   a2a4621df7c5b25d85c04665732423992e8def98
+   74cdee48818225e8b43d39803c97471903ef6d1f
+
+2. Refactored structure of the Project
+   Module `Project` now a proper entry point to the library.
+   Many stuff from bap utility moved there.
+   See 96bd334a0d8af17a6dfd21eff9ec710d448f13e8 for more details.
+
+   This is a breaking change. It hides `project` record and removes
+   access to some information, that was previously marked as deprecated:
+   - symbols as a mapping from memory to string
+   - base as a memory.
+
+   Instead of old symbols table we now have a better interface, see
+   below. Instead of base, we now represent all memory as an interval
+   map (Memmap).
+
+
+3. New model for symbols
+
+   Previosly symbols were modeled as contiguous chunk of memory,
+   marked with name. Moreover, data sharing between different symbols
+   weren't allowed. Since this release, symbols can be a noncontiguous,
+   and share data. A new interface is implemented in `Symtab` module.
+
+4. Plugins dependency and autoloading
+
+   Plugins now can now specify dependencies to other plugins, that may
+   be auto-loaded by the library.
+   See db2a175ba8e6708753a06a2428940c857a1910ec
+
+5. Extended BIL helpers
+   See 65f472c08d27020a6570b7992b93397346251d1e
+
+6. Exposed ELF library
+
+7. Fixed segment/section/region name hell
+   See 9a574498392c6a13606c9d202037daf137bb780c
+
+8. New universal values library
+
+   The library is based on Core_kernel's Univ, but with addition of
+   serialization, comparison and pretty-printing.
+   See 383003d60baa3434dd4cd8c894e1d8c2e889b4a2
+
+9. Added bap-fsi-benchmark utility
+
+   80382114f395bcf45925ae2e4bc5b9aac5bba4e7
+
+10. Fixed BIL piqi serialization
+
+   2a5c4671468c5a2699b6007a8af3fda8867e8eb8
+
+11. Fixed installation on more recent ubuntu
+
+  By defaulting LLVM version to 3.4 (and more clever
+  searching procedure)
+
+12. Lot's of bugfixes and small extensions
+
 0.9.7
 =====
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Overview
 
-[![Join the chat at https://gitter.im/BinaryAnalysisPlatform/bap](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/BinaryAnalysisPlatform/bap?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://travis-ci.org/BinaryAnalysisPlatform/bap.svg?branch=master)](https://travis-ci.org/BinaryAnalysisPlatform/bap) [![docs](https://img.shields.io/badge/doc-v0.9.7-green.svg)](http://binaryanalysisplatform.github.io/bap/api/v0.9.7/Bap.Std.html) [![docs](https://img.shields.io/badge/doc-master-green.svg)](http://binaryanalysisplatform.github.io/bap/api/master/Bap.Std.html)
+[![Join the chat at https://gitter.im/BinaryAnalysisPlatform/bap](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/BinaryAnalysisPlatform/bap?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://travis-ci.org/BinaryAnalysisPlatform/bap.svg?branch=master)](https://travis-ci.org/BinaryAnalysisPlatform/bap) [![docs](https://img.shields.io/badge/doc-v0.9.8-green.svg)](http://binaryanalysisplatform.github.io/bap/api/v0.9.8/Bap.Std.html) [![docs](https://img.shields.io/badge/doc-master-green.svg)](http://binaryanalysisplatform.github.io/bap/api/master/Bap.Std.html)
 
 BAP is a platform for binary analysis. It is written in OCaml, but can
-be used from other languages, for example, from Python.
+be used from other languages.
 
 # <a name="Installation"></a>Installation
 
@@ -27,30 +27,32 @@ $ pip install git+git://github.com/BinaryAnalysisPlatform/bap.git
 
 ## Using from OCaml
 
-There're two ways to use BAP. Compile your own application, and use
-BAP library, or write a plugin, that can still use the library, but
-will also get an access to decompiled binary. For the latter, write
-your plugin in OCaml using your
+There're two ways to use BAP: compile your own stand-alone
+application, and use BAP library, or write a plugin, that can still
+use the library, but will also get an access to decompiled binary, as
+well as intergration with tools and other plugins. For the latter,
+write your plugin in OCaml using your
 [favorite text editor](https://github.com/BinaryAnalysisPlatform/bap/wiki/Emacs)
 :
+
 ```sh
-$ cat mycode.ml
-open Bap.Std
-let main project = print_endline "Hello, World"
-let () = Project.register_plugin' main
+$ cat hello_world.ml
+open Bap.Std let main project =
+print_endline "Hello, World"
+let () = Project.register_pass "hello-world" main
 ```
 
 Next, build it with our `bapbuild` tool:
 
 ```sh
-$ bapbuild mycode.plugin
+$ bapbuild hello_world.plugin
 ```
 
 After this you can load your plugin with `-l` command line option, and
 get an immediate access to the decompiled binary:
 
 ```sh
-$ bap /bin/ls -lmycode
+$ bap /bin/ls -lhello-world
 ```
 
 `bapbuild` can compile a standalone applications, not only plugins. In

--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.4
 Name:        bap
-Version:     0.9.7
+Version:     0.9.8
 Synopsis:    BAP Core Library
 Authors:     BAP Team
 Maintainers: Ivan Gotovchits <ivg@ieee.org>

--- a/lib/bap/bap_project.mli
+++ b/lib/bap/bap_project.mli
@@ -49,10 +49,24 @@ val get : t -> 'a tag -> 'a option
 val has : t -> 'a tag -> bool
 
 type 'a register = ?deps:string list -> string -> 'a -> unit
+type error =
+  | Not_loaded of string
+  | Is_duplicate of string
+  | Not_found of string
+  | Doesn't_register of string
+  | Load_failed of string * Error.t
+  | Runtime_error of string * exn
+with sexp_of
+
+exception Pass_failed of error with sexp
 
 val register_pass : (t -> t) register
 val register_pass': (t -> unit) register
 val register_pass_with_args : (string array -> t -> t) register
 val register_pass_with_args' : (string array -> t -> unit) register
 
+val passes : ?library:string list -> unit -> string list Or_error.t
 val run_passes : ?library:string list -> ?argv:string array -> t -> t Or_error.t
+
+val passes_exn : ?library:string list -> unit -> string list
+val run_passes_exn : ?library:string list -> ?argv:string array -> t -> t

--- a/lib/bap_disasm/bap_disasm_arm_lifter.ml
+++ b/lib/bap_disasm/bap_disasm_arm_lifter.ml
@@ -978,7 +978,8 @@ let lift_special ops insn =
   match insn, ops with
   (* supervisor call *)
   | `SVC, [|Imm word; cond; _|] ->
-    exec [Bil.special (Format.asprintf "svc %a" Word.pp word)] cond
+    let num = Word.extract_exn ~hi:23 word in
+    exec [Bil.(cpuexn (Word.to_int num |> ok_exn))] cond
 
   | `MRS, [|Reg dest; cond; _|] ->
     let get_bits flag src lsb =

--- a/lib/bap_sema/bap_ir.ml
+++ b/lib/bap_sema/bap_ir.ml
@@ -475,7 +475,7 @@ module Ir_jmp = struct
         | Call sub -> Call.pp ppf sub
         | Ret  dst -> Format.fprintf ppf "return %a" Label.pp dst
         | Int (n,t) ->
-          Format.fprintf ppf "int %d return %%%a" n Tid.pp t
+          Format.fprintf ppf "interrupt 0x%X return %%%a" n Tid.pp t
 
       let pp_cond ppf cond =
         if Exp.(cond <> always) then

--- a/lib/bap_types/bap_helpers.mli
+++ b/lib/bap_types/bap_helpers.mli
@@ -57,7 +57,7 @@ module Exp : sig
   val exists : unit #finder -> exp -> bool
   val is_referenced : var -> exp -> bool
   val normalize_negatives : exp -> exp
-  val fold_constants : exp -> exp
+  val fold_consts : exp -> exp
   val fixpoint : (exp -> exp) -> (exp -> exp)
 end
 

--- a/src/readbin/bap_main.ml
+++ b/src/readbin/bap_main.ml
@@ -1,7 +1,7 @@
 open Core_kernel.Std
-open Or_error
-open Bap.Std
 open Bap_plugins.Std
+open Bap.Std
+open Or_error
 open Format
 open Options
 
@@ -33,20 +33,8 @@ module Program(Conf : Options.Provider) = struct
     | Some value -> f value
 
   let run project =
-    let system = "bap.pass" in
     let library = options.load_path in
-    List.iter options.plugins ~f:(fun name ->
-        Plugin.create ~library ~system name |>
-        function
-        | None ->
-          invalid_argf "Failed to find plugin with name '%s'" name ()
-        | Some p -> match Plugin.load p with
-          | Ok () -> ()
-          | Error err ->
-            invalid_argf "Failed to load plugin `%s': %s" name
-              (Error.to_string_hum err) ());
-
-    let project = Project.run_passes ~library project |> ok_exn in
+    let project = Project.run_passes_exn ~library project in
 
     Option.iter options.emit_ida_script (fun dst ->
         Out_channel.write_all dst
@@ -195,5 +183,5 @@ let () =
   Plugins.load ();
   match try_with_join (fun () -> Cmdline.parse () >>= start) with
   | Ok n -> exit n
-  | Error err -> eprintf "%a@." Error.pp err;
+  | Error err -> eprintf "Aborting because %a.@." Error.pp err;
     exit 1


### PR DESCRIPTION
Errors from plugins are now expressed in a more clean way. One can use
functions, that return `Or_error.t` to get the default error handling,
or to catch them itself, to get a full control.

Fixed passing options to plugins. Now the system will load a transitive
closure of dependencies before the command line parsing stage, cleanup
the plugin options from the command line and pass it to the main
utility.

ARM lifter now handles new instruction `svc` it is mapped to a `CpuExn`
statement. Also, slightly changed the printing of the `CpuExn`. It is
now printed with `interrupt` instead of previous `int`. (Much easier to
grep and more readable).

Fixed bug in IR lifter, when fall-through jumps were lost for regular
basic block without jumps at all.

Fixed fixpoint function. For some reason the book algorithm with one
comparison check doesn't work.