### PR TITLE
Redesign PHI-node representation.

### DIFF
--- a/lib/bap_disasm/bap_disasm_block.ml
+++ b/lib/bap_disasm/bap_disasm_block.ml
@@ -28,7 +28,7 @@ module Block = struct
 end
 
 
-let () = Pretty_printer.register ("Bap.Std.Block.pp")
+let () = Pretty_printer.register "Bap.Std.Block.pp"
 
 module Edge = struct
   type t = edge with compare
@@ -66,8 +66,9 @@ module Build(G : Graph.Builder.S
           ~init:(G.add_vertex gr src)
           ~f:(fun gr -> function
               | `Unresolved _ -> gr
-              | `Block (dst,_)
-                when not (bounded bound (Block.addr dst)) -> gr
+              | `Block (dst,(`Cond|`Jump))
+                when not (bounded bound (Block.addr dst))
+                     || Insn.is_call (Block.terminator src) -> gr
               | `Block (dst,kind) ->
                 Hash_set.add vis (Block.addr src);
                 let edge = Cfg.E.create src kind dst in

--- a/lib/bap_types/bap_exp.ml
+++ b/lib/bap_types/bap_exp.ml
@@ -165,6 +165,11 @@ module PP = struct
       pr "extract: %d:%d[%a]" hi lo pp exp
     | Concat (le, re) ->
       pr (a le ^^ "." ^^ a re) pp le pp re
+    | BinOp (Binop.EQ,e, Int x) | BinOp (Binop.EQ,Int x, e)
+      when Bitvector.(x = b1) -> pr ("%a") pp e
+    | BinOp (Binop.EQ,e, Int x) | BinOp (Binop.EQ,Int x, e)
+      when Bitvector.(x = b0) ->
+      pr ("%a(%a)") pp_unop Unop.NOT pp e
     | BinOp (op, le, re) ->
       pr (a le ^^ " %a " ^^ a re) pp le pp_binop op pp re
     | UnOp (op, exp) ->

--- a/lib/bap_types/bap_value.ml
+++ b/lib/bap_types/bap_value.ml
@@ -14,20 +14,6 @@ end
 type 'a tag = 'a Type_equal.Id.t
 type t = Univ.t
 
-(* The only shared
-*)
-
-(* uuid simultaneously has three representations:
-   int as an interned string
-   string as human readable identifier
-   bytes as compact string of bytes.
-
-   string and bytes representations are persistent, i.e.,
-   they do not change in time and space. Integer representation
-   is fast but online, i.e., is valid only for the run of the
-   program.
-*)
-
 module Typeid = struct
 
   module Bin = Bin_prot.Utils.Make_binable(struct


### PR DESCRIPTION
This PR changes representation of a phi node. Previously it was a pair
of a variable and a set of definitions. Now it is a pair of a variable,
and a dictionary `tid => exp`, exactly as in LLVM.

This PR also fixes #238 and resolves #237.

And also prettifies pretty printer.