### PR TITLE
Change Var module implementation.

### DIFF
--- a/lib/bap_disasm/bap_disasm_arm_lifter.ml
+++ b/lib/bap_disasm/bap_disasm_arm_lifter.ml
@@ -1072,7 +1072,7 @@ module CPU = struct
     ]
 
   let flags = Var.Set.of_list @@ [
-      nf; zf; cf; qf;
+      nf; zf; cf; qf; vf;
     ] @ Array.to_list ge
 
   let nf = nf
@@ -1080,28 +1080,19 @@ module CPU = struct
   let cf = cf
   let vf = vf
 
-  let is = Var.equal
+  let is = Var.same
 
-  let is_reg = Set.mem regs
+  let is_reg r = Set.mem regs (Var.base r)
   let is_sp = is sp
   let is_bp = is r11
   let is_pc = is pc
   let addr_of_pc m = Addr.(Memory.min_addr m ++ 8)
-  let is_flag = Set.mem flags
+  let is_flag r = Set.mem flags (Var.base r)
   let is_zf = is zf
   let is_cf = is cf
   let is_vf = is vf
   let is_nf = is nf
 
-  let is_return = is r0
-  let is_formal = function
-    | 0 -> is r0
-    | 1 -> is r1
-    | 2 -> is r2
-    | 3 -> is r3
-    | _ -> fun _ -> false
-
-  let is_permanent = Set.mem perms
   let is_mem = is mem
 end
 

--- a/lib/bap_disasm/bap_disasm_x86_lifter.ml
+++ b/lib/bap_disasm/bap_disasm_x86_lifter.ml
@@ -1006,8 +1006,7 @@ module ToIR = struct
         ]
         @
         let undef r =
-          let (n,_,t) = Var.V1.serialize r in
-          Bil.Move (r, Bil.Unknown (n^" undefined after bsf", t)) in
+          Bil.Move (r, Bil.Unknown (Var.name r^" is undefined after bsf", t)) in
         List.map ~f:undef [cf; oF; sf; af; pf]
       | Hlt -> [] (* x86 Hlt is essentially a NOP *)
       | Rdtsc ->
@@ -1403,8 +1402,7 @@ module ToIR = struct
         :: Bil.If (Bil.((Cast (HIGH, !!t, Var tdiv)) = int_exp 0 !!t), [], [Cpu_exceptions.divide_by_zero])
         :: fst (assn_dbl t assne)
         @ (let undef r =
-             let n,_,t = Var.V1.serialize r in
-             Bil.Move (r, Bil.Unknown ((n^" undefined after div"), t))
+             Bil.Move (r, Bil.Unknown ((Var.name r ^" undefined after div"), t))
            in
            List.map ~f:undef [cf; oF; sf; zf; af; pf])
       | Idiv(t, src) ->
@@ -1425,8 +1423,7 @@ module ToIR = struct
         :: Bil.If (Bil.((Cast (HIGH, !!t, Var tdiv)) = int_exp 0 !!t), [], [Cpu_exceptions.divide_by_zero])
         :: fst (assn_dbl t assne)
         @ (let undef r =
-             let n,_,t = Var.V1.serialize r in
-             Bil.Move (r, Bil.Unknown (n^" undefined after div", t)) in
+             Bil.Move (r, Bil.Unknown (Var.name r ^ "undefined after div", t)) in
            List.map ~f:undef [cf; oF; sf; zf; af; pf])
       | Cld ->
         [Bil.Move (df, exp_false)]
@@ -1491,9 +1488,9 @@ module Make_CPU(Env : ModeVars) = struct
 
   let addr_of_pc = Memory.max_addr
 
-  let is = Var.equal
-  let is_reg r = is pc r || Set.mem gpr r
-  let is_flag = Set.mem flags
+  let is = Var.same
+  let is_reg r = is pc r || Set.mem gpr (Var.base r)
+  let is_flag r = Set.mem flags (Var.base r)
   let is_zf = is zf
   let is_cf = is cf
   let is_vf = is oF

--- a/lib/bap_sema/bap_ir.ml
+++ b/lib/bap_sema/bap_ir.ml
@@ -113,6 +113,7 @@ module Array = struct
     then Array.map xs ~f:(fun x -> if is_target x then y else x)
     else xs
 
+
   let pp ppx ppf xs =
     Array.iter xs ~f:(fun x -> Format.fprintf ppf "%a" ppx x)
 end
@@ -231,8 +232,15 @@ module Term = struct
 
   let find t p tid = Array.find (t.get p.self) ~f:(fun x -> x.tid = tid)
 
+  let find_exn t p tid = Array.find_exn (t.get p.self) ~f:(fun x -> x.tid = tid)
+
   let remove t p tid =
     apply (Array.remove_if ~f:(fun x -> x.tid = tid)) t p
+
+  let change t p tid f =
+    match f (find t p tid) with
+    | None -> remove t p tid
+    | Some c -> update t p c
 
   let to_seq xs =
     Seq.init (Array.length xs) ~f:(Array.unsafe_get xs)
@@ -243,6 +251,8 @@ module Term = struct
 
   let to_sequence ?(rev=false) t p =
     if rev then to_seq_rev (t.get p.self) else to_seq (t.get p.self)
+
+  let enum = to_sequence
 
   let map t p ~f : 'a term = apply (Array.map ~f) t p
 

--- a/lib/bap_sema/bap_ir.mli
+++ b/lib/bap_sema/bap_ir.mli
@@ -53,9 +53,12 @@ module Term : sig
   val name : 'a t -> string
   val tid : 'a t -> tid
   val find : ('a,'b) cls -> 'a t -> tid -> 'b t option
+  val find_exn : ('a,'b) cls -> 'a t -> tid -> 'b t
   val update : ('a,'b) cls -> 'a t -> 'b t -> 'a t
   val remove : ('a,_) cls -> 'a t -> tid -> 'a t
+  val change : ('a,'b) cls -> 'a t -> tid -> ('b t option -> 'b t option) -> 'a t
   val to_sequence : ?rev:bool -> ('a,'b) cls -> 'a t -> 'b t seq
+  val enum : ?rev:bool -> ('a,'b) cls -> 'a t -> 'b t seq
   val map : ('a,'b) cls -> 'a t -> f:('b t -> 'b t) -> 'a t
   val filter_map : ('a,'b) cls -> 'a t -> f:('b t -> 'b t option) -> 'a t
   val concat_map : ('a,'b) cls -> 'a t -> f:('b t -> 'b t list) -> 'a t

--- a/lib/bap_sema/bap_sema_lift.ml
+++ b/lib/bap_sema/bap_sema_lift.ml
@@ -196,9 +196,9 @@ let resolve_jmp ~skip_calls addrs jmp =
   | Goto (Indirect (Bil.Int addr)) ->
     update_kind jmp addr (fun id -> Goto (Direct id))
   | Goto _ -> jmp
-  | Call _ when skip_calls -> jmp
   | Call call ->
     let jmp,call = match Call.target call with
+      | _ when skip_calls -> jmp, call
       | Indirect (Bil.Int addr) ->
         let new_call = ref call in
         let jmp = update_kind jmp addr

--- a/lib/bap_types/bap_var.ml
+++ b/lib/bap_types/bap_var.ml
@@ -1,43 +1,52 @@
 open Core_kernel.Std
 open Bap_common
 
+module Id = struct
+  type t = Int63.t
+  let id = ref Int63.zero
+
+  let create () =
+    Int63.incr id;
+    !id
+end
+
 module T = struct
   type t = {
     var : string;
-    uid : int;
+    ver : int;
     typ : typ;
     tmp : bool;
-  } with sexp, bin_io
+  } with sexp, bin_io,compare
 
-  let compare v1 v2 = compare_int v1.uid v2.uid
-  let hash v = v.uid
+  let hash v = String.hash v.var
   let module_name = "Bap.Std.Var"
 
   let pp fmt v =
-    let name =
-      if v.tmp then sprintf "%s_%d" v.var v.uid else v.var in
-    Format.fprintf fmt "%s" name
-    (* Format.fprintf fmt "%s:%a" name Bap_type.pp v.typ *)
+    Format.fprintf fmt "%s%s" v.var
+      (if v.ver <> 0 then sprintf ".%d" v.ver else "" )
 end
+
 
 include T
 
 let name v = v.var
+let renumber v ver = {v with ver}
+let base v = {v with ver = 0}
 let typ  v = v.typ
 let is_tmp v = v.tmp
 
-let create =
-  let var_counter = ref 0 in
-  fun ?(tmp=false) var typ ->
-    incr var_counter;
-    if var_counter.contents < 0
-    then failwith "new_var: var_counter wrapped around"
-    else {uid = !var_counter; var; typ; tmp}
+let create ?(tmp=false) name typ =
+  let var = if not tmp then name
+    else name ^ "_" ^ Int63.to_string (Id.create ()) in
+  {ver = 0; var; typ; tmp}
+
+let version {ver} = ver
+let same x y = base x = base y
 
 module V1 = struct
-  type r = string * int * typ
-  let serialize v = v.var, v.uid, v.typ
-  let deserialize (var,uid,typ) = {var; uid; typ; tmp=false}
+  type r = string * int * typ * bool
+  let serialize v = v.var, v.ver, v.typ, v.tmp
+  let deserialize (var,ver,typ,tmp) = {var; ver; typ; tmp}
 end
 
 include Regular.Make(T)

--- a/lib/bap_types/bap_var.mli
+++ b/lib/bap_types/bap_var.mli
@@ -17,6 +17,14 @@ include Regular with type t := t
 
 val create : ?tmp:bool -> string -> typ -> t
 
+val renumber : t -> int -> t
+
+val version : t -> int
+
+val base : t -> t
+
+val same : t -> t -> bool
+
 (** [name var] returns a name assosiated with variable  *)
 val name : t -> string
 
@@ -26,10 +34,11 @@ val typ : t -> typ
 (** [is_tmp] true if variable is temporary  *)
 val is_tmp : t -> bool
 
+
 (**/**)
 
 module V1 : sig
-  type r = string * int * typ
+  type r = string * int * typ * bool
   val serialize   : t -> r
   val deserialize : r -> t
 end

--- a/lib/bap_types/bil_piqi.ml
+++ b/lib/bap_types/bil_piqi.ml
@@ -80,18 +80,20 @@ let rec type_of_piqi = function
 
 
 let var_to_piqi v =
-  let (name,id,typ) = Var.V1.serialize v in
+  let (name,id,typ,tmp) = Var.V1.serialize v in
   let module P = Stmt_piqi in {
     P.Var.name = name;
     P.Var.id  = id;
     P.Var.typ = type_to_piqi typ;
+    P.Var.tmp = tmp;
   }
 
 let var_of_piqi p =
   let module P = Stmt_piqi in
   Var.V1.deserialize (p.P.Var.name,
                       p.P.Var.id,
-                      type_of_piqi p.P.Var.typ)
+                      type_of_piqi p.P.Var.typ,
+                      p.P.Var.tmp)
 
 let endianness_to_piqi : endian -> Stmt_piqi.endian = function
   | LittleEndian -> `little_endian

--- a/lib/bap_types/type.piqi
+++ b/lib/bap_types/type.piqi
@@ -86,6 +86,12 @@
     .name typ
     .type typ
   ]
+
+  .field [
+    .name tmp
+    .type bool
+  ]
+
 ]
 
 % bitvectors

--- a/src/readbin/bap_main.ml
+++ b/src/readbin/bap_main.ml
@@ -92,8 +92,7 @@ module Program(Conf : Options.Provider) = struct
       if options.output_phoenix <> None then
         let module Phoenix = Phoenix.Make(Env) in
         let dest = Phoenix.store () in
-        printf "Phoenix data was stored in %s folder@." dest
-    in
+        printf "Stored data in folder %s@." dest in
 
     if options.dump_symbols <> None then
       let serialized =

--- a/src/readbin/cmdline.ml
+++ b/src/readbin/cmdline.ml
@@ -29,13 +29,16 @@ let cfg_format : 'a list Term.t =
     ])
 
 let output_phoenix : _ Term.t =
-  let doc = "Output data in a phoenix format. Output folder \
+  let doc = "Output information about processed binary in a human \
+             readable format. This will emit CFG for each format in \
+             dot format. It will also store BIL and ASM code in html \
+             format.Output folder \
              can be optionally specified. If omitted, the \
              basename of the target file will be used as a \
              directory name." in
   let vopt = Some (Sys.getcwd ()) in
   Arg.(value & opt ~vopt (some string) None &
-       info ["phoenix"] ~doc)
+       info ["phoenix"; "output"] ~doc)
 
 let output_dump : _ list Term.t =
   let values = [


### PR DESCRIPTION
This PR introduces a slight change in `var` representation.
Now variables can be versioned, i.e., a version number can be attached
to a variable to represent the same variable but in different time or
space. This is in particular useful for SSA form. See documentation in
Var module for more information.

Also small changes:

- Fix bug, that was introduced when I fixed #238. Due to the new bug,
  some blocks in IR became unreachable.

- BIL lifters now use sameness to compare variables. I.e., `CPU.is_*`
  works fine in SSA form.

- Added three new functions to Term module:
  - `change` for upsert operation
  - `find_exn` because sometimes it can be guaranteed
  - `enum` as a synonym to `to_sequence`

- added new option `output` as a synonym to `phoenix`.
  This will fix #241.