### PR TITLE
Resolve #254

### DIFF
--- a/lib/bap_types/type.piqi
+++ b/lib/bap_types/type.piqi
@@ -97,7 +97,7 @@
 % bitvectors
 .alias [
   .name bitvector
-  .type binary
+  .type string
 ]
 
 % an address is now a bitvector

--- a/opam
+++ b/opam
@@ -50,7 +50,7 @@ depends: [
     "lwt"
     "oasis" {build & >= "0.4.0"}
     "ocamlgraph"
-    "ocurl"
+    "ocurl" {<= "0.7.1"}
     "re"
     "uri"
     "utop"

--- a/opam.deps
+++ b/opam.deps
@@ -10,7 +10,7 @@ fileutils
 lwt
 oasis
 ocamlgraph
-ocurl
+ocurl.0.7.1
 re
 uri
 zarith


### PR DESCRIPTION
Bitvectors were represented as binary data. Although it worked well
with piqi-to-piqi transformation this work fine, it actually rendered
json and xml formats unusable. This PR will change bitvector to a string
representation.