### PR TITLE
This PR tentatively introduces Graphlib library.

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -9,7 +9,7 @@ Copyrights:  (C) 2014 Carnegie Mellon University
 Plugins:     META (0.4)
 AlphaFeatures: ocamlbuild_more_args
 BuildTools: ocamlbuild, camlp4o
-XOCamlbuildExtraArgs: -j 2
+XOCamlbuildExtraArgs: -j 1
 BuildDepends:
               bin_prot.syntax,
               camlp4,
@@ -100,7 +100,7 @@ Library types
   FindlibParent:   bap
   FindlibName:     types
   CompiledObject:  best
-  BuildDepends:    zarith, uuidm
+  BuildDepends:    zarith, uuidm, ocamlgraph
   InternalModules:
                    Bap_addr,
                    Bap_arch,
@@ -111,10 +111,18 @@ Library types
                    Bap_common,
                    Bap_config,
                    Bap_exp,
+                   Bap_graph,
+                   Bap_graph_intf,
+                   Bap_graph_regular,
+                   Bap_graph_regular_intf,
+                   Bap_graph_pp,
+                   Bap_ir,
+                   Bap_ir_graph,
                    Bap_helpers,
                    Bap_int_conversions,
                    Bap_integer,
                    Bap_integer_intf,
+                   Bap_opaque,
                    Bap_regular,
                    Bap_seq,
                    Bap_size,
@@ -145,7 +153,7 @@ Library serialization
   BuildTools: ocamlbuild, piqi
   DataFiles:    *.piqi
   CompiledObject: best
-  BuildDepends: piqilib,piqirun,piqirun.pb,piqirun.ext,bap
+  BuildDepends: piqirun,piqirun.pb,piqirun.ext,bap
   Modules:   Bil_piqi
   InternalModules:
              Stmt_piqi,
@@ -296,7 +304,6 @@ Library sema
   InternalModules:
                  Bap_sema,
                  Bap_sema_lift,
-                 Bap_ir,
                  Bap_lnf
 
 Library types_test
@@ -306,7 +313,8 @@ Library types_test
   CompiledObject: best
   BuildDepends:   bap, bap.conceval, oUnit
   Modules:        Test_bitvector,
-                  Test_conceval
+                  Test_conceval,
+                  Test_graph
 
 Library image_test
   Path:           lib_test/bap_image
@@ -357,7 +365,7 @@ Library benchmarks
   CompiledObject: best
   BuildDepends:   bap, core, core_bench, threads
   Install:        false
-  Modules:        Bench_image
+  Modules:        Bench_dom, Bench_image
 
 Library core_lwt
   Path:           lwt
@@ -456,7 +464,7 @@ Executable run_benchmarks
 
 Test unit_tests
   TestTools: run_tests
-  Command: $run_tests
+  Command: $run_tests -runner sequential
 
 Test inline_tests
   TestTools: run_tests

--- a/benchmarks/bench_dom.ml
+++ b/benchmarks/bench_dom.ml
@@ -1,0 +1,90 @@
+open Core.Std
+open Core_bench.Std
+open Bap.Std
+open Format
+
+let filename = "arm-binaries/coreutils/coreutils_O1_ls"
+let sizes_to_test = 10
+
+module Cfg = Graphlib.Ir
+module CFG = Graphlib.To_ocamlgraph(Cfg)
+module DOM = Graph.Dominator.Make(CFG)
+module SCC = Graph.Components.Make(CFG)
+
+let proj = Project.from_file filename |> ok_exn
+
+let syms = Project.symbols proj
+
+(** [scale_linear ~input:(x1,x2) ~output:(y1,y2)]
+    will return a linear function $f(x) = ax + b$ such that:
+
+    {[
+      f x1 = y1;
+      f x2 = y2;
+    ]} *)
+let scale_linear ~input:(x1,x2) ~output:(y1,y2) =
+  let open Float in
+  let x1,x2,y1,y2 = float x1, float x2, float y1, float y2 in
+  let a = (y1 - y2) / (x1 - x2) in
+  let b = y1 - x1 * (y1 - y2) / (x1-x2) in
+  fun x -> to_int (round (a * (float x) + b))
+
+
+let functions,sizes,index =
+  let functions = Term.enum sub_t (Project.program proj) |>
+                  Seq.map ~f:Cfg.of_sub |> Seq.to_array in
+  let size g = Cfg.number_of_nodes g + Cfg.number_of_edges g in
+  Array.sort functions ~cmp:(fun x y -> Int.compare (size x) (size y));
+  let max_idx = Array.length functions - 1 in
+  let min_size = size functions.(0) in
+  let max_size = min 1000 @@ size functions.(max_idx) in
+  let size =
+    scale_linear ~input:(0,sizes_to_test-1) ~output:(min_size,max_size) in
+  let index =
+    scale_linear ~input:(min_size,max_size) ~output:(0,max_idx) in
+  let sizes = List.init sizes_to_test ~f:size in
+  functions,List.rev sizes,index
+
+let ocamlgraph cfg entry =
+  DOM.compute_idom cfg entry
+
+let graphlib cfg entry =
+  Tree.parent (Graphlib.dominators (module Cfg) cfg entry)
+
+let dom algo cfg =
+  algo cfg (Seq.hd_exn @@ Cfg.nodes cfg)
+
+let run f size =
+  stage (fun () -> f functions.(index size))
+
+
+let graphlib_scc cfg =
+  Graphlib.strong_components (module Cfg) cfg |>
+  Partition.equiv
+
+let ocamlgraph_scc cfg =
+  let _,get = SCC.scc cfg in
+  fun x y -> get x = get y
+
+let indexed = Bench.Test.create_indexed ~args:sizes
+
+
+let dom_test =
+  Bench.Test.create_group ~name:"dom" [
+    indexed ~name:"ocamlgraph" (run (dom ocamlgraph));
+    indexed ~name:"graphlib" (run (dom graphlib));
+  ]
+
+
+
+let scc_test =
+  Bench.Test.create_group ~name:"scc" [
+    indexed ~name:"graphlib" (run graphlib_scc);
+    indexed ~name:"ocamlgraph" (run ocamlgraph_scc);
+  ]
+
+
+let tests = [
+  dom_test;
+  scc_test;
+]

--- a/benchmarks/bench_image.ml
+++ b/benchmarks/bench_image.ml
@@ -37,7 +37,7 @@ let sum_fold () =
 
 let sum_foldm () =
   let (_ : word Or_error.t) =
-    Memory.With_error.fold mem ~f:(fun w1 w2 -> Word.Int.(!$w1 + !$w2)) ~init:zero
+    Memory.With_error.fold mem ~f:(fun w1 w2 -> Word.Int_err.(!$w1 + !$w2)) ~init:zero
   in ()
 
 let sum_fold_tab () =
@@ -52,3 +52,5 @@ let test = Bench.Test.create_group ~name:"image" [
     Bench.Test.create ~name:"Bap_image.map_sum_foldm"  sum_foldm;
     Bench.Test.create ~name:"Bap_image.map_sum_table"  sum_fold_tab;
   ]
+
+let tests = [test]

--- a/benchmarks/bench_image.mli
+++ b/benchmarks/bench_image.mli
@@ -1,3 +1,3 @@
 open Core_bench.Std
 
-val test : Bench.Test.t
+val tests : Bench.Test.t list

--- a/benchmarks/run_benchmarks.ml
+++ b/benchmarks/run_benchmarks.ml
@@ -2,8 +2,10 @@ open Core.Std
 open Core_bench.Std
 open Bap.Std
 
-let benchmarks = Bench.make_command [
-    Bench_image.test;
+let benchmarks = Bench.make_command @@ List.concat [
+    Bench_dom.tests;
+    Bench_image.tests;
   ]
+
 
 let () = Command.run benchmarks

--- a/lib/bap/bap.ml
+++ b/lib/bap/bap.ml
@@ -13,6 +13,30 @@ module Std = struct
   type elf = Elf.t
   module Signatures = Bap_signatures
   module Byteweight = Bap_byteweight
+
+  include Bap_graph_intf
+  open Bap_graph
+  type nonrec 'a tree = 'a tree
+  type nonrec 'a frontier = 'a frontier
+  type nonrec 'a partition = 'a partition
+  type nonrec 'a group = 'a group
+  type nonrec 'a path = 'a path
+  type nonrec equiv = equiv
+
+  module Group = Group
+  module Tree = Tree
+  module Frontier = Frontier
+  module Partition = Partition
+  module Equiv = Equiv
+  module Path = Path
+
+  module Graphlib = struct
+    include Bap_graph
+    module type Graphs = Bap_graph_regular_intf.S
+    include Bap_graph_regular
+    module Ir = Bap_ir_graph
+  end
+
 end
 
 (* load internal plugins *)

--- a/lib/bap/bap_project.ml
+++ b/lib/bap/bap_project.ml
@@ -61,7 +61,9 @@ let from_image ?(name=fun _ -> None) ?(roots=[]) img =
     | Some name -> Some name
     | None -> Table.find_addr (Image.symbols img) addr |>
               Option.map ~f:(fun (_,sym) -> Image.Symbol.name sym) in
-  let roots = roots @ image_roots in
+  let roots = match roots @ image_roots with
+    | [] -> [Image.entry_point img]
+    | xs -> xs in
   let disasm = disassemble_image ~roots img in
   let cfg = Disasm.blocks disasm in
   let symbols = Symtab.reconstruct ~name ~roots cfg in

--- a/lib/bap_disasm/bap_disasm.ml
+++ b/lib/bap_disasm/bap_disasm.ml
@@ -227,7 +227,7 @@ module Disasm = struct
       open Format
       type t = error
 
-      let module_name = "Bap.Std.Disasm.Error"
+      let module_name = Some "Bap.Std.Disasm.Error"
 
       let pp fmt t : unit =
         match t with

--- a/lib/bap_disasm/bap_disasm_arm.ml
+++ b/lib/bap_disasm/bap_disasm_arm.ml
@@ -15,7 +15,7 @@ module Cond = struct
   include Regular.Make(struct
       type t = cond with bin_io, compare, sexp
       let hash (cond : t) = Hashtbl.hash cond
-      let module_name = "Bap.Std.ARM.Cond"
+      let module_name = Some "Bap.Std.ARM.Cond"
       let pp fmt cond =
         Format.fprintf fmt "%a" Sexp.pp (sexp_of_t cond)
     end)
@@ -51,7 +51,7 @@ module Reg = struct
   include Regular.Make(struct
       type t = reg with bin_io, compare, sexp
       let hash (reg : t) = Hashtbl.hash reg
-      let module_name = "Bap.Std.ARM.Reg"
+      let module_name = Some "Bap.Std.ARM.Reg"
       let pp fmt reg =
         Format.fprintf fmt "%a" Sexp.pp (sexp_of_t reg)
     end)
@@ -62,7 +62,7 @@ end
 module Op = struct
   include Regular.Make(struct
       type t = op with bin_io, compare, sexp
-      let module_name = "Bap.Std.ARM.Op"
+      let module_name = Some "Bap.Std.ARM.Op"
       let pp fmt op =
         Format.fprintf fmt "%a" Sexp.pp (sexp_of_t op)
       let hash (op : op) = Hashtbl.hash op
@@ -84,7 +84,7 @@ module Insn = struct
 
   include Regular.Make(struct
       type t = insn with bin_io, compare, sexp
-      let module_name = "Bap.Std.ARM.Insn"
+      let module_name = Some "Bap.Std.ARM.Insn"
       let pp fmt insn =
         Format.fprintf fmt "%a" Sexp.pp (sexp_of_t insn)
       let hash (insn : t) = Hashtbl.hash insn

--- a/lib/bap_disasm/bap_disasm_basic.ml
+++ b/lib/bap_disasm/bap_disasm_basic.ml
@@ -98,7 +98,7 @@ module Reg = struct
     type t = reg
     with bin_io, sexp, compare
 
-    let module_name = "Bap.Std.Reg"
+    let module_name = Some "Bap.Std.Reg"
 
     let pp fmt t =
       Format.fprintf fmt "%s" @@ name t
@@ -139,7 +139,7 @@ module Imm = struct
   module T = struct
     type t = imm
     with bin_io, sexp, compare
-    let module_name = "Bap.Std.Imm"
+    let module_name = Some "Bap.Std.Imm"
     let pp fmt t =
       let x = to_int64 t in
       if Int64.is_negative x then
@@ -169,7 +169,7 @@ module Fmm = struct
     type t = fmm
     with bin_io, sexp, compare
 
-    let module_name = "Bap.Std.Fmm"
+    let module_name = Some "Bap.Std.Fmm"
     let hash t = Float.hash (to_float t)
     let pp fmt t =
       Format.fprintf fmt "%a" Float.pp (to_float t)
@@ -198,7 +198,7 @@ module Op = struct
       | Reg reg -> pr ch "Reg(\"%a\")" Reg.pp reg
 
 
-    let module_name = "Bap.Std.Op"
+    let module_name = Some "Bap.Std.Op"
 
     let hash = function
       | Reg r -> Reg.hash r

--- a/lib/bap_disasm/bap_disasm_insn.ml
+++ b/lib/bap_disasm/bap_disasm_insn.ml
@@ -129,7 +129,7 @@ end
 include Regular.Make(struct
     type nonrec t = t with sexp, bin_io, compare
     let hash = code
-    let module_name = "Bap.Std.Insn"
+    let module_name = Some "Bap.Std.Insn"
 
     let string_of_ops ops =
       Array.map ops ~f:Op.to_string |> Array.to_list |>

--- a/lib/bap_disasm/bap_disasm_rec.ml
+++ b/lib/bap_disasm/bap_disasm_rec.ml
@@ -508,7 +508,7 @@ module Block = struct
 
   include Printable(struct
       type t = block
-      let module_name = "Bap.Std.Disasm_expert.Recursive.Block"
+      let module_name = Some "Bap.Std.Disasm_expert.Recursive.Block"
       let pp fmt  ({addr; mem = lazy mem} : block) =
         Format.fprintf fmt "[%s, %s]"
           Addr.(string_of_value addr)

--- a/lib/bap_dwarf/dwarf_fbi.ml
+++ b/lib/bap_dwarf/dwarf_fbi.ml
@@ -51,7 +51,7 @@ module Fn = struct
           Some Addr.(pc_lo ++ off) in
       pc_hi >>| fun pc_hi -> {pc_lo; pc_hi}
     let hash = Hashtbl.hash
-    let module_name = "Bap.Std.Dwarf.Fn"
+    let module_name =  "Bap.Std.Dwarf.Fn"
   end
   include T
   include Identifiable.Make(struct

--- a/lib/bap_image/bap_image.ml
+++ b/lib/bap_image/bap_image.ml
@@ -31,7 +31,7 @@ module Segment = struct
     type t = Segment.t with bin_io, compare, sexp
     let hash = Addr.hash +> Location.addr +> Segment.location
     let pp fmt t = Format.fprintf fmt "%s" @@ Segment.name t
-    let module_name = "Bap.Std.Image.Segment"
+    let module_name = Some "Bap.Std.Image.Segment"
   end
 
   let name = Segment.name
@@ -53,7 +53,7 @@ module Symbol = struct
     type t = Symbol.t with bin_io, compare, sexp
     let hash = Addr.hash +> Location.addr +> fst +> Symbol.locations
     let pp fmt t = Format.fprintf fmt "%s" @@ Symbol.name t
-    let module_name = "Bap.Std.Image.Symbol"
+    let module_name = Some "Bap.Std.Image.Symbol"
   end
   include Symbol
   include Regular.Make(T)

--- a/lib/bap_image/bap_memory.ml
+++ b/lib/bap_image/bap_memory.ml
@@ -422,7 +422,7 @@ include Printable(struct
     open Format
     type nonrec t = t
 
-    let module_name = "Bap.Std.Memory"
+    let module_name = Some "Bap.Std.Memory"
 
     let print_word fmt addr =
       let width = Addr.bitwidth addr / 4 in

--- a/lib/bap_types/bap_arch.ml
+++ b/lib/bap_types/bap_arch.ml
@@ -8,7 +8,7 @@ module T = struct
 
   let hash = Hashtbl.hash
 
-  let module_name = "Bap.Std.Arch"
+  let module_name = Some "Bap.Std.Arch"
 
   let to_string = function
     | `x86 -> "i386"

--- a/lib/bap_types/bap_bitvector.ml
+++ b/lib/bap_types/bap_bitvector.ml
@@ -56,7 +56,7 @@ module type Kernel = sig
   val bits_of_z  : t -> string
   val compare  : t -> t -> int
   val hash : t -> int
-  val module_name : string
+  val module_name : string option
   include Pretty_printer.S with type t := t
   include Stringable with type t := t
 end
@@ -66,7 +66,7 @@ module Make(Size : Compare) : Kernel = struct
   open Internal
   type nonrec t = t with bin_io, sexp
 
-  let module_name = "Bap.Std.Bitvector"
+  let module_name = Some "Bap.Std.Bitvector"
 
   let znorm z w = Bignum.(z land ((one lsl w) - one))
 

--- a/lib/bap_types/bap_common.ml
+++ b/lib/bap_types/bap_common.ml
@@ -12,12 +12,14 @@ open Core_kernel.Std
 module Bitvector = Bap_bitvector
 module Integer   = Bap_integer
 module Regular   = Bap_regular
+module Opaque    = Bap_opaque
 module Printable = Regular.Printable
 module Trie      = Bap_trie
 
 (** {2 Basic Interfaces}  *)
 module type Integer   = Integer.S
 module type Regular   = Regular.S
+module type Opaque    = Opaque.S
 module type Printable = Regular.Printable
 module type Trie      = Trie.S
 

--- a/lib/bap_types/bap_exp.ml
+++ b/lib/bap_types/bap_exp.ml
@@ -145,6 +145,8 @@ module PP = struct
 
   let rec pp fmt exp =
     let open Bap_bil.Exp in
+    let open Bap_bil.Binop in
+    let open Bap_bil.Unop in
     let is_imm = function
       | Var _ | Int _ -> true
       | _ -> false in
@@ -165,13 +167,17 @@ module PP = struct
       pr "extract: %d:%d[%a]" hi lo pp exp
     | Concat (le, re) ->
       pr (a le ^^ "." ^^ a re) pp le pp re
-    | BinOp (Binop.EQ,e, Int x) | BinOp (Binop.EQ,Int x, e)
+    | BinOp (EQ,e, Int x) | BinOp (EQ,Int x, e)
       when Bitvector.(x = b1) -> pr ("%a") pp e
-    | BinOp (Binop.EQ,e, Int x) | BinOp (Binop.EQ,Int x, e)
+    | BinOp (EQ,e, Int x) | BinOp (EQ,Int x, e)
       when Bitvector.(x = b0) ->
       pr ("%a(%a)") pp_unop Unop.NOT pp e
     | BinOp (op, le, re) ->
       pr (a le ^^ " %a " ^^ a re) pp le pp_binop op pp re
+    | UnOp (NOT, BinOp(LE,le,re)) ->
+      pr (a le ^^ " > " ^^ a re) pp le pp re
+    | UnOp (NOT, BinOp(LT,le,re)) ->
+      pr (a le ^^ " >= " ^^ a re) pp le pp re
     | UnOp (op, exp) ->
       pr ("%a" ^^ a exp) pp_unop op pp exp
     | Var var -> Bap_var.pp fmt var
@@ -187,6 +193,6 @@ end
 include Regular.Make(struct
     type t = Bap_bil.exp with bin_io, compare, sexp
     let hash = Hashtbl.hash
-    let module_name = "Bap.Std.Exp"
+    let module_name = Some "Bap.Std.Exp"
     let pp = PP.pp
   end)

--- a/lib/bap_types/bap_graph.ml
+++ b/lib/bap_types/bap_graph.ml
@@ -1,0 +1,1027 @@
+open Core_kernel.Std
+open Bap_common
+open Bap_graph_intf
+open Format
+
+module Seq = struct
+  include Sequence
+  include Bap_seq
+end
+
+module type Graph = Graph
+
+type 'a seq = 'a Seq.t
+
+
+class type ['a] set = object
+  method enum : 'a Seq.t
+  method mem : 'a -> bool
+end
+
+class type ['a,'b] map = object
+  method find : 'a -> 'b option
+end
+
+type 'a tree = {
+  all : 'a list;
+  par : ('a, 'a) map;
+  cld : ('a,'a set) map;
+  ans : ('a,'a set) map;
+  des : ('a,'a set) map;
+}
+
+let create_set set = object
+  method enum = Set.to_sequence set
+  method mem x = Set.mem set x
+end
+
+let create_map find = object
+  method find = find
+end
+
+let string_of_set ~sep pp_elt set =
+  Seq.map set#enum ~f:(asprintf "%a" pp_elt) |>
+  Seq.to_list |> String.concat ~sep
+
+
+let empty_set map =
+  Set.empty ~comparator:(Map.comparator map)
+
+let create_ancestors empty find : ('a,'a set) map =
+  let rec walk set x = match find x with
+    | None -> set
+    | Some p -> walk (Set.add set p) p in
+  object
+    method find x = Some (create_set (walk empty x))
+  end
+
+let create_descendants children : ('a,'a set) map =
+  let rec walk set x = match Map.find children x with
+    | None -> set
+    | Some cs -> Set.union cs @@ Set.fold cs ~init:set ~f:walk in
+  object
+    method find x =
+      Some (create_set (walk (empty_set children) x))
+  end
+
+let create_tree parents children = {
+  all = Map.keys children;
+  par = create_map parents;
+  ans = create_ancestors (empty_set children) parents;
+  des = create_descendants children;
+  cld = object
+    method find x =
+      Option.(Map.find children x >>| create_set)
+  end
+}
+
+let enum = function
+  | Some x -> x#enum
+  | None -> Seq.empty
+
+module Tree = struct
+  type 'a t = 'a tree
+
+  let children t x = t.cld#find x |> enum
+  let parent t x = t.par#find x
+  let ancestors t x = t.ans#find x |> enum
+  let descendants t x = t.des#find x |> enum
+  let mem table t p = match (table t)#find p with
+    | None -> fun _ -> false
+    | Some xs -> xs#mem
+
+  let is_ancestor_of t ~child = mem (fun t -> t.ans) t child
+  let is_descendant_of t ~parent = mem (fun t -> t.des) t parent
+  let is_child_of t ~parent = mem (fun t -> t.cld) t parent
+
+  let to_sequence t = Seq.of_list t.all
+
+  let pp pp_elt ppf tree =
+    fprintf ppf "@.@[<v2>digraph {";
+    begin match tree.all with
+      | [p] -> fprintf ppf "@;%a" pp_elt p
+      | _ -> List.iter tree.all ~f:(fun p ->
+          Seq.iter (children tree p) ~f:(fun c ->
+              fprintf ppf "@;%a -> %a" pp_elt p pp_elt c));
+    end;
+    pp_close_box ppf ();
+    fprintf ppf "@]@.}"
+end
+
+module Frontier = struct
+  type 'a t = {
+    all : 'a list;
+    map : ('a,'a set) map
+  }
+  let create all map = {all; map}
+
+  let enum t x = t.map#find x |> enum
+  let mem t x = match t.map#find x with
+    | None -> fun _ -> false
+    | Some xs -> xs#mem
+
+  let to_sequence t = Seq.of_list t.all
+
+  let pp pp_elt ppf t =
+    List.iter t.all ~f:(fun src ->
+        match t.map#find src with
+        | None -> fprintf ppf "()"
+        | Some set ->
+          fprintf ppf "[%a => (%s)]@." pp_elt src
+            (string_of_set ~sep:" " pp_elt set))
+end
+
+module Equiv = struct
+  type t = int with bin_io, compare, sexp
+  let to_int = ident
+  include Regular.Make(struct
+      include Int
+      let module_name = Some "Bap.Std.Equiv"
+    end)
+end
+
+type equiv = Equiv.t
+
+module Group = struct
+  (* top of set should be included into the set *)
+  type 'a t = {
+    top : 'a;
+    set : 'a set;
+    ord : equiv;
+  }
+
+  let create top set ord = {top; set; ord}
+  let enum t = t.set#enum
+  let mem t = t.set#mem
+  let top t = t.top
+  let to_equiv t = t.ord
+  let pp pp_elt ppf t =
+    fprintf ppf "{%d: %a => (%s)}"
+      t.ord pp_elt t.top (string_of_set ~sep:" " pp_elt t.set)
+end
+
+type 'a group = 'a Group.t
+
+module Partition = struct
+  type 'a t = {
+    roots : 'a array;
+    groups: 'a set array;
+    find  : 'a -> int option;
+  }
+
+  (* takes a mapping from node to its root *)
+  let create comparator comps =
+    let roots,groups =
+      Hashtbl.fold comps ~init:(Map.empty ~comparator)
+        ~f:(fun ~key:node ~data:root map ->
+            Map.add_multi map ~key:root ~data:node) |>
+      Map.to_alist |> List.unzip in
+    let roots = Array.of_list roots in
+    let groups = Array.of_list_map groups ~f:(fun xs ->
+        create_set (Set.of_list ~comparator xs)) in
+    let {Comparator.compare} = comparator in
+    let find_root x =
+      Array.binary_search roots ~compare `First_equal_to x in
+    let find x = Option.Monad_infix.(Hashtbl.find comps x >>= find_root) in
+    {roots; groups; find}
+
+  let nth_group t n = Group.create t.roots.(n) t.groups.(n) n
+  let groups t = Seq.(range 0 (Array.length t.roots) >>| nth_group t)
+  let group t x = Option.(t.find x >>| nth_group t)
+  let equiv t x y = Option.equal Equiv.equal (t.find x) (t.find y)
+  let number_of_groups t = Array.length t.roots
+  let of_equiv t i =
+    if i >= 0 && i < Array.length t.roots
+    then Some (nth_group t i) else None
+  let pp pp_elt ppf t =
+    fprintf ppf "@;@[<v2>partition = {";
+    Seq.iter (groups t) ~f:(fprintf ppf "@;%a" (Group.pp pp_elt));
+    fprintf ppf "@]@;}"
+end
+
+type 'a partition = 'a Partition.t
+type 'a frontier = 'a Frontier.t
+
+module To_ocamlgraph(G : Graph) = struct
+  type t = G.t
+  type edge = G.edge
+  type vertex = G.node
+
+  module V = G.Node
+
+  module E = struct
+    include G.Edge
+    type vertex = G.node
+    let create x y l = create x l y
+  end
+
+  let is_directed = G.is_directed
+
+  let is_empty g = G.number_of_nodes g = 0
+
+  let nb_vertex = G.number_of_nodes
+  let nb_edges = G.number_of_edges
+  let out_degree g n = G.Node.outputs n g |> Seq.length
+  let in_degree g n = G.Node.inputs n g |> Seq.length
+  let mem_vertex g n = G.Node.mem n g
+  let mem_edge g x y = G.Node.has_edge x y g
+  let succ g n = G.Node.succs n g |> Seq.to_list_rev
+  let pred g n = G.Node.preds n g |> Seq.to_list_rev
+  let succ_e g n = G.Node.outputs n g |> Seq.to_list_rev
+  let pred_e g n = G.Node.inputs n g |> Seq.to_list_rev
+  let iter_vertex f g = G.nodes g |> Seq.iter ~f
+  let iter_edges_e f g = G.edges g |> Seq.iter ~f
+  let iter_succ f g n = G.Node.succs n g |> Seq.iter ~f
+  let iter_pred f g n = G.Node.preds n g |> Seq.iter ~f
+
+  let fold_vertex f g init =
+    G.nodes g |> Seq.fold ~f:(fun init x -> f x init) ~init
+
+  let iter_edges f g =
+    G.edges g |> Seq.iter ~f:(fun e -> f (G.Edge.src e) (G.Edge.dst e))
+
+  let fold_edges f g init =
+    G.edges g |> Seq.fold ~init ~f:(fun init e ->
+        f (G.Edge.src e) (G.Edge.dst e) init)
+
+  let fold_edges_e f g init =
+    G.edges g |> Seq.fold ~init ~f:(fun init e -> f e init)
+
+  let map_vertex f g =
+    G.nodes g |> Seq.fold ~init:G.empty ~f:(fun g v ->
+        G.Node.insert (f v) g)
+
+  let find_edge g x y = match G.Node.edge x y g with
+    | Some e -> e
+    | None -> raise Not_found
+
+  let find_all_edges g x y = G.Node.edges x y g |> Seq.to_list_rev
+
+
+  let fold_succ f g n init =
+    G.Node.succs n g |> Seq.fold ~init ~f:(fun a x -> f x a)
+
+  let fold_pred f g n init =
+    G.Node.preds n g |> Seq.fold ~init ~f:(fun a x -> f x a)
+
+  let iter_succ_e f g n = G.Node.outputs n g |> Seq.iter ~f
+
+  let iter_pred_e f g n = G.Node.inputs n g |> Seq.iter ~f
+
+  let fold_succ_e f g n init =
+    G.Node.outputs n g |> Seq.fold ~init ~f:(fun a x -> f x a)
+
+  let fold_pred_e f g n init =
+    G.Node.inputs n g |> Seq.fold ~init ~f:(fun a x -> f x a)
+
+  let empty = G.empty
+  let add_vertex g n = G.Node.insert n g
+  let remove_vertex g n = G.Node.remove n g
+  let add_edge g n =
+    invalid_arg "add_edge operation is not supported"
+
+  let add_edge_e g e = G.Edge.insert e g
+
+  let remove_edge g x y =
+    G.Node.edges x y g |> Seq.fold ~init:g ~f:(fun g e ->
+        G.Edge.remove e g)
+
+  let remove_edge_e g e = G.Edge.remove e g
+
+  let mem_edge_e g e =
+    let es = G.Node.edges (G.Edge.src e) (G.Edge.dst e) g in
+    Seq.mem es e ~equal:(fun x y -> G.Edge.compare x y = 0)
+end
+
+let seq_of_fold fold g =
+  let open Seq.Generator in
+  fold (fun v m -> m >>= fun () -> yield v) g (return ()) |> run
+
+module Of_ocamlgraph(G : Graph.Sig.P) = struct
+  type t = G.t
+  type node = G.V.t
+  type edge = G.E.t
+
+  let is_directed = G.is_directed
+
+  let empty = G.empty
+
+  let nodes = seq_of_fold G.fold_vertex
+  let edges = seq_of_fold G.fold_edges_e
+
+  let number_of_edges = G.nb_edges
+  let number_of_nodes = G.nb_vertex
+
+  module Node = struct
+    type t = node
+    type edge = G.E.t
+    type graph = G.t
+    type label = G.V.label
+
+    let create = G.V.create
+    let label = G.V.label
+    let mem n g = G.mem_vertex g n
+    let succs n g = seq_of_fold (fun f -> G.fold_succ f g) n
+    let preds n g = seq_of_fold (fun f -> G.fold_pred f g) n
+    let outputs n g = seq_of_fold (fun f -> G.fold_succ_e f g) n
+    let inputs n g = seq_of_fold (fun f -> G.fold_pred_e f g) n
+    let insert n g = G.add_vertex g n
+    let update n g = G.add_vertex (G.remove_vertex g n) n
+    let remove n g = G.remove_vertex g n
+    let has_edge x y g = G.mem_edge g x y
+    let edge x y g = try Some (G.find_edge g x y) with Not_found -> None
+    let edges x y g = G.find_all_edges g x y |> Seq.of_list
+
+    include Opaque.Make(struct
+        type t = node
+        let hash = G.V.hash
+        let compare = G.V.compare
+      end)
+  end
+
+  module Edge = struct
+    type t = edge
+    type node = Node.t
+    type graph = G.t
+    type label = G.E.label
+
+    let create x y l = G.E.create x l y
+    let label = G.E.label
+    let src = G.E.src
+    let dst = G.E.dst
+    let mem e g = G.mem_edge_e g e
+    let insert e g = G.add_edge_e g e
+    let update e g = G.add_edge_e (G.remove_edge_e g e) e
+    let remove e g = G.remove_edge_e g e
+    include Opaque.Make(struct
+        type t = edge
+        let hash = Hashtbl.hash
+        let compare = G.E.compare
+      end)
+  end
+
+  include Printable(struct
+      type nonrec t = t
+      let module_name = None
+      let pp ppf graph =
+        let open Bap_graph_pp in
+        let string_of_node =
+          by_natural_order symbols Node.compare
+            (nodes graph) in
+        Dot.pp_graph
+          ~string_of_node
+          ~nodes_of_edge:(fun e -> Edge.(src e, dst e))
+          ~nodes:(nodes graph)
+          ~edges:(edges graph)  ppf
+
+    end)
+
+  include Opaque.Make(struct
+      type t = G.t
+      let hash g =
+        Seq.fold (edges g) ~init:0 ~f:(fun hash x ->
+            hash lxor Edge.hash x)
+
+      (* Note:
+         The comparison function is rather inefficient here, since
+         we can't rely that the order of iteration on edges and nodes
+         will the same for otherwise equal graphs.
+
+         It is usually the same for persistant graphs, built from
+         maps. But in general we may not rely on this fact. So, we
+         can't just compare using fold over set of edges and nodes,
+         as in that case the following will not hold:
+
+                  assert (remove n (insert n g) = g)
+      *)
+
+      let cmp (type t)
+          (module C : Comparable with type t = t) enum x y =
+        let set x = Seq.fold (enum x) ~f:Set.add ~init:C.Set.empty in
+        C.Set.compare (set x) (set  y)
+
+      (* complexity: O(e*log(e) + n*log(n)), where [e] is a number of
+         edges and [n] is a number of nodes. See a note above for the
+         clarification *)
+      let compare x y =
+        match cmp (module Edge) edges x y with
+        | 0 -> cmp (module Node) nodes x y
+        | n -> n
+    end)
+end
+
+
+let create
+    (type t) (type a) (type b)
+    (module G : Graph with type t = t
+                       and type Node.label = a
+                       and type Edge.label = b)
+    ?(nodes=[]) ?(edges=[]) () =
+  let g =
+    List.fold edges ~init:G.empty ~f:(fun g (src,dst,data) ->
+        G.Edge.insert (G.Edge.create
+                         (G.Node.create src)
+                         (G.Node.create dst) data) g) in
+  List.fold nodes ~init:g ~f:(fun g n -> G.Node.insert (G.Node.create n) g)
+
+
+
+let compare (type e) (type g) (type n)
+    (module E : Graph with type t = e and type node = n)
+    (module G : Graph with type t = g and type node = n) e g =
+  let module Edges = Set.Make(struct
+      type t = E.Node.t * E.Node.t with compare
+      let sexp_of_t = sexp_of_opaque
+      let t_of_sexp = opaque_of_sexp
+    end) in
+  let module Nodes = E.Node.Set in
+  let set empty x = Seq.fold x ~f:Set.add ~init:empty in
+  let edges edges src dst empty g =
+    edges g |> Seq.map ~f:(fun e -> src e, dst e) |> set empty in
+  let e_edges = edges E.edges E.Edge.src E.Edge.dst Edges.empty e in
+  let g_edges = edges G.edges G.Edge.src G.Edge.dst Edges.empty g in
+  match Edges.compare e_edges g_edges with
+  | 0 -> 0
+  | n ->
+    let ens = set Nodes.empty (E.nodes e) in
+    let gns = set Nodes.empty (G.nodes g) in
+    Nodes.compare ens gns
+
+type number = {pre : int; rpost : int}
+
+module Ordering(G : Graph) = struct
+  type t = {
+    numbers : number G.Node.Map.t;
+    nodes_left : int;
+    nodes_entered : int;
+  }
+
+  let init g = {
+    numbers = G.Node.Map.empty;
+    nodes_left = G.number_of_nodes g;
+    nodes_entered = 0;
+  }
+
+  let enter t u = {
+    t with
+    nodes_entered = t.nodes_entered + 1;
+    numbers = Map.change t.numbers u (fun _ -> Some {
+        pre = t.nodes_entered;
+        rpost = 0;
+      })
+  }, t.nodes_entered
+
+  let leave t u = {
+    t with
+    nodes_left = t.nodes_left - 1;
+    numbers = Map.change t.numbers u (function
+        | None -> assert false
+        | Some n -> Some {n with rpost = t.nodes_left - 1})
+  }, t.nodes_left - 1
+
+  let number t u = Map.find t.numbers u
+end
+
+let pass _ _ s = s
+
+let depth_first_search
+    (type g) (type n) (type e)
+    (module G : Graph with type t = g
+                       and type node = n
+                       and type edge = e)
+    ?(rev=false) ?start
+    ?(start_tree=(fun _ s -> s))
+    ?(enter_node=pass)
+    ?(leave_node=pass)
+    ?(enter_edge=pass)
+    ?(leave_edge=pass) g ~init  =
+  let module Order = Ordering(G) in
+  let adj = if rev then G.Node.inputs else G.Node.outputs in
+  let dst = if rev then G.Edge.src else G.Edge.dst in
+  let tailrec = G.number_of_nodes g > 10000 in
+  let rec visit ord u state k =
+    let ord, pre = Order.enter ord u in
+    let state = enter_node pre u state in
+    let ord,state =
+      adj u g |> Seq.fold ~init:(ord,state) ~f:(fun (ord,state) e ->
+          let v = dst e in
+          let kind = match Order.number ord v with
+            | None -> `Tree
+            | Some {rpost = 0} -> `Back
+            | Some t -> if pre < t.pre then `Forward else `Cross in
+          let finish (ord,state) = ord, leave_edge kind e state in
+          let state = enter_edge kind e state in
+          if tailrec
+          then if kind = `Tree
+            then visit ord v state (fun s -> k (finish s))
+            else k (finish (ord,state))
+          else if kind = `Tree
+          then finish (visit ord v state k)
+          else finish (ord,state)) in
+    let ord,rpost = Order.leave ord u in
+    ord, leave_node rpost u state in
+  let ord  = Order.init g in
+  let init = match start with
+    | None -> ord,init
+    | Some s -> if G.Node.mem s g
+      then visit ord s (start_tree s init) ident else ord,init in
+  G.nodes g |> Seq.fold ~init ~f:(fun (ord,state) u ->
+      match Order.number ord u with
+      | None -> visit ord u (start_tree u state) ident
+      | _ -> ord,state) |> snd
+
+let depth_first_visit graph ?rev ?start g ~init vis  =
+  depth_first_search graph ?rev ?start g ~init
+    ~start_tree:vis#start_tree
+    ~enter_node:vis#enter_node
+    ~leave_node:vis#leave_node
+    ~enter_edge:vis#enter_edge
+    ~leave_edge:vis#leave_edge
+
+class ['n,'e,'s] dfs_identity_visitor : ['n,'e,'s] dfs_visitor =
+  object
+    method start_tree   _ s = s
+    method enter_node _ _ s = s
+    method leave_node _ _ s = s
+    method enter_edge _ _ s = s
+    method leave_edge _ _ s = s
+  end
+
+let reverse_postorder_traverse graph ?rev ?start g =
+  depth_first_search graph ?rev ?start g ~init:[]
+    ~leave_node:(fun _ n ns -> n :: ns) |> Seq.of_list
+
+let postorder_traverse graph ?rev ?start g =
+  let open Seq.Generator in
+  depth_first_search ?rev ?start graph g ~init:(return ())
+    ~leave_node:(fun _ n ns -> ns >>= fun () -> yield n) |> run
+
+let create_namer (type t) (type n)
+    (module G : Graph with type t = t and type node = n) g =
+  let namer =
+    depth_first_search (module G) g ~init:G.Node.Map.empty
+      ~leave_node:(fun rpost n names ->
+          Map.add names ~key:n ~data:(Int.to_string rpost)) in
+  Map.find_exn namer
+
+let nil _ = []
+
+let to_dot
+    (type t) (type n) (type e)
+    (module G : Graph with type t = t and type node = n
+                                      and type edge = e)
+    ?(graph_attrs=nil)
+    ?(node_attrs=nil)
+    ?(edge_attrs=nil)
+    ?(string_of_node)
+    ?(string_of_edge)
+    ?channel ?formatter ?filename g  =
+  let string_of_node = match string_of_node with
+    | Some namer -> namer
+    | None -> create_namer (module G) g in
+  let module Dottable = struct
+    module G = To_ocamlgraph(G)
+    include G
+    let graph_attributes = graph_attrs
+    let default_vertex_attributes _ = []
+    let vertex_name = string_of_node
+    let vertex_attributes = node_attrs
+    let get_subgraph _ = None
+    let default_edge_attributes _ = []
+    let edge_attributes e =
+      let attrs = edge_attrs e in
+      List.find attrs ~f:(function `Label _ -> true | _ -> false)
+      |> function
+      | Some _ -> attrs
+      | None -> match string_of_edge with
+        | None -> attrs
+        | Some f -> `Label (f e) :: attrs
+
+  end in
+  let module Dot = Graph.Graphviz.Dot(Dottable) in
+  Option.iter channel (fun chan -> Dot.output_graph chan g);
+  Option.iter formatter (fun ppf -> Dot.fprint_graph ppf g);
+  Option.iter filename (Out_channel.with_file ~f:(fun chan ->
+      Dot.output_graph chan g))
+
+
+(** Immediate dominators.
+    This algorithm implements «A simple, fast dominance algorithm»
+    [1], with some modifications, that allows it to run on arbitrary
+    graphs.
+
+    If provided with a graph and an entry node it will span only
+    connected part of the graph, ignoring unreachable nodes. It will
+    return a parent node as an immediate dominator of any unreachable
+    node
+
+    [1]: Cooper, Keith D., Timothy J. Harvey, and Ken Kennedy. "A simple,
+    fast dominance algorithm." Software Practice & Experience 4 (2001):
+    1-10.
+
+*)
+let idom (type t) (type n) (type e)
+    (module G : Graph with type t = t
+                       and type node = n
+                       and type edge = e)
+    ?(rev=false) g entry =
+  let adj = if rev then G.Node.succs else G.Node.preds in
+  let len = with_return (fun {return} ->
+      depth_first_search ~rev (module G) g ~init:0 ~start:entry
+        ~start_tree:(fun _ len -> if len <> 0 then return len else len)
+        ~enter_node:(fun _ _ len -> len + 1)) in
+  let node = Array.create ~len entry in
+  let pnums = G.Node.Table.create ~size:len () in
+  let doms = Array.create ~len ~-1 in
+  let pnum = Hashtbl.find_exn pnums in
+  if len > 0 then doms.(len - 1) <- len - 1;
+  with_return (fun {return} ->
+      depth_first_search ~rev (module G) g ~init:0 ~start:entry
+        ~leave_node:(fun _ n i ->
+            if i >= len then return ();
+            node.(i) <- n;
+            Hashtbl.replace pnums ~key:n ~data:i;
+            i + 1) |> (ignore : int -> _));
+  let rec lift x y : int = match x,y with
+    | -1,_ | _, -1 -> len - 1
+    | _ -> if x < y then lift doms.(x) y else x in
+  let rec intersect x y : int =
+    if x = y then x else
+      let x = lift x y in
+      let y = lift y x in
+      intersect x y in
+  let rec loop () =
+    Seq.range 1 len |> Seq.fold ~init:false ~f:(fun changed i ->
+        let i = len - i - 1 in
+        let new_idom =
+          adj node.(i) g |>
+          Seq.fold ~init:(-1) ~f:(fun new_idom p ->
+              try (* unreachable predeccessors are invisible *)
+                let pn = pnum p in
+                if doms.(pn) < 0 then new_idom
+                else if new_idom < 0 then pn
+                else intersect new_idom pn
+              with Not_found -> new_idom ) in
+        let changed' = doms.(i) <> new_idom in
+        if changed' then doms.(i) <- new_idom;
+        changed' || changed) && loop () in
+  loop () |> (ignore : bool -> _);
+  `idom (fun n ->
+      try
+        let i = pnum n in
+        Option.some_if (i <> len - 1) node.(doms.(i))
+      with Not_found ->
+        if G.Node.mem n g
+        then Some node.(len - 1) else None)
+
+
+let dominators (type t) (type n) (type e)
+    (module G : Graph
+      with type t = t
+       and type edge = e
+       and type node = n) ?rev g entry =
+  let `idom parent = idom ?rev (module G) g entry in
+  let init = G.nodes g |> Seq.fold ~init:G.Node.Map.empty ~f:(fun t n ->
+      Map.add t ~key:n ~data:[]) in
+  let children = G.nodes g |> Seq.fold ~init ~f:(fun tree n ->
+      match parent n with
+      | Some p -> Map.add_multi tree ~key:p ~data:n
+      | None -> tree) |> Map.map ~f:G.Node.Set.of_list in
+  create_tree parent children
+
+module type Dom_frontier_algo = functor (G : Graph) -> sig
+  val compute : ?rev:bool -> G.t -> G.node tree -> G.Node.Set.t G.Node.Map.t
+end
+
+module Dom_frontier_cooper(G:Graph) = struct
+  let compute ?(rev=false) g tree =
+    let adj = if rev then G.Node.succs else G.Node.preds in
+    let idom = Tree.parent tree in
+    let rec walk top dfs r =
+      if Option.equal G.Node.equal (Some r) top then dfs
+      else match idom r with
+        | None   -> Set.add dfs r
+        | Some p -> walk top (Set.add dfs r) p in
+    G.nodes g |> Seq.fold ~init:G.Node.Map.empty ~f:(fun dfs n ->
+        let adj = adj n g in
+        let dom = idom n in
+        Seq.fold adj ~init:G.Node.Set.empty ~f:(walk dom) |>
+        Set.fold ~init:dfs ~f:(fun dfs visited ->
+            Map.change dfs visited (function
+                | None -> Some (G.Node.Set.singleton n)
+                | Some set -> Some (Set.add set n))))
+end
+
+let dom_frontier_generic (type t) (type n) (type e)
+    (module Algo : Dom_frontier_algo)
+    (module G : Graph
+      with type t = t
+       and type node = n
+       and type edge = e) ?rev g idom : n Frontier.t =
+  let module Algo = Algo(G) in
+  let frontier = Algo.compute ?rev g idom in
+  let frontier = Map.map frontier ~f:create_set in
+  Frontier.create (Map.keys frontier) (object
+    method find = Map.find frontier
+  end)
+
+let dom_frontier g =
+  dom_frontier_generic (module Dom_frontier_cooper) g
+
+
+
+
+
+
+
+let strong_components
+    (type t) (type n) (type e)
+    (module G : Graph with type t = t
+                       and type node = n
+                       and type edge = e) g =
+  let roots = G.Node.Table.create () in
+  let comps = G.Node.Table.create ~size:(G.number_of_nodes g) () in
+  let root = Hashtbl.find_exn roots in
+  let spill_comp root stack =
+    List.drop_while stack ~f:(fun c ->
+        Hashtbl.add_exn comps ~key:c ~data:root;
+        G.Node.(c <> root)) |> List.tl_exn in
+  depth_first_search (module G) g ~init:[]
+    ~enter_node:(fun t v stack ->
+        Hashtbl.add_exn roots ~key:v ~data:(t,v); v :: stack)
+    ~leave_node:(fun _ v stack ->
+        G.Node.outputs v g |> Seq.iter ~f:(fun e ->
+            let w = G.Edge.dst e in
+            if not (Hashtbl.mem comps w) then
+              let min x y = if fst x < fst y then x else y in
+              let data = min (root v) (root w) in
+              Hashtbl.change roots v (fun _ -> Some data));
+        if G.Node.(snd (root v) = v)
+        then spill_comp v stack else stack) |> function
+  | [] -> Partition.create G.Node.comparator comps
+  | _ -> assert false
+
+
+module Path = struct
+  type 'a t = {
+    edges  : 'a array;
+    weight : int;
+  } with bin_io, compare, sexp, fields
+  let create edges weight = {
+    edges = Array.of_list_rev edges;
+    weight;
+  }
+  let length t = Array.length t.edges
+  let edges t = Seq.of_array t.edges
+  let edges_rev t =
+    let len = length t in
+    Seq.range 0 len |> Seq.map ~f:(fun i -> t.edges.(len - i - 1))
+
+  let start t = t.edges.(0)
+  let finish t = t.edges.(length t - 1)
+
+  let pp pp_elt ppf t =
+    fprintf ppf "@[<2>{ %a" pp_elt t.edges.(0);
+    Seq.range 1 (length t) |> Seq.iter  ~f:(fun i ->
+        fprintf ppf ", %a" pp_elt t.edges.(i));
+    fprintf ppf "}@]"
+end
+
+type 'a path = 'a Path.t
+
+let shortest_path
+    (type t) (type n) (type e)
+    (module G : Graph with type t = t
+                       and type node = n
+                       and type edge = e)
+    ?(weight=(fun _ -> 1)) ?(rev=false) g v1 v2 =
+  let cmp (n,_,_) (m,_,_) = Int.compare n m in
+  let adj = if rev then G.Node.inputs else G.Node.outputs in
+  let dst = if rev then G.Edge.src else G.Edge.dst in
+  let visited = G.Node.Hash_set.create () in
+  let dist = G.Node.Table.create  () in
+  let q = Heap.create ~cmp () in
+  let rec loop () = match Heap.pop q with
+    | None -> None
+    | Some (w,v,p) when G.Node.equal v v2 -> Some (Path.create p w)
+    | Some (w,v,p) ->
+      if not (Hash_set.mem visited v) then update v w p;
+      loop ()
+  and update v w p =
+    Hash_set.add visited v;
+    adj v g |> Seq.iter ~f:(fun e ->
+        let ev = dst e in
+        let dev = w + weight e in
+        match Hashtbl.find dist ev with
+        | Some w when w < dev -> ()
+        | _ ->
+          Hashtbl.replace dist ev dev;
+          Heap.add q (dev, ev, e :: p)) in
+  Heap.add q (0, v1, []);
+  Hashtbl.set dist v1 0;
+  loop ()
+
+let is_reachable graph ?rev g u v =
+  shortest_path graph ?rev g u v <> None
+
+let fold_reachable (type t) (type n) (type e)
+    (module G : Graph with type t = t
+                       and type node = n
+                       and type edge = e) ?rev ~init ~f g start =
+  with_return (fun {return} ->
+      depth_first_search (module G) g ?rev ~start ~init
+        ~start_tree:(fun n s  ->
+            if G.Node.(n = start) then s else return s)
+        ~enter_node:(fun _ n u -> f u n))
+
+
+
+
+
+module Filtered
+    (G : Graph)
+    (Has : Predicate with type edge = G.edge and type node = G.node) =
+struct
+  type t = G.t
+  type node = G.node
+  type edge = G.edge
+
+  module Has = struct
+    let node = Has.node
+    let edge e =
+      Has.edge e && node (G.Edge.dst e) && node (G.Edge.src e)
+  end
+
+  let (//) xs f = Seq.filter xs ~f
+
+  let empty = G.empty
+  let is_directed = G.is_directed
+  let nodes g = G.nodes g // Has.node
+  let edges g = G.edges g // Has.edge
+  let number_of_nodes g = Seq.length (nodes g)
+  let number_of_edges g = Seq.length (edges g)
+
+
+  module Node = struct
+    include G.Node
+    let mem n g = Has.node n && mem n g
+    let enum enum n g = if Has.node n then enum n g else Seq.empty
+    let succs n g   = enum succs n g   // Has.node
+    let preds n g   = enum preds n g   // Has.node
+    let inputs n g  = enum inputs n g  // Has.edge
+    let outputs n g = enum outputs n g // Has.edge
+    let edges n m g =
+      if Has.node n && Has.node m then edges n m g // Has.edge else Seq.empty
+    let edge n m g = edges n m g |> Seq.hd
+    let has_edge n m g = match edge n m g with
+      | None -> false
+      | _ -> true
+  end
+
+  module Edge = G.Edge
+
+  include (G : Opaque with type t := t)
+  include (G : Printable with type t := t)
+end
+
+
+let filtered (type t) (type n) (type e)
+    (module G : Graph with type t = t
+                       and type node = n
+                       and type edge = e)
+    ?(skip_node=fun _ -> false)
+    ?(skip_edge=fun _ -> false) () :
+  (module Graph with type t = t
+                 and type node = n
+                 and type edge = e) =
+  let module R = Filtered(G)(struct
+      type edge = e
+      type node = n
+      let edge e = not (skip_edge e)
+      let node n = not (skip_node n)
+    end) in
+  (module R)
+
+module type Morph = Isomorphism
+
+module Mapper
+    (G  : Graph)
+    (N  : Morph with type s = G.node)
+    (E  : Morph with type s = G.edge)
+    (NL : Morph with type s = G.Node.label)
+    (EL : Morph with type s = G.Edge.label)
+= struct
+  type t = G.t
+  type node = N.t
+  type edge = E.t
+
+  let (/@) xs f = Seq.map xs ~f
+
+  let empty = G.empty
+  let is_directed = G.is_directed
+  let nodes g = G.nodes g /@ N.forward
+  let edges g = G.edges g /@ E.forward
+
+  let number_of_nodes = G.number_of_nodes
+  let number_of_edges = G.number_of_edges
+
+  module Node = struct
+    type t = node
+    type edge = E.t
+    type label = NL.t
+    type graph = G.t
+    open G.Node
+    let create lab = N.forward (create (NL.backward lab))
+    let label n = NL.forward (label (N.backward n))
+    let mem n g = mem (N.backward n) g
+    let succs n g = succs (N.backward n) g /@ N.forward
+    let preds n g = preds (N.backward n) g /@ N.forward
+    let inputs n g = inputs (N.backward n) g /@ E.forward
+    let outputs n g = outputs (N.backward n) g /@ E.forward
+    let insert n g = insert (N.backward n) g
+    let remove n g = remove (N.backward n) g
+    let update n g = update (N.backward n) g
+    let has_edge n m g = has_edge (N.backward n) (N.backward m) g
+    let edge n m g =
+      Option.(edge (N.backward n) (N.backward m) g >>| E.forward)
+    let edges n m g =
+      edges (N.backward n) (N.backward m) g /@ E.forward
+    include Opaque.Make(struct
+        type t = node
+        let compare x y = G.Node.compare (N.backward x) (N.backward y)
+        let hash x = hash (N.backward x)
+      end)
+  end
+
+  module Edge = struct
+    type t = edge
+    type node = N.t
+    type label = EL.t
+    type graph = G.t
+
+    open G.Edge
+
+    let create n m l =
+      create (N.backward n) (N.backward m) (EL.backward l) |> E.forward
+    let label e = label (E.backward e) |> EL.forward
+    let src e = src (E.backward e) |> N.forward
+    let dst e = dst (E.backward e) |> N.forward
+    let mem e g = mem (E.backward e) g
+    let insert e g = insert (E.backward e) g
+    let update e g = update (E.backward e) g
+    let remove e g = remove (E.backward e) g
+    include Opaque.Make(struct
+        type t = edge
+        let compare x y =
+          G.Edge.compare (E.backward x) (E.backward y)
+        let hash x = hash (E.backward x)
+      end)
+  end
+
+  include (G : Opaque with type t := t)
+  include (G : Printable with type t := t)
+end
+
+
+let view (type t)
+    (type n) (type e) (type a) (type b)
+    (type m) (type f) (type c) (type d)
+    (module G : Graph with type t = t
+                       and type node = n
+                       and type edge = e
+                       and type Node.label = a
+                       and type Edge.label = b)
+    ~node:(nf,nb) ~edge:(ef,eb)
+    ~node_label:(nlf,nlb)
+    ~edge_label:(elf,elb) :
+  (module Graph with type t = t
+                 and type node = m
+                 and type edge = f
+                 and type Node.label = c
+                 and type Edge.label = d) =
+  let module N = struct
+    type s = n
+    type t = m
+    let forward = nf
+    let backward = nb
+  end in
+  let module E = struct
+    type s = e
+    type t = f
+    let forward = ef
+    let backward = eb
+  end in
+  let module NL = struct
+    type s = a
+    type t = c
+    let forward = nlf
+    let backward = nlb
+  end in
+  let module EL = struct
+    type s = b
+    type t = d
+    let forward = elf
+    let backward = elb
+  end in
+  let module M = Mapper(G)(N)(E)(NL)(EL) in
+  (module M)

--- a/lib/bap_types/bap_graph.mli
+++ b/lib/bap_types/bap_graph.mli
@@ -1,0 +1,233 @@
+open Core_kernel.Std
+open Bap_graph_intf
+open Bap_common
+open Format
+
+type 'a tree
+type 'a frontier
+type 'a partition
+type 'a group
+type 'a path
+type equiv
+
+module type Graph = Graph
+
+val create : (module Graph with type t = 'c
+                            and type Node.label = 'a
+                            and type Edge.label = 'b) ->
+  ?nodes:'a list ->
+  ?edges:('a * 'a * 'b) list -> unit -> 'c
+
+
+
+val to_dot :
+  (module Graph with type t = 'c
+                 and type node = 'n
+                 and type edge = 'e) ->
+  ?graph_attrs:('c -> graph_attr list) ->
+  ?node_attrs:('n -> node_attr list) ->
+  ?edge_attrs:('e -> edge_attr list) ->
+  ?string_of_node:('n -> string) ->
+  ?string_of_edge:('e -> string) ->
+  ?channel:out_channel ->
+  ?formatter:formatter ->
+  ?filename:string -> 'c -> unit
+
+val depth_first_search : (module Graph with type t = 'c
+                                        and type node = 'n
+                                        and type edge = 'e) ->
+  ?rev:bool -> ?start:'n ->
+  ?start_tree:('n -> 's -> 's) ->
+  ?enter_node:(int -> 'n -> 's -> 's) ->
+  ?leave_node:(int -> 'n -> 's -> 's) ->
+  ?enter_edge:(edge_kind -> 'e -> 's -> 's) ->
+  ?leave_edge:(edge_kind -> 'e -> 's -> 's) ->
+  'c -> init:'s -> 's
+
+val depth_first_visit : (module Graph with type t = 'c
+                                       and type node = 'n
+                                       and type edge = 'e) ->
+  ?rev:bool -> ?start:'n -> 'c -> init:'s -> ('n,'e,'s) dfs_visitor -> 's
+
+class ['n,'e,'s] dfs_identity_visitor : ['n,'e,'s] dfs_visitor
+
+val reverse_postorder_traverse :
+  (module Graph with type t = 'c
+                 and type node = 'n
+                 and type edge = 'e) -> ?rev:bool -> ?start:'n -> 'c -> 'n Sequence.t
+
+val postorder_traverse :
+  (module Graph with type t = 'c
+                 and type node = 'n
+                 and type edge = 'e) -> ?rev:bool -> ?start:'n -> 'c -> 'n Sequence.t
+
+val dominators : (module Graph with type t = 'c
+                                and type node = 'n
+                                and type edge = 'e) -> ?rev:bool -> 'c -> 'n -> 'n tree
+
+val dom_frontier : (module Graph with type t = 'c
+                                  and type node = 'n
+                                  and type edge = 'e) -> ?rev:bool -> 'c -> 'n tree -> 'n frontier
+
+val strong_components :
+  (module Graph with type t = 'c
+                 and type node = 'n
+                 and type edge = 'e) -> 'c -> 'n partition
+
+val shortest_path :
+  (module Graph with type t = 'c
+                 and type node = 'n
+                 and type edge = 'e) ->
+  ?weight:('e -> int) -> ?rev:bool -> 'c -> 'n -> 'n -> 'e path option
+
+val is_reachable :
+  (module Graph with type t = 'c
+                 and type node = 'n
+                 and type edge = 'e) ->
+  ?rev:bool -> 'c -> 'n -> 'n -> bool
+
+
+val fold_reachable :
+  (module Graph with type t = 'c
+                 and type node = 'n
+                 and type edge = 'e) ->
+  ?rev:bool -> init:'a -> f:('a -> 'n -> 'a) -> 'c -> 'n -> 'a
+
+
+val compare :
+  (module Graph with type t = 'a
+                 and type node = 'n) ->
+  (module Graph with type t = 'b
+                 and type node = 'n) ->
+  'a -> 'b -> int
+
+val filtered :
+  (module Graph with type t = 'c
+                 and type node = 'n
+                 and type edge = 'e) ->
+  ?skip_node:('n -> bool) ->
+  ?skip_edge:('e -> bool) -> unit ->
+  (module Graph with type t = 'c
+                 and type node = 'n
+                 and type edge = 'e)
+
+val view :
+  (module Graph with type t = 'c
+                 and type node = 'n
+                 and type edge = 'e
+                 and type Node.label = 'a
+                 and type Edge.label = 'b) ->
+  node:(('n -> 'f) * ('f -> 'n)) ->
+  edge:(('e -> 'd) * ('d -> 'e)) ->
+  node_label:(('a -> 'p) * ('p -> 'a)) ->
+  edge_label:(('b -> 'r) * ('r -> 'b)) ->
+  (module Graph with type t = 'c
+                 and type node = 'f
+                 and type edge = 'd
+                 and type Node.label = 'p
+                 and type Edge.label = 'r)
+
+
+
+
+module To_ocamlgraph(G : Graph) :
+  Graph.Sig.P with type t = G.t
+               and type V.t = G.node
+               and type E.t = G.edge
+               and type V.label = G.Node.label
+               and type E.label = G.Edge.label
+
+module Of_ocamlgraph(G : Graph.Sig.P) :
+  Graph with type t = G.t
+         and type node = G.V.t
+         and type edge = G.E.t
+         and type Node.label = G.V.label
+         and type Edge.label = G.E.label
+
+
+module Filtered
+    (G : Graph)
+    (P : Predicate with type node = G.node
+                    and type edge = G.edge) :
+  Graph with type t = G.t
+         and type node = G.node
+         and type edge = G.edge
+         and module Node = G.Node
+         and module Edge = G.Edge
+
+module Mapper
+    (G  : Graph)
+    (N  : Isomorphism with type s = G.node)
+    (E  : Isomorphism with type s = G.edge)
+    (NL : Isomorphism with type s = G.Node.label)
+    (EL : Isomorphism with type s = G.Edge.label) :
+  Graph with type t = G.t
+         and type node = N.t
+         and type edge = E.t
+         and type Node.label = NL.t
+         and type Edge.label = EL.t
+
+
+
+module Tree : sig
+  type 'a t = 'a tree
+
+  val children : 'a t -> 'a -> 'a Sequence.t
+  val parent : 'a t -> 'a -> 'a option
+  val ancestors : 'a t -> 'a -> 'a Sequence.t
+  val descendants : 'a t -> 'a -> 'a Sequence.t
+
+  val is_child_of : 'a t -> parent:'a -> 'a -> bool
+  val is_ancestor_of : 'a t -> child:'a -> 'a -> bool
+  val is_descendant_of : 'a t -> parent:'a -> 'a -> bool
+
+  val to_sequence : 'a t -> 'a Sequence.t
+  val pp : (formatter -> 'a -> unit) -> formatter -> 'a t -> unit
+end
+
+module Frontier : sig
+  type 'a t = 'a frontier
+  val enum : 'a t -> 'a -> 'a Sequence.t
+  val mem : 'a t -> 'a -> 'a -> bool
+
+  val to_sequence : 'a t -> 'a Sequence.t
+  val pp : (formatter -> 'a -> unit) -> formatter -> 'a t -> unit
+end
+
+module Partition : sig
+  type 'a t = 'a partition
+  val groups : 'a t -> 'a group Sequence.t
+  val group : 'a t -> 'a -> 'a group option
+  val equiv : 'a t -> 'a -> 'a -> bool
+  val number_of_groups : 'a t -> int
+  val of_equiv : 'a t -> equiv -> 'a group option
+  val pp : (formatter -> 'a -> unit) -> formatter -> 'a t -> unit
+end
+
+module Group : sig
+  type 'a t = 'a group
+  val enum : 'a group -> 'a Sequence.t
+  val mem  : 'a group -> 'a -> bool
+  val top  : 'a group -> 'a
+  val to_equiv : 'a group -> equiv
+  val pp : (formatter -> 'a -> unit) -> formatter -> 'a t -> unit
+end
+
+
+module Equiv : sig
+  type t
+  val to_int : t -> int
+  include Regular with type t := t
+end
+
+
+module Path : sig
+  type 'e t = 'e path
+  val edges : 'e t -> 'e Sequence.t
+  val edges_rev : 'e t -> 'e Sequence.t
+  val start : 'e t -> 'e
+  val finish : 'e t -> 'e
+  val weight : 'e t -> int
+  val length : 'e t -> int
+  val pp : (formatter -> 'a -> unit) -> formatter -> 'a t -> unit
+end

--- a/lib/bap_types/bap_graph_intf.ml
+++ b/lib/bap_types/bap_graph_intf.ml
@@ -1,0 +1,112 @@
+open Core_kernel.Std
+open Bap_common
+
+
+module type Node = sig
+  type t
+  type graph
+  type label
+  type edge
+
+  val create : label -> t
+  val label  : t -> label
+  val mem    : t -> graph -> bool
+  val succs  : t -> graph -> t Sequence.t
+  val preds  : t -> graph -> t Sequence.t
+  val inputs : t -> graph -> edge Sequence.t
+  val outputs: t -> graph -> edge Sequence.t
+  val insert : t -> graph -> graph
+  val update : t -> graph -> graph
+  val remove : t -> graph -> graph
+  val has_edge : t -> t -> graph -> bool
+  val edge : t -> t -> graph -> edge option
+  val edges : t -> t -> graph -> edge Sequence.t
+  include Opaque with type t := t
+end
+
+module type Edge = sig
+  type t
+  type node
+  type graph
+  type label
+  val create : node -> node -> label -> t
+  val label : t -> label
+  val src : t -> node
+  val dst : t -> node
+  val mem : t -> graph -> bool
+  val insert : t -> graph -> graph
+  val update : t -> graph -> graph
+  val remove : t -> graph -> graph
+  include Opaque with type t := t
+end
+
+module type Graph = sig
+  type node
+  type edge
+
+  type t
+
+
+  module Node : Node with type graph = t
+                      and type t = node
+                      and type edge = edge
+
+  module Edge : Edge with type graph = t
+                      and type t = edge
+                      and type node = node
+  val empty : t
+
+  val nodes : t -> node Sequence.t
+  val edges : t -> edge Sequence.t
+
+  val is_directed : bool
+
+  val number_of_edges : t -> int
+  val number_of_nodes : t -> int
+
+  include Opaque with type t := t
+  include Printable with type t := t
+end
+
+type ('c,'n,'e) graph =
+  (module Graph with type t = 'c
+                 and type node = 'n
+                 and type edge = 'e)
+
+
+module type Predicate = sig
+  type edge
+  type node
+  val edge : edge -> bool
+  val node : node -> bool
+end
+
+
+module type Isomorphism = sig
+  type s
+  type t
+  val forward  : s -> t
+  val backward : t -> s
+end
+
+type edge_kind = [
+  | `Tree
+  | `Back
+  | `Cross
+  | `Forward
+]
+
+
+class type ['n,'e,'s] dfs_visitor = object
+  method start_tree : 'n -> 's -> 's
+  method enter_node : int -> 'n -> 's -> 's
+  method leave_node : int -> 'n -> 's -> 's
+  method enter_edge : edge_kind -> 'e -> 's -> 's
+  method leave_edge : edge_kind -> 'e -> 's -> 's
+end
+
+
+
+type node_attr = Graph.Graphviz.DotAttributes.vertex
+type edge_attr = Graph.Graphviz.DotAttributes.edge
+type graph_attr = Graph.Graphviz.DotAttributes.graph

--- a/lib/bap_types/bap_graph_pp.ml
+++ b/lib/bap_types/bap_graph_pp.ml
@@ -1,0 +1,96 @@
+open Core_kernel.Std
+open Bap_common
+open Format
+
+module Seq = Sequence
+
+type scheme = string * (string -> string)
+
+type 'n symbolizer = 'n -> string
+
+
+(** [next_char c] returns next a lowercase character following the
+    [c], if it exists   *)
+let next_char char : char option =
+  match (Char.to_int char + 1) |> Char.of_int with
+  | Some c when Char.(is_lowercase c && is_alpha c) -> Some c
+  | _ -> None
+
+(** [next_sym s] generates new fresh symbol, assuming that [s] is the
+    highest generated symbol.  The function will at first use all
+    lowercase symbols from [[a-z]], and then fall back to a simple
+    scheme [node_n], where n goes from zero to max_int.*)
+let next_sym sym : string =
+  match String.split sym ~on:'_' with
+  | [v] when String.length v = 1 ->
+    (match next_char v.[0] with
+     | Some c -> String.of_char c
+     | None -> "node_1")
+  | [v;n] -> let m = Int.of_string n + 1 in
+    sprintf "%s_%d" v m
+  | _ -> assert false
+
+let next_num num : string =
+  Int.to_string (Int.of_string num + 1)
+
+let symbols = ("a",next_sym)
+let numbers = ("0",next_num)
+let nothing = ("",ident)
+
+let create_scheme ~next init = init,next
+
+
+
+let by_given_order (type a) (init,next) compare nodes =
+  let module T = Comparator.Make(struct
+      type t = a
+      let compare = compare
+      let sexp_of_t = sexp_of_opaque
+    end) in
+  let comparator = T.comparator in
+  Seq.fold nodes ~init:(Map.empty ~comparator,init) ~f:(fun (names,name) node ->
+      Map.add names ~key:node ~data:name, next name) |> fst |>
+  Map.find_exn
+
+let by_natural_order (type a) variant compare nodes =
+  let module T = Comparator.Make(struct
+      type t = a
+      let compare = compare
+      let sexp_of_t = sexp_of_opaque
+    end) in
+  let comparator = T.comparator in
+  Seq.fold nodes ~init:(Set.empty ~comparator) ~f:Set.add |>
+  Set.to_sequence |> by_given_order variant compare
+
+module Dot = struct
+  let pp_label ppf lab = match lab with
+    | "" -> ()
+    | lab -> Format.fprintf ppf "[label=\"%s\"]" lab
+
+  let pp_edge ppf (src,dst,lab) =
+    fprintf ppf "\"%s\" -> \"%s\"%a" src dst pp_label lab
+
+  let pp_node ppf (name,label) =
+    match label with
+    | "" -> fprintf ppf "\"%s\"" name
+    | _ ->  fprintf ppf "\"%s\"[label=\"%s\"]" name label
+
+  let noname _ = ""
+
+  let pp_graph
+      ?(attrs=[])
+      ?string_of_node:(node=noname)
+      ?(node_label=noname)
+      ?(edge_label=noname)
+      ~nodes_of_edge ~nodes ~edges ppf =
+    let nodes = Seq.map nodes ~f:(fun n -> node n,node_label n) in
+    let edges = Seq.map edges ~f:(fun e ->
+        let src,dst = nodes_of_edge e in
+        node src, node dst, edge_label e) in
+    let attrs = if attrs = [] then "" else
+        sprintf "@;%s" (String.concat ~sep:"@;" attrs) in
+    fprintf ppf "@.@[<v2>digraph {%s" attrs;
+    Seq.iter nodes ~f:(fprintf ppf "@;%a" pp_node);
+    Seq.iter edges ~f:(fprintf ppf "@;%a" pp_edge);
+    fprintf ppf "@]@.}"
+end

--- a/lib/bap_types/bap_graph_pp.mli
+++ b/lib/bap_types/bap_graph_pp.mli
@@ -1,0 +1,36 @@
+open Core_kernel.Std
+open Format
+
+type scheme
+type 'a symbolizer = ('a -> string)
+
+(** [create_scheme ~next init] create a name generator, that will
+    start with [init] and apply [next] on it infinitly. *)
+val create_scheme : next:(string -> string) -> string -> scheme
+
+(** lower case symbols, starting from 'a' and moving up to 'z'.
+    As 'z' is reached, all foregoing symbols will have a form
+    of 'node_N' where 'N' is an increasing natural number. *)
+val symbols : scheme
+
+(** numbers from zero to inifinity ([Sys.max_int] in fact) *)
+val numbers : scheme
+(** empty string  *)
+val nothing : scheme
+
+val by_given_order : scheme -> ('a -> 'a -> int) -> 'a Sequence.t -> 'a symbolizer
+val by_natural_order : scheme -> ('a -> 'a -> int) -> 'a Sequence.t -> 'a symbolizer
+
+
+
+module Dot : sig
+  val pp_graph :
+    ?attrs:string list ->
+    ?string_of_node: 'n symbolizer ->
+    ?node_label: 'n symbolizer ->
+    ?edge_label: 'e symbolizer ->
+    nodes_of_edge : ('e -> 'n * 'n) ->
+    nodes: 'n Sequence.t ->
+    edges: 'e Sequence.t -> formatter -> unit
+
+end

--- a/lib/bap_types/bap_graph_regular.ml
+++ b/lib/bap_types/bap_graph_regular.ml
@@ -1,0 +1,385 @@
+open Core_kernel.Std
+open Bap_common
+open Bap_bil
+open Bap_graph_intf
+open Format
+
+module Seq = Sequence
+
+module Make(Node : Opaque)(Edge : Opaque) = struct
+
+  type edge_label = Edge.t with compare
+
+  type edge = {
+    src : Node.t;
+    dst : Node.t;
+    data : edge_label;
+  } with compare, fields
+
+  module Arrow = Opaque.Make(struct
+      type t = Node.t * edge_label with compare
+      let hash (n,d) = Node.hash n lxor Edge.hash d
+    end)
+
+
+  type node_info = {
+    inc : Arrow.Set.t;
+    out : Arrow.Set.t;
+  } with compare, fields
+
+  type graph = node_info Node.Map.t
+  with compare
+
+  let empty_node = {inc = Arrow.Set.empty; out = Arrow.Set.empty}
+
+  module Node = struct
+    type nonrec edge = edge
+    type label = Node.t
+    type nonrec graph = graph
+
+    let create = ident
+    let label = ident
+    let mem n g = Map.mem g n
+    let adj dir n g  = Map.find g n |> function
+      | None -> Seq.empty
+      | Some ns ->
+        Set.to_sequence (dir ns) |> Seq.map ~f:fst
+
+    let succs n = adj out n
+    let preds n = adj inc n
+
+    let edges dir reorder n g = Map.find g n |> function
+      | None -> Seq.empty
+      | Some ns -> Set.to_sequence (dir ns) |>
+                   Seq.map ~f:(fun (m,data) ->
+                       let src,dst = reorder n m in
+                       {src;dst;data})
+
+    let inputs  n = edges inc (fun dst src -> src,dst) n
+    let outputs n = edges out (fun src dst -> src,dst) n
+    let insert n g = Map.change g n (function
+        | None -> Some empty_node
+        | other -> other)
+
+    let update n g : graph = Map.find g n |> function
+      | None -> g
+      | Some data -> Map.add g ~key:n ~data
+
+
+    let remove n g = Map.remove g n
+
+    let edges src dst' g = Map.find g src |> function
+      | None -> Seq.empty
+      | Some ns -> Set.to_sequence ns.out |>
+                   Seq.filter_map ~f:(fun (dst,data) ->
+                       if Node.(dst = dst') then Some {src; dst; data}
+                       else None)
+
+    let edge src dst g = edges src dst g |> Seq.hd
+
+    let has_edge src dst g = edge src dst g <> None
+    include Node
+  end
+
+  module Edge = struct
+    type t = edge
+    type node = Node.t
+    type label = edge_label
+    type nonrec graph = graph
+
+    let create src dst data = {src; dst; data}
+    let label e = e.data
+    let src e = e.src
+    let dst e = e.dst
+    let mem e g = match Map.find g e.src with
+      | None -> false
+      | Some a -> Set.mem a.out (e.dst,e.data)
+
+    let insert_arrow src dst field e g =
+      Map.change g (src e) (function
+          | None ->
+            Some (Fieldslib.Field.fset field empty_node
+                    (Arrow.Set.singleton (dst e, e.data)))
+          | Some ns ->
+            let set = Fieldslib.Field.get field ns in
+            Some (Fieldslib.Field.fset field ns
+                    (Set.add set (dst e, e.data))))
+
+    let insert e (g : graph) : graph =
+      insert_arrow src dst Fields_of_node_info.out e g |>
+      insert_arrow dst src Fields_of_node_info.inc e
+
+    let update_arrow field arr n g = Map.change g n (function
+        | None -> None
+        | Some ns ->
+          let set = Fieldslib.Field.get field ns in
+          Some (Fieldslib.Field.fset field ns
+                  (Set.add set arr)))
+
+    let update e g : graph =
+      Node.(update e.src g |> update e.dst) |>
+      update_arrow Fields_of_node_info.out (e.dst,e.data) e.src |>
+      update_arrow Fields_of_node_info.inc (e.src,e.data) e.dst
+
+
+    let remove_arrow field arr src g = Map.change g src (function
+        | None -> None
+        | Some ns ->
+          let set = Fieldslib.Field.get field ns in
+          Some (Fieldslib.Field.fset field ns
+                  (Set.remove set arr)))
+
+    let remove e g : graph =
+      remove_arrow Fields_of_node_info.out (e.dst,e.data) e.src g |>
+      remove_arrow Fields_of_node_info.inc (e.src,e.data) e.dst
+
+    include Opaque.Make(struct
+        type t = edge with compare
+        let hash e = Edge.hash e.data
+      end)
+  end
+
+  type t = graph with compare
+  type node = Node.t
+
+  let is_directed = true
+
+  let empty = Node.Map.empty
+
+  let nodes g = Map.keys g |> Seq.of_list
+
+  let edges g = nodes g |>
+                Seq.concat_map ~f:(fun src -> Node.outputs src g)
+
+  let number_of_nodes g = Map.length g
+
+  let number_of_edges g =
+    Map.fold g ~init:0 ~f:(fun ~key:_ ~data:{out} sum ->
+        sum + Set.length out)
+
+  include Opaque.Make(struct
+      open Format
+      type t = graph with compare
+      let hash g =
+        nodes g |> Seq.fold ~init:0 ~f:(fun hash n ->
+            Node.hash n lxor hash)
+    end)
+
+  include Printable(struct
+      type nonrec t = t
+      let module_name = None
+      let pp ppf graph =
+        let open Bap_graph_pp in
+        let string_of_node =
+          by_natural_order symbols Node.compare (nodes graph) in
+        Dot.pp_graph
+          ~string_of_node
+          ~nodes_of_edge:(fun e -> Edge.(src e, dst e))
+          ~nodes:(nodes graph)
+          ~edges:(edges graph)  ppf
+
+    end)
+end
+
+module type Printable_graph = sig
+  module G : Graph
+  val pp_node : formatter -> G.node -> unit
+  val pp_edge : formatter -> G.Edge.label -> unit
+  val module_name : string option
+end
+
+module Printable_graph(Graph_pp : Printable_graph) = struct
+  open Graph_pp
+  include G
+  include Printable(struct
+      type t = G.t
+
+      let pp_label ppf lab = match asprintf "%a" pp_edge lab with
+        | "" -> ()
+        | l -> fprintf ppf "[label=%S]" l
+
+      let pp_edge ppf e =
+        Format.fprintf ppf "\"%a\" -> \"%a\"%a"
+          pp_node (Edge.src e) pp_node (Edge.dst e)
+          pp_label (Edge.label e)
+
+      let pp ppf g =
+        let open Format in
+        fprintf ppf "@.@[<v2>digraph {";
+        Seq.iter (nodes g) ~f:(fun n -> fprintf ppf "@;\"%a\"" pp_node n);
+        Seq.iter (edges g) ~f:(fun e -> fprintf ppf "@;%a" pp_edge e);
+        fprintf ppf "@]@.}"
+
+      let module_name = module_name
+    end)
+end
+
+module type Product = sig
+  include Opaque
+  val pp : formatter -> t -> unit
+  val name : string
+end
+
+
+module Make_factory(P : Product) = struct
+  open Bap_graph
+  type node = P.t
+
+  let make_name name = Some ("Bap.Std.Graphlib."^P.name^"."^name)
+
+  module Tree = struct
+    type t = P.t tree
+    include Printable(struct
+        type nonrec t = t
+        let pp = Tree.pp P.pp
+        let module_name = make_name "Tree"
+      end)
+  end
+
+  module Frontier = struct
+    type t = node frontier
+    include Printable(struct
+        type nonrec t = t
+        let pp = Frontier.pp P.pp
+        let module_name = make_name "Frontier"
+      end)
+  end
+
+  module Group = struct
+    type t = node group
+    include Printable(struct
+        type nonrec t = t
+        let pp = Group.pp P.pp
+        let module_name = make_name "Group"
+      end)
+  end
+
+  module Partition = struct
+    type t = node partition
+    include Printable(struct
+        type nonrec t = t
+        let pp = Partition.pp P.pp
+        let module_name = make_name "Partition"
+      end)
+  end
+
+  module Path = struct
+    type t = node path
+    include Printable(struct
+        type nonrec t = t
+        let pp = Path.pp P.pp
+        let module_name = make_name "Path"
+      end)
+  end
+
+  module Bool = Printable_graph(struct
+      module G = Make(P)(Bool)
+      let pp_node = P.pp
+      let pp_edge ppf x = fprintf ppf "%c" (if x then 't' else 'f')
+      let module_name = make_name "Bool"
+    end)
+
+  module Char = Printable_graph(struct
+      module G = Make(P)(Char)
+      let pp_node = P.pp
+      let pp_edge = Char.pp
+      let module_name = make_name "Char"
+    end)
+
+  module Unit = Printable_graph(struct
+      module G = Make(P)(Unit)
+      let pp_node = P.pp
+      let pp_edge _ _ = ()
+      let module_name = make_name "Unit"
+    end)
+
+  module Value = Printable_graph(struct
+      module G = Make(P)(Bap_value)
+      let pp_node = P.pp
+      let pp_edge = Bap_value.pp
+      let module_name = make_name "Value"
+    end)
+
+  module Word = Printable_graph(struct
+      module G = Make(P)(Bitvector)
+      let pp_node = P.pp
+      let pp_edge = Bitvector.pp
+      let module_name = make_name "Word"
+    end)
+
+  module Int = Printable_graph(struct
+      module G = Make(P)(Int)
+      let pp_node = P.pp
+      let pp_edge = Int.pp
+      let module_name = make_name "Int"
+    end)
+
+  module String = Printable_graph(struct
+      module G = Make(P)(String)
+      let pp_node = P.pp
+      let pp_edge = String.pp
+      let module_name = make_name "String"
+    end)
+
+  module Var = Printable_graph(struct
+      module G = Make(P)(Bap_var)
+      let pp_node = P.pp
+      let pp_edge = Bap_var.pp
+      let module_name = make_name "Var"
+    end)
+
+  module RExp = struct
+    module G = Make(P)(struct type t = exp include Bap_exp end)
+    let pp_node = P.pp
+    let pp_edge = Bap_exp.pp
+    let module_name = make_name "Exp"
+  end
+  module Exp = Printable_graph(RExp)
+
+  module RStmt = struct
+    module G = Make(P)(struct type t = stmt include Bap_stmt end)
+    let pp_node = P.pp
+    let pp_edge = Bap_stmt.pp
+    let module_name = make_name "Stmt"
+  end
+
+  module Stmt = Printable_graph(RStmt)
+
+  module RType = struct
+    module G = Make(P)(struct type t = typ include Bap_type end)
+    let pp_node = P.pp
+    let pp_edge = Bap_type.pp
+    let module_name = make_name "Type"
+  end
+
+  module Type = Printable_graph(RType)
+
+  module Tid = Printable_graph(struct
+      module G = Make(P)(Bap_ir.Tid)
+      let pp_node = P.pp
+      let pp_edge = Bap_ir.Tid.pp
+      let module_name = make_name "Tid"
+    end)
+end
+
+module PChar = struct include Char let name = "Char" end
+module PInt = struct include Int let name = "Int" end
+module PValue = struct include Bap_value let name = "Value" end
+module PString = struct include String let name = "String" end
+module PWord = struct include Bitvector let name = "Word" end
+module PVar = struct include Bap_var let name = "Var" end
+module PExp = struct type t = exp include Bap_exp let name = "Exp" end
+module PStmt = struct type t = stmt include Bap_stmt let name = "Stmt" end
+module PTid = struct include Bap_ir.Tid let name = "Tid" end
+module PType = struct type t = typ include Bap_type let name = "Type" end
+
+module Char = Make_factory(PChar)
+module Int = Make_factory(PInt)
+module Value = Make_factory(PValue)
+module Word = Make_factory(PWord)
+module String = Make_factory(PString)
+module Var = Make_factory(PVar)
+module Exp = Make_factory(PExp)
+module Stmt = Make_factory(PStmt)
+module Tid  = Make_factory(PTid)
+module Type = Make_factory(PType)

--- a/lib/bap_types/bap_graph_regular.mli
+++ b/lib/bap_types/bap_graph_regular.mli
@@ -1,0 +1,23 @@
+open Core_kernel.Std
+open Bap_common
+open Bap_graph_intf
+open Bap_graph
+open Bap_bil
+open Bap_graph_regular_intf
+
+module Make(Node : Opaque)(Edge : Opaque) : Graph
+  with type node = Node.t
+   and type Node.label = Node.t
+   and type Edge.label = Edge.t
+
+
+module Char   : S with type node = char
+module Int    : S with type node = int
+module Word   : S with type node = word
+module Type   : S with type node = typ
+module Value  : S with type node = Bap_value.t
+module String : S with type node = string
+module Var    : S with type node = var
+module Exp    : S with type node = exp
+module Stmt   : S with type node = stmt
+module Tid    : S with type node = Bap_ir.tid

--- a/lib/bap_types/bap_graph_regular_intf.ml
+++ b/lib/bap_types/bap_graph_regular_intf.ml
@@ -1,0 +1,54 @@
+open Bap_common
+open Bap_graph_intf
+open Bap_graph
+open Bap_bil
+
+module type S = sig
+  type node
+  module Bool : Graph with type node = node
+                       and type Node.label = node
+                       and type Edge.label = bool
+  module Char : Graph with type node = node
+                       and type Node.label = node
+                       and type Edge.label = char
+  module Unit : Graph with type node = node
+                       and type Node.label = node
+                       and type Edge.label = unit
+  module Value : Graph with type node = node
+                        and type Node.label = node
+                        and type Edge.label = Bap_value.t
+  module Word : Graph with type node = node
+                       and type Node.label = node
+                       and type Edge.label = word
+  module Int : Graph with type node = node
+                      and type Node.label = node
+                      and type Edge.label = int
+  module String : Graph with type node = node
+                         and type Node.label = node
+                         and type Edge.label = string
+  module Exp : Graph with type node = node
+                      and type Node.label = node
+                      and type Edge.label = exp
+
+  module Stmt : Graph with type node = node
+                       and type Node.label = node
+                       and type Edge.label = stmt
+
+  module Var : Graph with type node = node
+                      and type Node.label = node
+                      and type Edge.label = var
+
+  module Tid : Graph with type node = node
+                      and type Node.label = node
+                      and type Edge.label = Bap_ir.tid
+
+  module Type : Graph with type node = node
+                       and type Node.label = node
+                       and type Edge.label = typ
+
+  module Tree : Printable with type t = node tree
+  module Frontier : Printable with type t = node frontier
+  module Path : Printable with type t = node path
+  module Partition : Printable with type t = node partition
+  module Group : Printable with type t = node group
+end

--- a/lib/bap_types/bap_helpers.ml
+++ b/lib/bap_types/bap_helpers.ml
@@ -114,7 +114,8 @@ include struct
         | (PLUS|LSHIFT|RSHIFT|ARSHIFT|OR|XOR), Int v, e
         | (PLUS|MINUS|LSHIFT|RSHIFT|ARSHIFT|OR|XOR), e, Int v
           when Word.is_zero v -> e
-        | TIMES,e,Int v | TIMES, Int v, e when Word.is_one v -> e
+        | (TIMES|AND),e,Int v
+        | (TIMES|AND), Int v, e when Word.is_one v -> e
         | (TIMES|AND), e, Int v
         | (TIMES|AND), Int v, e when Word.is_zero v -> Int v
         | (OR|AND), v1, v2 when equal v1 v2 -> v1

--- a/lib/bap_types/bap_ir_graph.ml
+++ b/lib/bap_types/bap_ir_graph.ml
@@ -1,0 +1,458 @@
+open Core_kernel.Std
+open Bap_graph
+open Bap_ir
+open Bap_common
+open Bap_bil
+open Option.Monad_infix
+
+module Jmp = Ir_jmp
+module Blk = Ir_blk
+module Sub = Ir_sub
+module Seq = struct
+  include Sequence
+  include Bap_seq
+end
+type 'a seq = 'a Seq.t
+
+module Pred = struct
+  type t = Tid.Set.t Tid.Map.t with bin_io, compare, sexp
+  (** [remove src dst preds] remove a predecessor [src] from
+      a set of predecessors of [dst] *)
+  let remove src dst rdep =
+    Map.change rdep dst (function
+        | None -> None
+        | Some xs -> Some (Set.remove xs src))
+
+  let remove_all src rdep =
+    Map.map rdep ~f:(Set.filter ~f:(fun id -> id <> src))
+
+  let insert src dst rdep =
+    Map.change rdep dst (function
+        | None -> Some (Tid.Set.singleton src)
+        | Some xs -> Some (Set.add xs src))
+end
+
+(* internal representation of a graph:
+   sub is the program itself
+   preds is a mapping from a node to its predcessors,
+   that is used to speed up backward processing.*)
+type t = {
+  preds : Pred.t;
+  sub  : sub term;
+} with bin_io, compare, sexp
+
+type node = blk term with bin_io, compare, sexp
+
+type edge = {
+  src : blk term;
+  dst : blk term;
+  pos : int;
+} with bin_io, compare, sexp
+
+let empty_sub = Sub.create ()
+
+(** extracts a successor's tid from a jump term  *)
+let succ_tid_of_jmp jmp : tid option = match Jmp.kind jmp with
+  | Goto (Direct tid) -> Some tid
+  | Int (_,tid) -> Some tid
+  | Call t -> Option.(Call.return t >>= function
+    | Direct tid -> Some tid
+    | _ -> None)
+  | _ -> None
+
+let succ_of_jmp sub jmp =
+  match succ_tid_of_jmp jmp with
+  | Some tid -> Term.find blk_t sub tid
+  | _ -> None
+
+let succs_of_blk blk =
+  Term.enum jmp_t blk |> Seq.filter_map ~f:succ_tid_of_jmp
+
+type difference_kind =
+  | Target_change of tid * tid
+  | New_jmp of tid
+  | Del_jmp of tid
+with variants,sexp
+
+let jmp_set b = Term.enum jmp_t b |> Seq.map ~f:Term.tid |>
+                Seq.fold ~init:Tid.Set.empty ~f:Set.add
+
+(** [control_flow_difference bx by] computes a changes in control flow
+    produced by blocks [bx] and [by]. Only changes, that affects graph
+    toplogy are computed, i.e., change in a condition expression, or
+    change of the order doesn't affect the topology.  If jump kind is
+    changed form local (goto) to some non-local, then it will be
+    removed from the set of edges. *)
+let control_flow_difference bx by =
+  let (jxs,jys) = (jmp_set bx, jmp_set by) in
+  let news = Set.diff jys jxs in
+  let dels = Set.diff jxs jys in
+  let coms = Set.inter jxs jys in
+  let to_changes kind b js =
+    let succ j = Term.find_exn jmp_t b j |> succ_tid_of_jmp in
+    Set.to_list js |> List.filter_map ~f:succ |> List.map ~f:kind in
+  let dels = to_changes del_jmp bx dels in
+  let news = to_changes new_jmp by news in
+  Set.fold coms ~init:(news @ dels) ~f:(fun changes id ->
+      let jx = Term.find_exn jmp_t bx id in
+      let jy = Term.find_exn jmp_t by id in
+      match succ_tid_of_jmp jx, succ_tid_of_jmp jy with
+      | None,_ -> changes
+      | _,None -> del_jmp id :: changes
+      | Some tx, Some ty ->
+        if Tid.(tx = ty) then changes
+        else target_change tx ty :: changes)
+
+let blocks_of_tids sub ts =
+  Set.to_sequence ts |> Seq.map ~f:(Term.find_exn blk_t sub)
+
+module Node = struct
+  type label = node
+  type graph = t
+  type t = node
+  type nonrec edge = edge
+
+  let create = ident
+
+  let label = ident
+
+  let succs blk t : node seq =
+    Term.enum jmp_t blk |>
+    Seq.filter_map ~f:(succ_of_jmp t.sub)
+
+  let preds blk t : node seq =
+    match Map.find t.preds (Term.tid blk) with
+    | None -> Seq.empty
+    | Some ts -> blocks_of_tids t.sub ts
+
+  let inputs dst t = match Map.find t.preds (Term.tid dst) with
+    | None -> Seq.empty
+    | Some ps ->
+      blocks_of_tids t.sub ps |> Seq.concat_map ~f:(fun src ->
+          Term.enum jmp_t src |> Seq.filter_mapi ~f:(fun pos jmp ->
+              match succ_tid_of_jmp jmp with
+              | None -> None
+              | Some tid when tid <> Term.tid dst -> None
+              | Some tid -> Some {src; pos; dst}))
+
+  let outputs src t : edge seq =
+    Term.enum jmp_t src |> Seq.filter_mapi ~f:(fun pos jmp ->
+        succ_of_jmp t.sub jmp >>| fun dst -> {src; pos; dst})
+
+  let update blk' t =
+    let bid = Term.tid blk' in
+    match Term.find blk_t t.sub bid with
+    | None -> t
+    | Some blk ->
+      let sub = Term.update blk_t t.sub blk' in
+      match control_flow_difference blk blk' with
+      | [] -> {t with sub}
+      | ds -> List.fold ~init:{t with sub} ds ~f:(fun t -> function
+          | New_jmp dst -> {t with preds = Pred.insert bid dst t.preds}
+          | Del_jmp dst -> {t with preds = Pred.remove bid dst t.preds}
+          | Target_change (tx,ty) ->
+            t.preds |>
+            Pred.remove bid tx |>
+            Pred.insert bid ty |> fun preds -> {t with preds})
+
+  let change update f blk t = {
+    sub = Term.change blk_t t.sub (Term.tid blk) (fun _ -> update blk);
+    preds = succs_of_blk blk |>
+            Seq.fold ~init:t.preds
+              ~f:(fun preds dst -> f (Term.tid blk) dst preds)
+  }
+
+  let update_preds f blk t =
+    succs_of_blk blk |>
+    Seq.fold ~init:t.preds
+      ~f:(fun preds dst -> f (Term.tid blk) dst preds)
+
+  let insert blk t : graph =
+    let sub = if Sub.(t.sub = empty_sub)
+      then Sub.create () else t.sub in
+    {
+      preds = update_preds Pred.insert blk t;
+      sub = Term.append blk_t sub blk;
+    }
+
+  let remove blk t =
+    let sub = Term.remove blk_t t.sub (Term.tid blk) |>
+              Term.map blk_t ~f:(fun src ->
+                  Term.filter jmp_t src ~f:(fun jmp ->
+                      match succ_tid_of_jmp jmp with
+                      | None -> true
+                      | Some dst -> dst <> Term.tid blk)) in
+    let preds = Pred.remove_all (Term.tid blk) t.preds in
+    {sub; preds}
+
+
+  let mem blk t = Map.mem t.preds (Term.tid blk)
+
+  let upsert blk t =
+    if mem blk t then update blk t else insert blk t
+
+  let edges src dst t : edge seq =
+    inputs dst t |> Seq.filter ~f:(fun e -> Term.same e.src src)
+
+  let edge src dst t : edge option =
+    edges src dst t |> Seq.hd
+
+  (* can be defined as [let mem t s d = find t s d <> None],
+     but the following would be more efficient. *)
+  let has_edge src dst t : bool =
+    Map.find t.preds (Term.tid dst) |> function
+    | None -> false
+    | Some ps -> Set.mem ps (Term.tid src)
+
+  include Regular.Make(struct
+      type t = blk term with bin_io, sexp
+      let compare x y = Term.(Tid.compare (tid x) (tid y))
+      let pp = Blk.pp
+      let hash x = Tid.hash (Term.tid x)
+      let module_name = Some "Bap.Std.Graphlib.Ir.Node"
+    end)
+
+end
+
+module Edge = struct
+  type label = int
+  type nonrec node = node
+  type graph = t
+  type t = edge with compare
+
+  let null = Exp.Int Bitvector.b0
+  let dummy = Jmp.create_goto ~cond:null (Label.indirect null)
+
+  let insert_jmp src pos dst =
+    let n = Term.length jmp_t src - pos in
+    let src = Fn.apply_n_times ~n
+        (fun b -> Term.append jmp_t b dummy) src in
+    let jmp = Jmp.create_goto (Label.direct (Term.tid dst)) in
+    {src = Term.append jmp_t src jmp; dst; pos}
+
+  let create src dst pos : edge =
+    let tid = Term.tid dst in
+    match Term.nth jmp_t src pos with
+    | None -> insert_jmp src pos dst
+    | Some jmp -> match succ_tid_of_jmp jmp with
+      | Some id when Tid.equal id tid -> {src; dst; pos}
+      | _ ->
+        let src = Term.change jmp_t src (Term.tid jmp) (fun _ ->
+            Some (Jmp.create_goto (Label.direct tid))) in
+        {src; dst; pos}
+
+  let label e : label = e.pos
+  let src e = e.src
+  let dst e = e.dst
+
+  (* this implementation is O(N), where N is the amount of blocks.
+     We can't do better unless we provide more bookkeeping.  *)
+  let mem e g = match Term.find blk_t g.sub (Term.tid e.src) with
+    | None -> false
+    | Some src -> match Term.nth jmp_t src e.pos with
+      | None -> false
+      | Some jmp -> match succ_tid_of_jmp jmp with
+        | None -> false
+        | Some id -> Tid.equal id (Term.tid e.dst)
+
+
+  let jmps_before e src =
+    Seq.take (Term.enum jmp_t src) e.pos
+
+  let jmps_after e src =
+    Seq.drop (Term.enum jmp_t src) (e.pos + 1)
+
+  let jmps dir e g =
+    match Term.find blk_t g.sub (Term.tid e.src) with
+    | None -> Seq.empty
+    | Some src -> match dir with
+      | `after -> jmps_after e src
+      | `before -> jmps_before e src
+
+  let edges dir e g =
+    jmps dir e g |> Seq.filter_mapi ~f:(fun pos jmp ->
+        match succ_tid_of_jmp jmp with
+        | None -> None
+        | Some _ -> Some {e with pos})
+
+  let jmp e = Term.nth_exn jmp_t e.src e.pos
+
+  let tid e = Term.tid (jmp e)
+
+  let simpl = Bap_helpers.Exp.(fixpoint fold_consts)
+
+  let cond e g =
+    jmps `before e g |>
+    Seq.fold ~init:(Jmp.cond (jmp e)) ~f:(fun cond jmp ->
+        let c = Exp.UnOp (Unop.NOT, Jmp.cond jmp) in
+        Exp.BinOp (Binop.AND,cond,c)) |> simpl
+
+  let insert e t = Node.(upsert e.dst t |> upsert e.src)
+
+  let update e t = Node.(update e.dst t |> update e.src)
+
+  let cut_tail pos blk =
+    let b = Blk.Builder.init ~copy_phis:true ~copy_defs:true blk in
+    Term.enum jmp_t blk |> Seq.iteri ~f:(fun i jmp ->
+        if i < pos then Blk.Builder.add_jmp b jmp);
+    Blk.Builder.result b
+
+  let make_dummy jmp blk =
+    Term.change jmp_t blk (Term.tid jmp) (fun _ -> Some dummy)
+
+  let tail_length blk =
+    with_return (fun {return} ->
+        Term.enum ~rev:true jmp_t blk |>
+        Seq.fold ~init:0 ~f:(fun len jmp ->
+            if Term.same jmp dummy then (len + 1)
+            else return len))
+
+  let remove e t =
+    match Term.find blk_t t.sub (Term.tid e.src) with
+    | None -> t
+    | Some src ->
+      let len = Term.length jmp_t src in
+      let src = match Term.nth jmp_t src e.pos with
+        | None -> src
+        | Some jmp -> make_dummy jmp src in
+      let n = tail_length src in
+      let src = if n = 0 then src else cut_tail (len - n) src in
+      Node.update src t
+
+  include Regular.Make(struct
+      type t = edge with bin_io, compare, sexp
+      let module_name = Some "Bap.Std.Graphlib.Ir.Edge"
+      let hash t = Blk.hash t.src lxor Blk.hash t.dst
+      let pp ppf x =
+        Option.iter (Term.nth jmp_t x.src x.pos) ~f:(Jmp.pp ppf)
+    end)
+end
+
+let empty = {
+  sub = Sub.create ();
+  preds = Tid.Map.empty;
+}
+
+let create ?tid ?name () = {
+  empty with
+  sub = Sub.create ?tid ?name ();
+}
+
+let nodes t = Term.enum blk_t t.sub
+
+let edges t =
+  nodes t |> Seq.concat_map ~f:(fun src -> Node.outputs src t)
+
+let number_of_edges t =
+  Seq.(Map.to_sequence t.preds >>| snd |>
+       sum (module Int) ~f:Set.length)
+
+
+let number_of_nodes t = Term.length blk_t t.sub
+
+let preds_of_sub sub : Tid.Set.t Tid.Map.t =
+  Term.enum blk_t sub |>
+  Seq.fold ~init:Tid.Map.empty ~f:(fun ins src ->
+      let src_id = Term.tid src in
+      Term.enum jmp_t src |>
+      Seq.fold ~init:ins ~f:(fun ins jmp ->
+          match succ_tid_of_jmp jmp with
+          | None -> ins
+          | Some tid -> Map.change ins tid (function
+              | None -> Some (Tid.Set.singleton src_id)
+              | Some set -> Some (Set.add set src_id))))
+
+let of_sub sub = {
+  preds = preds_of_sub sub;
+  sub;
+}
+
+let to_sub t = t.sub
+
+let compare x y = Sub.compare x.sub y.sub
+
+let is_directed = true
+
+include Regular.Make(struct
+    type nonrec t = t with bin_io, compare, sexp
+    let module_name = Some "Bap.Std.Graphlib.Ir"
+    let hash g = Sub.hash g.sub
+    let pp ppf g =
+      let open Bap_graph_pp in
+      let node_label blk =
+        let open Bap_ir in
+        let phis =
+          Term.enum phi_t blk |> Seq.map ~f:Ir_phi.to_string in
+        let defs =
+          Term.enum def_t blk |> Seq.map ~f:Ir_def.to_string in
+        let jmps =
+          Term.enum jmp_t blk |> Seq.filter_map ~f:(fun jmp ->
+              match Jmp.kind jmp with
+              | Call _ | Ret _ | Int (_,_) -> Some (Jmp.to_string jmp)
+              | Goto _ -> match succ_tid_of_jmp jmp with
+                | None -> Some (Jmp.to_string jmp)
+                | Some _ -> None) in
+        let lines =
+          List.concat @@ List.map [phis; defs; jmps] ~f:Seq.to_list in
+        let body = String.concat lines |> String.concat_map
+                     ~f:(function '\n' -> "\\l"
+                                | c -> Char.to_string c) in
+        sprintf "%s\n%s" (Term.name blk) body in
+      let string_of_node b = sprintf "%s" (Term.name b) in
+      let edge_label e = match Edge.cond e g with
+        | Exp.Int w when Bitvector.is_one w -> ""
+        | exp -> Bap_exp.to_string exp  in
+      let nodes_of_edge e = Edge.(src e, dst e) in
+      Dot.pp_graph
+        ~attrs:["node[shape=box]"]
+        ~string_of_node ~node_label ~edge_label
+        ~nodes_of_edge ~nodes:(nodes g) ~edges:(edges g) ppf
+  end)
+
+let pp_blk ppf blk = Format.fprintf ppf "\"%a\"" Tid.pp (Term.tid blk)
+
+module Tree = struct
+  type t = blk term tree
+  include Printable(struct
+      type nonrec t = t
+      let pp = Tree.pp pp_blk
+      let module_name = Some "Bap.Std.Graphlib.Ir.Tree"
+    end)
+end
+
+module Frontier = struct
+  type t = blk term frontier
+  include Printable(struct
+      type nonrec t = t
+      let pp = Frontier.pp pp_blk
+      let module_name = Some "Bap.Std.Graphlib.Ir.Frontier"
+    end)
+end
+
+
+module Group = struct
+  type t = blk term group
+  include Printable(struct
+      type nonrec t = t
+      let pp = Group.pp pp_blk
+      let module_name = Some "Bap.Std.Graphlib.Ir.Group"
+    end)
+end
+
+module Partition = struct
+  type t = blk term partition
+  include Printable(struct
+      type nonrec t = t
+      let pp = Partition.pp pp_blk
+      let module_name = Some "Bap.Std.Graphlib.Ir.Partition"
+    end)
+end
+
+module Path = struct
+  type t = node path
+  include Printable(struct
+      type nonrec t = t
+      let pp = Path.pp pp_blk
+      let module_name = Some "Bap.Std.Graphlib.Ir.Path"
+    end)
+end

--- a/lib/bap_types/bap_ir_graph.mli
+++ b/lib/bap_types/bap_ir_graph.mli
@@ -1,0 +1,54 @@
+open Core_kernel.Std
+open Bap_common
+open Bap_bil
+open Bap_ir
+open Bap_graph_intf
+open Bap_graph
+
+(* this module implements a graph structure on top of
+   sub term. This is not a control flow graph, just a
+   regular graph (no entry or exit node requirements
+   are requested) *)
+
+type t
+type edge
+
+module Edge : sig
+  include Edge with type graph = t
+                and type node = blk term
+                and type t = edge
+
+  val jmps  : [`after | `before] -> t -> graph -> jmp term Sequence.t
+  val edges : [`after | `before] -> t -> graph -> t Sequence.t
+  val jmp : t -> jmp term
+  val tid : t -> tid
+  val cond : t -> graph -> exp
+
+  include Printable with type t := t
+end
+
+module Node : sig
+  include Node with type graph = t
+                and type t = blk term
+                and type edge = edge
+                and type label = blk term
+  include Printable with type t := t
+end
+
+include Graph with type t := t
+               and type node = blk term
+               and type edge := edge
+               and type Node.label = blk term
+               and module Node := Node
+               and module Edge := Edge
+
+val create : ?tid:tid -> ?name:string -> unit -> t
+val of_sub : sub term -> t
+val to_sub : t -> sub term
+
+
+module Tree : Printable with type t = node tree
+module Frontier : Printable with type t = node frontier
+module Path : Printable with type t = node path
+module Partition : Printable with type t = node partition
+module Group : Printable with type t = node group

--- a/lib/bap_types/bap_opaque.ml
+++ b/lib/bap_types/bap_opaque.ml
@@ -1,0 +1,21 @@
+open Core_kernel.Std
+open Bap_regular
+
+module type S = sig
+  type t
+  include Comparable with type t := t
+  include Hashable with type t := t
+end
+
+module Make(M : sig
+    type t with compare
+    val hash : t -> int
+  end) = struct
+  module M = struct
+    include M
+    let sexp_of_t = sexp_of_opaque
+    let t_of_sexp = opaque_of_sexp
+  end
+  include Comparable.Make(M)
+  include Hashable.Make(M)
+end

--- a/lib/bap_types/bap_regular.mli
+++ b/lib/bap_types/bap_regular.mli
@@ -20,10 +20,10 @@ module Make(M : sig
     type t with bin_io, sexp, compare
     include Pretty_printer.S with type t := t
     val hash : t -> int
-    val module_name : string
+    val module_name : string option
   end ) : S with type t := M.t
 
 module Printable(M : sig
     include Pretty_printer.S
-    val module_name : string
+    val module_name : string option
   end) : Printable with type t := M.t

--- a/lib/bap_types/bap_seq.ml
+++ b/lib/bap_types/bap_seq.ml
@@ -20,6 +20,20 @@ let is_empty : 'a seq -> bool = length_is_bounded_by ~max:0
 
 let filter s ~f = filteri s ~f:(fun _ x -> f x)
 
+(* honestly stolen from newer core_kernel, to
+   get compatiblity with older library versions *)
+let compare compare_a t1 t2 =
+  with_return (fun r ->
+      iter (zip_full t1 t2) ~f:(function
+          | `Left _        -> r.return 1
+          | `Right _       -> r.return (-1)
+          | `Both (v1, v2) ->
+            let c = compare_a v1 v2 in
+            if c <> 0
+            then r.return c);
+      0);
+
+
 module Export = struct
   let (^::) = cons
 end

--- a/lib/bap_types/bap_seq.mli
+++ b/lib/bap_types/bap_seq.mli
@@ -10,6 +10,7 @@ val is_empty : 'a seq -> bool
 
 (** for compatibility with Core kernel < 111.28  *)
 val filter : 'a seq -> f:('a -> bool) -> 'a seq
+val compare : ('a -> 'b -> int) -> 'a seq -> 'b seq -> int
 
 module Export : sig
   val (^::) : 'a -> 'a seq -> 'a seq

--- a/lib/bap_types/bap_size.ml
+++ b/lib/bap_types/bap_size.ml
@@ -52,7 +52,7 @@ module T = struct
   open Format
 
   type t = size with bin_io, compare, sexp
-  let module_name = "Bap.Std.Size"
+  let module_name = Some "Bap.Std.Size"
 
   let pp fmt n =
     fprintf fmt "u%u" (to_bits n)

--- a/lib/bap_types/bap_stmt.ml
+++ b/lib/bap_types/bap_stmt.ml
@@ -50,7 +50,7 @@ end
 include Regular.Make(struct
     type t = Bap_bil.stmt with bin_io, compare, sexp
     let hash = Hashtbl.hash
-    let module_name = "Bap.Std.Stmt"
+    let module_name = Some "Bap.Std.Stmt"
     let pp = pp
   end)
 
@@ -59,6 +59,6 @@ module Stmts_pp = struct
   include Printable(struct
       type nonrec t = t
       let pp = pp_stmts
-      let module_name = "Bap.Std.Bil"
+      let module_name = Some "Bap.Std.Bil"
     end)
 end

--- a/lib/bap_types/bap_type.ml
+++ b/lib/bap_types/bap_type.ml
@@ -6,7 +6,7 @@ open Type
 
 module T = struct
   type t = typ with bin_io, compare, sexp
-  let module_name = "Bap.Std.Type"
+  let module_name = Some "Bap.Std.Type"
 
   let pp fmt = function
     | Imm n -> fprintf fmt "u%u" n

--- a/lib/bap_types/bap_types.ml
+++ b/lib/bap_types/bap_types.ml
@@ -16,9 +16,11 @@ module Std = struct
   module Regular = Regular
   module Integer = Integer
   module Printable = Printable
+  module Opaque = Opaque
   module Trie = Trie
 
   module type Regular = Regular
+  module type Opaque = Opaque
   module type Integer = Integer
   module type Printable = Printable
   module type Trie = Trie

--- a/lib/bap_types/bap_value.ml
+++ b/lib/bap_types/bap_value.ml
@@ -41,7 +41,7 @@ module Typeid = struct
       include Sexp
       include Stringable
       let hash = Hashtbl.hash
-      let module_name = "Bap.Std.Value.Typeid"
+      let module_name = Some "Bap.Std.Value.Typeid"
       let pp ppf t = Uuidm.print ppf t
     end)
   include Uuidm
@@ -203,5 +203,5 @@ include Regular.Make(struct
     let pp ppf v = match typeof v with
       | Some t -> t.pp ppf v
       | None -> Format.fprintf ppf "<poly>"
-    let module_name = "Bap.Std.Value"
+    let module_name = Some "Bap.Std.Value"
   end)

--- a/lib/bap_types/bap_var.ml
+++ b/lib/bap_types/bap_var.ml
@@ -19,7 +19,7 @@ module T = struct
   } with sexp, bin_io,compare
 
   let hash v = String.hash v.var
-  let module_name = "Bap.Std.Var"
+  let module_name = Some "Bap.Std.Var"
 
   let pp fmt v =
     Format.fprintf fmt "%s%s" v.var

--- a/lib/bap_types/conceval.ml
+++ b/lib/bap_types/conceval.ml
@@ -20,7 +20,7 @@ module T = struct
   and memory = t Mem.t
   with bin_io, compare, sexp
 
-  let module_name = "Bap.Std.Conceval"
+  let module_name = Some "Bap.Std.Conceval"
   let hash = Hashtbl.hash
 
   open Format

--- a/lib_test/.merlin
+++ b/lib_test/.merlin
@@ -13,3 +13,4 @@ S bap_elf
 S bap_image
 S bap_types
 S bap_sema
+PKG oUnit

--- a/lib_test/bap/run_tests.ml
+++ b/lib_test/bap/run_tests.ml
@@ -4,6 +4,7 @@ let suite =
   "BAP" >::: [
     Test_bitvector.suite;
     Test_conceval.suite;
+    Test_graph.suite;
     Test_image.suite;
     Test_table.suite;
     Test_memmap.suite;

--- a/lib_test/bap_types/test_graph.ml
+++ b/lib_test/bap_types/test_graph.ml
@@ -1,0 +1,489 @@
+(*
+
+  This tests are based on Theorems and Lemmas from [1].
+
+
+  [1]: Offner, Carl D. "Notes on graph algorithms used in optimizing
+  compilers." Notes from University of Massachusetts, Boston (2013).
+
+ *)
+
+open Core_kernel.Std
+open Bap.Std
+open OUnit2
+open Format
+
+(** required interface for functor testing different algorithm  *)
+module type Graph_for_algo = Graph
+  with type Node.label = int
+   and type Edge.label = unit
+
+module Test_algo(Gl : Graph_for_algo) = struct
+  module G = Graphlib.To_ocamlgraph(Gl)
+  module Rand = Graph.Rand.P(G)
+  module Dom = Graph.Dominator.Make(G)
+
+  module Node = Gl.Node
+  module Edge = Gl.Edge
+
+  let node = Gl.Node.create
+  let edge x y = Gl.Edge.create (node x) (node y) ()
+  let node_printer x = sprintf "%d" @@ Gl.Node.label x
+
+
+  type node_info = {
+    enter : int;
+    leave : int;
+    rpost : int;
+    pre   : int;
+  }
+
+  let empty = {
+    enter = -1;
+    leave = -1;
+    rpost = -1;
+    pre   = -1;
+  }
+
+  (* collects timestamps (time of entry, and time of leaving of a node,
+     as well as preorder and reverse post order ordinals.  Lemma 1.2 is
+     checked in a process of collecting. Also, some asserts based on
+     definitions are also checked.  @return total time, spent in
+     traversing, and a mapping from nodes to their numbering info.
+     Note: time is incremented by any of the following events:
+     enter_node, leave_node. Edges events are ignored. *)
+  let timestamps ty gr : int * ('n,node_info,_) Map.t =
+    Graphlib.depth_first_search ty gr ~init:(0,Node.Map.empty)
+      ~enter_node:(fun pre node (time,stamps) ->
+          time + 1, Map.change stamps node @@ function
+          | None -> Some {empty with pre; enter = time}
+          | _ -> assert_failure "Node was entered several times")
+      ~leave_node:(fun rpost node (time,stamps) ->
+          time + 1, Map.change stamps node @@ function
+          | None -> assert_failure "Node was left without entering"
+          | Some info ->
+            assert_bool "Lemma 1.2: entry[x] < leave[x]" @@
+            (info.enter < time);
+            Some {info with rpost; leave = time})
+
+  module Span = struct
+    type t = {
+      children : Node.Set.t Node.Map.t;
+      iparents : Node.t Node.Map.t;
+    }
+
+    let empty = {
+      children = Node.Map.empty;
+      iparents = Node.Map.empty;
+    }
+
+    let add_relation t ~parent ~child = {
+      children = Map.change t.children parent( function
+          | None -> Some (Node.Set.singleton child)
+          | Some cs when Set.mem cs child ->
+            assert_failure "Child was already adopted"
+          | Some cs -> Some (Set.add cs child));
+      iparents = Map.change t.iparents child @@ function
+        | None -> Some parent
+        | Some parent -> assert_failure "Child has more than one parent";
+    }
+
+    let children t parent = match Map.find t.children parent with
+      | None -> Node.Set.empty
+      | Some children -> children
+
+    let parent t child = Map.find t.iparents child
+
+    (* computes a set of all descendands of a given parent
+       (transitive closure) *)
+    let rec descendants t parent =
+      (* according to [1] each node is descendant of itself. *)
+      let init = Node.Set.singleton parent in
+      Set.fold (children t parent) ~init ~f:(fun ds parent ->
+          Set.union ds (descendants t parent))
+
+    (* computes a set of all ancestors. *)
+    let ancestors t child =
+      let rec loop parents child = match parent t child with
+        | None -> parents
+        | Some parent -> loop (Set.add parents parent) parent in
+      loop Node.Set.empty child
+  end
+
+  let build_tree g =
+    Graphlib.depth_first_search (module Gl) g ~init:Span.empty
+      ~enter_edge:(fun kind edge tree -> match kind with
+          | `Tree -> Span.add_relation tree
+                       ~parent:(Edge.src edge)
+                       ~child:(Edge.dst edge)
+          | _ -> tree)
+
+  let lemma_1_3 stamps ctxt : bool =
+    let is_sorted = List.is_sorted ~compare:Int.compare in
+    let nodes = Map.to_sequence stamps in
+    Seq.cartesian_product nodes nodes |>
+    Seq.for_all ~f:(fun ((_,x),(_,y)) ->
+        is_sorted [x.enter; x.leave; y.enter; y.leave] ||
+        is_sorted [x.enter; y.enter; y.leave; x.leave] ||
+        is_sorted [y.enter; x.enter; x.leave; y.leave] ||
+        is_sorted [y.enter; y.leave; x.enter; x.leave])
+
+
+  (** Lemma 1.4:
+      pre[x] < pre[y] && rpost[x] < rpost[y] <=> x `is_ancestor_of` y *)
+  let lemma_1_4 stamps tree ctxt : bool =
+    let prop x y = x.pre < y.pre && x.rpost < y.rpost in
+    let nodes = Map.to_sequence stamps in
+    Seq.cartesian_product nodes nodes |>
+    Seq.for_all ~f:(fun ((nx,x),(ny,y)) ->
+        prop x y ==> Set.mem (Span.ancestors tree ny) nx)
+    &&
+    Seq.for_all nodes ~f:(fun (ny,y) ->
+        Set.for_all (Span.ancestors tree ny) ~f:(fun nx ->
+            match Map.find stamps nx with
+            | None -> assert_failure "unstamped node"
+            | Some x -> prop x y))
+
+  let theorem_1_5 stamps graph ctxt : bool =
+    Graphlib.depth_first_search (module Gl) graph ~init:true
+      ~enter_edge:(fun kind e -> function
+          | false -> false
+          | true ->
+            let x = match Map.find stamps (Gl.Edge.src e) with
+              | None -> assert_failure "edge with unstamped src"
+              | Some x -> x in
+            let y = match Map.find stamps (Gl.Edge.dst e) with
+              | None -> assert_failure "edge with unstamped dst"
+              | Some y -> y in
+            match kind with
+            | `Back    -> x.pre >= y.pre && x.rpost >= y.rpost
+            | `Tree    -> x.pre < y.pre && x.rpost < y.rpost
+            | `Cross   -> x.pre > y.pre && x.rpost < y.rpost
+            | `Forward -> x.pre < y.pre && x.rpost < y.rpost)
+
+
+  let test g =
+    let time,stamps = timestamps (module Gl) g in
+    let tree = build_tree g in
+    assert_bool "Total time = |V|/2" (time / 2 = Gl.number_of_nodes g);
+    let test prep ctxt = assert_bool "doesn't hold" (prep ctxt) in
+    [
+      "L 1.3" >:: test @@ lemma_1_3 stamps;
+      "L 1.4" >:: test @@ lemma_1_4 stamps tree;
+      "T 1.5" >:: test @@ theorem_1_5 stamps g
+    ]
+
+  let random_graph () =
+    let v = Random.int (1 + 500) in
+    let e = v * 3 / 2 in
+    Rand.labeled (fun _ _ -> ()) ~loops:true ~e ~v ()
+
+  let randoms =
+    List.init 100 ~f:(fun n ->
+        sprintf "Graph.%d" n >::: test @@ random_graph ())
+
+  let random_flowgraph size =
+    let g =
+      Seq.range 0 size |> Seq.fold ~init:Gl.empty ~f:(fun g i ->
+          Gl.Node.insert (node i) g) in
+    let g =
+      Seq.range 0 (size-1) |> Seq.fold ~init:g ~f:(fun g i ->
+          Gl.Edge.insert (edge i (i+1)) g) in
+    Seq.range 0 size |> Seq.fold ~init:g ~f:(fun g i ->
+        if Random.float 1.0 < 0.3 then
+          let dst =
+            if Random.float 1.0 < 0.2
+            then Random.int (i + 1)
+            else i + Random.int (size - i) in
+          Gl.Edge.insert (edge i dst) g
+        else g)
+
+
+  let compare_dom gr ctxt =
+    let size = Gl.number_of_nodes gr in
+    let exp_idom = Dom.compute_idom gr (node 0) in
+    let dom_tree = Graphlib.dominators (module Gl) gr (node 0) in
+    let got_idom n = match Tree.parent dom_tree n with
+      | None -> assert_failure "child has no parents"
+      | Some p -> p in
+    Seq.range 1 size |> Seq.map ~f:node |> Seq.iter ~f:(fun n ->
+        assert_equal ~ctxt ~printer:node_printer
+          (exp_idom n) (got_idom n))
+
+  let compare_dom_frontier gr ctxt =
+    let idom = Graphlib.dominators (module Gl) gr (node 0) in
+    let dfrt =
+      Graphlib.dom_frontier (module Gl) gr idom in
+    let exp_idom = Dom.compute_idom gr (node 0) in
+    let dom_tree = Dom.idom_to_dom_tree gr exp_idom in
+    let exp_dfrt = Dom.compute_dom_frontier gr dom_tree exp_idom in
+    let set_of_frontier n = Frontier.enum dfrt n |>
+                            Seq.to_list_rev in
+    Seq.range 0 (Gl.number_of_nodes gr) |>
+    Seq.map ~f:node |>  Seq.iter ~f:(fun n ->
+        let exp = Node.Set.of_list (exp_dfrt n) in
+        let got = Node.Set.of_list (set_of_frontier n) in
+        assert_equal ~ctxt  ~cmp:Node.Set.equal exp got)
+
+  let compare_scc gr ctxt =
+    let scc = Graphlib.strong_components (module Gl) gr in
+    let module SCC = Graph.Components.Make(G) in
+    let _,comp_num = SCC.scc gr in
+    let our_equiv = Partition.equiv scc in
+    let exp_equiv x y = comp_num x = comp_num y in
+    Seq.cartesian_product (Gl.nodes gr) (Gl.nodes gr) |>
+    Seq.iter ~f:(fun (x,y) ->
+        assert_equal ~ctxt  ~printer:string_of_bool
+          (exp_equiv x y) (our_equiv x y))
+
+
+  let doms = List.init 100 ~f:(fun n ->
+      let size = 1 + Random.int 200 in
+      let gr = random_flowgraph size in
+      [
+        sprintf "Dom.%d" n >:: compare_dom gr;
+        sprintf "DomF.%d" n >:: compare_dom_frontier gr;
+        sprintf "Scc.%d" n >:: compare_scc gr;
+      ])
+
+  let suite name =
+    name >::: [
+      "Random Graphs" >::: randoms;
+      "Random Flow Graphs" >::: List.concat doms;
+    ]
+end
+
+
+module type Factory = sig
+  type t
+  val create : unit -> t
+  module E : Graph with type node = t and type Edge.label = t
+  module G : Graph with type node = t and type Edge.label = t
+end
+
+
+module Construction(Factory : Factory) = struct
+  open Factory
+  type graphs = E.t * G.t
+
+
+  (* we're using comparison function from G module as we do not trust
+     in the E module (it may be from ocamlgraph using the polymorphic
+     compare function) *)
+  module Nodes = G.Node.Set
+  module Edges = Set.Make(struct
+      type t = G.Node.t * G.Node.t * G.Node.t with compare
+      let sexp_of_t = sexp_of_opaque
+      let t_of_sexp = opaque_of_sexp
+    end)
+
+  let make_edges (type g)
+      (module G : Graph with type t = g
+                         and type node = t
+                         and type Edge.label = t) g =
+    G.edges g |> Seq.map ~f:(fun e ->
+        G.Edge.src e, G.Edge.dst e, G.Edge.label e) |>
+    Seq.fold ~init:Edges.empty ~f:Set.add
+
+  let compare e g : int =
+    let ees = make_edges (module E) e in
+    let ges = make_edges (module G) g in
+    match Edges.compare ees ges with
+    | 0 -> 0
+    | n ->
+      let set enum g =
+        enum g |> Seq.fold ~init:Nodes.empty ~f:Set.add in
+      Nodes.compare (set E.nodes e) (set G.nodes g)
+
+  let random_elt number enum e =
+    let n = number e in
+    if n > 0 then Seq.nth (enum e) (Random.int n)
+    else None
+
+  let random_node = random_elt E.number_of_nodes E.nodes
+  let random_edge = random_elt E.number_of_edges E.edges
+
+  let insert_edge (e,g) : graphs =
+    let src,dst,lab = Factory.(create (), create (), create ()) in
+    E.Edge.insert (E.Edge.create src dst lab) e,
+    G.Edge.insert (G.Edge.create src dst lab) g
+
+  let insert_node (e,g) : graphs =
+    let x = Factory.create () in
+    E.Node.insert x e,
+    G.Node.insert x g
+
+  let remove_node (e,g) : graphs =
+    match random_node e with
+    | None -> (e,g)
+    | Some n -> E.Node.remove n e, G.Node.remove n g
+
+  let remove_edge (e,g) : graphs =
+    match random_edge e with
+    | None -> (e,g)
+    | Some edge ->
+      let src = E.Edge.src edge in
+      let dst = E.Edge.dst edge in
+      let lab = E.Edge.label edge in
+      E.Edge.remove (E.Edge.create src dst lab) e,
+      G.Edge.remove (G.Edge.create src dst lab) g
+
+  let constructives = [insert_node; insert_edge]
+  let destructives  = [remove_node; remove_edge]
+
+  let constructive_scheme : (graphs -> graphs) list = List.concat [
+      constructives; constructives; destructives
+    ]
+
+  let validate (e,g) ctxt =
+    assert_bool "structures differ" (compare e g = 0)
+
+  let run (scheme : (graphs -> graphs) list) length ctxt =
+    let scheme = Array.of_list scheme in
+    let nextop g = scheme.(Random.int (Array.length scheme)) g in
+    let rec loop g = function
+      | 0 -> g
+      | n ->
+        validate g ctxt;
+        loop (nextop g) (n-1) in
+    loop (E.empty, G.empty) length |> ignore
+
+  let suite : test =
+    "constructive" >:: run constructive_scheme 1000
+end
+
+
+module ODIU =
+  Graphlib.Of_ocamlgraph(Graph.Persistent.Digraph.Concrete(Int))
+
+module OBIU =
+  Graphlib.Of_ocamlgraph
+    (Graph.Persistent.Digraph.ConcreteBidirectional(Int))
+
+module OBII =
+  Graphlib.Of_ocamlgraph
+    (Graph.Persistent.Digraph.ConcreteBidirectionalLabeled
+       (Int)(struct include Int let default = 0 end))
+
+module OBSS =
+  Graphlib.Of_ocamlgraph
+    (Graph.Persistent.Digraph.ConcreteBidirectionalLabeled
+       (Tid)(struct include Tid
+       let default = Tid.create () end))
+
+
+let graphs_for_algo : (module Graph_for_algo) list = [
+  (module ODIU);
+  (module OBIU);
+  (module Graphlib.Int.Unit);
+]
+
+module Int100 : Factory = struct
+  type t = int
+  let create () = Random.int 100
+  module E = OBII
+  module G = Graphlib.Int.Int
+end
+
+module Test_IR = struct
+  module G = Graphlib.Ir
+
+  let entry = Blk.create ()
+  let b1 = Blk.create ()
+  let b2 = Blk.create ()
+  let b3 = Blk.create ()
+  let b4 = Blk.create ()
+  let b5 = Blk.create ()
+  let b6 = Blk.create ()
+  let exit = Blk.create ()
+
+  let i = Var.create "i" reg32_t
+  let j = Var.create "j" reg32_t
+  let k = Var.create "k" bool_t
+
+  let _1 = Bil.int (Word.one 32)
+  let _2 = Bil.int (Word.of_int32 2l)
+  let _F = Bil.int Word.b0
+  let _T = Bil.int Word.b1
+
+  let def var exp b = Term.append def_t b @@ Def.create var exp
+  let cond blk cond t f =
+    let jt = Jmp.create_goto ~cond (Label.direct (Term.tid t)) in
+    let jf = Jmp.create_goto (Label.direct (Term.tid f)) in
+    let blk = Term.append jmp_t blk jt in
+    Term.append jmp_t blk jf
+  let goto dst src = Term.append jmp_t src @@
+    Jmp.create_goto (Label.direct (Term.tid dst))
+
+  let entry = entry |>
+              goto b1
+
+  let b1 = b1       |>
+           def k _F |>
+           def i _1 |>
+           def j _2 |>
+           goto b2
+
+  let b2 = cond b2 Bil.(var i <= var j) b3 b4
+
+  let b3 = b3                     |>
+           def j Bil.(var j * _2) |>
+           def k _T               |>
+           def i Bil.(var i + _1) |>
+           goto b2
+
+  let b4 = cond b4 Bil.(var k) b5 b6
+
+  let b5 =
+    let call = Call.create ()
+        ~return:(Label.direct (Term.tid exit))
+        ~target:(Label.indirect (Bil.var j)) in
+    let use = Jmp.create_call call in
+    Term.append jmp_t b5 use
+
+
+  let b6 = def i Bil.(var i + _1) b6 |> goto exit
+
+  let sub_of_blks blks =
+    let sub = Sub.create ~name:"example" () in
+    List.fold blks ~init:sub ~f:(Term.append blk_t)
+
+  let blks = [entry; b1; b2; b3; b4; b5; b6; exit]
+
+  let sub = sub_of_blks blks
+
+  let etalon = G.of_sub sub
+
+  let insert blks ctxt =
+    let init = G.create ~tid:(Term.tid sub) ~name:(Sub.name sub) () in
+    let g = List.fold blks ~init ~f:(Fn.flip G.Node.insert) in
+    let etalon = G.edges g |> Seq.fold ~init:etalon ~f:(fun etalon e ->
+        G.Edge.remove e etalon) in
+    let msg = "all edges should be removed" in
+    assert_equal ~ctxt ~msg ~cmp:Int.equal ~printer:Int.to_string
+      0 (G.number_of_edges etalon)
+
+
+  let insert_randomly ctxt =
+    Seq.range 0 1000 |> Seq.iter ~f:(fun _ ->
+        insert (List.permute blks) ctxt)
+
+  let suite = [
+    "in order" >:: insert_randomly
+  ]
+
+end
+
+module Test_int100 = Construction(Int100)
+
+
+
+let suite =
+  "Graph" >::: [
+    "Algo" >:::
+    List.mapi graphs_for_algo ~f:(fun n (module G) ->
+        let module Test = Test_algo(G) in
+        Test.suite (sprintf "%d" n));
+    "Construction" >::: [Test_int100.suite];
+    "IR" >::: Test_IR.suite
+  ]

--- a/lib_test/bap_types/test_graph.mli
+++ b/lib_test/bap_types/test_graph.mli
@@ -1,0 +1,1 @@
+val suite : OUnit2.test

--- a/src/readbin/bap_main.ml
+++ b/src/readbin/bap_main.ml
@@ -182,5 +182,5 @@ let () =
   Plugins.load ();
   match try_with_join (fun () -> Cmdline.parse () >>= start) with
   | Ok n -> exit n
-  | Error err -> eprintf "Aborting because %a.@." Error.pp err;
+  | Error err -> eprintf "Exiting because %a.@." Error.pp err;
     exit 1

--- a/src/readbin/cmdline.ml
+++ b/src/readbin/cmdline.ml
@@ -265,4 +265,4 @@ let parse () =
 
   match Term.eval ~argv ~catch:false program with
   | `Ok opts -> Ok opts
-  | _ -> Or_error.errorf "no cmdline options provided\n"
+  | _ -> Or_error.errorf "nothing to do"

--- a/src/server/manager.ml
+++ b/src/server/manager.ml
@@ -10,7 +10,7 @@ module Id = struct
       exn -> Or_error.errorf "Bad ID format: '%s'" s
   include Regular.Make(struct
       include Int64
-      let module_name = "Manager.Id"
+      let module_name = Some "Manager.Id"
     end)
 end
 


### PR DESCRIPTION
Graphlib extends OCamlGraph with a new modern and more rich interface.
It also provides:

- two new graph types
- depth_first_search algorithm
- dominators algorithm
- dominance frontier
- strongly connected components
- shortest path and reachability algorithms
- auxiliary data structures, like Rose Trees, Partition Sets, Frontiers,
  Paths, etc;
- functor that implements new interface on top of ocamlgraph modules
- functor that implements an old ocamlgraph interface on top of modules,
  that implements a newer [Graph] interface;
- pretty-printing for all graphs and auxiliary data structures;
- generic dot printing.

The library uses first class modules instead of functors, thus making
working with graph syntactically easier.

Note: this is a pre-release. I feel there still rough edges (and nodes)
left in the library. But everyone is welcome to play with it. Feedback
is very welcome.