### PR TITLE
Fixes to trie data structure.

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -128,6 +128,7 @@ Library types
                    Bap_size,
                    Bap_stmt,
                    Bap_trie,
+                   Bap_trie_intf,
                    Bap_type,
                    Bap_types,
                    Bap_value,
@@ -315,7 +316,8 @@ Library types_test
   BuildDepends:   bap, bap.conceval, oUnit
   Modules:        Test_bitvector,
                   Test_conceval,
-                  Test_graph
+                  Test_graph,
+                  Test_trie
 
 Library image_test
   Path:           lib_test/bap_image

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -808,12 +808,18 @@ module Std : sig
     (** [find trie key] finds data associated with [key]  *)
     val find : 'a t -> key -> 'a option
 
+    (** [walk trie key ~init ~f] walks down the tree starting from the
+        root and ending with the last token of the key. Function [f]
+        is fold over values associated with all substrings of the key,
+        starting from a zero substring. *)
+    val walk : 'a t -> key -> init:'b -> f:('b -> 'a option -> 'b) -> 'b
+
     (** [remove trie key] removes value bound with [key] if any.  *)
     val remove : 'a t -> key -> unit
 
-    (** [longest_match trie k] find the longest key in a [trie] that
-        is a substring of [k]. Returns a pair - a length of matched
-        key and data, associated with that key  *)
+    (** [longest_match trie k] find the value associated with a
+        longest substring of a key [k]. Returns a pair - a length of
+        matched key and data, associated with that key. *)
     val longest_match : 'a t -> key -> (int * 'a) option
 
     (** [length trie] returns the amount of entries in the [trie]  *)
@@ -859,8 +865,23 @@ module Std : sig
     (** Create a trie for a given [Key]  *)
     module Make(Key : Key) : Trie with type key = Key.t
 
-    (** Predefined trie with [String] as a [Key]  *)
-    module String : Trie with type key = string
+    (** Minimum required interface for a token data type  *)
+    module type Token = sig
+      type t  with bin_io, compare, sexp
+      val hash : t -> int
+    end
+
+    (** Prefix and suffix tries for specified token types.  *)
+    module Array : sig
+      module Prefix(Tok : Token) : Trie with type key = Tok.t array
+      module Suffix(Tok : Token) : Trie with type key = Tok.t array
+    end
+
+    (** Predefined prefix and suffix string tries.    *)
+    module String : sig
+      module Prefix : Trie with type key = string
+      module Suffix : Trie with type key = string
+    end
   end
 
   (** Type to represent machine word  *)

--- a/lib/bap_types/bap_bitvector.mli
+++ b/lib/bap_types/bap_bitvector.mli
@@ -1,4 +1,5 @@
 open Core_kernel.Std
+
 type t
 exception Width with sexp
 type endian =
@@ -58,11 +59,11 @@ end
 module Int_exn : Bap_integer.S with type t = t
 module Trie : sig
   module Big : sig
-    module Bits : Bap_trie.S  with type key = t
-    module Bytes : Bap_trie.S with type key = t
+    module Bits : Bap_trie_intf.S  with type key = t
+    module Bytes : Bap_trie_intf.S with type key = t
   end
   module Little : sig
-    module Bits : Bap_trie.S  with type key = t
-    module Bytes : Bap_trie.S with type key = t
+    module Bits : Bap_trie_intf.S  with type key = t
+    module Bytes : Bap_trie_intf.S with type key = t
   end
 end

--- a/lib/bap_types/bap_common.ml
+++ b/lib/bap_types/bap_common.ml
@@ -21,7 +21,7 @@ module type Integer   = Integer.S
 module type Regular   = Regular.S
 module type Opaque    = Opaque.S
 module type Printable = Regular.Printable
-module type Trie      = Trie.S
+module type Trie      = Bap_trie_intf.S
 
 type endian = Bitvector.endian =
     LittleEndian | BigEndian

--- a/lib/bap_types/bap_trie.mli
+++ b/lib/bap_types/bap_trie.mli
@@ -1,26 +1,16 @@
 open Core_kernel.Std
 open Format
-module type Key = sig
-  type t
-  type token with bin_io, compare, sexp
-  val length : t -> int
-  val nth_token : t -> int -> token
-  val token_hash : token -> int
-end
+open Bap_trie_intf
 
-module type S = sig
-  type 'a t with bin_io, sexp
-  type key
-  val create : unit -> 'a t
-  val add : 'a t -> key:key -> data:'a -> unit
-  val change : 'a t -> key -> ('a option -> 'a option) -> unit
-  val find : 'a t -> key -> 'a option
-  val remove : 'a t -> key -> unit
-  val longest_match : 'a t -> key -> (int * 'a) option
-  val length : 'a t -> int
-  val pp : (formatter -> 'a -> unit) -> formatter -> 'a t -> unit
-end
 
 module Make(Key : Key) : S with type key = Key.t
 
-module String : S with type key = string
+module Array : sig
+  module Prefix(Tok : Token) : S with type key = Tok.t array
+  module Suffix(Tok : Token) : S with type key = Tok.t array
+end
+
+module String : sig
+  module Prefix : S with type key = string
+  module Suffix : S with type key = string
+end

--- a/lib/bap_types/bap_trie_intf.ml
+++ b/lib/bap_types/bap_trie_intf.ml
@@ -1,0 +1,28 @@
+open Format
+
+module type Token = sig
+  type t  with bin_io, compare, sexp
+  val hash : t -> int
+end
+
+module type Key = sig
+  type t
+  type token with bin_io, compare, sexp
+  val length : t -> int
+  val nth_token : t -> int -> token
+  val token_hash : token -> int
+end
+
+module type S = sig
+  type 'a t with bin_io, sexp
+  type key
+  val create : unit -> 'a t
+  val add : 'a t -> key:key -> data:'a -> unit
+  val change : 'a t -> key -> ('a option -> 'a option) -> unit
+  val find : 'a t -> key -> 'a option
+  val walk : 'a t -> key -> init:'b -> f:('b -> 'a option -> 'b) -> 'b
+  val remove : 'a t -> key -> unit
+  val longest_match : 'a t -> key -> (int * 'a) option
+  val length : 'a t -> int
+  val pp : (formatter -> 'a -> unit) -> formatter -> 'a t -> unit
+end

--- a/lib/bap_types/bap_types.ml
+++ b/lib/bap_types/bap_types.ml
@@ -17,7 +17,10 @@ module Std = struct
   module Integer = Integer
   module Printable = Printable
   module Opaque = Opaque
-  module Trie = Trie
+  module Trie = struct
+    include Bap_trie_intf
+    include Bap_trie
+  end
 
   module type Regular = Regular
   module type Opaque = Opaque

--- a/lib_test/bap/run_tests.ml
+++ b/lib_test/bap/run_tests.ml
@@ -2,6 +2,7 @@ open OUnit2
 
 let suite =
   "BAP" >::: [
+    Test_trie.suite;
     Test_bitvector.suite;
     Test_conceval.suite;
     Test_graph.suite;

--- a/lib_test/bap_types/test_trie.ml
+++ b/lib_test/bap_types/test_trie.ml
@@ -1,0 +1,66 @@
+open Core_kernel.Std
+open Bap.Std
+open OUnit2
+
+module T = Trie.String.Prefix;;
+
+let find _ =
+  let t = T.create () in
+  T.add t "" 0;
+  T.add t "a" 1;
+  T.add t "abcde" 3;
+
+  assert_bool "1." (T.longest_match t "" = Some (0,0));
+  assert_bool "1.a" (T.longest_match t "a" = Some (1,1));
+  assert_bool "1.ab" (T.longest_match t "ab" = Some (1,1));
+  assert_bool "1.abc" (T.longest_match t "abc" = Some (1,1));
+  assert_bool "1.abcd" (T.longest_match t "abcd" = Some (1,1));
+  assert_bool "1.abcde" (T.longest_match t "abcde" = Some (5,3));
+  assert_bool "1.abcdef" (T.longest_match t "abcdef" = Some (5,3));
+  assert_bool "1.nothing" (T.longest_match t "nothing" = Some (0,0));
+
+  T.add t "abc" 2;
+
+  assert_bool "2." (T.longest_match t "" = Some (0,0));
+  assert_bool "2.a" (T.longest_match t "a" = Some (1,1));
+  assert_bool "2.ab" (T.longest_match t "ab" = Some (1,1));
+  assert_bool "2.abc" (T.longest_match t "abc" = Some (3,2));
+  assert_bool "2.abcd" (T.longest_match t "abcd" = Some (3,2));
+  assert_bool "2.abcde" (T.longest_match t "abcde" = Some (5,3));
+  assert_bool "2.abcdef" (T.longest_match t "abcdef" = Some (5,3));
+  assert_bool "2.nothing" (T.longest_match t "nothing" = Some (0,0));
+
+  T.remove t "abc";
+
+  assert_bool "3." (T.longest_match t "" = Some (0,0));
+  assert_bool "3.a" (T.longest_match t "a" = Some (1,1));
+  assert_bool "3.ab" (T.longest_match t "ab" = Some (1,1));
+  assert_bool "3.abc" (T.longest_match t "abc" = Some (1,1));
+  assert_bool "3.abcd" (T.longest_match t "abcd" = Some (1,1));
+  assert_bool "3.abcde" (T.longest_match t "abcde" = Some (5,3));
+  assert_bool "3.abcdef" (T.longest_match t "abcdef" = Some (5,3));
+  assert_bool "3.nothing" (T.longest_match t "nothing" = Some (0,0));
+
+  T.remove t "";
+
+  assert_bool "4." (T.longest_match t "" = None);
+  assert_bool "4.a" (T.longest_match t "a" = Some (1,1));
+  assert_bool "4.ab" (T.longest_match t "ab" = Some (1,1));
+  assert_bool "4.abc" (T.longest_match t "abc" = Some (1,1));
+  assert_bool "4.abcd" (T.longest_match t "abcd" = Some (1,1));
+  assert_bool "4.abcde" (T.longest_match t "abcde" = Some (5,3));
+  assert_bool "4.abcdef" (T.longest_match t "abcdef" = Some (5,3));
+  assert_bool "4.nothing" (T.longest_match t "nothing" = None);
+
+  assert_bool "5." (T.find t "" = None);
+  assert_bool "5.a" (T.find t "a" = Some 1);
+  assert_bool "5.ab" (T.find t "ab" = None);
+  assert_bool "5.abc" (T.find t "abc" = None);
+  assert_bool "5.abcd" (T.find t "abcd" = None);
+  assert_bool "5.abcde" (T.find t "abcde" = Some 3);
+  assert_bool "5.abcdef" (T.find t "abcdef" = None);
+  assert_bool "5.nothing" (T.find t "nothing" = None)
+
+let suite = "Trie" >::: [
+    "find" >:: find;
+  ]

--- a/lib_test/bap_types/test_trie.mli
+++ b/lib_test/bap_types/test_trie.mli
@@ -1,0 +1,2 @@
+open OUnit2
+val suite : test


### PR DESCRIPTION
- Data can be attached to the trie's root (i.e., to an empty key),
  this will resolve #271.

- Test suite is added, some bugs were fixed.

- A `walk` algorithm is added, that will fold function over all substrings
  of a key. (In fact all other search functions are implemented using
  this walk function).

- A family of two new functors is added: Array.Prefix and Array.Suffix,
  to create, correspondingly, prefix and suffix tries with array keys.

- Trie.String is now also a family - Trie.String.Prefix and
  Trie.String.Suffix.