### PR TITLE
Generate a BIL Special when semantics unknown

### DIFF
--- a/lib/bap_disasm/bap_disasm_insn.ml
+++ b/lib/bap_disasm/bap_disasm_insn.ml
@@ -68,7 +68,7 @@ let of_basic ?bil insn =
     code = Insn.code insn;
     name = Insn.name insn;
     asm  = normalize_asm (Insn.asm insn);
-    bil  = Option.value bil ~default:[];
+    bil  = Option.value bil ~default:[Bil.special "Unknown Semantics"];
     ops  = Insn.ops insn;
     is_jump;
     is_conditional_jump;


### PR DESCRIPTION
This patch makes it possible to distinguish `nop`s (which provide an empty list for BIL semantics when implemented) and unimplemented instructions by making the unimplemented instructions produce a `Special`.

[Build](https://travis-ci.org/maurer/bap/builds/75508717)