### PR TITLE
Fix memory issues in disassembler

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -5131,6 +5131,10 @@ module Std : sig
           process of disassembly can be driven using [stop], [step], [back]
           and [jump] functions, described later.
 
+          @param backlog defines a size of history of states, that can
+          be used for backtracking. Defaults to some positive natural
+          number.
+
           @param stop_on defines a set of predicates that will be checked
           on each step to decide whether it should stop here and call a
           user-provided [hit] function, or it should continue. The descision
@@ -5172,6 +5176,7 @@ module Std : sig
           assembly string and kinds even if the corresponding modes are
           disabled.  *)
       val run :
+        ?backlog:int ->
         ?stop_on:pred list ->
         ?invalid:(('a,'k,'s,'r) state -> mem -> 's -> 'r) ->
         ?stopped:(('a,'k,'s,'r) state -> 's -> 'r) ->

--- a/lib/bap_disasm/bap_disasm_basic.mli
+++ b/lib/bap_disasm/bap_disasm_basic.mli
@@ -129,6 +129,7 @@ val store_kinds : ('a,_) t -> ('a,kinds) t
     assembly string and kinds even if the corresponding modes are
     disabled.  *)
 val run :
+  ?backlog:int ->
   ?stop_on:pred list ->
   ?invalid:(('a,'k,'s,'r) state -> mem -> 's -> 'r) ->
   ?stopped:(('a,'k,'s,'r) state -> 's -> 'r) ->


### PR DESCRIPTION
There were actually two issues, that played along.

1. The backlog history was unbounded, and if the state is changed after
each byte, they may become very long. Now it is bounded and user
controlled.

2. The other issue is more problematic. It looks like OCaml GC has a
memory leak with lazy values stored inside an array. As for now, the
insns are no more lazy, until we found out a more suitable workaround or
until upstream is fixed.