### PR TITLE
Add support for thumb, make arches more explicit.

### DIFF
--- a/bapdoc.ml
+++ b/bapdoc.ml
@@ -42,6 +42,7 @@ let find_p4_with s =
     if has_type || has_module || not is_word
     then None else Some i
 
+open Printf
 
 (* right now we will just kill `with', but later we can transform them
    to "@with ..." comment, that can be later processed to output
@@ -53,7 +54,7 @@ let preprocess_with oc s = match find_p4_with s with
     | Some j,_ when j > i ->
       output oc s 0 i;
       output oc s j (String.length s - j)
-    | _, Some j -> if j < i then output oc s 0 i
+    | _, Some k when k < i -> output oc s 0 i
     | _ -> output_string oc s
 
 

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -2121,15 +2121,31 @@ module Std : sig
     ] with bin_io, compare, enumerate, sexp
 
     type arm = [
-      | `arm
-      | `armeb
       | `armv4
-      | `armv4t
       | `armv5
       | `armv6
       | `armv7
-      | `thumb
-      | `thumbeb
+    ] with bin_io, compare, enumerate, sexp
+
+    type armeb = [
+      | `armv4eb
+      | `armv5eb
+      | `armv6eb
+      | `armv7eb
+    ] with bin_io, compare, enumerate, sexp
+
+    type thumb = [
+      | `thumbv4
+      | `thumbv5
+      | `thumbv6
+      | `thumbv7
+    ] with bin_io, compare, enumerate, sexp
+
+    type thumbeb = [
+      | `thumbv4eb
+      | `thumbv5eb
+      | `thumbv6eb
+      | `thumbv7eb
     ] with bin_io, compare, enumerate, sexp
 
     type aarch64 = [
@@ -2180,6 +2196,9 @@ module Std : sig
     type t = [
       | aarch64
       | arm
+      | armeb
+      | thumb
+      | thumbeb
       | hexagon
       | mips
       | nvptx
@@ -5814,7 +5833,6 @@ module Std : sig
       val rsp : var
       val rsi : var
       val rdi : var
-      val rip : var
       val rax : var
       val rbx : var
       val rcx : var

--- a/lib/bap_image/bap_native_loader.ml
+++ b/lib/bap_image/bap_native_loader.ml
@@ -120,7 +120,7 @@ let img_of_elf data elf : Img.t Or_error.t =
     | EM_386, _ -> Ok `x86
     | EM_X86_64, _ -> Ok `x86_64
     | EM_ARM, LittleEndian -> Ok `armv7
-    | EM_ARM, BigEndian -> Ok `armeb
+    | EM_ARM, BigEndian -> Ok `armv7eb
     | EM_AARCH64, LittleEndian -> Ok `aarch64
     | EM_AARCH64, BigEndian -> Ok `aarch64_be
     | EM_SPARC,_ -> Ok `sparc

--- a/lib/bap_types/bap_arch.ml
+++ b/lib/bap_types/bap_arch.ml
@@ -22,11 +22,10 @@ module T = struct
     | "x86-64" | "x86_64" | "amd64" | "x64" | "x86_64h" -> "x86_64"
     | "powerpc" -> "ppc"
     | "arm" -> "armv7"
+    | "thumb" -> "thumbv7"
+    | "armeb" -> "armv7eb"
+    | "thumbeb" -> "thumbv7eb"
     | "xscale"  -> "arm"
-    | "thumbv4t" -> "armv4t"
-    | "armv5t" | "armv5e" | "thumbv5" | "thumbv5e" -> "armv5"
-    | "thumbv6" -> "armv6"
-    | "thumbv7" -> "armv7"
     | "powerpc64" | "ppu" -> "ppc64"
     | "sparc64" -> "sparcv9"
     | "s390x" -> "systemz"
@@ -41,20 +40,20 @@ module T = struct
     Option.try_with (fun () -> of_string_exn s)
 
   let addr_size : t -> addr_size = function
-    | #arm | `x86 | `ppc | `mips | `mipsel | `sparc
+    | #arm | #armeb | #thumb | #thumbeb
+    | `x86 | `ppc | `mips | `mipsel | `sparc
     | `nvptx | `hexagon |  `r600 | `xcore  -> `r32
 
     | #aarch64 | `mips64el |`sparcv9|`ppc64le|`x86_64
     | `ppc64|`nvptx64 | `systemz | `mips64 -> `r64
 
   let endian : t -> endian = function
-    | `armeb  | `aarch64_be | `thumbeb -> BigEndian
+    | #armeb  | `aarch64_be | #thumbeb -> BigEndian
     | `mipsel | `mips64el | `ppc64le -> LittleEndian
-    | #arm | #x86 | #aarch64 | #r600
+    | #arm | #thumb | #x86 | #aarch64 | #r600
     | #hexagon | #nvptx | #xcore -> LittleEndian
     | #ppc | #mips | #sparc | #systemz   -> BigEndian
 end
 
-(* derive Identifiable interface from Core *)
 include T
 include Regular.Make(T)

--- a/lib/bap_types/bap_common.ml
+++ b/lib/bap_types/bap_common.ml
@@ -77,16 +77,33 @@ module Arch = struct
   ] with bin_io, compare, enumerate, sexp
 
   type arm = [
-    | `arm
-    | `armeb
     | `armv4
-    | `armv4t
     | `armv5
     | `armv6
     | `armv7
-    | `thumb
-    | `thumbeb
   ] with bin_io, compare, enumerate, sexp
+
+  type armeb = [
+    | `armv4eb
+    | `armv5eb
+    | `armv6eb
+    | `armv7eb
+  ] with bin_io, compare, enumerate, sexp
+
+  type thumb = [
+    | `thumbv4
+    | `thumbv5
+    | `thumbv6
+    | `thumbv7
+  ] with bin_io, compare, enumerate, sexp
+
+  type thumbeb = [
+    | `thumbv4eb
+    | `thumbv5eb
+    | `thumbv6eb
+    | `thumbv7eb
+  ] with bin_io, compare, enumerate, sexp
+
 
   type aarch64 = [
     | `aarch64
@@ -136,6 +153,9 @@ module Arch = struct
   type t = [
     | aarch64
     | arm
+    | armeb
+    | thumb
+    | thumbeb
     | hexagon
     | mips
     | nvptx

--- a/lib_test/bap_project/test_project.ml
+++ b/lib_test/bap_project/test_project.ml
@@ -13,7 +13,7 @@ type case = {
 }
 
 let arm = {
-  arch = `arm;
+  arch = `armv7;
   addr = 16;
   code = "\x00\x20\xA0\xE3";
   bil  = "R2 := 0x0:32";

--- a/src/server/server.ml
+++ b/src/server/server.ml
@@ -66,7 +66,7 @@ module Handlers(Ctxt : sig
     let kinds = Kind.all in
     let ds =
       Response.disassembler
-        ~name:"llvm" ~arch:`arm ~kinds
+        ~name:"llvm" ~arch:`armv7 ~kinds
         ~has_name:true ~has_bil:true ~has_ops:true ~has_target:true ::
       List.map Arch.all ~f:(fun arch ->
           Response.disassembler ~name:"llvm" ~arch


### PR DESCRIPTION
This PR will fix #290:
```sh
$ echo "0x88,0xb0" | bap-mc --arch=thumb --show-insn
sub sp, #0x20
```

It may also break some code, as it removes wildcard `arm` and `thumb`
architectures, that were previously defaulted to the latest arch. Now
one should provide explicitly `armv7` or `thumbv7`.

`Arch.of_string` function will still understand `arm` and `thumb`
short-cuts defaulting them to `armv7` and `thumbv7` correspondingly.

Big-endian variants of arm and thumb are also fixed.