### PR TITLE
Add `r128 and `r256 sizes

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -899,6 +899,8 @@ module Std : sig
       | `r16
       | `r32
       | `r64
+      | `r128
+      | `r256
     ] with variants
 
     type 'a p = 'a constraint 'a = [< all]

--- a/lib/bap_image/bap_image.ml
+++ b/lib/bap_image/bap_image.ml
@@ -83,6 +83,8 @@ type words = {
   r16 : word table Lazy.t;
   r32 : word table Lazy.t;
   r64 : word table Lazy.t;
+  r128 : word table Lazy.t;
+  r256 : word table Lazy.t;
 }
 
 type t = {
@@ -212,6 +214,8 @@ let create_words secs = {
   r16 = lazy (words_of_table `r16 secs);
   r32 = lazy (words_of_table `r32 secs);
   r64 = lazy (words_of_table `r64 secs);
+  r128 = lazy (words_of_table `r128 secs);
+  r256 = lazy (words_of_table `r256 secs);
 }
 
 let register_backend ~name backend =
@@ -309,7 +313,9 @@ let words t (size : size) : word table =
     | `r8  -> t.words.r8
     | `r16 -> t.words.r16
     | `r32 -> t.words.r32
-    | `r64 -> t.words.r64 in
+    | `r64 -> t.words.r64
+    | `r128 -> t.words.r128
+    | `r256 -> t.words.r256 in
   table
 
 let segments t = t.segments

--- a/lib/bap_image/bap_memory.mli
+++ b/lib/bap_image/bap_memory.mli
@@ -98,6 +98,8 @@ module Input : sig
   val uint16 : word reader
   val int32  : word reader
   val int64  : word reader
+  val int128 : word reader
+  val int256 : word reader
 end
 
 (** {3 Printing and outputing}  *)

--- a/lib/bap_types/bap_common.ml
+++ b/lib/bap_types/bap_common.ml
@@ -35,6 +35,8 @@ module Size = struct
     | `r16
     | `r32
     | `r64
+    | `r128
+    | `r256
   ] with bin_io, compare, sexp, variants
 
   type 'a p = 'a constraint 'a = [< all]

--- a/lib/bap_types/bap_size.ml
+++ b/lib/bap_types/bap_size.ml
@@ -8,6 +8,8 @@ let to_bits : 'a -> int = function
   | `r16  -> 16
   | `r32  -> 32
   | `r64  -> 64
+  | `r128  -> 128
+  | `r256  -> 256
 
 let to_bytes x = to_bits x / 8
 
@@ -16,6 +18,8 @@ let of_int : int -> size Or_error.t = function
   | 16  -> Ok `r16
   | 32  -> Ok `r32
   | 64  -> Ok `r64
+  | 128 -> Ok `r128
+  | 256 -> Ok `r256
   | n   -> errorf "unsupported word size: %d" n
 
 let of_int_exn n = ok_exn (of_int n)

--- a/lib/bap_types/type.piqi
+++ b/lib/bap_types/type.piqi
@@ -16,6 +16,8 @@
   .option [.name r16]
   .option [.name r32]
   .option [.name r64]
+  .option [.name r128]
+  .option [.name r256]
 ]
 
 .alias [


### PR DESCRIPTION
See #126 and #130; this restores support for lifting a variety of memory-related SSE instructions (e.g. `f3 0f 7f 04 38 movdqu %xmm0,(%eax,%edi,1)`), while breaking less stuff than #126.