### PR TITLE
Small client/server fixes. 

### DIFF
--- a/python/bap.py
+++ b/python/bap.py
@@ -248,6 +248,7 @@ class Bap(object):
             try:
                 self.capabilities = self.call({'init' : {
                     'version' : '0.1'}}).next()['capabilities']
+                break
             except Exception:
                 if attempt + 1 == RETRIES:
                     raise

--- a/src/server/server.ml
+++ b/src/server/server.ml
@@ -250,8 +250,10 @@ let run_exn (requests, replies) : unit Lwt.t =
           Response.create id msg |> reply
         | Error err' ->
           let err = Error.of_list [err; err'] in
-          let msg = Error.to_string_hum err in
-          warning_f ~section "Ignoring junk request: %s" msg)
+          let str = Error.to_string_hum err in
+          warning_f ~section "Ignoring junk request: %s" str >>= fun () ->
+          let msg = Response.error `Error str in
+          Response.create (Id.of_string "0") msg |> reply)
 
 
 let run (pipe : (request, response) Transport.pipe)


### PR DESCRIPTION
Server should still respond when client does not supply id. E.g. `curl --data "{\"init\": {\"version\": \"0.1\"}}" 127.0.0.1:8080` does not get a response.

Client should break on successful connection.