### PR TITLE
Parallel matching for values.

### DIFF
--- a/lib/bap_types/bap_value.ml
+++ b/lib/bap_types/bap_value.ml
@@ -166,6 +166,38 @@ module Tag = struct
 
 end
 
+module Match = struct
+
+  module Map = Type_equal.Id.Uid.Map
+
+  type 's t = {
+    default : (unit -> 's);
+    handlers : (value -> 's) Map.t;
+  }
+
+  let empty = Map.empty
+
+  let default default = {
+    handlers = empty;
+    default = default;
+  }
+
+  let case t f (tab : 's t) =
+    let handlers = Map.add tab.handlers (Type_equal.Id.uid t)
+        (fun v -> f (get_exn t v)) in
+    {tab with handlers}
+
+  let run v tab =
+    match Map.find tab.handlers (Univ.type_id_uid v) with
+    | Some f -> f v
+    | None -> tab.default ()
+
+  let switch = run
+
+  let select x y = switch y x
+end
+
+
 module Dict = struct
 
   type t = value Typeid.Map.t with bin_io, compare, sexp

--- a/lib/bap_types/bap_value.mli
+++ b/lib/bap_types/bap_value.mli
@@ -45,6 +45,14 @@ module Tag : sig
   val same_witness_exn : 'a t -> 'b t -> ('a,'b) Type_equal.t
 end
 
+module Match : sig
+  type 'a t
+  val switch : value -> 's t -> 's
+  val select : 's t -> value -> 's
+  val case : 'a tag -> ('a -> 's) -> 's t -> 's t
+  val default : (unit -> 's) -> 's t
+end
+
 module Typeid : Regular with type t = typeid
 
 include Regular with type t := t


### PR DESCRIPTION
This PR introduces a parallel matching for values of type [value].

So that if you have a value, and you want to pattern match it against
several tags, then now you can use the following syntax:

```ocaml
let lift v = Value.Match.(begin
    switch v @@
    case memory_load   (fun x -> `Load x)  @@
    case memory_store  (fun x -> `Store x) @@
    case register_read (fun x -> `Read x)  @@
    default (fun () -> `Unknown)
  end)
```

where `memory_load`, `memory_store` and `register_read` a values of type
`'a tag`. Of course, `'a` is totally polymorphic and is not unified
between branches (i.e., you can use `int tag`, `string tag` in the same
`switch` expression).