### PR TITLE
A proposal to change BIL.

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -167,7 +167,7 @@ module Std : sig
       of the same type we usually disambiguate them with keywords,
       e.g., [Bil.Load of (exp,exp,endian,size)] has function
       {{!Bil.load}Bil.load} with type:
-      [mem:exp -> addr:exp -> endian -> size -> exp]
+      [mem:var -> addr:exp -> endian -> size -> exp]
 
       {3:value Value}
 
@@ -1511,8 +1511,8 @@ module Std : sig
 
       (** BIL expression variants  *)
       type exp =
-        | Load    of exp * exp * endian * size (** load from memory *)
-        | Store   of exp * exp * exp * endian * size (** store to memory  *)
+        | Load    of var * exp * endian * size (** load from memory *)
+        | Store   of var * exp * exp * endian * size (** store to memory  *)
         | BinOp   of binop * exp * exp  (** binary operation  *)
         | UnOp    of unop * exp         (** unary operation *)
         | Var     of var                (** variable *)
@@ -1626,8 +1626,8 @@ module Std : sig
     val sle : binop
     val neg : unop
     val not : unop
-    val load : mem:exp -> addr:exp -> endian -> size -> exp
-    val store : mem:exp -> addr:exp -> exp -> endian -> size -> exp
+    val load : mem:var -> addr:exp -> endian -> size -> exp
+    val store : mem:var -> addr:exp -> exp -> endian -> size -> exp
     val binop : binop -> exp -> exp -> exp
     val unop : unop -> exp -> exp
     val var : var -> exp
@@ -1754,14 +1754,14 @@ module Std : sig
       method leave_exp : exp -> 'a -> 'a
 
       (** [Load (src,addr,endian,size)]  *)
-      method enter_load : mem:exp -> addr:exp -> endian -> size -> 'a -> 'a
-      method visit_load : mem:exp -> addr:exp -> endian -> size -> 'a -> 'a
-      method leave_load : mem:exp -> addr:exp -> endian -> size -> 'a -> 'a
+      method enter_load : mem:var -> addr:exp -> endian -> size -> 'a -> 'a
+      method visit_load : mem:var -> addr:exp -> endian -> size -> 'a -> 'a
+      method leave_load : mem:var -> addr:exp -> endian -> size -> 'a -> 'a
 
       (** [Store (dst,addr,src,endian,size)]  *)
-      method enter_store : mem:exp -> addr:exp -> exp:exp -> endian -> size -> 'a -> 'a
-      method visit_store : mem:exp -> addr:exp -> exp:exp -> endian -> size -> 'a -> 'a
-      method leave_store : mem:exp -> addr:exp -> exp:exp -> endian -> size -> 'a -> 'a
+      method enter_store : mem:var -> addr:exp -> exp:exp -> endian -> size -> 'a -> 'a
+      method visit_store : mem:var -> addr:exp -> exp:exp -> endian -> size -> 'a -> 'a
+      method leave_store : mem:var -> addr:exp -> exp:exp -> endian -> size -> 'a -> 'a
 
       (** [BinOp (op,e1,e2)]  *)
       method enter_binop : binop -> exp -> exp -> 'a -> 'a
@@ -1873,8 +1873,8 @@ module Std : sig
 
       (** {3 Expressions}  *)
       method map_exp : exp -> exp
-      method map_load : mem:exp -> addr:exp -> endian -> size -> exp
-      method map_store : mem:exp -> addr:exp -> exp:exp -> endian -> size -> exp
+      method map_load : mem:var -> addr:exp -> endian -> size -> exp
+      method map_store : mem:var -> addr:exp -> exp:exp -> endian -> size -> exp
       method map_binop : binop -> exp -> exp -> exp
       method map_unop : unop -> exp -> exp
       method map_cast : cast -> nat1 -> exp -> exp

--- a/lib/bap_disasm/bap_disasm_arm_lifter.ml
+++ b/lib/bap_disasm/bap_disasm_arm_lifter.ml
@@ -301,9 +301,9 @@ let lift_bits mem ops (insn : Arm.Insn.bits ) =
     let src1 = Env.of_reg src1 |> Bil.var in
     let src2 = Env.of_reg src2 |> Bil.var in
     exec Bil.([
-        assn temp (load (var Env.mem) src2 LittleEndian `r8);
+        assn temp (load Env.mem src2 LittleEndian `r8);
         Env.mem :=
-          store (var Env.mem) src2 (extract 7 0 src1) LittleEndian `r8;
+          store Env.mem src2 (extract 7 0 src1) LittleEndian `r8;
         assn dest (cast unsigned 32 (var temp));
       ]) cond
 

--- a/lib/bap_disasm/bap_disasm_arm_mem.ml
+++ b/lib/bap_disasm/bap_disasm_arm_mem.ml
@@ -65,12 +65,11 @@ let lift_r  ~(dst1 : Var.t) ?(dst2 : Var.t option) ~(base : Var.t)
       | B | H -> [Bil.move dst1 rhs]
       | W | D -> [] in
     let loads =
-      let mem = Bil.var (Env.mem) in
       if size = D then [
-        Bil.move dst1 (load mem address);
-        Bil.move (uw dst2) (load mem Bil.(address + four));
+        Bil.move dst1 (load Env.mem address);
+        Bil.move (uw dst2) (load Env.mem Bil.(address + four));
       ] else [
-        assn temp (load mem address);
+        assn temp (load Env.mem address);
       ] in
     List.concat [
       pre_write_back;
@@ -87,15 +86,14 @@ let lift_r  ~(dst1 : Var.t) ?(dst2 : Var.t option) ~(base : Var.t)
       | W | D -> [] in
     let stores =
       let m = Env.mem in
-      let v = Bil.var m in
       match size with
       | D -> [
-          Bil.move m (store v address Bil.(var dst1));
-          Bil.move m (store v
+          Bil.move m (store m address Bil.(var dst1));
+          Bil.move m (store m
                         Bil.(address + four) Bil.(var (uw dst2)));
         ]
       | B | H | W -> [
-          Bil.move m (store v address Bil.(var temp));
+          Bil.move m (store m address Bil.(var temp));
         ] in
     List.concat [
       trunc;                   (* truncate the value if necessary *)
@@ -122,12 +120,11 @@ let lift_m dest_list base mode update operation =
       in [Bil.move base Bil.(var base +-  int dest_len)] in
   let create_access i dest =
     let offset_e = Word.of_int ~width:32 (calc_offset i) in
-    let mem = Bil.var Env.mem in
     let addr = Bil.(var o_base + int offset_e) in
     match operation with
-    | Ld -> assn dest Bil.(load mem addr LittleEndian `r32)
+    | Ld -> assn dest Bil.(load Env.mem addr LittleEndian `r32)
     | St -> Bil.move Env.mem
-              Bil.(store Env.(var mem) addr (var dest) LittleEndian `r32) in
+              Bil.(store Env.mem addr (var dest) LittleEndian `r32) in
   (* Jmps should always be the last statement *)
   let rec move_jump_to_end l =
     match l with

--- a/lib/bap_disasm/bap_disasm_x86_lifter.ml
+++ b/lib/bap_disasm/bap_disasm_x86_lifter.ml
@@ -30,12 +30,12 @@ module ToIR = struct
       | X8664 -> R64.mem in
     let sz = size_of_typ t in
     match s with
-    | None -> Bil.Move (mem, Bil.(Store (Var mem, a, e, LittleEndian, sz)))
-    | Some v -> Bil.Move (mem, Bil.(Store (Var mem, Var v + a, e,
+    | None -> Bil.Move (mem, Bil.(Store (mem, a, e, LittleEndian, sz)))
+    | Some v -> Bil.Move (mem, Bil.(Store (mem, Var v + a, e,
                                            LittleEndian, sz)))
 
   let storem mode t a e =
-    Bil.Move (mode, Bil.(Store (Var mode, a, e, LittleEndian, t)))
+    Bil.Move (mode, Bil.(Store (mode, a, e, LittleEndian, t)))
 
   (* copypasted from op2e_s below, but keeps the opcode width *)
   let op2e_s_keep_width mode ss has_rex t = function

--- a/lib/bap_disasm/bap_disasm_x86_utils.ml
+++ b/lib/bap_disasm/bap_disasm_x86_utils.ml
@@ -252,10 +252,9 @@ let load_s mode s t a =
   let mem = match mode with
     | X86 -> R32.mem
     | X8664 -> R64.mem in
-  let mem_e = Bil.var mem in
   match s with
-  | None -> Bil.load mem_e a LittleEndian t
-  | Some v -> Bil.(load mem_e (var v + a) LittleEndian t)
+  | None -> Bil.load mem a LittleEndian t
+  | Some v -> Bil.(load mem (var v + a) LittleEndian t)
 
 let resize_word v width = Word.extract_exn ~hi:(width - 1) v
 

--- a/lib/bap_types/bap_bil.ml
+++ b/lib/bap_types/bap_bil.ml
@@ -60,9 +60,9 @@ with bin_io, compare, sexp
 module Exp = struct
   type exp =
     (** Load    (mem,  idx,  endian,  size) *)
-    | Load    of exp * exp * endian * size
+    | Load    of var * exp * endian * size
     (** Store   (mem,  idx,  val,  endian,  size) *)
-    | Store   of exp * exp * exp * endian * size
+    | Store   of var * exp * exp * endian * size
     | BinOp   of binop * exp * exp
     | UnOp    of unop * exp
     | Var     of var

--- a/lib/bap_types/bap_bil_adt.ml
+++ b/lib/bap_types/bap_bil_adt.ml
@@ -37,9 +37,9 @@ module Exp = struct
 
   let rec pp ch = function
     | Load (x,y,e,s) ->
-      pr ch "Load(%a,%a,%a,%a)" pp x pp y pp_endian e pp_size s
+      pr ch "Load(%a,%a,%a,%a)" pp_var x pp y pp_endian e pp_size s
     | Store (x,y,z,e,s) ->
-      pr ch "Store(%a,%a,%a,%a,%a)" pp x pp y pp z pp_endian e pp_size s
+      pr ch "Store(%a,%a,%a,%a,%a)" pp_var x pp y pp z pp_endian e pp_size s
     | BinOp (op,x,y) ->
       pr ch "%a(%a,%a)" (pp_sexp sexp_of_binop) op pp x pp y
     | UnOp (op,x) ->

--- a/lib/bap_types/bap_exp.ml
+++ b/lib/bap_types/bap_exp.ml
@@ -162,13 +162,11 @@ module PP = struct
         (if is_imm e then "%a" else "(%a)") in
     let pr s = fprintf fmt s in
     match exp with
-    | Load (Var _ as mem, idx, edn, s) ->
-      pr "%a[%a, %a]:%a" pp mem pp idx pp_edn edn Bap_size.pp s
     | Load (mem, idx, edn, s) ->
-      pr "(%a)[%a, %a]:%a" pp mem pp idx pp_edn edn Bap_size.pp s
+      pr "%a[%a, %a]:%a" Bap_var.pp mem pp idx pp_edn edn Bap_size.pp s
     | Store (mem, idx, exp, edn, s) ->
       pr "@[<2>%a@;with [%a, %a]:%a <- %a@]"
-        pp mem pp idx pp_edn edn Bap_size.pp s pp exp
+        Bap_var.pp mem pp idx pp_edn edn Bap_size.pp s pp exp
     | Ite (ce, te, fe) ->
       pr "@[<2>if %a@;then %a@;else %a@]" pp ce pp te pp fe
     | Extract (hi, lo, exp) ->

--- a/lib/bap_types/bap_exp.mli
+++ b/lib/bap_types/bap_exp.mli
@@ -42,8 +42,8 @@ module Unop : sig
 end
 
 module Exp : sig
-  val load : mem:exp -> addr:exp -> endian -> size -> exp
-  val store : mem:exp -> addr:exp -> exp -> endian -> size -> exp
+  val load : mem:var -> addr:exp -> endian -> size -> exp
+  val store : mem:var -> addr:exp -> exp -> endian -> size -> exp
   val binop : binop -> exp -> exp -> exp
   val unop : unop -> exp -> exp
   val var : var -> exp

--- a/lib/bap_types/bap_visitor.ml
+++ b/lib/bap_types/bap_visitor.ml
@@ -42,14 +42,14 @@ class ['a] visitor = object (self : 's)
   method leave_store ~mem ~addr ~exp e s x = x
   method visit_store ~mem ~addr ~exp e s x =
     self#enter_store ~mem ~addr ~exp e s x |>
-    self#visit_exp mem |> self#visit_exp addr |> self#visit_exp exp |>
+    self#visit_var mem |> self#visit_exp addr |> self#visit_exp exp |>
     self#leave_store ~mem ~addr ~exp e s
 
   method enter_load ~mem ~addr _e _s x = x
   method leave_load ~mem ~addr _e _s x = x
   method visit_load ~mem ~addr _e _s x =
     self#enter_load ~mem ~addr _e _s x |>
-    self#visit_exp mem |> self#visit_exp addr |>
+    self#visit_var mem |> self#visit_exp addr |>
     self#leave_load ~mem ~addr _e _s
 
   method enter_cast _ _ e x =  x
@@ -215,12 +215,12 @@ class mapper = object (self : 's)
     Exp.BinOp (op, self#map_exp e1, self#map_exp e2)
 
   method map_store ~mem ~addr ~exp e s =
-    Exp.Store (self#map_exp mem,
+    Exp.Store (self#map_sym mem,
                self#map_exp addr,
                self#map_exp exp, e, s)
 
   method map_load ~mem ~addr e s =
-    Exp.Load (self#map_exp mem, self#map_exp addr, e, s)
+    Exp.Load (self#map_sym mem, self#map_exp addr, e, s)
 
   method map_cast ct cs e = Exp.Cast (ct,cs,self#map_exp e)
 

--- a/lib/bap_types/bap_visitor.mli
+++ b/lib/bap_types/bap_visitor.mli
@@ -125,14 +125,14 @@ class ['a] visitor : object
   method leave_exp : exp -> 'a -> 'a
 
   (** {4 [Load (src,addr,endian,size)]}  *)
-  method enter_load : mem:exp -> addr:exp -> endian -> size -> 'a -> 'a
-  method visit_load : mem:exp -> addr:exp -> endian -> size -> 'a -> 'a
-  method leave_load : mem:exp -> addr:exp -> endian -> size -> 'a -> 'a
+  method enter_load : mem:var -> addr:exp -> endian -> size -> 'a -> 'a
+  method visit_load : mem:var -> addr:exp -> endian -> size -> 'a -> 'a
+  method leave_load : mem:var -> addr:exp -> endian -> size -> 'a -> 'a
 
   (** {4 [Store (dst,addr,src,endian,size)]}  *)
-  method enter_store : mem:exp -> addr:exp -> exp:exp -> endian -> size -> 'a -> 'a
-  method visit_store : mem:exp -> addr:exp -> exp:exp -> endian -> size -> 'a -> 'a
-  method leave_store : mem:exp -> addr:exp -> exp:exp -> endian -> size -> 'a -> 'a
+  method enter_store : mem:var -> addr:exp -> exp:exp -> endian -> size -> 'a -> 'a
+  method visit_store : mem:var -> addr:exp -> exp:exp -> endian -> size -> 'a -> 'a
+  method leave_store : mem:var -> addr:exp -> exp:exp -> endian -> size -> 'a -> 'a
 
   (** {4 [BinOp (op,e1,e2)]}  *)
   method enter_binop : binop -> exp -> exp -> 'a -> 'a
@@ -238,8 +238,8 @@ class mapper : object
 
   (** {3 Expressions}  *)
   method map_exp : exp -> exp
-  method map_load : mem:exp -> addr:exp -> endian -> size -> exp
-  method map_store : mem:exp -> addr:exp -> exp:exp -> endian -> size -> exp
+  method map_load : mem:var -> addr:exp -> endian -> size -> exp
+  method map_store : mem:var -> addr:exp -> exp:exp -> endian -> size -> exp
   method map_binop : binop -> exp -> exp -> exp
   method map_unop : unop -> exp -> exp
   method map_cast : cast -> nat1 -> exp -> exp

--- a/lib/bap_types/bil_piqi.ml
+++ b/lib/bap_types/bil_piqi.ml
@@ -106,12 +106,12 @@ let endianness_of_piqi = function
 let rec exp_to_piqi : exp -> Stmt_piqi.expr =
   function
   | Load (m, i, e, s) ->
-    let m = exp_to_piqi m in
+    let m = var_to_piqi m in
     let i = exp_to_piqi i in
     let e = endianness_to_piqi e in
     `load {P.Load.memory=m; address=i; endian=e; size=s;}
   | Store (m, i, v, e, size) ->
-    let m = exp_to_piqi m in
+    let m = var_to_piqi m in
     let i = exp_to_piqi i in
     let v = exp_to_piqi v in
     let e = endianness_to_piqi e in
@@ -156,12 +156,12 @@ let rec exp_to_piqi : exp -> Stmt_piqi.expr =
 
 let rec exp_of_piqi = function
   | `load {P.Load.memory; address; endian; size} ->
-    let m = exp_of_piqi memory in
+    let m = var_of_piqi memory in
     let i = exp_of_piqi address in
     let e = endianness_of_piqi endian in
     Load (m, i, e, size)
   | `store {P.Store.memory; address; value; endian; size} ->
-    let m = exp_of_piqi memory in
+    let m = var_of_piqi memory in
     let i = exp_of_piqi address in
     let v = exp_of_piqi value in
     let e = endianness_of_piqi endian in

--- a/lib/bap_types/conceval.ml
+++ b/lib/bap_types/conceval.ml
@@ -173,12 +173,12 @@ let handle_cast cast_kind size v =
 let rec eval_exp state exp =
   let result = match exp with
     | Load (arr, idx, endian, t) ->
-      (match Memory.load (eval_exp state arr) (eval_exp state idx) endian t with
+      (match Memory.load (State.peek_exn state arr) (eval_exp state idx) endian t with
        | Some v -> v
        | None -> Un ("Load from uninitialized memory",
                      Type.imm Size.(to_bits t)))
     | Store (arr, idx, v, endian, t) ->
-      Memory.store (eval_exp state arr) (eval_exp state idx) (eval_exp state v)
+      Memory.store (State.peek_exn state arr) (eval_exp state idx) (eval_exp state v)
         endian t
     | BinOp (op, l, r) -> handle_binop op (eval_exp state l) (eval_exp state r)
     | UnOp (op, v) -> handle_unop op (eval_exp state v)

--- a/lib/bap_types/exp.piqi
+++ b/lib/bap_types/exp.piqi
@@ -28,7 +28,7 @@
   .name load
   .field [
     .name memory
-    .type expr
+    .type var
   ]
   .field [
     .name address
@@ -48,7 +48,7 @@
   .name store
   .field [
     .name memory
-    .type expr
+    .type var
   ]
   .field [
     .name address


### PR DESCRIPTION
This PR proposes to disallow nested load and store operations in BIL.
Essentially, this is the core part of a change:

```diff
- | Load    of exp * exp * endian * size (** load from memory *)
- | Store   of exp * exp * exp * endian * size (** store to memory  *)
+ | Load    of var * exp * endian * size (** load from memory *)
+ | Store   of var * exp * exp * endian * size (** store to memory  *)
```

Motivation
==========

Before showing a motivating example, let me refresh your memory with
syntax and operating semantics of BIL. (I will drop sizes and endianess
from discussion for simplicity, they really do not affect the described
problem). Whenever I refer to an operational semantics, or typing rules,
I'm actually referring to a BAP handbook, from old BAP.

We denote a load from address `a` of memory object `m` with the abstract
entity,

   `Load(m,a)`

or with the following syntax:

   `m[a]`

We denote a storage of value `v` to address `a` of memory object `m` as,

   `Store(m,a,v)`

or with the following syntax:

   `m[a <- v]`.

A memory object `m` can be any expression. In a well-formed program,
this expression should be of type `mem_t`. So let us narrow our
discussion only to well-typed programs, to exclude expressions like
`(1+2)[3]`.

There're three kinds of expressions that may result in a well formed
memory object:

  - Var v, that will be looked up in context D
  - Store(m,a,v), that extends memory object m with binding `a <- v`
  - Let (v,x,m), that substitutes `v` for `x` in the expression `m`,
    that may result in a valid memory object.

Again, for simplicity, let us reason only about `Var` and `Store`.

Since memory object is an expression we can encode nested (or parallel)
store operations, like this:

   `Store (Store (m,a1,x1),a2,x2)`

or in our concrete syntax:

   `m[a1 <- x1][a2 <- x2]`

Since the above expression is a proper memory object, it can be used
in the load instruction:

   `m[a1 <- x1][a2 <- x2][a1]`

that should, according to the operational semantics, evaluate to `x1`.

But consider the following expression:

   `m[a1 <- x1][a2 <- m[a1 <- x2][a1]][a1]`

This expression is also well formed and it also must evaluate to
`x2`, according to our operational semantics.

The problem arises, when we try to model semantics of a BIL with some
simple model of computation, like register machine with RAM.

Expressions in BIL don't have side effects. When we store a side
effect, visible to a machine, occurs when we assign a new memory object
to an old one. (Usually we limit ourselves to machines with only one
memory). For example,

  `m := m[a1 <- x1][a2 <- x2]`

will result in an ordered sequence of two side effects:

   1. store x1 at a1
   2. store x2 at a2

For load expressions there is no place for side effects at all.
(This is another problem, as memory access is also a side effect
that affects system, but this is another story).

Now let's try to figure out what side-effects will have the following
statement:

   `m := m[a1 <- x1][a2 <- m[a1 <- x2][a1]]`

Maybe:

   1. store x1 at a1
   2. store x2 at a1
   3. store x2 at a1

This will lead to an incorrect memory, as we have `x2` at `a1` instead
of `x1`. We can enumerate other possibilities, and it looks like that we
will end up with the only choice, that is valid - ignore nested write,
as it wasn't "commited" to a memory with an assignment statement.

The problem, actually, arose from a fact that `m[a1 <- x2]` from
mathematical perspective, creates a fresh new clone of memory `m` and
extends it with binding `a1 <- x2`. So that, loads

   `(m[a1 <- x1][a2 <- m[a1 <- x2][a1]])[a1]`

and

   `m[a1 <- x2][a1]`

are created from two different memory objects that have diverged at some
point of their history.

We can highlight the problem by desugaring this parallel match into a
series of assignments, while preserving SSA form (just for clarity).

`m := m[a1 <- x1][a2 <- m[a1 <- x2][a1]]` is transformed to:

```
  1: m1 = m[a1 <- x1]
  2: m2 = m[a1 <- x2]
  3: m3 = m1[a2 <- m2[a1]]
```

Here we clearly see that at program point (3) we simultaneously have two
different versions of memory, m1 and m2, that are clones of original
memory `m` with the same cell holding different values.

Unfortunately, we cannot model this memory cloning, not because it is
hard to implement (it is not), but because it moves us significantly far
away from real machines, that we would like to model. They are
deterministic and can't clone itself. There is only one memory (or
finite amount of designated memories), and each load and store
operations corresponds to a particular physical effect on a particular
memory address of real memory chip.

So, the real problem here is that we trying to model load and stores
with side effectless expressions. Although this is mathematically nice,
this indeed moves us away from real machines. But I'm not proposing to
raise them into statements, this is a too big change.

Instead, I'm claiming that if we limit the expressiveness of load and
store expressions we can get clean side effects that model memory
effects close to real machines, while still preserving flexibility of
memory objects as expressions [1].

By limiting `mem` in `Load(mem,addr)` to be a variable, we attach a side
effect to occur simultaneously with a context lookup.  Whenever we look
a `mem` variable we atomically lookup for the `addr` offset of this
memory. We're also protected from any side-effects, occuring in
evaluating of `addr` expression, since the only way to modify memory is
to perform explicit assignment.

By limiting `mem` in `Store(mem,addr,x)` expression, we allow to update
memory only explicitly via `Move` operation, and with one storage
operation per Move statement. This provides us with an excellent place
for a side-effect (at the end of the statement).

With a new scheme, we cannot encode our motivating example.  And  that's
right, since it is impossible to implement it on a real machine (as it
is impossible that the same address has two different values at the same
time).

[1]: Unfortunately, limiting load and stores will not solve all our problems,
as we still have `let` expression, where memory object produced by a
store expression can occur without requiring explicit side-effect, e.g.,

      `let m = m[a <- x1] in m[a] + 1`

That's why I still think that we need to get rid of let expressions. To
continue let's just assume, that already got rid of them.