### PR TITLE
Add PFSM assisted shingled disassembler, lifter and unit tests

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -268,6 +268,8 @@ Library disasm
                  Bap_disasm_x86_types,
                  Bap_disasm_x86_utils,
                  Bap_disasm_basic,
+                 Bap_disasm_shingled,
+                 Bap_disasm_shingled_lifter,
                  Bap_disasm_block,
                  Bap_disasm_block_intf,
                  Bap_disasm_insn,
@@ -277,6 +279,7 @@ Library disasm
                  Bap_disasm_symtab,
                  Bap_disasm_types,
                  Bap_insn_kind,
+                 Bap_insn_aliasing,
                  Bap_byteweight,
                  Bap_signatures
 

--- a/lib/bap_disasm/bap_disasm_shingled.ml
+++ b/lib/bap_disasm/bap_disasm_shingled.ml
@@ -1,0 +1,127 @@
+open Core_kernel.Std
+open Bap_types.Std
+open Bap_insn_aliasing
+
+module Dis = Bap_disasm_basic
+module Memory = Bap_memory
+module Memmap = Bap_memmap
+module Insn = Bap_disasm_insn
+
+type insn = Bap_disasm_insn.t
+type sheerable = Maybe_code of insn
+               | Data
+
+let prev_chunk mem ~addr =
+  let prev_addr = Addr.pred addr in
+  Memory.view ~from:prev_addr mem
+
+let disasm dis mem =
+  let open Seq.Generator in
+  let prev = prev_chunk mem in
+  let rec back cur_mem =
+    let cur_point = Memory.min_addr cur_mem in
+    let elem = match Dis.insn_of_mem dis cur_mem with
+      | Ok (mem, insn, _) ->  (mem, insn)
+      | Error _ -> (cur_mem, None) in
+    match prev ~addr:cur_point with
+    | Ok next_mem -> yield elem >>= fun () -> back next_mem
+    | Error _ -> yield elem >>= fun () -> return () in
+  match (Memory.view mem ~from:(Memory.max_addr mem)) with
+  | Ok mem -> back mem
+  | Error err -> raise (Error.to_exn err)
+
+let all_shingles dis mem ~init ~at =
+  Sequence.fold (Sequence.Generator.run (disasm dis mem)) ~init ~f:at
+
+let markup dis gmem =
+  let open Seq.Generator in
+  let shingles = Memmap.empty in
+  let at shingles (mem, insn) = (
+    match insn with
+    | None -> (Memmap.add shingles mem Data)
+    | Some insn -> 
+      (Memmap.add shingles mem (Maybe_code (Insn.of_basic insn))) 
+  ) in (all_shingles dis gmem ~init:shingles ~at)
+
+let static_successors gmin gmax lmem insn =
+  let fall_through =
+    if not (is_exec_ok gmin gmax lmem) then [None, `Fall]
+    else
+      let i = Word.((Memory.min_addr lmem) ++ (Memory.length lmem)) in      
+      [Some i, `Fall] in
+  if (Insn.may_affect_control_flow insn) then (
+    let targets = (Insn.bil insn |> dests_of_bil) in
+    if (not @@ Insn.is_unconditional_jump insn) then
+      List.append fall_through targets
+    else
+      targets
+  ) else fall_through
+
+
+(* Sheer simply prunes known unacceptable receiving state points by
+   calculating the transitive closure of a node set of x, if it
+   contains an invalid instruction, this x is invalid too  *)
+let sheer shingles gmem =
+  (* depth first search for all that bad points to *)
+  let mark_data shingles mem =
+    Memmap.add (Memmap.remove shingles mem) mem Data in
+  let gmin = Memory.min_addr gmem in
+  let gmax = Memory.max_addr gmem in
+  let target_in_mem =
+    targ_in_mem gmin gmax in
+  let get_targets = static_successors gmin gmax in
+  let lookup addr = Memmap.lookup shingles addr |>
+          Seq.find ~f:(fun (mem,_) ->
+                        Addr.equal addr (Memory.min_addr mem)) in
+  let find_mem addr f default= match lookup addr with
+    | Some (mem, _) -> f default mem
+    | _ -> default in
+  let is_data addr = not (target_in_mem addr) ||
+                     match lookup addr with
+                     | Some (mem, (Maybe_code _)) -> false
+                     | _ -> true in
+  let rec sheer_data shingles addr = 
+    if not (target_in_mem addr) then
+      (find_mem addr mark_data shingles)
+    else
+      match lookup addr with
+      | Some (mem, (Maybe_code insn)) ->
+        let targets = (get_targets mem insn) in
+        let shingles, result = List.fold ~init:(shingles,false) targets
+            ~f:(fun (shingles, so_far) (target,_) ->
+                match target with
+                | Some target ->
+                  if (so_far || (is_data target)) then
+                    mark_data shingles mem, true
+                  else
+                    sheer_data shingles target, false
+                | None -> mark_data shingles mem, true) in
+        let shingles, final_result =
+          List.fold ~init:(shingles, false || result) targets
+            ~f:(fun (shingles, so_far) (target,_) ->
+                match target with
+                | Some target ->
+                  if (so_far || is_data target) then
+                    mark_data shingles mem, true
+                  else shingles, so_far
+                | None -> shingles, true
+              ) in
+        if result then
+          sheer_data (mark_data shingles mem) (Addr.succ addr)
+        else sheer_data shingles (Addr.succ addr)
+      | Some (_, Data) | None -> sheer_data shingles (Addr.succ addr)
+  in sheer_data shingles gmin
+
+(* TODO: this should apply the PFSM to the memmap to make selections *)
+let maximum_probable_paths shingles gmem =
+  let shingles = sheer shingles gmem in
+  Memmap.filter_map shingles ~f:(function
+      | Maybe_code insn -> Some insn
+      | _ -> None)
+
+let sheered_shingles ?backend arch ?dis mem =
+  let backend = Option.value backend ~default:"llvm" in
+  let dis = Option.value dis ~default:
+      (Dis.create ~backend (Arch.to_string arch) |> ok_exn)  in
+  let shingles = markup dis mem in
+  maximum_probable_paths shingles mem

--- a/lib/bap_disasm/bap_disasm_shingled.mli
+++ b/lib/bap_disasm/bap_disasm_shingled.mli
@@ -1,0 +1,26 @@
+open Core_kernel.Std
+open Bap_arch
+open Bap_types.Std
+
+module Memory = Bap_memory
+open Memory
+module Memmap = Bap_memmap
+module Insn= Bap_disasm_insn
+
+module Dis = Bap_disasm_basic
+
+(** This is a conservative byte offset disassembler; everything that *)
+    (** is returned in a list of type mem * insn option. It is tail
+    recursive  *)
+val all_shingles : ('a, 'b) Dis.t -> Memory.t -> init:('c) ->
+  at:('c -> Memory.t * (Dis.asm, Dis.kinds) Dis.insn option -> 'c) ->
+  'c
+
+(** Applies a couple of techniques to try and sheer off noise, *)
+    (** dropping obviously recognizable data, and attempting a maximal
+    recognition backward propagation of fall through and
+    subsuequently a probabilistic finite state machine for selecting
+    maximally probable execution sequences based on a corpus of
+    trianing data. *)
+val sheered_shingles :?backend:string -> arch ->
+  ?dis:(Dis.empty, Dis.empty) Dis.t -> Memory.t -> Insn.t Memmap.t

--- a/lib/bap_disasm/bap_disasm_shingled_lifter.ml
+++ b/lib/bap_disasm/bap_disasm_shingled_lifter.ml
@@ -1,0 +1,43 @@
+(* Uses shingled to get list of insns for every offset *)
+open Core_kernel.Std
+open Or_error
+open Bap_types.Std
+
+module Dis = Bap_disasm_basic
+module Insn = Bap_disasm_insn
+module Memory = Bap_memory
+module Arch= Bap_arch
+module Memmap = Bap_memmap
+exception Create_mem of Error.t
+
+let create_memory arch s addr =
+  let endian = Arch.endian arch in
+  Memory.create endian addr @@
+  Bigstring.of_string s |> function
+  | Ok r -> r
+  | Error e -> raise (Create_mem e)
+
+let lift_all ?backend ?min_addr arch string_mem =
+  let addr_size= Size.to_bits @@ Arch.addr_size arch in
+  let min_addr =
+    Option.value min_addr ~default:(Addr.of_int addr_size 0) in
+  let backend = Option.value backend ~default:"llvm" in
+  let gmem = (create_memory arch string_mem min_addr) in
+  let dis = Dis.create ~backend (Arch.to_string arch) |> ok_exn in
+  let open Seq.Generator in
+  Bap_disasm_shingled.all_shingles dis gmem ~init:[]
+    ~at:(fun accu (mem,insn) -> match insn with
+        | Some insn -> Insn.(bil @@ of_basic insn) ::accu
+        | None -> accu)
+
+
+let lift_sheered ?backend ?min_addr arch string_mem =
+  let addr_size= Size.to_bits @@ Arch.addr_size arch in
+  let min_addr =
+    Option.value min_addr ~default:(Addr.of_int addr_size 0) in
+  let gmem = (create_memory arch string_mem min_addr) in
+  let shingles = Bap_disasm_shingled.sheered_shingles
+      ?backend arch gmem in
+  Memmap.map shingles ~f:(fun insn ->
+      Insn.(bil insn))
+    

--- a/lib/bap_disasm/bap_disasm_std.ml
+++ b/lib/bap_disasm/bap_disasm_std.ml
@@ -27,6 +27,8 @@ module Block   = Bap_disasm_block
     blocks. *)
 module Disasm_expert = struct
   module Basic = Bap_disasm_basic
+  module Shingled = Bap_disasm_shingled
+  module Shingled_lifter = Bap_disasm_shingled_lifter
   module Recursive = Bap_disasm_rec
   module Kind = Bap_insn_kind
   module Insn = Bap_disasm_basic.Insn

--- a/lib/bap_disasm/bap_insn_aliasing.ml
+++ b/lib/bap_disasm/bap_insn_aliasing.ml
@@ -1,0 +1,40 @@
+open Core_kernel.Std
+open Bap_types.Std
+
+module Dis = Bap_disasm_basic
+module Memory = Bap_memory
+
+let fold_consts = Bil.(fixpoint fold_consts)
+
+let kind_of_dests = function
+  | xs when List.for_all xs ~f:(fun (_,x) -> x = `Fall) -> `Fall
+  | xs -> if List.exists  xs ~f:(fun (_,x) -> x = `Jump)
+    then `Jump
+    else `Cond
+
+
+let kind_of_branches t f =
+  match kind_of_dests t, kind_of_dests f with
+  | `Jump,`Jump -> `Jump
+  | `Fall,`Fall -> `Fall
+  | _           -> `Cond
+
+let rec dests_of_bil bil =
+  fold_consts bil |> List.concat_map ~f:dests_of_stmt
+and dests_of_stmt = let open Bil in function
+  | Jmp (Bil.Int addr) -> [Some addr,`Jump]
+  | Jmp (_) -> [None, `Jump]
+  | If (_,yes,no) -> merge_branches yes no
+  | While (_,ss) -> dests_of_bil ss
+  | _ -> []
+and merge_branches yes no =
+  let x = dests_of_bil yes and y = dests_of_bil no in
+  let kind = kind_of_branches x y in
+  List.(rev_append x y >>| fun (a,_) -> a,kind)
+
+let is_exec_ok gmem_min gmem_max lmem  =
+  Addr.((Memory.min_addr lmem) >= gmem_min) &&
+  Addr.((Memory.max_addr lmem) <= gmem_max)
+
+let targ_in_mem gmem_min gmem_max addr =
+  Addr.(addr >= gmem_min && addr < gmem_max)

--- a/lib/bap_disasm/bap_transmat_normal.ml
+++ b/lib/bap_disasm/bap_transmat_normal.ml
@@ -1,0 +1,166 @@
+open Bap.Std
+open Core_kernel.Std
+open Bigarray
+open Bap_insn_aliasing
+
+type mat = (float, float64_elt, c_layout) Array2.t
+type bijective_insnmap = int String.Table.t * string Int.Table.t
+type corpus = insn memmap
+type t = {tmat : mat; arch : Arch.t; insn_ids : bijective_insnmap;
+          size : int}
+
+let column_total mat i j =
+  let rec total j =
+    if not (j = 0) then (mat.{i,j} +. (total (j-1))) else mat.{i,j}
+  in total j
+
+let probabilities newmat oldmat size = 
+  let rec initialize i j =
+    if not (i > 0) then
+      newmat.{i,j} <- oldmat.{i,j} /. (column_total oldmat i (size-1));
+    initialize (i-1) j in
+  initialize (size-1) (size-1)
+
+let copy newmat oldmat size =
+  let rec initialize i j =
+    if (not (i > 0)) then (
+      newmat.{i, j} <- oldmat.{i,j};
+      initialize i (j-1)
+    ) else
+      initialize (i-1) j in initialize size size
+
+(* TODO test to make sure that order of i, j is correct *)
+let transition_of_data totals =
+  let size = Array2.dim1 totals in
+  let transitions = Array2.create Float64 c_layout size size in
+  probabilities transitions totals size
+
+let totals_fname arch = (Arch.to_string arch) ^ "_transition_totals"
+let insn_map_fname arch = (Arch.to_string arch) ^ "_insn_ids"
+
+let totals_of_arch arch =
+  let ids_to_insns = (Int.Table.create ()) in
+  let insns_file = (insn_map_fname arch) in
+  let insns_to_ids = (if (Sys.file_exists insns_file) then (
+      let contents = In_channel.with_file
+          insns_file ~f:In_channel.input_all in
+      (Sexp.of_string contents |> String.Table.t_of_sexp
+         (Int.t_of_sexp));
+    ) else (String.Table.create ())) in
+  Hashtbl.iter insns_to_ids ~f:(fun ~key ~data ->
+      ignore (Hashtbl.add ids_to_insns ~key:data ~data:key));
+  let s = (totals_fname arch) in
+  let mat, size = if (Sys.file_exists s) then (
+    let contents = In_channel.with_file s ~f:In_channel.input_all in
+    let elements = Sexp.of_string contents |>
+                   List.t_of_sexp
+                     (fun srow -> (
+                          List.t_of_sexp
+                            (fun element ->
+                              Float.t_of_sexp element) srow))  in
+    let size = max 500 (List.length elements) in
+    let mat = Array2.create Float64 c_layout size size in
+    Array2.fill mat 0.0;
+    let total = ref 0.0 in
+    List.iteri elements ~f:(fun i row ->
+        List.iteri row ~f:(fun j column_elem ->
+            total := !total +. column_elem;
+            (mat.{i,j} <- column_elem)
+          )
+      );
+    print_endline ("total: " ^ Float.to_string !total);
+    mat, size
+  ) else Array2.create Float64 c_layout 500 500, 500 in
+  { tmat=mat; arch; insn_ids=(insns_to_ids, ids_to_insns); size }
+
+let of_arch arch =
+  let { tmat=totals; arch; insn_ids; size } = totals_of_arch arch in
+  let insn_to_ids, ids_to_insns = insn_ids in
+  { tmat = (transition_of_data totals); arch;
+    insn_ids = (insn_to_ids, ids_to_insns); size }
+
+let write_transmat transmat =
+  let convert transmat =
+    let size = (Array2.dim1 transmat.tmat) -1 in
+    let rec fill1 i j = 
+      let rec fill2 j =
+        if j > 0 then
+          (transmat.tmat.{i,j}) :: (fill2 (j-1))
+        else [transmat.tmat.{i,j}] in
+      if i > 0 then
+        (fill2 j) :: fill1 (i-1) j
+      else [fill2 j] in fill1 size size in
+  let data = convert transmat in      
+  let data = List.sexp_of_t
+      (fun column -> List.sexp_of_t Float.sexp_of_t column)
+      data |> Sexp.to_string in
+  Out_channel.write_all (totals_fname transmat.arch) data;
+  let insn_to_ids,_ = transmat.insn_ids in
+  let ids = String.Table.sexp_of_t Int.sexp_of_t insn_to_ids in
+  Out_channel.write_all
+    (insn_map_fname transmat.arch) (Sexp.to_string ids)
+
+let remap_all transmat =
+  let size = Array2.dim1 transmat.tmat in
+  let to_replace =
+    Array2.create Float64 c_layout size size in
+  Array2.fill to_replace 0.0;
+  copy to_replace transmat.tmat transmat.size
+
+
+let map_insn transmat insn =
+  let instructions = transmat.insn_ids in
+  let count = Hashtbl.length @@ fst instructions in
+  (match (Hashtbl.find (fst instructions) (Insn.name insn)) with
+  | None -> (
+      (match (Hashtbl.add
+                (fst instructions)
+             ) ~key:(Insn.name insn) ~data:(count) with
+      | _ -> ());
+      (match (Hashtbl.add
+                (snd instructions) ~key:(count) ~data:(Insn.name insn)) with
+      | _ -> ());
+    )
+  | _ -> ());
+  if (count >= transmat.size) then
+    remap_all transmat, count+1
+  else transmat, count+1
+
+let update_from_shingles transmat corp =
+  let zero = (Addr.of_int ~width:(Size.to_bits @@ Arch.addr_size transmat.arch) 0) in
+  let min_addr = Option.value (Memmap.min_addr corp) ~default:zero in
+  let max_addr = Option.value (Memmap.max_addr corp) ~default:zero in
+  let targets = get_targets min_addr max_addr in
+  let final = Memmap.to_sequence corp |> Seq.fold ~init:transmat ~f:(fun accu (mem, oinsn) ->
+      List.fold ~init:accu (targets mem oinsn)
+          ~f:(fun accu (addr, etype) ->
+              match addr with
+              | Some addr -> 
+                Seq.fold ~init:accu (Memmap.lookup corp addr)
+                  ~f:(fun transmat (targ_mem, targ_insn) ->
+                      if (addr=(Memory.min_addr targ_mem)) then (
+                        let accu, target =
+                          map_insn accu targ_insn in
+                        let accu, origin = 
+                          map_insn accu oinsn in
+                        (accu.tmat.{target, origin }
+                         <- accu.tmat.{target, origin } +. 1.0); 
+                        accu
+                      ) else transmat)
+          | None -> transmat (* cannot associate a statistic with a target
+                          that may not have been computable  *)
+        );
+    ) in
+  write_transmat final
+
+let update_from_disasm transmat disasm = 
+  let corp = ref Memmap.empty in
+  Seq.iter (Disasm.insns disasm)
+    ~f:(fun (mem, insn) -> (corp := Memmap.add !corp mem insn));
+  update_from_shingles transmat !corp
+
+let transition transmat from_insn to_insn =
+  let transmat, target = map_insn transmat to_insn in
+  let transmat, origin = map_insn transmat from_insn in
+  (transmat.tmat).{target, origin}
+

--- a/lib/bap_disasm/bap_transmat_normal.mli
+++ b/lib/bap_disasm/bap_transmat_normal.mli
@@ -1,0 +1,36 @@
+open Bap.Std
+open Bigarray
+
+type t
+type corpus = insn memmap
+type mat = (float, float64_elt, c_layout) Array2.t
+
+(** of_arch is the main and only constructor here, and naturally *)
+    (** it does the job of retrieving from a retained data
+    store the statistics specific to an architecture *)
+val of_arch : arch -> t
+
+(** a constructor identical to of_arch, except that it does not *)
+    (** perform the actual probability calculation. *)
+val totals_of_arch : arch -> t
+
+(** transition accepts a training data matrix and two instructions *)
+    (** and subsequently returns the corresponding statistical
+    likelihood of transition. *)
+val transition : t -> insn -> insn -> float
+
+(** update_from_shingles accepts a corpus, which is a collection of instructions *)
+    (** These instructions are examined to determine static
+    successors, and for each static successor it updates the
+    statistic accordingly. *)
+val update_from_shingles : t -> corpus -> unit
+
+(** A convenience function that facilitates the translation from *)
+    (** disasm to a memmap; it updates the training data *)
+val update_from_disasm : t -> disasm -> unit
+
+(** transition_of_data computes the transition matrix when given a
+    totals and then calculates and returns transition probabilities
+    using it
+*)
+val transition_of_data : mat -> mat

--- a/lib_test/bap_disasm/test_training.ml
+++ b/lib_test/bap_disasm/test_training.ml
@@ -1,0 +1,25 @@
+open OUnit2
+open Core_kernel.Std
+open Bap.Std
+open Or_error
+open Format
+module Dis = Disasm_expert.Basic
+
+let train filename =
+  let img, errs = Image.create filename |> ok_exn in
+  let arch = Image.arch img in
+  let transmat = Bap_transmat_normal.totals_of_arch arch in
+  Bap_transmat_normal.update_from_disasm transmat @@ disassemble_image img 
+
+let test_training test_ctxt =
+  let files = Sys.readdir (Sys.getcwd () ^ "/corpora") in
+  Array.iter files ~f:(fun f -> train (Sys.getcwd () ^ "/corpora/" ^ f))
+
+let () =
+  let suite = 
+  "suite">:::
+    [
+      "test_training">:: test_training;
+    ] in
+  run_test_tt_main suite
+;;


### PR DESCRIPTION
This commit adds a shingled disassembler and lifter
and makes it available under
Bap.Std.Disasm_expert.{Shingled, Shingled_lifter}.
It works in a Continuation Passing Style as much as
realistically possible, and utilizes a single pass
analysis to traverse possible code sequences down to
known data, wherein such can be sheered off. Additionally,
the skeleton implementation of a training corpus facility
to build a probabilistic finite state machine for future
higher accuracy selections of possible code sequences, and
heurism facilitation is provided. Lastly, a lifter module
grants users an easy ability to drive the shingled
disassembler as either a graph sheering capability or a
simple conservative pass. Execution speed is expected to
be all but linear save for the usage of memmap, which forces
theoretical considerations to judge O(n*log(n)). Memory is
 expected to be linear, O(n). 

It is duly noted that precise conformance to the original paper's
original graph sheering techniques may result in at maximum
two edge cases possibly missed; that is, sheering occurs
only on one half of the expected potential cases that can be
affected. At the current time, supposing a sequence of static
successors lead to a known data, their reverse transitive closure
is traversed and subsequently marked data. However, 1) in the case
that a known data proceeds a body of instructions, those
instructions are missed. Additionally, 2) there is at least a
scenario wherein a sequence of data bytes that are static
successors to expected valid code are sheered off by means of
reverse static successor traversal. However, testing and data
driven knowledge will inform future recourse, and additionally
various future improvements through use will also advise 
any potential performance improvements.