### PR TITLE
Add ansi color tagging, fix few bugs.

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -3017,6 +3017,16 @@ module Std : sig
   (** Color something with a color  *)
   val color : color tag
 
+
+  (** print marked entity with the specified color.  (the same
+      as color, but pretty printing function will output ascii escape
+      sequence of corresponding color.  *)
+  val foreground : color tag
+
+
+  (** print marked entity with specified color. See [foreground].  *)
+  val background : color tag
+
   (** A human readable comment *)
   val comment : string tag
 

--- a/lib/bap_types/bap_attributes.ml
+++ b/lib/bap_types/bap_attributes.ml
@@ -17,6 +17,35 @@ module Color = struct
     Format.fprintf ppf "%a" Sexp.pp (sexp_of_t color)
 end
 
+module Foreground = struct
+  type t = Color.t with bin_io, compare, sexp
+  let to_ascii = function
+    | `black   -> "\x1b[30m"
+    | `red     -> "\x1b[31m"
+    | `green   -> "\x1b[32m"
+    | `yellow  -> "\x1b[33m"
+    | `blue    -> "\x1b[34m"
+    | `magenta -> "\x1b[35m"
+    | `cyan    -> "\x1b[36m"
+    | `white   -> "\x1b[37m"
+  let pp ppf c = Format.fprintf ppf "%s" @@ to_ascii c
+end
+
+module Background = struct
+  type t = Color.t with bin_io, compare, sexp
+  let to_ascii : t -> string = function
+    | `black   -> "\x1b[40m"
+    | `red     -> "\x1b[41m"
+    | `green   -> "\x1b[42m"
+    | `yellow  -> "\x1b[43m"
+    | `blue    -> "\x1b[44m"
+    | `magenta -> "\x1b[45m"
+    | `cyan    -> "\x1b[46m"
+    | `white   -> "\x1b[47m"
+
+  let pp ppf c = Format.fprintf ppf "%s" @@ to_ascii c
+end
+
 type color = Color.t with bin_io, compare, sexp
 
 let comment = register (module String)
@@ -62,3 +91,11 @@ let subroutine_name = register (module String)
 let filename = register (module String)
     ~name:"filename"
     ~uuid:"9701d189-24e3-4348-8610-0dedf780d06b"
+
+let foreground = register (module Foreground)
+    ~name:"foreground"
+    ~uuid:"56b29739-2df4-4e6c-9f63-15e20edf1857"
+
+let background = register (module Background)
+    ~name:"background"
+    ~uuid:"9a80a9cc-4106-48fc-abf3-55d7b333e734"


### PR DESCRIPTION
This is a small technical update. Other than few bug fixes this and
there it brings a new feature: ansi color tags.

Ansi colors
===========

We now have two new tags: `foreground` and `background`. They can be
used to add attributes to IR terms. The pretty printing function of
this values will print corresponding color in ANSI escape codes. So,
the only thing that you need is to mark you term with some color, e.g.,

```ocaml
Term.set_attr t foreground `green
```

or

```ocaml
Term.set_attr t background `red
```

And then if you enable attribute printing, you will see colors, if your
terminal supports this. Just in case if you forgot how to enable
printing attributes a gentle reminder: use `--emit-attr` option, like
this,

```
bap --emit-attr=foreground
```

to get a colored foreground, or,

```
bap --emit-attr=background
```

for background. Use shell globbing (if you're using shell), to get both:

```
bap --emit-attr={fore,back}ground
```

To enable colors in your emacs compilation buffer, add the following to
your .emacs

```lisp
(require 'ansi-color)
(defun colorize-compilation-buffer ()
  (toggle-read-only)
  (ansi-color-apply-on-region (point-min) (point-max))
  (toggle-read-only))
(add-hook 'compilation-filter-hook 'colorize-compilation-buffer)
```