### PR TITLE
Allow to introduce new tag values in plugins.

### DIFF
--- a/lib/bap_types/bap_value.ml
+++ b/lib/bap_types/bap_value.ml
@@ -11,8 +11,14 @@ module type S = sig
   val pp : Format.formatter -> t -> unit
 end
 
+
 type 'a tag = 'a Type_equal.Id.t
 type t = Univ.t
+
+module type Tag = sig
+  type t
+  val tag : t tag
+end
 
 module Typeid = Bap_uuid
 
@@ -24,6 +30,8 @@ type type_info = {
   of_string : string -> Univ.t;
   to_string : Univ.t -> string;
   compare : Univ.t -> Univ.t -> int;
+  witness : (module S);
+  tag : (module Tag);
 }
 
 let types : type_info Type_equal.Id.Uid.Table.t  =
@@ -32,29 +40,49 @@ let types : type_info Type_equal.Id.Uid.Table.t  =
 let info_of_uuid uuid =
   Hashtbl.to_alist types |> List.find ~f:(fun (k,i) -> i.uuid = uuid)
 
+let unpack_tag (type a) (module T : Tag with type t = a) = T.tag
+
+external unsafe_cast : (module Tag) -> (module Tag with type t = 'a) = "%identity"
+
+let same_modules (module X : S) (module Y : S) =
+  phys_same X.compare Y.compare
+
+let tag_of_info (type a) (module S : S with type t = a) info
+  : a tag option =
+  if same_modules info.witness (module S)
+  then Some (unpack_tag (unsafe_cast info.tag))
+  else None
+
 let register (type a) ~name ~uuid
     (typ : (module S with type t = a)) : a tag =
   let module S = (val typ) in
-  if info_of_uuid uuid <> None then
-    invalid_argf "UUID %s is already in use" (Typeid.to_string uuid) ();
-  let tag = Type_equal.Id.create name S.sexp_of_t in
-  let pp ppf univ = S.pp ppf (Univ.match_exn univ tag) in
-  let of_string str =
-    Univ.create tag (Binable.of_string (module S) str) in
-  let to_string x =
-    Binable.to_string (module S) (Univ.match_exn x tag) in
-  let compare x y = match Univ.match_ x tag, Univ.match_ y tag with
-    | Some x, Some y -> S.compare x y
-    | _,_ -> Type_equal.Id.Uid.compare
-               (Univ.type_id_uid x) (Univ.type_id_uid y) in
-  let info = {
-    uuid; pp;
-    of_string;
-    to_string;
-    compare;
-  } in
-  Hashtbl.add_exn types ~key:(Type_equal.Id.uid tag) ~data:info;
-  tag
+  match info_of_uuid uuid with
+  | None ->
+    let tag = Type_equal.Id.create name S.sexp_of_t in
+    let pp ppf univ = S.pp ppf (Univ.match_exn univ tag) in
+    let of_string str =
+      Univ.create tag (Binable.of_string (module S) str) in
+    let to_string x =
+      Binable.to_string (module S) (Univ.match_exn x tag) in
+    let compare x y = match Univ.match_ x tag, Univ.match_ y tag with
+      | Some x, Some y -> S.compare x y
+      | _,_ -> Type_equal.Id.Uid.compare
+                 (Univ.type_id_uid x) (Univ.type_id_uid y) in
+    let info = {
+      uuid; pp;
+      of_string;
+      to_string;
+      compare;
+      witness = (module S);
+      tag = (module (struct type t = a let tag = tag end));
+    } in
+    Hashtbl.add_exn types ~key:(Type_equal.Id.uid tag) ~data:info;
+    tag
+  | Some (_,info) -> match tag_of_info typ info with
+    | None ->
+      invalid_argf "UUID %s is already in use" (Typeid.to_string uuid) ()
+    | Some tag -> tag
+
 
 module Nil = struct
   type t = Typeid.t * string with sexp_of


### PR DESCRIPTION
This PR allows to introduces new tags in plugins and pass values
of the specified tag between two different plugins.

Previously it wasn't possible, since a module that defines a tag
was evaluated per each plugin, and a failure exception was thrown
after the first evaluation, stating that the tag value is already
registered.

This PR fixes this in the following way. On a first registration
we store the provided module as well as freshly create tag value
in the info data structure. On consequent registration we look at
the type info table and if we find the same module as a user is
trying to register then we're returning a stored tag, otherwise
we bail out with an error. Of course, OCaml type system will not
allow us to extract a tag value from monomorphic table, so here
we use dark magic, and type cast it. It is unsound, but can be
considered safe, because we have at least two witnesses of type
equality. The first witness is that uuid of both types is equal
(but this is not enough, since a user can accidentally (by copy
pasting) provide the same uuid for two different types). The
second witness is that both types share the same comparison function.
It looks like, that the latter is enough to prove that the types,
are the same, since we're requiring to pass a module as a value,
and packing actually creates a record with functions. For example,
the following two modules will not be considered equal:

```ocaml
module X = struct
  type t = int
  let compare = compare

module Y = struct
  type t = float
  let compare = compare
end
```

A full example, showing how a user can pass a value of arbitrary
type between two plugins is provided below:

```ocaml
                               (* definition.ml *)

    open Core_kernel.Std
    open Bap.Std

    let note = Value.Tag.register
        ~name:"note"
        ~uuid:"e4562d18-3ac5-4070-bc12-b99b9856dfce"
        (module String)
```
```ocaml
                              (* definition.mli *)

    open Bap.Std

    val note : string tag
```
```ocaml
                                 (* pass1.ml   *)

    open Bap.Std
    open Definition

    let main proj =
      Project.set proj note "hello"

    let () =
      Project.register_pass "pass1" main
```
```ocaml
                                 (* pass2.ml   *)

    open Bap.Std
    open Core_kernel.Std
    open Definition

    let main proj =
      match Project.get proj note with
      | Some note -> printf "Note: %s\n" note
      | None -> printf "No notes\n"

    let () = Project.register_pass' "pass2" main
```
compile with
```
bapbuild pass1.plugin && bapbuild pass2.plugin && bap /bin/true -lpass1 -lpass2
```

expected output:

```
Note: hello
```