### PR TITLE
Refine plugin system

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -5445,7 +5445,7 @@ module Std : sig
     (** [to_sequence symtab] returns a sequence of functions  *)
     val to_sequence : t -> fn seq
 
-    (** [name_of_fn fn] returns symbol name  *)
+    (** [name_of_fn fn] returns symbol's name  *)
     val name_of_fn : fn -> string
 
     (** [entry_of_fn fn] returns an entry block of a given function [fn]  *)
@@ -7608,17 +7608,16 @@ module Std : sig
         removing all arguments that doesn't start with
         [--name-]. Then, from all command arguments that are left, the
         [--name-] prefix is substituted with [--]. For example, if
-        [argv] contained [ [| "bap"; "-lcallgraph";
+        [argv] contained [ [| "bap"; "-lcallgraph"; "--callgraph"
         "--callgraph-help"|]] then pass that registered itself under
         [callgraph] name will receive the following array of arguments
         [ [| "callgraph"; --help |] ]. That means, that plugins can't
         accept arguments that are anonymous or short options.
 
-        Note: currently only the following syntax is supported:
-         [--plugin-name-agrument-name=value], the following IS NOT
-         supported [--plugin-name-argument-name value].
     *)
-    val run_passes : ?library:string list -> ?argv:string array -> t -> t Or_error.t
+    val run_pass :
+      ?library:string list ->
+      ?argv:string array -> t -> string -> t Or_error.t
 
 
     (** [passes ?library ()] returns a transitive closure of all
@@ -7631,7 +7630,9 @@ module Std : sig
         handling/printing.
         @raise Pass_failed if failed to load, or if plugin failed at runtime.
     *)
-    val run_passes_exn : ?library:string list -> ?argv:string array -> t -> t
+    val run_pass_exn :
+      ?library:string list ->
+      ?argv:string array -> t -> string -> t
 
 
     (** [passes_exn proj] is the same as {!passes}, but raises

--- a/lib/bap/bap_load_plugins.ml
+++ b/lib/bap/bap_load_plugins.ml
@@ -7,12 +7,11 @@ let load pkg =
   Bap_toplevel.eval cmd
 
 let () =
-  Plugins.all () |>
+  Plugin.find_libraries () |>
   List.iter ~f:(fun pkg -> match load pkg with
       | Ok true -> ()
       | Ok false -> assert false
       | Error err ->
-        eprintf "failed to load plugin into toplevel: (%s)%s: %s"
-          (Plugin.system pkg)
+        eprintf "failed to load plugin into toplevel: %s: %s"
           (Plugin.name pkg)
           (Error.to_string_hum err))

--- a/lib/bap/bap_plugin.mli
+++ b/lib/bap/bap_plugin.mli
@@ -3,18 +3,30 @@ open Core_kernel.Std
 type t
 
 
-val create : ?library:string list -> ?path:string -> system:string -> string -> t option
+(** [of_path path] create a plugin of the provided path  *)
+val of_path : string -> t
+
+(** [find_plugin ?library name] searches for a plugin named
+    [name.plugin] or [name] if [name] ends with [.plugin] in
+    current directory, then in each directory specified by
+    [BAP_PLUGIN_PATH] environment variable, then in each folder
+    specified by a [library] list (defaults to an empty list).
+    Returns the first found plugin, if any. *)
+val find_plugin : ?library:string list -> string -> t option
+
+(** [find_library] searches using findlib for a library that is
+    dynamically linkable and has a [plugin_system] field set to
+    "bap.plugin". *)
+val find_library : string -> t option
+
+(** [find_libraries ()] loads all finlib packages in the findlib path
+    with META file containing entry [plugin_system] equal to [system],
+    and returns a list of results of each load operation *)
+val find_libraries: unit -> t list
 
 (** [load plugin] loads given [plugin]  *)
 val load : t -> unit Or_error.t
 
-val name : t -> string
-
 val path : t -> string
 
-val system : t -> string
-
-(** [find ~system] loads all finlib packages in the findlib path with
-    META file containing entry [plugin_system] equal to [system], and
-    returns a list of results of each load operation *)
-val find_all: system:string -> t list
+val name : t -> string

--- a/lib/bap/bap_plugins.ml
+++ b/lib/bap/bap_plugins.ml
@@ -14,20 +14,14 @@ module Std = struct
     | Error err -> Error.to_string_hum err
 
   module Plugins = struct
-    let load ?(systems=systems) () =
-      List.iter systems
-        ~f:(fun system ->
-            List.iter (Bap_plugin.find_all ~system)
-              ~f:(fun pkg -> match Bap_plugin.load pkg with
-                  | Ok () -> ()
-                  | Error err ->
-                    eprintf
-                      "failed to load plugin %s of system %s: %s\n"
-                      (Bap_plugin.name pkg)
-                      system
-                      (Error.to_string_hum err)))
-    let all () =
-      List.map systems ~f:(fun s -> Bap_plugin.find_all ~system:s) |>
-      List.concat
+    let load  () =
+      Plugin.find_libraries () |>
+      List.iter ~f:(fun pkg -> match Plugin.load pkg with
+          | Ok () -> ()
+          | Error err ->
+            eprintf
+              "failed to load plugin %s: %s\n"
+              (Plugin.name pkg)
+              (Error.to_string_hum err))
   end
 end

--- a/lib/bap/bap_plugins.mli
+++ b/lib/bap/bap_plugins.mli
@@ -1,8 +1,4 @@
-(** Loads all known to bap plugins.
-
-    If you want to load a plugin unknown to bap, use [Plugin] module
-    directly.
-*)
+(** Bap Plugin Library *)
 
 open Core_kernel.Std
 
@@ -13,40 +9,36 @@ module Std : sig
   module Plugin : sig
     type t = plugin
 
-    (** [create ?library ?path ~system name] if file is not [None]
-        then create a plugin targeting this file, otherwise look at
-        current working directory for file named [name.plugin], if it
-        doesn't exist, then search for the plugin with a given [name]
-        and [system] first in folders specified by [BAP_PLUGIN_PATH]
-        environment variable, and if nothing found, continue with all
-        folders specified with [library] parameter, and finally search
-        in findlib system.
-        If more than one plugin exists, then the first found is used.
-    *)
-    val create :
-      ?library:string list ->
-      ?path:string ->
-      system:string -> string -> t option
+    (** [of_path path] create a plugin of the provided path  *)
+    val of_path : string -> t
 
-    (** [load plugin] loads given [plugin]  *)
-    val load : t -> unit Or_error.t
+    (** [find_plugin ?library name] searches for a plugin named
+        [name.plugin] or [name] if [name] ends with [.plugin] in
+        current directory, then in each directory specified by
+        [BAP_PLUGIN_PATH] environment variable, then in each folder
+        specified by a [library] list (defaults to an empty list).
+        Returns the first found plugin, if any. *)
+    val find_plugin : ?library:string list -> string -> t option
 
-    val name : t -> string
+    (** [find_library] searches using findlib for a library that is
+        dynamically linkable and has a [plugin_system] field set to
+        "bap.plugin". *)
+    val find_library : string -> t option
+
+    (** [find_libraries ()] loads all finlib packages in the findlib path
+        with META file containing entry [plugin_system] equal to [system],
+        and returns a list of results of each load operation *)
+    val find_libraries: unit -> t list
 
     val path : t -> string
 
-    val system : t -> string
+    val name : t -> string
 
-    (** [find ~system] loads all finlib packages in the findlib path with
-        META file containing entry [plugin_system] equal to [system], and
-        returns a list of results of each load operation *)
-    val find_all: system:string -> t list
-
+    (** [load plugin] loads given [plugin]  *)
+    val load : t -> unit Or_error.t
   end
 
   module Plugins : sig
-    val load : ?systems:string list -> unit -> unit
-    val all : unit -> plugin list
+    val load : unit -> unit
   end
-
 end

--- a/lib/bap/bap_project.ml
+++ b/lib/bap/bap_project.ml
@@ -205,13 +205,20 @@ let register_pass ?deps n v : unit =
 let register_pass' ?deps n v : unit =
   register_pass ?deps n (fun p -> v p; p)
 
+
 let prepare_args argv name =
   let prefix = "--" ^ name ^ "-" in
-  Array.filter_map argv ~f:(fun arg ->
-      if arg = argv.(0) then Some name
-      else match String.chop_prefix arg ~prefix with
-        | None -> None
-        | Some arg -> Some ("--" ^ arg))
+  let is_key = String.is_prefix ~prefix:"-" in
+  Array.fold argv ~init:([],`drop) ~f:(fun (args,act) arg ->
+      let take arg = ("--" ^ arg) :: args in
+      if arg = argv.(0) then (name::args,`drop)
+      else match String.chop_prefix arg ~prefix, act with
+        | None,`take when is_key arg -> args,`drop
+        | None,`take -> arg::args,`drop
+        | None,`drop -> args,`drop
+        | Some arg,_ when String.mem arg '=' -> take arg,`drop
+        | Some arg,_ -> take arg,`take) |>
+  fst |> List.rev |> Array.of_list
 
 type error =
   | Not_loaded of string
@@ -229,7 +236,7 @@ let fail name error = plugin_failure (error name)
 let load ?library name : unit =
   match find name with
   | Some _ -> ()
-  | None -> match Plugin.create ?library ~system:"bap.pass" name with
+  | None -> match Plugin.find_plugin ?library name with
     | None -> fail name not_found
     | Some p -> match Plugin.load p with
       | Error err -> plugin_failure (load_failed name err)
@@ -263,13 +270,15 @@ let rec run ?library ?(argv=Sys.argv) (passed,proj) name =
         exn -> plugin_failure (runtime_error name exn) in
     name :: passed, proj
 
-let run_passes_exn ?library ?argv proj =
+let prepare_passes ?library ?argv () =
   let passes = DList.to_list passes |> List.map ~f:(fun p -> p.name) in
   match List.find_a_dup passes with
   | Some name -> fail name is_duplicate
-  | None ->
-    load_deps ?library ();
-    List.fold passes ~init:([],proj) ~f:(run ?library ?argv) |> snd
+  | None -> load_deps ?library ()
+
+let run_pass_exn ?library ?argv proj pass =
+  prepare_passes ?library ?argv ();
+  run ?library ?argv ([],proj) pass |> snd
 
 let make_error = function
   | Not_loaded name ->
@@ -287,8 +296,8 @@ let make_error = function
     errorf "plugin %s failed in runtime with exception %s"
       name (Exn.to_string exn)
 
-let run_passes ?library ?argv proj : t Or_error.t =
-  try Ok (run_passes_exn ?library ?argv proj) with
+let run_pass ?library ?argv proj name : t Or_error.t =
+  try Ok (run_pass_exn ?library ?argv proj name) with
   | Pass_failed error -> make_error error
   | exn -> errorf "unexpected error when running plugins: %s"
              (Exn.to_string exn)

--- a/lib/bap/bap_project.mli
+++ b/lib/bap/bap_project.mli
@@ -67,7 +67,8 @@ val register_pass_with_args : (string array -> t -> t) register
 val register_pass_with_args' : (string array -> t -> unit) register
 
 val passes : ?library:string list -> unit -> string list Or_error.t
-val run_passes : ?library:string list -> ?argv:string array -> t -> t Or_error.t
-
+val run_pass :
+  ?library:string list -> ?argv:string array -> t -> string -> t Or_error.t
 val passes_exn : ?library:string list -> unit -> string list
-val run_passes_exn : ?library:string list -> ?argv:string array -> t -> t
+val run_pass_exn : ?library:string list -> ?argv:string array -> t ->
+  string -> t

--- a/src/readbin/bap_main.ml
+++ b/src/readbin/bap_main.ml
@@ -36,8 +36,8 @@ module Program(Conf : Options.Provider) = struct
 
   let run project =
     let library = options.load_path in
-    let project = Project.run_passes_exn ~library project in
-
+    let project = options.plugins |> List.fold ~init:project
+                    ~f:(Project.run_pass_exn ~library) in
     Option.iter options.emit_ida_script (fun dst ->
         Out_channel.write_all dst
           ~data:(Idapy.extract_script (Project.memory project)));

--- a/src/readbin/options.ml
+++ b/src/readbin/options.ml
@@ -27,10 +27,10 @@ type t = {
   print_symbols : [`with_name | `with_addr | `with_size] list;
   use_ida : string option option;
   sigfile : string option;
-  plugins : string list;
   emit_ida_script : string option;
   load_path : string list;
   emit_attr : string list;
+  plugins : string list;
 } with sexp, fields
 
 module type Provider = sig


### PR DESCRIPTION
This PR introduces some breaking changes, so read carefully.

The PR further decouples the notion of a plugin and a pass, as well as
separates a process of loading a plugin from its execution.

A plugin, as it was always been, is a dynamically linked library, that
can be loaded by a bap fronted to perform some side-effectfull
computation (usually to register itself in some plugin extension
point).

TL;DR
=====
1. use `-l<file-name>` to load a plugin
2. use `--<pass-name>` to run a pass.

Loading plugins from command line
=================================

Previously the `-l` option was used to load a plugin, that should be a
program pass (or analysis in other words) and then executes it. Now this
option only loads the plugin (that can be any plugin), but doesn't
execute it. To run a pass with name <name> use `--<name>` commandline
option. For example, suppose you have file `mycode.ml` with the
following contents:

```ocaml
open Bap.Std

let main project = print_endline "Hello, World"
let () = Project.register_pass' "hello" main
```

Then you can run this pass with the following command line sentence:

```sh
$ bapbuild mycode.plugin
$ bap /bin/ls -lmycode --hello
```

Good news - you can now specify your pass several times, and it will be
run the same amount of times:

```sh
$ bap /bin/ls -lmycode --hello --hello --hello
```

Will print "Hello, World" three times. If your plugin has dependencies,
then they will be loaded once and executed as many times, as you run
your plugin.

If you need a more sophisticated control over running plugins, then you
can run any registered pass from your program directly, using
a `Project.run_pass` function.

Also, since this PR we totally separate a pass name from a filename,
that contains the pass. They still can be the same, of course. But in
general a name of the file is irrelevant and only used for `-l` option.
That also means, that your single plugin, can add more than one pass. It
may even generate passes dynamically based on command line.

Installing plugins
==================

It was the same before, but still worthwhile to mention, that any
plugins, that are installed into opam (more precisely findlib known
location) will be loaded automatically. In particular that means, that
we can ship bap with a bunch of passes, that will be loaded
automatically, and can be run by using only the `--pass-name` option.

P.S. I will provide some harness, that will simplify the installation
separately.

Passing options to plugins
==========================

The options are passed in the same manner, i.e., to pass an option
`<option>` to a plugin `<plugin>` use `--<plugin>-<option>`, and it will
be passed to the plugin as `<option>`. The only difference is that
you can pass options without `=` sign, e.g., `--myplugin-help groff`,
an old (--myplugin-help=groff) style is also supported). Also, your
options can be argumentless, but to remove ambiguity make sure, that
they are not followed by a positional parameter.