### PR TITLE
Bump core_kernel minver

### DIFF
--- a/opam
+++ b/opam
@@ -41,7 +41,7 @@ depends: [
     "bitstring"
     "camlzip"
     "cmdliner" {>= "0.9.6"}
-    "core_kernel" {>= "111.28.0" & < "112.35.0"}
+    "core_kernel" {>= "112.17.0" & < "112.35.0"}
     "ezjsonm" {>= "0.4.0" & < "0.4.1" }
     "faillib"
     "fileutils"


### PR DESCRIPTION
We use `Bigstring.write_bin_prot`, which is not present in our previous
lower bound.