### PR TITLE
Enable caching of built deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: c
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 sudo: false
+cache:
+  directories:
+    - $HOME/.opam
+  before_cache:
+    - rm -rf $HOME/.opam/log
 addons:
   apt:
     sources:


### PR DESCRIPTION
This caches the contents of the `~/.opam` folder which should speed up the build by skipping rebuild of dependencies when unnecessary. Compare:
[No Cache](https://travis-ci.org/BinaryAnalysisPlatform/bap/builds/103706830) / [Cache](https://travis-ci.org/maurer/bap/builds/103887970)

Oddly, no speedup is observed here, but I am tempted to chalk that up to the immense variability of the time used to download components. It might also be possible with better understanding of the test script you're using to cause the fetched software to be cached as well.