### PR TITLE
Added polymorphic printers

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,8 +1,8 @@
 FLG -short-paths
 FLG -w -4-33-40-41-42-43-34-44
+FLG -ppx 'ppx-jane -as-ppx -inline-test-lib bap'
 
 PKG core_kernel
-PKG ppx_jane
 PKG fileutils
 PKG uri
 

--- a/_tags.in
+++ b/_tags.in
@@ -1,7 +1,7 @@
 # OASIS_START
 # OASIS_STOP
 true: short_paths
-true: annot, bin_annot
+true: bin_annot
 true: debug
 <**/*.ml{,i}>: predicate(ppx_driver)
 <**/*.ml{,i}> and not <lib/bap_elf/elf_parse.ml>: pp(ppx-jane -dump-ast -inline-test-lib bap)

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -3050,13 +3050,14 @@ module Std : sig
     (** implements common accessors for the array, like [find], [fold],
         [iter], etc  *)
     include Container.S1 with type 'a t := 'a t
+
+    val pp : 'a printer -> 'a t printer
   end
 
 
   (** BAP IR.
 
       Program is a tree of terms.
-
   *)
   type 'a term [@@deriving bin_io, compare, sexp]
 
@@ -3605,6 +3606,8 @@ module Std : sig
     (** [regions table] returns in an ascending order of addresses all
         elements mapped in a [table] *)
     val elements : ('a t -> 'a seq) ranged
+
+    val pp : 'a printer -> 'a t printer
   end
 
   (** A locations of a chunk of memory  *)
@@ -3879,6 +3882,8 @@ module Std : sig
     val to_sequence : 'a t -> (mem * 'a) seq
 
     include Container.S1 with type 'a t := 'a t
+
+    val pp : 'a printer -> 'a t printer
   end
 
 

--- a/lib/bap/bap_install_printers.ml
+++ b/lib/bap/bap_install_printers.ml
@@ -3,6 +3,11 @@ open Bap.Std
 open Or_error
 open Format
 
+
+let install_printer printer =
+  Topdirs.dir_install_printer std_formatter
+    (Longident.parse printer)
+
 let install_printers () =
   List.iter (Pretty_printer.all ()) ~f:(fun printer ->
       let printer =
@@ -11,7 +16,6 @@ let install_printers () =
             ~pattern:"Core"
             ~with_:"Core_kernel"
         else printer in
-      Topdirs.dir_install_printer std_formatter
-        (Longident.parse printer))
+      install_printer printer)
 
-let () = install_printers () 
+let () = install_printers ()

--- a/lib/bap/core_printers.ml
+++ b/lib/bap/core_printers.ml
@@ -1,0 +1,56 @@
+open Core_kernel.Std
+open Bap.Std
+open Format
+
+
+let pp_comma ppf () = pp_print_string ppf ", "
+
+let pair pp_key pp_elem ppf (k,v) =
+  fprintf ppf "%a => %a" pp_key k pp_elem v
+
+let pp_map key elem pp_cmp ppf map =
+  Seq.pp (pair key elem) ppf (Map.to_sequence map)
+
+let pp_set pp_elem pp_cmp ppf set =
+  Seq.pp pp_elem ppf (Set.to_sequence set)
+
+
+let enum f s = Seq.of_list (f s)
+
+let pp_doubly_linked pp ppf s = Seq.pp pp ppf (Doubly_linked.to_sequence s)
+let pp_stack pp ppf s = Seq.pp pp ppf (enum Stack.to_list s)
+let pp_heap  pp ppf s = Seq.pp pp ppf (enum Heap.to_list s)
+let pp_fheap  pp ppf s = Seq.pp pp ppf (enum Fheap.to_list s)
+let pp_bag   pp ppf s = Seq.pp pp ppf (enum Bag.to_list s)
+let pp_queue pp ppf s = Seq.pp pp ppf (enum Queue.to_list s)
+let pp_fqueue pp ppf s = Seq.pp pp ppf (enum Fqueue.to_list s)
+let pp_deque pp ppf s = Seq.pp pp ppf (enum Deque.to_list s)
+let pp_fdeque pp ppf s = Seq.pp pp ppf (enum Fdeque.to_list s)
+let pp_hashset pp ppf set = Seq.pp pp ppf (enum Hash_set.to_list set)
+
+let pp_hashtbl key elem ppf map =
+  Seq.pp (pair key elem) ppf (enum Hashtbl.to_alist map)
+
+
+let pp_blang pp_elem ppf expr =
+  let sexp_of_elem e = sexp_of_string (asprintf "%a" pp_elem e) in
+  fprintf ppf "%a" Sexp.pp (Blang.sexp_of_t sexp_of_elem expr)
+
+let install name =
+  Pretty_printer.register (sprintf "Core_printers.%s" name)
+
+let () = List.iter ~f:install [
+    "pp_map";
+    "pp_set";
+    "pp_doubly_linked";
+    "pp_stack";
+    "pp_heap";
+    "pp_bag";
+    "pp_queue";
+    "pp_fqueue";
+    "pp_deque";
+    "pp_fdeque";
+    "pp_hashset";
+    "pp_hashtbl";
+    "pp_blang"
+]

--- a/lib/bap_build/bap_build.ml
+++ b/lib/bap_build/bap_build.ml
@@ -20,11 +20,9 @@ module Plugin_rules = struct
   let default_tags = [
     "thread";
     "debug";
-    "annot";
-    "bin_annot";
     "short_paths";
     "custom";
-    "pp(ppx-jane -dump-ast -inline-test-lib bap)"
+    "ppx(ppx-bap)"
   ]
 
   let needs_threads pkgs =

--- a/lib/bap_disasm/bap_disasm_std.ml
+++ b/lib/bap_disasm/bap_disasm_std.ml
@@ -35,9 +35,5 @@ type rooter = Rooter.t
 type symbolizer = Symbolizer.t
 type brancher = Brancher.t
 type reconstructor = Reconstructor.t
-type edge = Block.edge [@@deriving compare, sexp]
-type jump = Block.jump [@@deriving compare, sexp]
-
-(* see: https://github.com/janestreet/ppx_sexp_conv/issues/3 *)
-let __jump_of_sexp__ = Block.__jump_of_sexp__
-let __edge_of_sexp__ = Block.__edge_of_sexp__
+type edge = Block.edge [@@deriving compare, sexp_poly]
+type jump = Block.jump [@@deriving compare, sexp_poly]

--- a/lib/bap_dwarf/dwarf_input.ml
+++ b/lib/bap_dwarf/dwarf_input.ml
@@ -19,14 +19,14 @@ let read_cstring src ~pos_ref : string t =
     pos_ref := (pos + 1); (* move over the null byte  *)
     return dst
 
-let%test_module _ = (module struct
+let%test_module "read_cstring" = (module struct
   let str = "hello\000,\000world\000!\000"
   let pos_ref = ref 0
-  let%test _ = read_cstring str ~pos_ref = Ok "hello"
-  let%test _ = read_cstring str ~pos_ref = Ok ","
-  let%test _ = read_cstring str ~pos_ref = Ok "world"
-  let%test _ = read_cstring str ~pos_ref = Ok "!"
-  let%test _ = String.length str = pos_ref.contents
+  let%test "hello" = read_cstring str ~pos_ref = Ok "hello"
+  let%test "comma" = read_cstring str ~pos_ref = Ok ","
+  let%test "world" = read_cstring str ~pos_ref = Ok "world"
+  let%test "emark" = read_cstring str ~pos_ref = Ok "!"
+  let%test "full"  = String.length str = pos_ref.contents
 end)
 
 let read_leb128 inj str ~pos_ref =
@@ -162,7 +162,6 @@ let pair read1 read2 str ~pos_ref =
   read1 str ~pos_ref >>= fun w1 ->
   read2 str ~pos_ref >>= fun w2 ->
   return (w1,w2)
-
 
 let unit_size endian str ~pos_ref =
   read_int32 endian W32 str ~pos_ref >>= function

--- a/lib/bap_image/bap_fileutils.ml
+++ b/lib/bap_image/bap_fileutils.ml
@@ -1,5 +1,4 @@
 open Core_kernel.Std
-open Bap_types.Std
 open Option.Monad_infix
 
 let mapfile path : Bigstring.t option =
@@ -29,12 +28,12 @@ let parse_name filename =
   let name,ver = split_right ~after:'-' filename in
   extension name >>| fun ext -> ext,ver
 
-let%test_module _ = (module struct
-  let%test _ = parse_name "subs" = None
-  let%test _ = parse_name "subs.sexp" = Some ("sexp",None)
-  let%test _ = parse_name "subs.sexp-1.0" = Some ("sexp", Some "1.0")
-  let%test _ = parse_name "subs.local.sexp" = Some ("sexp",None)
-  let%test _ = parse_name "subs." = Some ("",None)
-  let%test _ = parse_name "subs-1.0" = None
-  let%test _ = parse_name "subs.sexp-" = Some ("sexp", Some "")
+let%test_module "fileutils" = (module struct
+  let%test "1" = parse_name "subs" = None
+  let%test "2" = parse_name "subs.sexp" = Some ("sexp",None)
+  let%test "3" = parse_name "subs.sexp-1.0" = Some ("sexp", Some "1.0")
+  let%test "4" = parse_name "subs.local.sexp" = Some ("sexp",None)
+  let%test "5" = parse_name "subs." = Some ("",None)
+  let%test "6" = parse_name "subs-1.0" = None
+  let%test "7" = parse_name "subs.sexp-" = Some ("sexp", Some "")
 end)

--- a/lib/bap_image/bap_memmap.ml
+++ b/lib/bap_image/bap_memmap.ml
@@ -242,18 +242,15 @@ module C = Container.Make(
   struct
     type 'a t = 'a node option
     let rec fold m ~init ~f = Option.fold m ~init:init ~f:(fun acc m ->
-        fold m.rhs ~init:(f (fold m.lhs ~init:acc ~f) m.data) ~f
-      )
+        fold m.rhs ~init:(f (fold m.lhs ~init:acc ~f) m.data) ~f)
 
     let rec iter m ~f = Option.iter m ~f:(fun m ->
         iter m.lhs ~f;
         f m.data;
-        iter m.rhs ~f
-      )
+        iter m.rhs ~f)
 
     let iter  = `Custom iter
-  end
-  )
+  end)
 
 let fold = C.fold
 let count = C.count
@@ -270,3 +267,14 @@ let to_list = C.to_list
 let to_array = C.to_array
 let min_elt = C.min_elt
 let max_elt = C.max_elt
+
+let pp pp_elt ppf map =
+  let module M = Bap_memory in
+  let pp_mem ppf mem =
+    let a1,a2 = M.min_addr mem, M.max_addr mem in
+    Format.fprintf ppf "[%a - %a]" Addr.pp a1 Addr.pp a2 in
+  let pp_elt ppf (k,v) =
+    Format.fprintf ppf "%a => %a" pp_mem k pp_elt v in
+  Seq.pp pp_elt ppf (to_sequence map)
+
+let () = Pretty_printer.register "Bap.Std.Memmap.pp"

--- a/lib/bap_image/bap_memmap.mli
+++ b/lib/bap_image/bap_memmap.mli
@@ -105,3 +105,6 @@ val remove_dominators : 'a t -> mem -> 'a t
 val to_sequence : 'a t -> (mem * 'a) Sequence.t
 
 include Container.S1 with type 'a t := 'a t
+
+
+val pp : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit

--- a/lib/bap_image/bap_table.ml
+++ b/lib/bap_image/bap_table.ml
@@ -17,9 +17,9 @@ module Mem = struct
     let hash m = Addr.hash (repr m)
   end
   let sexp_of_t = T.sexp_of_t
-  let to_string mem =
+  let pp ppf mem =
     let a1,a2 = min_addr mem, max_addr mem in
-    Format.asprintf "[%a - %a]" Addr.pp a1 Addr.pp a2
+    Format.fprintf ppf "[%a - %a]" Addr.pp a1 Addr.pp a2
   include Comparable.Make(T)
   include Hashable.Make(T)
 end
@@ -107,6 +107,10 @@ let has_intersections tab (x : mem) : bool =
 
     Otherwise, the only solution (other then just reimplementing our
     own tree) is to sequence all keys and return the head.
+
+    TODO: it looks like that a new `closest_key` function is able to
+    find the matching key. So we can reimplement this function more
+    efficiently.
 *)
 let left_bound tab x =
   let rec search_left p = match prev_key tab.map p with
@@ -422,3 +426,13 @@ let rev_map_exn : type c . (mem,c) r ->
 
 let rev_map ~one_to t tab =
   try_with (fun () -> rev_map_exn one_to t tab)
+
+let pp_comma ppf () =
+  Format.pp_print_string ppf ", "
+
+let pp pp_elem ppf tab =
+  let pp_elem ppf (k,v) =
+    Format.fprintf ppf "%a => %a" Mem.pp k pp_elem v in
+  Seq.pp pp_elem ppf (to_sequence tab)
+
+let () = Pretty_printer.register "Bap.Std.Table.pp"

--- a/lib/bap_image/bap_table.mli
+++ b/lib/bap_image/bap_table.mli
@@ -1,19 +1,3 @@
-(** Table.
-
-    Tables are used to partition memory region into a set of
-    non-intersecting areas. Each area is assosiated with arbitrary
-    value of type ['a] bound to the type of the table.
-
-    All operations over tables are purely applicative, i.e. there is
-    no observable side-effects. Although, they employ some kind of
-    caching underneath the hood, so that they perform better if
-    they're  build once and used many times.
-
-    Tables can be also linked. For example, if you have two tables
-    mapping the same memory region to a different sets of values, you
-    can create a mapping from one set of values to another. See [link]
-    function for mode details.
-*)
 open Core_kernel.Std
 open Bap_types.Std
 
@@ -21,29 +5,10 @@ type 'a t [@@deriving sexp_of]
 type mem = Bap_memory.t
 type 'a hashable = 'a Hashtbl.Hashable.t
 
-(** creates an empty table  *)
 val empty : 'a t
-
-(** creates a table containing one bindins  *)
 val singleton : mem -> 'a -> 'a t
-
-(** [add table mem v] returns a new table with added mapping from a
-    mem region [mem] to a data value [v] *)
 val add : 'a t -> mem -> 'a -> 'a t Or_error.t
-
-(** returns a new table with all mappings from the mem region
-    [mem] removed *)
 val remove : 'a t -> mem -> 'a t
-
-(** [change tab mem ~f] function [f] is applied to a set of all memory
-    regions that intersects with [mem]. If function [f] evaluates to
-    [`remap (new_mem,y)] then all memory regions that have had
-    intersections with [mem] will be removed from the new map and
-    memory region [new_mem] will be mapped to [y]. If [f] evaluates to
-    [`remove], then the regions will be removed, and nothing will be
-    added. If it evaluates to [`skip] then the table will be returned
-    unchanged.  Intersections are passed sorted in an ascending order.
-*)
 val change : 'a t -> mem -> f:((mem * 'a) seq -> [
     | `rebind of mem * 'a         (** add new mapping instead  *)
     | `update of ((mem * 'a) -> 'a) (** update all bindings      *)
@@ -51,154 +16,26 @@ val change : 'a t -> mem -> f:((mem * 'a) seq -> [
     | `ignore])                  (** don't touch anything     *)
   -> 'a t
 
-(** [length table] returns a number of entries in the table  *)
 val length : 'a t -> int
-
-(** [find table mem] finds an element mapped to the memory region [mem]  *)
 val find : 'a t -> mem -> 'a option
-
-(** [find_addr tab addr] finds a memory region that contains a
-    specified [addr]   *)
 val find_addr : 'a t -> addr -> (mem * 'a) option
-
-(** [intersections table mem] returns all mappings in a [table] that
-    have intersections with [mem] *)
 val intersections : 'a t -> mem -> (mem * 'a) seq
-
-(** [fold_intersections table mem] folds over all regions
-    intersecting with [mem] *)
 val fold_intersections : 'a t -> mem -> init:'b -> f:(mem -> 'a -> 'b -> 'b) -> 'b
-
-(** [has_intersections tab mem] is true iff some portion of [mem] is
-    is already mapped in [tab]. *)
 val has_intersections : 'a t -> mem -> bool
-
-(** [mem table mem] is true if table contains mem region [mem]  *)
 val mem : _ t -> mem -> bool
-
-(** [next table elt] returns element next to [elt], if any *)
 val next : 'a t -> mem -> (mem * 'a) option
-
-(** [next table elt] returns element preceding to [elt], if any *)
 val prev : 'a t -> mem -> (mem * 'a) option
-
-(** [min tab] return the lowest binding  *)
 val min : 'a t -> (mem * 'a) option
-
-(** [max tab] return the highest binding  *)
 val max : 'a t -> (mem * 'a) option
 
-(** Relation multiplicity.
-    For a given type ['a] creates type ['m]
-*)
 type ('a,'m) r
-
-(** {4 Table relations}  *)
-
-(** [0..*]  *)
 val many : ('a, 'a seq) r
-
 val at_least_one : ('a, 'a * 'a seq) r
-
-(** [1..1]     *)
 val one : ('a, 'a) r
-
-(** [0..1]  *)
 val maybe_one : ('a, 'a option) r
-
-
-(** [link relation t t1 t2] takes two tables and returns a mapping
-    from elements of one table to elements of other table.
-
-    Parameter [t] specifies a [hashable] typeclass of the type ['a]. If
-    type ['a] implements [Hashable] interface, then you can obtain it
-    with [hashable] function, e.g. [Int.hashable] with return the
-    appropriate type class. If ['a] doesn't implement [Hashable], then
-    it can be implemented manually.
-
-    Relation specifies the multiplicity of the relation between
-    entities from table [t1] to entities from table [t2], and is
-    summarized below:
-
-    - [one_to_many] means that a particular region from table [t1] can
-      span several memory regions from table [t2]. Example: segments
-      to symbols relation.
-
-    - [one_to_one] means that for each value of type ['a] there is
-      exactly one value of type ['b]. This relation should be used with
-      caution, since it is quantified over _all_ values of type
-      ['a]. Indeed, it should be used only for cases, when it can be
-      guaranteed, that it is impossible to create such value of type
-      ['b], that has no correspondence in table [t2]. Otherwise,
-      [one_to_maybe_one] relation should be used. Example: llvm
-      machine code to assembly string relation.
-
-    - [one_to_maybe_one] means that for each value in table [t1] there
-      exists at most one value in table [t2]. Example: function to
-      symbol relation.
-
-
-    {5 Examples}
-    {[
-      let mc_of_insn  = link one_to:one Insn.hashable insns mcs
-      let syms_of_sec = link one_to:many Sec.hashable  secs syms
-    ]} *)
-
 val link : one_to:('b,'r) r -> 'a hashable -> 'a t -> 'b t -> 'a -> 'r
-
-
-(** [rev_map arity t tab] creates a reverse mapping from values of
-    typeclass [t] stored in table [tab] to memory regions.
-
-    Note. not every mapping is reversable, for example, trying to obtain
-    a reverse of surjective mapping as a one-to-one mapping will
-    result in an error. But surjective mappings can be reversed
-    using [~one_to:many] mapping. A particular example of surjective
-    mapping is [symbol] tables, in a case when functions can occupy
-    several non-contiguous regions of memory.
-
-    {5 Examples}
-
-    To create a mapping from a function symbol to sequence of memory
-    regions with it code:
-
-    {[rev_map one_to:many Sym.hashable tab]}
-
-*)
 val rev_map : one_to:(mem,'r) r -> 'a hashable -> 'a t -> ('a -> 'r) Or_error.t
-
-(** {3 Iterators}
-
-    This section provides a common set of iterators. Note: name
-    iterator is used in a functional meaning, i.e., an iterator is a
-    function that takes a data structure and another function, and
-    applies it to all elements in some manner.
-
-    All iterators share some common part of interface that was lifted
-    to a ['a ranged] type. When you see
-
-    [('a t -> f:('a -> bool) -> bool) ranged]
-
-    just mentally substitute it with:
-
-    [?start -> ?until -> 'a t -> f:('a -> bool) -> bool].
-
-    In other words ['f ranged] just prepends [?start -> ?until ->] to
-    function with type ['f] (do not forget that ['f] can be an arrow
-    type).
-
-    [start] and [until] parameters allows to narrow iteration to some
-    subset of table. If they are unspecified then iteration would be
-    performed on all table entries in an ascending order of
-    addresses. If they are specified, then if [start <= until], then
-    iteration will be performed in the same order but on a specified
-    subset. In the case, when [start > until], iteration will be
-    performed in a decreasing order.
-*)
-type 'a ranged
-  = ?start:mem   (** defaults to the lowest mapped region *)
-  -> ?until:mem   (** defaults to the highest mapped area  *)
-  -> 'a
+type 'a ranged = ?start:mem -> ?until:mem -> 'a
 
 val exists   : ('a t -> f:(mem -> 'a -> bool) -> bool) ranged
 val for_all  : ('a t -> f:(mem -> 'a -> bool) -> bool) ranged
@@ -218,23 +55,12 @@ val iteri : ('a t -> f:(mem -> 'a -> unit) -> unit) ranged
 val map : ('a t -> f:('a -> 'b) -> 'b t) ranged
 val mapi : ('a t -> f:(mem -> 'a -> 'b) -> 'b t) ranged
 
-(** removes all mappings that do not satisfy the predicate  *)
 val filter : ('a t -> f:('a -> bool) -> 'a t) ranged
 val filter_map : ('a t -> f:('a -> 'b option) -> 'b t) ranged
 
 val filteri : ('a t -> f:(mem -> 'a -> bool) -> 'a t) ranged
 val filter_mapi : ('a t -> f:(mem -> 'a -> 'b option) -> 'b t) ranged
-
-
-(** [to_sequence tab] converts the table [t] to a
-    sequence of key-value pairs.  *)
 val to_sequence : ('a t -> (mem * 'a) Sequence.t) ranged
-
-
-(** [regions table] returns in an ascending order of addresses all
-    memory regions mapped in a [table] *)
 val regions : ('a t -> mem seq) ranged
-
-(** [regions table] returns in an ascending order of addresses all
-    elements mapped in a [table] *)
 val elements : ('a t -> 'a seq) ranged
+val pp : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit

--- a/lib/bap_types/bap_attributes.ml
+++ b/lib/bap_types/bap_attributes.ml
@@ -46,9 +46,7 @@ module Background = struct
   let pp ppf c = Format.fprintf ppf "%s" @@ to_ascii c
 end
 
-type color = Color.t [@@deriving bin_io, compare, sexp]
-(* see: https://github.com/janestreet/ppx_sexp_conv/issues/3 *)
-let __color_of_sexp__ = Color.__t_of_sexp__
+type color = Color.t [@@deriving bin_io, compare, sexp_poly]
 
 let comment = register (module String)
     ~name:"comment"

--- a/lib/bap_types/bap_vector.ml
+++ b/lib/bap_types/bap_vector.ml
@@ -1,5 +1,7 @@
 open Core_kernel.Std
 open Regular.Std
+open Format
+
 type 'a t = {
   mutable size : int;
   mutable data : 'a array;
@@ -118,3 +120,13 @@ let to_list vec =
 
 let min_elt = C.min_elt
 let max_elt = C.max_elt
+
+let pp pp_elem ppf vec =
+  let n = length vec in
+  fprintf ppf "{@[<2>";
+  iteri vec ~f:(fun i x ->
+      if i < n - 1 then fprintf ppf "%a;@ " pp_elem x);
+  if n > 0 then fprintf ppf "%a" pp_elem vec.data.(n-1);
+  fprintf ppf "@]}"
+
+let () = Pretty_printer.register "Bap.Std.Vector.pp"

--- a/lib/bap_types/bap_vector.mli
+++ b/lib/bap_types/bap_vector.mli
@@ -1,4 +1,6 @@
 open Core_kernel.Std
+open Format
+
 type 'a t [@@deriving bin_io, compare, sexp]
 val create : ?capacity:int -> 'a -> 'a t
 val append : 'a t -> 'a -> unit
@@ -15,3 +17,4 @@ val index_exn : ?equal:('a -> 'a -> bool) -> 'a t -> 'a -> int
 val index_with : ?equal:('a -> 'a -> bool) -> default:int -> 'a t -> 'a -> int
 
 include Container.S1 with type 'a t := 'a t
+val pp : (formatter -> 'a -> unit) -> formatter -> 'a t -> unit

--- a/lib/graphlib/graphlib.mli
+++ b/lib/graphlib/graphlib.mli
@@ -510,6 +510,9 @@ module Std : sig
     (** [of_equiv p n] rebuilds a group from an equivalence class
         ordinal number. *)
     val of_equiv : 'a t -> equiv -> 'a group option
+
+    (** [pp pp_elem p] prints partition [p] using element printer [pp_elem]  *)
+    val pp : 'a printer -> 'a t printer
   end
 
   (** Group is a non-empty set that is a result of partitioning of an
@@ -524,7 +527,7 @@ module Std : sig
         designated one.  *)
     val enum : 'a group -> 'a seq
 
-    (** [mem group x] checks membership of [x] in a given group.  *)
+    (** [mem group x] checks membership of [x] in a given [group].  *)
     val mem  : 'a group -> 'a -> bool
 
     (** [top group] returns the top element of a group also known as a
@@ -535,6 +538,10 @@ module Std : sig
     (** [to_equiv g] returns the ordinal number representing the
         particular group [g] *)
     val to_equiv : 'a group -> equiv
+
+    (** [pp pp_elem g] prints group [g] using element printer [pp_elem]  *)
+    val pp : 'a printer -> 'a t printer
+
   end
 
   (** Ordinal for representing equivalence. Useful, for indexing

--- a/lib/graphlib/graphlib_graph.ml
+++ b/lib/graphlib/graphlib_graph.ml
@@ -100,6 +100,8 @@ module Tree = struct
     end;
     pp_close_box ppf ();
     fprintf ppf "@]@.}"
+
+  let () = Pretty_printer.register "Graphlib.Std.Tree.pp"
 end
 
 module Frontier = struct
@@ -123,6 +125,8 @@ module Frontier = struct
         | Some set ->
           fprintf ppf "[%a => (%s)]@." pp_elt src
             (string_of_set ~sep:" " pp_elt set))
+
+  let () = Pretty_printer.register "Graphlib.Std.Frontier.pp"
 end
 
 module Equiv = struct
@@ -132,11 +136,10 @@ module Equiv = struct
       include Int
       let module_name = Some "Graphlib.Std.Equiv"
       let version = "0.1"
-
     end)
 end
 
-type equiv = Equiv.t
+type equiv = Equiv.t [@@deriving bin_io, compare, sexp]
 
 module Group = struct
   (* top of set should be included into the set *)
@@ -154,6 +157,8 @@ module Group = struct
   let pp pp_elt ppf t =
     fprintf ppf "{%d: %a => (%s)}"
       t.ord pp_elt t.top (string_of_set ~sep:" " pp_elt t.set)
+
+  let () = Pretty_printer.register "Graphlib.Std.Group.pp"
 end
 
 type 'a group = 'a Group.t
@@ -193,6 +198,8 @@ module Partition = struct
     fprintf ppf "@;@[<v2>partition = {";
     Seq.iter (groups t) ~f:(fprintf ppf "@;%a" (Group.pp pp_elt));
     fprintf ppf "@]@;}"
+
+  let () = Pretty_printer.register "Graphlib.Std.Partition.pp"
 end
 
 type 'a partition = 'a Partition.t
@@ -818,6 +825,7 @@ module Path = struct
     Seq.range 1 (length t) |> Seq.iter  ~f:(fun i ->
         fprintf ppf ", %a" pp_elt t.edges.(i));
     fprintf ppf "}@]"
+  let () = Pretty_printer.register "Graphlib.Std.Path.pp"
 end
 
 type 'a path = 'a Path.t

--- a/lib/regular/regular.mli
+++ b/lib/regular/regular.mli
@@ -618,12 +618,6 @@ module Std : sig
     val is_empty : 'a t -> bool
 
     val pp : 'a printer -> 'a t printer
-    val pp_bools : bool t printer
-    val pp_chars : char t printer
-    val pp_floats : float t printer
-    val pp_ints : int t printer
-    val pp_strings : string t printer
-
   end
 
   (** type abbreviation for ['a Sequence.t]  *)

--- a/lib/regular/regular_seq.mli
+++ b/lib/regular/regular_seq.mli
@@ -20,12 +20,6 @@ val max_printer_depth : int ref
 
 val pp : (formatter -> 'a -> unit) -> formatter -> 'a seq -> unit
 
-val pp_bools : formatter -> bool seq -> unit
-val pp_chars : formatter -> char seq -> unit
-val pp_floats : formatter -> float seq -> unit
-val pp_ints : formatter -> int seq -> unit
-val pp_strings : formatter -> string seq -> unit
-
 include Binable.S1 with type 'a t := 'a seq
 module Export : sig
   val (^::) : 'a -> 'a seq -> 'a seq

--- a/lib_test/bap_dwarf/run_tests.ml
+++ b/lib_test/bap_dwarf/run_tests.ml
@@ -1,9 +1,19 @@
+open Core_kernel.Std
 open OUnit2
+
+module Dwarf = Bap_dwarf.Std
 
 let suite =
   "DWARF" >::: [
     Test_leb128.suite;
   ]
 
+let run_inline_tests () =
+  Ppx_inline_test_lib.Runtime.(summarize () |>
+                               Test_result.record;
+                               Test_result.exit ())
+
 let () =
-  run_test_tt_main suite
+  if Array.mem Sys.argv "inline-test-runner"
+  then run_inline_tests ()
+  else run_test_tt_main suite

--- a/oasis/bap
+++ b/oasis/bap
@@ -92,7 +92,7 @@ Library bap_image
   Path:          lib/bap_image/
   FindlibParent: bap
   FindlibName:   image
-  BuildDepends:  bap.types, ppx_test
+  BuildDepends:  bap.types
   InternalModules:
                  Bap_fileutils,
                  Bap_image,
@@ -174,6 +174,7 @@ Library top
   Path: lib/bap
   FindLibParent: bap
   FindLibName: top
+  Modules : Core_printers
   InternalModules:
             Bap_install_printers,
             Bap_load_plugins
@@ -266,7 +267,7 @@ Test unit_tests
 
 Test inline_tests
   TestTools: run_tests
-  Command: $run_tests inline-test-runner dummy -show-counts
+  Command: $run_tests inline-test-runner bap -show-counts
 
 Executable "bapbuild"
   Path:           tools

--- a/oasis/common
+++ b/oasis/common
@@ -10,7 +10,7 @@ Plugins:     META (0.4)
 AlphaFeatures: ocamlbuild_more_args
 BuildTools: ocamlbuild
 XOCamlbuildExtraArgs:
-     -j 8
+     -j 2
      -use-ocamlfind
      -classic-display
      -plugin-tags "'package(findlib),package(core_kernel),package(ppx_driver.ocamlbuild)'"

--- a/oasis/src
+++ b/oasis/src
@@ -129,7 +129,7 @@ Library dwarf
   Path:          lib/bap_dwarf
   FindlibName:   bap-dwarf
   Build$:        flag(dwarf)
-  BuildDepends:  bap, ppx_test
+  BuildDepends:  bap
   Modules:       Bap_dwarf
 
   InternalModules:
@@ -152,7 +152,7 @@ Executable run_dwarf_tests
   Path:		  lib_test/bap_dwarf
   Build$:	  flag(tests) && flag(dwarf)
   CompiledObject: best
-  BuildDepends:	  bap, oUnit, bap-piqi, dwarf_test
+  BuildDepends:	  bap, oUnit, bap-dwarf, dwarf_test
   Install:	  false
   MainIs: run_tests.ml
 
@@ -160,6 +160,11 @@ Test dwarf_tests
  TestTools: run_dwarf_tests
  Run$: flag(tests) && flag(dwarf)
  Command: $run_dwarf_tests
+
+Test dwarf_inline_tests
+ TestTools: run_dwarf_tests
+ Run$: flag(tests) && flag(dwarf)
+ Command: $run_dwarf_tests inline-test-runner bap -show-counts
 
 
 ########## Bap_elf Library ########################

--- a/opam/opam
+++ b/opam/opam
@@ -48,7 +48,6 @@ depends: [
     "camlzip"
     "cmdliner" {>= "0.9.6"}
     "ppx_jane" {>= "113.24.01"}
-    "ppx_test"
     "core_kernel" {>= "113.24.00"}
     "ezjsonm"
     "faillib"

--- a/tools/baptop
+++ b/tools/baptop
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec utop -require "bap.top" "$@"
+exec utop -ppx ppx-bap -short-paths -require "bap.top" "$@"

--- a/tools/postinstall.ml
+++ b/tools/postinstall.ml
@@ -31,11 +31,11 @@ let create_man prog =
 
 
 let main () =
-  let utils = ["baptop"] in
+  let utils = ["baptop"; "ppx-bap"] in
   let helps = List.map create_man tools |> List.concat in
   FileUtil.mkdir ~parent:true mandir;
   FileUtil.cp (manpages @ helps) mandir;
   FileUtil.cp (List.map (fun t -> "tools" / t) utils) bindir;
-  List.iter (fun name -> Unix.chmod (bindir / name) 0o700) utils
+  List.iter (fun name -> Unix.chmod (bindir / name) 0o770) utils
 
 let () = main ()

--- a/tools/ppx-bap
+++ b/tools/ppx-bap
@@ -1,0 +1,1 @@
+ppx-jane -as-ppx -inline-test-lib bap $@


### PR DESCRIPTION
This PR relies on a new and not yet released feature of OCaml compiler,
an ability to install polymorphic printers. Long story short, now when
you create a map, or set, etc, they will be printed, using installed
pretty printer instead of say that they are <poly>. I've installed
printers for all polymorphic types of bap and core_kernel.

also added ppx-bap tool and fixed few small issues