### PR TITLE
make installation more robust

### DIFF
--- a/myocamlbuild.ml.in
+++ b/myocamlbuild.ml.in
@@ -57,9 +57,18 @@ let mark_tags () =
     "pkg_core";
   ]
 
+(* we will pass this manually, util it is fixed *)
+let pr_6184_hack = function
+  | After_rules ->
+    (* Pass -predicates to ocamldep *)
+    pflag ["ocaml"; "ocamldep"] "predicate" (fun s -> S [A "-predicates"; A s])
+  | _ -> ()
+
+
 let () =
   mark_tags ();
   Ocamlbuild_plugin.dispatch (fun hook ->
       dispatch hook;
       dispatch_default hook;
+      pr_6184_hack hook;
       Ppx_driver_ocamlbuild.dispatch hook)

--- a/opam/opam
+++ b/opam/opam
@@ -30,7 +30,9 @@ install: [
 ]
 
 remove: [
-  ["ocamlfind" "remove" "bap"]
+  [make "uninstall"]
+  ["rm" "-f" "%{prefix}%/bin/baptop"]
+  ["rm" "-f" "%{prefix}%/bin/ppx-bap"]
   ["rm" "-rf" "%{prefix}%/share/bap"]
   ["rm" "-f" "%{man}%/man1/bap-mc.1"]
   ["rm" "-f" "%{man}%/man1/bap.1"]


### PR DESCRIPTION
1. Add a small hack, that will add `-predicates` flag to `ocamldep`.
   Without the flag, `ocamldep` will try to fallback on `ppx`
   executable, that might not be installed, if an old version of opam is
   used.

2. Used `make uninstall` in oasis. It looks like that new opam is clever
   enough to figure out that we need the source tree to remove it. In any
   case it would be better to switch to opam-install for installation and
   uninstallation.