### PR TITLE
added lost module Bap_trace_id

### DIFF
--- a/oasis/traces
+++ b/oasis/traces
@@ -12,6 +12,7 @@ Library trace
   InternalModules: Bap_trace_binprot,
                    Bap_trace_events,
                    Bap_trace_event_types,
+                   Bap_trace_id,
                    Bap_trace_meta,
                    Bap_trace_meta_types,
                    Bap_trace_std,


### PR DESCRIPTION
Bap_trace_id module wasn't mentioned in oasis file, and this caused an undefined module error while linking with bap-traces library.