### PR TITLE
Add autoload option to pass

### DIFF
--- a/plugins/dump_symbols/dump_symbols_main.ml
+++ b/plugins/dump_symbols/dump_symbols_main.ml
@@ -17,9 +17,8 @@ let file : string option Term.t =
   Arg.(value & opt (some string) None & info ["file"] ~doc ~docv:"FILE")
 
 let output oc syms =
-  let sexp_of_sym x = [%sexp_of:string * int64 * int64] x in
   let output sym =
-    Sexp.output_hum oc (sexp_of_sym sym);
+    Sexp.output_hum oc ([%sexp_of:string * int64 * int64] sym);
     output_char oc '\n' in
   let word pro mem = ok_exn (Addr.to_int64 (pro mem)) in
   Symtab.to_sequence syms |> Seq.iter ~f:(fun (name,entry,cfg) ->

--- a/src/.merlin
+++ b/src/.merlin
@@ -1,6 +1,3 @@
 REC
 PKG cmdliner
-PKG bap-byteweight
-S .
 B ../_build/src
-B ../_build/lib/bap_ida

--- a/src/bap_options.ml
+++ b/src/bap_options.ml
@@ -5,16 +5,16 @@ type source = Bap_source_type.t [@@deriving sexp]
 type fmt_spec = Bap_fmt_spec.t [@@deriving sexp]
 
 type t = {
-  filename : string;
-  disassembler : string;
-  loader : string;
-  dump : fmt_spec list;
-  source : source;
-  verbose : bool;
-  brancher : string option;
-  symbolizers : string list;
-  rooters : string list;
-  symbols : string list;
-  reconstructor : string option;
-  passes : string list;
+  filename        : string;
+  disassembler    : string;
+  loader          : string;
+  dump            : fmt_spec list;
+  source          : source;
+  verbose         : bool;
+  brancher        : string option;
+  symbolizers     : string list;
+  rooters         : string list;
+  symbols         : string list;
+  reconstructor   : string option;
+  passes          : string list;
 } [@@deriving sexp, fields]

--- a/src/bap_plugin_loader.ml
+++ b/src/bap_plugin_loader.ml
@@ -89,7 +89,8 @@ let run_and_get_passes argv =
           (Plugin.name p) (Error.to_string_hum err));
   let noautoload = get_opt argv no_auto_load ~default:false in
   if not noautoload then autoload_plugins ~library ~verbose ~exclude;
-  let known_passes = Project.passes () in
+  let known_passes = Project.passes () |>
+                     List.map ~f:Project.Pass.name in
   let known_plugins = List.map known_plugins ~f:Plugin.name in
   let known_names = known_plugins @ known_passes in
   exit_if_plugin_help_was_requested known_names argv;

--- a/src/bap_plugin_loader.mli
+++ b/src/bap_plugin_loader.mli
@@ -1,3 +1,5 @@
+open Bap.Std
+
 exception Plugin_not_found of string
 
 (** [run argv] extracts and loads plugins from a command line


### PR DESCRIPTION
Now it is possible to instruct BAP to run pass automatically,
without requiring a user to pass an explicit `--<pass>` on the
command-line. This is useful in at least two cases:

1. If the pass implemented there is no obvious reason not to run it,
   so everyone will just pass the option to run it everytime they run
   bap.

2. With autoload option it is possible to design more complex
   command-line interfaces.

The order of executing of autorun passes is unspecified, unless there is
a dependency between them.