### PR TITLE
Fix a bug in bap_bundle.

### DIFF
--- a/lib/bap_bundle/bap_bundle.ml
+++ b/lib/bap_bundle/bap_bundle.ml
@@ -171,7 +171,7 @@ module Std = struct
           let filename = Zip.(entry.filename) in
           let process_file f =
             let name,chan =
-              Filename.open_temp_file bundle.name filename in
+              Filename.open_temp_file "bundle" "entry" in
             Zip.copy_entry_to_channel zin entry chan;
             Out_channel.close chan;
             f name;


### PR DESCRIPTION
Inserting a file with a compound path didn't work.