### PR TITLE
Pass predicate(ppx_driver) to the link phase

### DIFF
--- a/_tags.in
+++ b/_tags.in
@@ -4,4 +4,5 @@ true: short_paths
 true: bin_annot
 true: debug
 <**/*.ml{,i}>: predicate(ppx_driver)
+<**/*.native>: predicate(ppx_driver)
 <**/*.ml{,i}> and not <lib/bap_elf/elf_parse.ml>: pp(ppx-jane -dump-ast -inline-test-lib bap)

--- a/myocamlbuild.ml.in
+++ b/myocamlbuild.ml.in
@@ -61,7 +61,8 @@ let mark_tags () =
 let pr_6184_hack = function
   | After_rules ->
     (* Pass -predicates to ocamldep *)
-    pflag ["ocaml"; "ocamldep"] "predicate" (fun s -> S [A "-predicates"; A s])
+    pflag ["ocaml"; "ocamldep"] "predicate" (fun s -> S [A "-predicates"; A s]);
+
   | _ -> ()
 
 


### PR DESCRIPTION
This should help to link programs when old opam is used,
that doesn't install libexec part of the package, and
resolve #362.