### PR TITLE
robust plugin loader

### DIFF
--- a/lib/bap_plugins/bap_plugins.mli
+++ b/lib/bap_plugins/bap_plugins.mli
@@ -36,9 +36,11 @@ module Std : sig
     val list : ?library:string list -> unit -> plugin list
 
     (** [load ?library ()] loads [all ?library ()] plugins, and
-        returns a list of results *)
+        returns a list of results. Each result is either an
+        [Ok plugin], if [plugin] was loaded, or [Error (path,err)]
+        if plugin from a [path] has failed with an error [err].*)
     val load : ?library:string list ->
-      ?exclude:string list -> unit -> (plugin * unit Or_error.t) list
+      ?exclude:string list -> unit -> (plugin, string * Error.t) Result.t list
   end
 
   val list_loaded_units : unit -> string list

--- a/src/bap_main.ml
+++ b/src/bap_main.ml
@@ -38,6 +38,10 @@ let rooter o src args = match o.rooters with
   | [] -> choose_default_rooter src args
   | ss -> union_rooters ss src args
 
+let rooter o src args = match rooter o src args with
+  | None -> assert false
+  | rooter -> rooter
+
 let project_or_exn = function
   | Ok p -> p
   | Error e -> raise (Failed_to_create_project e)
@@ -108,6 +112,11 @@ let process options project =
 
 
 let create name options source arg =
+  let options = {
+    options with
+    rooters = options.symbols @ options.rooters;
+    symbolizers = options.symbols @ options.symbolizers;
+  } in
   match Project.Factory.find source name arg with
   | None -> raise (Unknown_format name)
   | Some create ->


### PR DESCRIPTION
This PR will make a plugin loader more robust to a malicious user. It
will not fail if a plugin is not a plugin, or if it can't be load. It
will print a warning and continue. In a verbose mode it will print an
extended error message.

This will fix #351 and partially resolve #353.