### PR TITLE
resolve PLT entries

### DIFF
--- a/plugins/llvm/llvm_binary.hpp
+++ b/plugins/llvm/llvm_binary.hpp
@@ -201,6 +201,24 @@ struct symbol {
 
         if (error_code err = sym.getSize(this->size_))
             llvm_binary_fail(err);
+
+        uint32_t flags;
+        if (error_code err = sym.getFlags(flags))
+            llvm_binary_fail(err);
+
+        if (flags & SymbolRef::SF_Undefined) {
+            uint64_t addr;
+            if (error_code err = sym.getValue(addr))
+                llvm_binary_fail(err);
+            // This will not work for x86-64, since they usually zero
+            // the value. BFD library uses index correspondence
+            // between plt entry and relocation, to name the plt
+            // entry. We can't afford this.
+            if (addr) {
+                addr_ = addr;
+                size_ = 8;
+            }
+        }
     }
 
     const std::string& name() const { return name_; }


### PR DESCRIPTION
TL;DR
-----

No more IDA. Ok, at least on ARM. This is a hacky support for resolving
PLT entries, that works at least on ARM ELF, i.e., on our most favorite
targets. Support for other targets might be added later, but there are
problems.

Implementation details
----------------------

If an undefined symbol has a value, then use it as an address.
Since the value size is a not a size of a plt entry, but a size of the
real symbol, that would be loaded (at least for elf-arm), a hack is used
to hardcode the size to 8 bytes.

This will not work for x86-64, since the value is usually zeroed by the
elf64-x86-64 backend. In fact, only for elf64-x86-64 backend there are
36 different kinds of relocations, each giving their own meaning to the
entries in the symbol table. And each backend define its own relocations
and policies. So, the resolution of the entries should be performed on
the backend level, before a transformation to an abstract symbol or
relocation.

How `objdump` works
-------------------

You might be interested how `objdump` resolves the plt entries. First of
all it actually performed on a backend side. So for each possible
target, and supported relocation it is different. For `elf64-x86-64` and
`R_X86_64_JUMP_SLOT` relocation, it will rely on a fact, that ith
relocation corresponds to the ith PLT entry. Since BFD knows the size of
PLT entry, it is easy to find out the corresponding PLT entry. Of
course, this is fragile and works only for binaries created by a libbfd,
or someone, who tries to conform to it. We cannot rely on this in the
loader backend. But we can easily implement the same logic in a separate
plugin, that will provide a symbolizer for `elf64-x86-64`.

Current status
--------------

Works for elf32-arm. Shouldn't break anything on other targets. Support
for other targets can be added as separate plugins, on per target
basis. Nothing magic here, just lots of reverse engineering.