### PR TITLE
Fix segment merging in the disassembler

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,10 +1,10 @@
 FLG -short-paths
 FLG -w -4-33-40-41-42-43-34-44
-FLG -ppx 'ppx-jane -as-ppx -inline-test-lib bap'
 
 PKG core_kernel
 PKG fileutils
 PKG uri
+PKG ppx_jane
 
 B _build
 B _build/lib/bap

--- a/lib/bap_disasm/bap_disasm.ml
+++ b/lib/bap_disasm/bap_disasm.ml
@@ -1,4 +1,5 @@
 open Core_kernel.Std
+open Graphlib.Std
 open Bap_types.Std
 
 open Or_error
@@ -28,7 +29,7 @@ type error = [
 type mem_state =
   | Failed of error                (** failed to decode anything    *)
   | Decoded of insn * error option (** decoded with optional errors *)
-[@@deriving sexp_of]
+  [@@deriving sexp_of]
 
 type cfg = Rec.cfg [@@deriving compare]
 
@@ -76,9 +77,7 @@ module Disasm = struct
     Rec.run ?backend ?brancher ?rooter arch mem >>| of_rec
 
   let merge_segments d1 d2 =
-    let merge g1 g2 =
-      Rec.Cfg.edges g2 |> Seq.fold ~init:g1 ~f:(fun g1 e ->
-          Rec.Cfg.Edge.insert e g1) in
+    let merge = Graphlib.union (module Rec.Cfg) in
     {cfg = merge d1.cfg d2.cfg; err = d1.err @ d2.err}
 
   let of_image ?backend ?brancher ?rooter image =

--- a/lib/graphlib/graphlib.mli
+++ b/lib/graphlib/graphlib.mli
@@ -622,6 +622,35 @@ module Std : sig
       ?nodes:'a list ->
       ?edges:('a * 'a * 'b) list -> unit -> 'c
 
+    (** [union (module G) g1 g2] returns a graph [g] that is a union
+        of graphs [g1] and [g2], i.e., contains all nodes and edges
+        from this graphs.
+
+        Postcondition: {v
+          - N(g) = N(g1) ∪ N(g2).
+          - E(g) = E(g1) ∪ E(g2).
+        v}
+    *)
+    val union :
+      (module Graph with type t = 'c
+                     and type node = 'n
+                     and type edge = 'e) -> 'c -> 'c -> 'c
+
+    (** [inter (module G) g1 g2] returns a graph [g] that is an
+        intersection of graphs [g1] and [g2], i.e., it contain
+        and edges from this graphs.
+
+        Postcondition: {v
+          - N(g) = N(g1) ∩ N(g2).
+          - E(g) = E(g1) ∩ E(g2).
+        v}
+    *)
+    val inter :
+      (module Graph with type t = 'c
+                     and type node = 'n
+                     and type edge = 'e) -> 'c -> 'c -> 'c
+
+
     (** [to_dot (module G) ~filename:"graph.dot" g] dumps graph [g]
         using [dot] format. This is a customizable version of printing
         function. For most cases it will be enough to use [G.pp] or

--- a/lib/graphlib/graphlib_graph.mli
+++ b/lib/graphlib/graphlib_graph.mli
@@ -20,6 +20,16 @@ val create : (module Graph with type t = 'c
 
 
 
+val union :
+  (module Graph with type t = 'c
+                 and type node = 'n
+                 and type edge = 'e) -> 'c -> 'c -> 'c
+
+val inter :
+  (module Graph with type t = 'c
+                 and type node = 'n
+                 and type edge = 'e) -> 'c -> 'c -> 'c
+
 val to_dot :
   (module Graph with type t = 'c
                  and type node = 'n

--- a/lib_test/bap/run_tests.ml
+++ b/lib_test/bap/run_tests.ml
@@ -20,9 +20,9 @@ let suite () =
 let load_plugins () =
   Plugins.load () |>
   List.iter ~f:(function
-      | _,Ok () -> ()
-      | p,Error e ->
-        assert_string ("plugin "^Plugin.name p^" failed: " ^
+      | Ok _ -> ()
+      | Error (p,e)->
+        assert_string ("failed to load plugin from " ^ p ^ ": " ^
                        Error.to_string_hum e))
 
 let run_unit_tests () =

--- a/opam/opam
+++ b/opam/opam
@@ -13,6 +13,7 @@ build: [
                  "--with-cxx=`which clang++`"
                  "--mandir=%{man}%"
                  "--enable-everything"
+                 "--enable-tests"
                  ]
   [make]
 ]


### PR DESCRIPTION
This will fix #372. The problem wasn't in the disassembler itself,
it was in a function that merges graphs from different segments. I
repeated an error, that I did at least three times so far -- merged
only edges and forgot about the nodes. Since `main` subroutine in the
example didn't have any incoming or outcoming edges, it wasn't added.

As a penance (and to prevent myself from repeating this error), I added
two new functions to `Graphlib` - `union` and `inter`, that performs
graph union and graph intersection operation.

Moreover, I've noticed, that tests were disabled, so last dozen or so
PR's were actually untested (just compiled). This PR also fixes this,
and adds tests for newly introduced operations.