### PR TITLE
Add "use file" option to api plugin

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -5,6 +5,7 @@ PKG core_kernel
 PKG fileutils
 PKG uri
 PKG ppx_jane
+PKG camlzip
 
 B _build
 B _build/lib/bap


### PR DESCRIPTION
For discussion. Api currently adds the header file to the database (zip)
without checking that it parses correctly first. So if you give it a file that
doesn't parse, it will try to use this broken file every time. Since there is
no easy way to remove the header (that I found), I just add an extra option
which will let you use a header file without using the add feature.

Also adds camlzip to .merlin