### PR TITLE
A DSL for term marking

### DIFF
--- a/plugins/propagate_taint/.merlin
+++ b/plugins/propagate_taint/.merlin
@@ -1,3 +1,4 @@
 REC
 PKG cmdliner
 PKG bap-microx
+B ../../_build/plugins/propagate_taint


### PR DESCRIPTION
This PR adds an extensible DSL for specifying marking schemes into the
taint propagation framework. This DSL provides a mechanism to specify
what to mark, and with which attribute. This PR makes the framework more
usable on its own, and less dependent on Saluki. Here is an excerpt from
the man page:

       Although the pass itself doesn't perform any analysis it can mark terms
       with attributes. Terms are marked according to a marking scheme
       specified with --mark-scheme=SCHEME or --mark-scheme-file=FILE. Each
       entry of the FILE, or SCHEME argument must conform to the following
       grammar:

             SCM    ::= (PREDS MARKS)
             PREDS  ::= PRED | (PRED1 .. PREDn)
             MARKS  ::= MARK | (MARK1 .. MARKn)
             MARK   ::= TAG  | (TAG VALUE)
             PRED   ::= "visited" | "has-seed" | "has-tainted-regs"
                      | "has-tainted-ptrs" | "has-taint"
             TAG    ::= "foreground" | "background" | "color"
                      | "comment" | "python" | "mark" | "weight"
                      | "tainted_reg" | "tainted_ptr"

       Each SCHEME is a pair consisting of a set of predicates and a set of
       marks. If all predicates matches, then all marks are applied to a term.
       Mark is represented by a pair consisting of tag name and a value. If
       tag value is of type unit, then it is just a tag.

In particular, this allows to seed new terms, based on terms. Allowing
to run several passes and specify more complex logic.