### PR TITLE
IR visitor, mapper and higher-order morphisms

### DIFF
--- a/lib/arm/arm_lifter.ml
+++ b/lib/arm/arm_lifter.ml
@@ -1094,8 +1094,8 @@ end
 
 
 (** Substitute PC with its value  *)
-let resolve_pc mem = Bil.map (object(self)
-    inherit Bil.mapper as super
+let resolve_pc mem = Stmt.map (object(self)
+    inherit Stmt.mapper as super
     method! map_var var =
       if Var.(equal var CPU.pc) then
         Bil.int (CPU.addr_of_pc mem)

--- a/lib/bap_disasm/bap_disasm_insn.ml
+++ b/lib/bap_disasm/bap_disasm_insn.ml
@@ -62,7 +62,7 @@ let normalize_asm asm =
     ~with_:" " |> String.strip
 
 let lookup_jumps bil = (object
-  inherit [kind list] Bil.visitor
+  inherit [kind list] Stmt.visitor
   method! enter_jmp ex _ =
     match ex with
     | Bil.Int _ when under_condition -> [`Conditional_branch]
@@ -72,7 +72,7 @@ let lookup_jumps bil = (object
 end)#run bil []
 
 let lookup_side_effects bil = (object
-  inherit [kind list] Bil.visitor
+  inherit [kind list] Stmt.visitor
   method! enter_store ~mem:_ ~addr:_ ~exp:_ _ _ acc =
     `May_store :: acc
   method! enter_load ~mem:_ ~addr:_ _ _ acc =

--- a/lib/bap_disasm/bap_disasm_reconstructor.ml
+++ b/lib/bap_disasm/bap_disasm_reconstructor.ml
@@ -21,11 +21,11 @@ let run (Reconstructor f) = f
 
 
 let dest_of_bil bil =
-  (object inherit [word] Bil.finder
+  (object inherit [word] Stmt.finder
     method! enter_jmp dst goto = match dst with
       | Bil.Int dst -> goto.return (Some dst)
       | _ -> goto
-  end)#find_in_bil bil
+  end)#find bil
 
 let find_calls name roots cfg =
   let starts = Addr.Table.create () in

--- a/lib/bap_sema/bap_sema_free_vars.ml
+++ b/lib/bap_sema/bap_sema_free_vars.ml
@@ -44,14 +44,14 @@ let free_vars_of_sub sub  =
   else dom_free_vars sub
 
 let has_sub_exp x = Exp.exists (object
-    inherit [unit] Bil.finder
+    inherit [unit] Exp.finder
     method! enter_exp exp search =
       if Exp.equal exp x then search.return (Some ())
       else search
   end)
 
 let substitute_exp x y = Exp.map (object
-    inherit Bil.mapper
+    inherit Exp.mapper
     method! map_exp exp =
       if Exp.equal exp x then y else x
   end)

--- a/lib/bap_sema/bap_sema_lift.ml
+++ b/lib/bap_sema/bap_sema_lift.ml
@@ -36,7 +36,8 @@ type linear =
   | Instr of Ir_blk.elt
 
 (* we're very conservative here *)
-let has_side_effect e scope = (object inherit [bool] Bil.visitor
+let has_side_effect e scope = (object
+  inherit [bool] Stmt.visitor
   method! enter_load  ~mem:_ ~addr:_ _e _s _r = true
   method! enter_store ~mem:_ ~addr:_ ~exp:_ _e _s _r = true
   method! enter_var v r = r || Bil.is_assigned v scope
@@ -181,7 +182,7 @@ let has_jump_under_condition bil =
   with_return (fun {return} ->
       let enter_control ifs = if ifs = 0 then ifs else return true in
       Bil.fold (object
-        inherit [int] Bil.visitor
+        inherit [int] Stmt.visitor
         method! enter_if ~cond ~yes:_ ~no:_ x = x + 1
         method! leave_if ~cond ~yes:_ ~no:_ x = x - 1
         method! enter_jmp _ ifs    = enter_control ifs

--- a/lib/bap_sema/bap_sema_ssa.ml
+++ b/lib/bap_sema/bap_sema_ssa.ml
@@ -77,7 +77,7 @@ let blocks_that_define_var var sub : tid list =
     of the variable to a top value of a stack for this variable, if it
     is not empty *)
 let substitute vars = (object
-  inherit Bil.mapper as super
+  inherit Exp.mapper as super
   method! map_sym z =
     match Hashtbl.find vars z with
     | None | Some [] -> z

--- a/lib/bap_types/bap_biri.mli
+++ b/lib/bap_types/bap_biri.mli
@@ -4,10 +4,10 @@ open Bap_bil
 open Bap_ir
 open Bap_result
 
-class context : program term ->  object('s)
+class context : ?main : sub term -> program term ->  object('s)
     inherit Bap_expi.context
-
     method program : program term
+    method main : sub term option
     method trace : tid list
     method enter_term : tid -> 's
     method set_next : tid option -> 's
@@ -19,6 +19,9 @@ class ['a] t : object
   inherit ['a] Bap_expi.t
 
   method enter_term : 't 'p . ('p,'t) cls -> 't term -> 'a u
+
+  method eval : 't 'p. ('p,'t) cls -> 't term -> 'a u
+
   method leave_term : 't 'p . ('p,'t) cls -> 't term -> 'a u
 
   method eval_sub : sub term -> 'a u

--- a/lib/bap_types/bap_bitvector.mli
+++ b/lib/bap_types/bap_bitvector.mli
@@ -6,10 +6,9 @@ exception Width [@@deriving sexp]
 type endian =
   | LittleEndian
   | BigEndian
-[@@deriving bin_io, compare, sexp]
+  [@@deriving bin_io, compare, sexp]
 
 include Regular with type t := t
-include Comparable.With_zero with type t := t
 include Bap_integer.S with type t := t
 module Mono : Comparable with type t := t
 val of_string : string -> t
@@ -44,6 +43,15 @@ val (--) : t -> int -> t
 val enum_bytes : t -> endian ->    t Sequence.t
 val enum_chars : t -> endian -> char Sequence.t
 val enum_bits  : t -> endian -> bool Sequence.t
+val validate_positive     : t Validate.check
+val validate_non_negative : t Validate.check
+val validate_negative     : t Validate.check
+val validate_non_positive : t Validate.check
+val is_positive     : t -> bool
+val is_non_negative : t -> bool
+val is_negative     : t -> bool
+val is_non_positive : t -> bool
+
 module Int_err : sig
   val (!$): t -> t Or_error.t
   val i1 :  t -> t Or_error.t

--- a/lib/bap_types/bap_ir.ml
+++ b/lib/bap_types/bap_ir.ml
@@ -107,17 +107,17 @@ type 'a term = {
 type label =
   | Direct of tid
   | Indirect of exp
-[@@deriving bin_io, compare, sexp]
+  [@@deriving bin_io, compare, sexp]
 
 type call = {target : label; return : label option}
-[@@deriving bin_io, compare, fields, sexp]
+  [@@deriving bin_io, compare, fields, sexp]
 
 type jmp_kind =
   | Call of call
   | Goto of label
   | Ret  of label
   | Int  of int * tid
-[@@deriving bin_io, compare, sexp]
+  [@@deriving bin_io, compare, sexp]
 
 
 type intent = In | Out | Both [@@deriving bin_io, compare, sexp]
@@ -133,7 +133,7 @@ type blk = {
 } [@@deriving bin_io, compare, fields, sexp]
 
 type arg = var * exp * intent option
-[@@deriving bin_io, compare, sexp]
+  [@@deriving bin_io, compare, sexp]
 
 type sub = {
   name : string;
@@ -143,7 +143,7 @@ type sub = {
 
 
 type path = int array
-[@@deriving bin_io, compare, sexp]
+  [@@deriving bin_io, compare, sexp]
 
 
 type program = {
@@ -218,7 +218,10 @@ module Leaf = struct
   let with_rhs def rhs = {def with self = (fst def.self, rhs)}
 end
 
+type nil [@@deriving bin_io, compare, sexp]
+
 type _ typ =
+  | Nil : nil typ
   | Top : program typ
   | Sub : sub typ
   | Arg : arg typ
@@ -236,6 +239,7 @@ type ('a,'b) cls = {
 }
 
 let string_of_typ : type a . a typ -> string = function
+  | Nil -> "nil"
   | Top -> "top"
   | Sub -> "sub"
   | Arg -> "arg"
@@ -253,8 +257,22 @@ let cls typ par nil field = {
   get = Field.get field;
 }
 
+
+
 let hash_of_term t = Tid.hash (tid t)
 let make_term tid self : 'a term = {tid; self; dict = Dict.empty}
+
+let nil_top = make_term Tid.nil {
+    subs = [| |] ; paths = Tid.Table.create ();
+  }
+
+let program_t = {
+  par = Nil;
+  typ = Top;
+  nil = nil_top;
+  set = (fun _ _ -> assert false);
+  get = (fun _ -> assert false);
+}
 
 let nil_def : def term =
   Leaf.make Tid.nil undefined_var undefined_exp
@@ -281,6 +299,285 @@ let blk_t : (sub,blk) cls = cls Blk Sub nil_blk Fields_of_sub.blks
 let arg_t : (sub,arg) cls = cls Arg Sub nil_arg Fields_of_sub.args
 let sub_t : (program, sub) cls =
   cls Sub Top nil_sub Fields_of_program.subs
+
+let term_pp pp_self ppf t =
+  let open Format in
+  let attrs = Dict.data t.dict in
+  Seq.iter attrs ~f:(fun attr ->
+      pp_open_tag ppf (asprintf "%a" pp_attr attr));
+  fprintf ppf "@[%a: %a@]@." Tid.pp t.tid pp_self t.self;
+  Seq.iter attrs ~f:(fun _ -> pp_close_tag ppf ())
+
+
+
+
+module Label = struct
+  type t = label
+  let direct x = Direct x
+  let indirect x = Indirect x
+  let create () = direct (Tid.create ())
+  let change ?(direct=ident) ?(indirect=ident) label =
+    match label with
+    | Direct x -> Direct (direct x)
+    | Indirect x -> Indirect (indirect x)
+
+  include Regular.Make(struct
+      type t = label [@@deriving bin_io, compare, sexp]
+      let module_name = Some "Bap.Std.Label"
+      let version = "0.1"
+
+      let hash = Hashtbl.hash
+      let pp ppf = function
+        | Indirect exp -> Bap_exp.pp ppf exp
+        | Direct tid -> Format.fprintf ppf "%s" @@ Tid.name tid
+    end)
+end
+
+module Call = struct
+  type t = call
+  let create ?return ~target ()  = {target; return}
+  let return t = t.return
+  let target t = t.target
+  let with_return t return = { t with return = Some return }
+  let with_target t target = { t with target }
+  let with_noreturn t = {t with return = None}
+
+  include Regular.Make(struct
+      type t = call [@@deriving bin_io, compare, sexp]
+      let module_name = Some "Bap.Std.Call"
+      let version = "0.1"
+
+
+      let pp_return ppf lab = match lab with
+        | Some label ->
+          Format.fprintf ppf "with return %a" Label.pp label
+        | None -> Format.fprintf ppf "with noreturn"
+
+      let pp ppf c =
+        Format.fprintf ppf "@[call %a %a@]"
+          Label.pp c.target pp_return c.return
+
+      let hash = Hashtbl.hash
+    end)
+end
+
+module Ir_arg = struct
+  type t = arg term
+  let create ?(tid=Tid.create()) ?intent var exp : t =
+    make_term tid (var,exp,intent)
+
+  let lhs    {self=(r,_,_)} = r
+  let rhs    {self=(_,r,_)} = r
+  let intent {self=(_,_,r)} = r
+  let map3 (x,y,z) ~f = (x,y, f z)
+  let with_intent (t : t) intent : t = {
+    t with self = map3 t.self ~f:(fun _ -> Some intent)
+  }
+  let with_unknown_intent t : t = {
+    t with self = map3 t.self ~f:(fun _ -> None)
+  }
+  let name arg = Var.name (lhs arg)
+
+  include Regular.Make(struct
+      type t = arg term [@@deriving bin_io, compare, sexp]
+      let module_name = Some "Bap.Std.Arg"
+      let version = "0.1"
+
+      let hash = hash_of_term
+
+      let string_of_intent = function
+        | Some In -> "in "
+        | Some Out -> "out "
+        | Some Both -> "in out "
+        | None -> ""
+
+      let pp_self ppf (var,exp,intent) =
+        Format.fprintf ppf "%s :: %s%a = %a"
+          (Var.name var)
+          (string_of_intent intent)
+          Bap_type.pp (Var.typ var)
+          Bap_exp.pp exp
+
+      let pp = term_pp pp_self
+    end)
+end
+
+
+module Ir_def = struct
+  type t = def term
+  include Leaf
+
+  let map_exp def ~f : def term =
+    with_rhs def (f (rhs def))
+
+  let substitute def x y = map_exp def ~f:(Exp.substitute x y)
+
+  let free_vars def = Exp.free_vars (rhs def)
+
+
+  include Regular.Make(struct
+      type t = def term [@@deriving bin_io, compare, sexp]
+      let module_name = Some "Bap.Std.Def"
+      let version = "0.1"
+
+      let hash = hash_of_term
+
+      let pp_self ppf (lhs,rhs) =
+        Format.fprintf ppf "%a := %a" Var.pp lhs Bap_exp.pp rhs
+
+      let pp = term_pp pp_self
+    end)
+end
+
+module Ir_phi = struct
+  type t = phi term
+  include Leaf
+
+  let of_list ?tid var bs : phi term =
+    create ?tid var (Tid.Map.of_alist_reduce bs ~f:(fun _ x -> x))
+
+  let create ?tid var src exp : phi term = of_list var [src,exp]
+
+  let values (phi : phi term) : (tid * exp) Seq.t =
+    Map.to_sequence (rhs phi)
+
+  let update (phi : phi term) tid exp : phi term =
+    with_rhs phi (Map.add (rhs phi) ~key:tid ~data:exp)
+
+  let remove phi tid : phi term =
+    with_rhs phi (Map.remove (rhs phi) tid)
+
+  let select phi tid : exp option =
+    Map.find (rhs phi) tid
+
+  let select_or_unknown phi tid = match select phi tid with
+    | Some thing -> thing
+    | None ->
+      let name = Format.asprintf "no path from %a" Tid.pp tid in
+      Bap_exp.Exp.unknown name (Var.typ (lhs phi))
+
+  let map_exp phi ~f : phi term =
+    with_rhs phi (Map.map (rhs phi) ~f)
+
+  let substitute phi x y = map_exp phi ~f:(Exp.substitute x y)
+
+  let free_vars phi =
+    values phi |> Seq.fold ~init:Bap_var.Set.empty ~f:(fun vars (_,e) ->
+        Set.union vars (Exp.free_vars e))
+
+  include Regular.Make(struct
+      type t = phi term [@@deriving bin_io, compare, sexp]
+      let module_name = Some "Bap.Std.Phi"
+      let version = "0.1"
+
+      let hash = hash_of_term
+
+      let pp_self ppf (lhs,rhs) =
+        Format.fprintf ppf "%a := phi(%s)"
+          Var.pp lhs
+          (String.concat ~sep:", " @@
+           List.map ~f:(fun (id,exp) ->
+               Format.asprintf "[%a, %%%a]" Bap_exp.pp exp Tid.pp id)
+             (Map.to_alist rhs))
+      let pp = term_pp pp_self
+    end)
+end
+
+module Ir_jmp = struct
+  type t = jmp term
+  include Leaf
+
+  let create_call ?tid ?(cond=always) call =
+    create ?tid cond (Call call)
+
+  let create_goto ?tid ?(cond=always) dest =
+    create ?tid cond (Goto dest)
+
+  let create_ret  ?tid ?(cond=always) dest =
+    create ?tid cond (Ret  dest)
+
+  let create_int  ?tid ?(cond=always) n t  =
+    create ?tid cond (Int (n,t))
+
+  let create      ?tid ?(cond=always) kind =
+    create ?tid cond kind
+
+  let kind = rhs
+  let cond = lhs
+  let with_cond = with_lhs
+  let with_kind = with_rhs
+
+  let exps (jmp : jmp term) : exp Sequence.t =
+    let open Sequence.Generator in
+    let label label = match label with
+      | Indirect exp -> yield exp
+      | Direct _ -> return () in
+    let call call =
+      Option.value_map ~default:(return ())
+        (Call.return call) ~f:label >>= fun () ->
+      label (Call.target call) in
+    let r = match kind jmp with
+      | Call t -> call  t
+      | Goto t | Ret  t -> label t
+      | _ -> return () in
+    run (r >>= fun () -> yield (cond jmp))
+
+  let map_exp (jmp : jmp term) ~f : jmp term =
+    let map_label label = match label with
+      | Indirect exp -> Label.indirect (f exp)
+      | Direct _ -> label in
+    let map_call call : call =
+      let return = Option.map (Call.return call) ~f:map_label in
+      let target = map_label (Call.target call) in
+      Call.create ?return ~target () in
+    let jmp = with_cond jmp (f (cond jmp)) in
+    let kind = match kind jmp with
+      | Call t -> Call (map_call  t)
+      | Goto t -> Goto (map_label t)
+      | Ret  t -> Ret  (map_label t)
+      | Int (_,_) as kind -> kind in
+    with_kind jmp kind
+
+  let substitute jmp x y = map_exp jmp ~f:(Exp.substitute x y)
+
+  let free_vars jmp =
+    exps jmp |> Seq.fold ~init:Bap_var.Set.empty ~f:(fun vars e ->
+        Set.union vars (Exp.free_vars e))
+
+  let eval jmp bili =
+    let eval_label = function
+      | Indirect dst -> bili#eval_jmp (Stmt.jmp dst)
+      | Direct _ -> assert false in
+    match kind jmp with
+    | Goto t -> eval_label t
+    | _ -> assert false
+
+
+  include Regular.Make(struct
+      type t = jmp term [@@deriving bin_io, compare, sexp]
+      let module_name = Some "Bap.Std.Jmp"
+      let version = "0.1"
+
+      let hash = hash_of_term
+
+      let pp_dst ppf = function
+        | Goto dst -> Format.fprintf ppf "goto %a" Label.pp dst
+        | Call sub -> Call.pp ppf sub
+        | Ret  dst -> Format.fprintf ppf "return %a" Label.pp dst
+        | Int (n,t) ->
+          Format.fprintf ppf "interrupt 0x%X return %%%a" n Tid.pp t
+
+      let pp_cond ppf cond =
+        if Exp.(cond <> always) then
+          Format.fprintf ppf "when %a " Bap_exp.pp cond
+
+      let pp_self ppf (lhs,rhs) =
+        Format.fprintf ppf "%a%a" pp_cond lhs pp_dst rhs
+
+      let pp = term_pp pp_self
+    end)
+end
+
 
 module Term = struct
   type 'a t = 'a term
@@ -409,280 +706,206 @@ module Term = struct
             if i = n then c else x) in
         {p with self = t.set p.self xs}
 
-  let pp pp_self ppf t =
-    let open Format in
-    let attrs = Dict.data t.dict in
-    Seq.iter attrs ~f:(fun attr ->
-        pp_open_tag ppf (asprintf "%a" pp_attr attr));
-    Format.fprintf ppf "@[%a: %a@]@." Tid.pp t.tid pp_self t.self;
-    Seq.iter attrs ~f:(fun _ -> pp_close_tag ppf ());
+  let pp = term_pp
+
+  type ('a,'b) cata = 'a term -> 'b
+
+  let this x t = x
+
+  let cata (type t) (cls : (_,t) cls)
+      ~init:default
+      ?(program : (program,'a) cata = this default)
+      ?(sub : (sub,'a) cata = this default)
+      ?(arg : (arg,'a) cata = this default)
+      ?(blk : (blk,'a) cata = this default)
+      ?(phi : (phi,'a) cata = this default)
+      ?(def : (def,'a) cata = this default)
+      ?(jmp : (jmp,'a) cata = this default)
+      (t : t term) : 'a = match cls.typ with
+    | Nil -> assert false
+    | Top -> program t
+    | Sub -> sub t
+    | Arg -> arg t
+    | Blk -> blk t
+    | Phi -> phi t
+    | Def -> def t
+    | Jmp -> jmp t
+
+  let match_failure _ = raise (Match_failure ("",0,0))
+  type ('a,'b) case = 'a -> 'b
+
+  let switch (type t)
+      (cls : (_,t) cls)
+      ~(program : (program,'a) cata)
+      ~(sub : (sub,'a) cata)
+      ~(arg : (arg,'a) cata)
+      ~(blk : (blk,'a) cata)
+      ~(phi : (phi,'a) cata)
+      ~(def : (def,'a) cata)
+      ~(jmp : (jmp,'a) cata)
+      (t : t term) : 'a = match cls.typ with
+    | Nil -> assert false
+    | Top -> program t
+    | Sub -> sub t
+    | Arg -> arg t
+    | Blk -> blk t
+    | Phi -> phi t
+    | Def -> def t
+    | Jmp -> jmp t
+
+
+  type ('a,'b) proj = 'a term -> 'b option
+
+  let nothing _ = None
+
+  let proj cls ?program ?sub ?arg ?blk ?phi ?def ?jmp t =
+    cata ~init:None ?program ?sub ?arg ?blk ?phi ?def ?jmp cls t
+
+  type 'a map = 'a term -> 'a term
+
+  let map_term (type t) (cls : (_,t) cls)
+      ?(program : program map = ident)
+      ?(sub : sub map = ident)
+      ?(arg : arg map = ident)
+      ?(blk : blk map = ident)
+      ?(phi : phi map = ident)
+      ?(def : def map = ident)
+      ?(jmp : jmp map = ident)
+      (t : t term) : t term = match cls.typ with
+    | Nil -> assert false
+    | Top -> program t
+    | Sub -> sub t
+    | Arg -> arg t
+    | Blk -> blk t
+    | Phi -> phi t
+    | Def -> def t
+    | Jmp -> jmp t
+
+
+  let map1 (x,y,z) ~f = (f x,y,z)
+  let map2 (x,y,z) ~f = (x,f y,z)
+
+  class mapper = object(self)
+    inherit Bil.exp_mapper
+    method map_term : 't 'p. ('p,'t) cls -> 't term -> 't term =
+      fun cls t -> map_term cls t
+          ~program:self#run
+          ~sub:self#map_sub
+          ~arg:self#map_arg
+          ~blk:self#map_blk
+          ~phi:self#map_phi
+          ~def:self#map_def
+          ~jmp:self#map_jmp
+
+    method run p = map sub_t ~f:(fun t -> self#map_term sub_t t) p
+    method map_sub sub = map arg_t ~f:(self#map_term arg_t) sub |>
+                         map blk_t ~f:(self#map_term blk_t)
+    method map_blk blk = map phi_t ~f:(self#map_term phi_t) blk |>
+                         map def_t ~f:(self#map_term def_t) |>
+                         map jmp_t ~f:(self#map_term jmp_t)
+
+
+
+    method map_arg arg = {
+      arg with
+      self = map1 ~f:self#map_sym arg.self |>
+             map2 ~f:self#map_exp
+    }
+
+    method map_phi phi =
+      let phi = Ir_phi.(with_lhs phi (self#map_sym (lhs phi))) in
+      Ir_phi.map_exp phi ~f:self#map_exp
+
+    method map_def def =
+      let def = Ir_def.(with_lhs def (self#map_sym (lhs def))) in
+      Ir_def.map_exp def ~f:self#map_exp
+
+    method map_jmp jmp = Ir_jmp.map_exp jmp ~f:self#map_exp
+  end
+
+  let visit cls ~f term init =
+    enum cls term |> Seq.fold ~init ~f:(fun x t -> f t x)
+
+  let fident t x = x
+
+  class ['a] visitor = object(self)
+    inherit ['a] Bil.exp_visitor
+    method visit_term : 't 'p. ('p,'t) cls -> 't term -> 'a -> 'a =
+      fun cls t x -> switch cls t
+          ~program:(fun t -> self#run t x)
+          ~sub:(fun t -> self#visit_sub t x)
+          ~arg:(fun t -> self#visit_arg t x)
+          ~blk:(fun t -> self#visit_blk t x)
+          ~phi:(fun t -> self#visit_phi t x)
+          ~def:(fun t -> self#visit_def t x)
+          ~jmp:(fun t -> self#visit_jmp t x)
+
+    method enter_program p x = x
+    method leave_program p x = x
+
+    method enter_sub sub x = x
+    method leave_sub sub x = x
+
+    method enter_blk blk x = x
+    method leave_blk blk x = x
+
+    method run p x =
+      self#enter_program p x |>
+      visit sub_t ~f:(fun t -> self#visit_term sub_t t) p |>
+      self#leave_program p
+
+    method visit_sub sub x =
+      self#enter_sub sub x |>
+      visit arg_t ~f:(self#visit_term arg_t) sub |>
+      visit blk_t ~f:(self#visit_term blk_t) sub |>
+      self#leave_sub sub
+
+    method visit_blk blk x =
+      self#enter_blk blk x |>
+      visit phi_t ~f:(self#visit_term phi_t) blk |>
+      visit def_t ~f:(self#visit_term def_t) blk |>
+      visit jmp_t ~f:(self#visit_term jmp_t) blk |>
+      self#leave_blk blk
+
+
+    method enter_arg : arg term -> 'a -> 'a = fident
+    method enter_phi : phi term -> 'a -> 'a = fident
+    method enter_def : def term -> 'a -> 'a = fident
+    method enter_jmp : jmp term -> 'a -> 'a = fident
+
+    method leave_arg : arg term -> 'a -> 'a = fident
+    method leave_phi : phi term -> 'a -> 'a = fident
+    method leave_def : def term -> 'a -> 'a = fident
+    method leave_jmp : jmp term -> 'a -> 'a = fident
+
+    method visit_arg arg x =
+      self#enter_arg arg x |>
+      self#visit_var (fst3 arg.self) |>
+      self#visit_exp (snd3 arg.self) |>
+      self#leave_arg arg
+
+    method visit_phi phi x =
+      self#enter_phi phi x |>
+      self#visit_var (fst phi.self) |> fun x ->
+      Map.fold (snd phi.self) ~init:x ~f:(fun ~key ~data x ->
+          self#visit_exp data x) |>
+      self#leave_phi phi
+
+    method visit_def def x =
+      self#enter_def def x |>
+      self#visit_var (fst def.self) |>
+      self#visit_exp (snd def.self) |>
+      self#leave_def def
+
+    method visit_jmp jmp x =
+      self#enter_jmp jmp x |> fun x ->
+      Seq.fold (Ir_jmp.exps jmp) ~init:x ~f:(fun x e ->
+          self#visit_exp e x) |>
+      self#leave_jmp jmp
+  end
+
 end
 
-module Label = struct
-  type t = label
-  let direct x = Direct x
-  let indirect x = Indirect x
-  let create () = direct (Tid.create ())
-  let change ?(direct=ident) ?(indirect=ident) label =
-    match label with
-    | Direct x -> Direct (direct x)
-    | Indirect x -> Indirect (indirect x)
-
-  include Regular.Make(struct
-      type t = label [@@deriving bin_io, compare, sexp]
-      let module_name = Some "Bap.Std.Label"
-      let version = "0.1"
-
-      let hash = Hashtbl.hash
-      let pp ppf = function
-        | Indirect exp -> Bap_exp.pp ppf exp
-        | Direct tid -> Format.fprintf ppf "%s" @@ Tid.name tid
-    end)
-end
-
-module Call = struct
-  type t = call
-  let create ?return ~target ()  = {target; return}
-  let return t = t.return
-  let target t = t.target
-  let with_return t return = { t with return = Some return }
-  let with_target t target = { t with target }
-  let with_noreturn t = {t with return = None}
-
-  include Regular.Make(struct
-      type t = call [@@deriving bin_io, compare, sexp]
-      let module_name = Some "Bap.Std.Call"
-      let version = "0.1"
-
-
-      let pp_return ppf lab = match lab with
-        | Some label ->
-          Format.fprintf ppf "with return %a" Label.pp label
-        | None -> Format.fprintf ppf "with noreturn"
-
-      let pp ppf c =
-        Format.fprintf ppf "@[call %a %a@]"
-          Label.pp c.target pp_return c.return
-
-      let hash = Hashtbl.hash
-    end)
-end
-
-module Ir_arg = struct
-  type t = arg term
-  let create ?(tid=Tid.create()) ?intent var exp : t =
-    make_term tid (var,exp,intent)
-
-  let lhs t = Tuple3.get1 t.self
-  let rhs t = Tuple3.get2 t.self
-  let intent t = Tuple3.get3 t.self
-  let with_intent (t : t) intent : t = {
-    t with self = Tuple3.map3 t.self ~f:(fun _ -> Some intent)
-  }
-  let with_unknown_intent t : t = {
-    t with self = Tuple3.map3 t.self ~f:(fun _ -> None)
-  }
-  let name arg = Var.name (lhs arg)
-
-  include Regular.Make(struct
-      type t = arg term [@@deriving bin_io, compare, sexp]
-      let module_name = Some "Bap.Std.Arg"
-      let version = "0.1"
-
-      let hash = hash_of_term
-
-      let string_of_intent = function
-        | Some In -> "in "
-        | Some Out -> "out "
-        | Some Both -> "in out "
-        | None -> ""
-
-      let pp_self ppf (var,exp,intent) =
-        Format.fprintf ppf "%s :: %s%a = %a"
-          (Var.name var)
-          (string_of_intent intent)
-          Bap_type.pp (Var.typ var)
-          Bap_exp.pp exp
-
-      let pp = Term.pp pp_self
-    end)
-end
-
-
-module Ir_def = struct
-  type t = def term
-  include Leaf
-
-  let map_exp def ~f : def term =
-    with_rhs def (f (rhs def))
-
-  let substitute def x y = map_exp def ~f:(Exp.substitute x y)
-
-  let free_vars def = Exp.free_vars (rhs def)
-
-
-  include Regular.Make(struct
-      type t = def term [@@deriving bin_io, compare, sexp]
-      let module_name = Some "Bap.Std.Def"
-      let version = "0.1"
-
-      let hash = hash_of_term
-
-      let pp_self ppf (lhs,rhs) =
-        Format.fprintf ppf "%a := %a" Var.pp lhs Bap_exp.pp rhs
-
-      let pp = Term.pp pp_self
-    end)
-end
-
-module Ir_phi = struct
-  type t = phi term
-  include Leaf
-
-  let of_list ?tid var bs : phi term =
-    create ?tid var (Tid.Map.of_alist_reduce bs ~f:(fun _ x -> x))
-
-  let create ?tid var src exp : phi term = of_list var [src,exp]
-
-  let values (phi : phi term) : (tid * exp) Seq.t =
-    Map.to_sequence (rhs phi)
-
-  let update (phi : phi term) tid exp : phi term =
-    with_rhs phi (Map.add (rhs phi) ~key:tid ~data:exp)
-
-  let remove phi tid : phi term =
-    with_rhs phi (Map.remove (rhs phi) tid)
-
-  let select phi tid : exp option =
-    Map.find (rhs phi) tid
-
-  let select_or_unknown phi tid = match select phi tid with
-    | Some thing -> thing
-    | None ->
-      let name = Format.asprintf "no path from %a" Tid.pp tid in
-      Bap_exp.Exp.unknown name (Var.typ (lhs phi))
-
-  let map_exp phi ~f : phi term =
-    with_rhs phi (Map.map (rhs phi) ~f)
-
-  let substitute phi x y = map_exp phi ~f:(Exp.substitute x y)
-
-  let free_vars phi =
-    values phi |> Seq.fold ~init:Bap_var.Set.empty ~f:(fun vars (_,e) ->
-        Set.union vars (Exp.free_vars e))
-
-  include Regular.Make(struct
-      type t = phi term [@@deriving bin_io, compare, sexp]
-      let module_name = Some "Bap.Std.Phi"
-      let version = "0.1"
-
-      let hash = hash_of_term
-
-      let pp_self ppf (lhs,rhs) =
-        Format.fprintf ppf "%a := phi(%s)"
-          Var.pp lhs
-          (String.concat ~sep:", " @@
-           List.map ~f:(fun (id,exp) ->
-               Format.asprintf "[%a, %%%a]" Bap_exp.pp exp Tid.pp id)
-             (Map.to_alist rhs))
-      let pp = Term.pp pp_self
-    end)
-end
-
-module Ir_jmp = struct
-  type t = jmp term
-  include Leaf
-
-  let create_call ?tid ?(cond=always) call =
-    create ?tid cond (Call call)
-
-  let create_goto ?tid ?(cond=always) dest =
-    create ?tid cond (Goto dest)
-
-  let create_ret  ?tid ?(cond=always) dest =
-    create ?tid cond (Ret  dest)
-
-  let create_int  ?tid ?(cond=always) n t  =
-    create ?tid cond (Int (n,t))
-
-  let create      ?tid ?(cond=always) kind =
-    create ?tid cond kind
-
-  let kind = rhs
-  let cond = lhs
-  let with_cond = with_lhs
-  let with_kind = with_rhs
-
-  let exps (jmp : jmp term) : exp Sequence.t =
-    let open Sequence.Generator in
-    let label label = match label with
-      | Indirect exp -> yield exp
-      | Direct _ -> return () in
-    let call call =
-      Option.value_map ~default:(return ())
-        (Call.return call) ~f:label >>= fun () ->
-      label (Call.target call) in
-    let r = match kind jmp with
-      | Call t -> call  t
-      | Goto t | Ret  t -> label t
-      | _ -> return () in
-    run (r >>= fun () -> yield (cond jmp))
-
-  let map_exp (jmp : jmp term) ~f : jmp term =
-    let map_label label = match label with
-      | Indirect exp -> Label.indirect (f exp)
-      | Direct _ -> label in
-    let map_call call : call =
-      let return = Option.map (Call.return call) ~f:map_label in
-      let target = map_label (Call.target call) in
-      Call.create ?return ~target () in
-    let jmp = with_cond jmp (f (cond jmp)) in
-    let kind = match kind jmp with
-      | Call t -> Call (map_call  t)
-      | Goto t -> Goto (map_label t)
-      | Ret  t -> Ret  (map_label t)
-      | Int (_,_) as kind -> kind in
-    with_kind jmp kind
-
-  let substitute jmp x y = map_exp jmp ~f:(Exp.substitute x y)
-
-  let free_vars jmp =
-    exps jmp |> Seq.fold ~init:Bap_var.Set.empty ~f:(fun vars e ->
-        Set.union vars (Exp.free_vars e))
-
-  let eval jmp bili =
-    let eval_label = function
-      | Indirect dst -> bili#eval_jmp (Stmt.jmp dst)
-      | Direct _ -> assert false in
-    match kind jmp with
-    | Goto t -> eval_label t
-    | _ -> assert false
-
-
-  include Regular.Make(struct
-      type t = jmp term [@@deriving bin_io, compare, sexp]
-      let module_name = Some "Bap.Std.Jmp"
-      let version = "0.1"
-
-      let hash = hash_of_term
-
-      let pp_dst ppf = function
-        | Goto dst -> Format.fprintf ppf "goto %a" Label.pp dst
-        | Call sub -> Call.pp ppf sub
-        | Ret  dst -> Format.fprintf ppf "return %a" Label.pp dst
-        | Int (n,t) ->
-          Format.fprintf ppf "interrupt 0x%X return %%%a" n Tid.pp t
-
-      let pp_cond ppf cond =
-        if Exp.(cond <> always) then
-          Format.fprintf ppf "when %a " Bap_exp.pp cond
-
-      let pp_self ppf (lhs,rhs) =
-        Format.fprintf ppf "%a%a" pp_cond lhs pp_dst rhs
-
-      let pp = Term.pp pp_self
-    end)
-end
 
 module Ir_blk = struct
   type t = blk term
@@ -883,7 +1106,7 @@ module Ir_blk = struct
           (Array.pp Ir_def.pp) self.defs
           (Array.pp Ir_jmp.pp) self.jmps
 
-      let pp = Term.pp pp_self
+      let pp = term_pp pp_self
     end)
 end
 
@@ -943,7 +1166,7 @@ module Ir_sub = struct
           (Array.pp Ir_arg.pp) self.args
           (Array.pp Ir_blk.pp) self.blks
 
-      let pp = Term.pp pp_self
+      let pp = term_pp pp_self
     end)
 end
 
@@ -1035,6 +1258,7 @@ module Ir_program = struct
     | Arg -> finder get_2nd args arg_of_path
     | Sub -> finder get_1st subs sub_of_path
     | Top -> (fun p tid -> Option.some_if (p.tid = tid) p)
+    | Nil -> assert false
 
   let lookup t = finder_of_type t.typ
 
@@ -1078,6 +1302,6 @@ module Ir_program = struct
       let pp_self ppf self =
         Format.fprintf ppf "@[<v>program@.%a@]"
           (Array.pp Ir_sub.pp) self.subs
-      let pp = Term.pp pp_self
+      let pp = term_pp pp_self
     end)
 end

--- a/lib/bap_types/bap_types.ml
+++ b/lib/bap_types/bap_types.ml
@@ -185,7 +185,8 @@ module Std = struct
   type dict  = Value.dict  [@@deriving bin_io, compare, sexp]
   type 'a tag = 'a Value.tag
 
-  class ['a] bil_visitor = ['a] Bap_visitor.visitor
+  class ['a] exp_visitor = ['a] Bap_visitor.bil_visitor
+  class ['a] bil_visitor = ['a] Bap_visitor.bil_visitor
 
   module Vector = Bap_vector
 

--- a/lib/bap_types/bap_visitor.mli
+++ b/lib/bap_types/bap_visitor.mli
@@ -1,242 +1,122 @@
-(** AST Visitors.
-
-    This module provides three classes that visits AST:
-
-    [visitor] that folds arbitrary value over the AST,
-    [finder] is a visitor, that can prematurely finish the traversal,
-    [mapper] that maps AST, allowing limited transformation
-    of its structure.
-
-    You can find some handy transformations in `Bap_helpers`
-    module. Note, all definitions from this module and `Bap_helpers`
-    is available under `Bil` namespace.
-
-
-*)
 open Core_kernel.Std
 open Bap_common
 open Bap_bil
 
-(** Both visitors provides some information about the current
-    position of the visitor *)
-class state : object
-  (** the stack of stmts that was already visited, with the last on
-      the top. Not including the currently visiting stmt. *)
-  val preds : bil
-
-  (** stmts that are not yet visited  *)
-  val succs : bil
-
-  (** a stack of stmts that are parents for the currently visiting
-      entity. The top one is the one that we're currently visiting. *)
-  val stmts_stack : bil
-
-  (** a stack of expr, that are parents for the currenly visiting
-      expression *)
+class exp_state : object
   val exps_stack  : exp  list
-
-  (** is [true] if we're visiting expression that is a jump target *)
-  val in_jmp : bool
-
-  (** is [true] if we're visiting expression that is on the left or
-      right side of the assignment. *)
-  val in_move : bool
-
-  (** is [true] if currently visiting expression or statement is
-      executed under condition.  *)
   val under_condition : bool
-  (** is [true] if currently visiting expression or statement is
-      executed under loop.  *)
+end
+
+class stmt_state : object
+  val preds : bil
+  val succs : bil
+  val stmts_stack : bil
+  val in_jmp : bool
+  val in_move : bool
   val in_loop : bool
 end
 
-(** Visitor.
-    Visits AST providing lots of hooks.
-
-    For each AST constructor [C] the visitor provides three methods:
-    [enter_C], [visit_C], [leave_C]. The default implementation for
-    [enter_C] and [leave_C] is to return its argument. The default
-    implementation for [visit_C] is the following:
-    1. call [enter_C]
-    2. visit all children
-    3. call [leave_C].
-
-    It is recommended to override [enter_C] method if you only need
-    to visit [C] constructor without changing a way you're visiting
-    the tree.
-
-    For example, to collect all resolved jumps one could write the
-    following function:
-
-    {[
-      let collect_calls bil = (object(self)
-        inherit [Word.t list] visitor
-        method! enter_int x js = if in_jmp then x :: js else js
-      end)#run bil []
-    ]}
-
-    The default entry point of the visitor is method [run], but
-    you can use any other method as well, for example, if you do
-    not have a statement at all and want to visit expression.
-*)
-class ['a] visitor : object
-  inherit state
-  (** {3 Default entry point}  *)
-  method run : bil -> 'a -> 'a
-
-  (** {3 Statements }  *)
-  method enter_stmt : stmt -> 'a -> 'a
-  method visit_stmt : stmt -> 'a -> 'a
-  method leave_stmt : stmt -> 'a -> 'a
-
-  (** {4 [Move(var,exp)]}  *)
-  method enter_move : var -> exp -> 'a -> 'a
-  method visit_move : var -> exp -> 'a -> 'a
-  method leave_move : var -> exp -> 'a -> 'a
-
-  (** {4 [Jmp exp]}  *)
-  method enter_jmp : exp -> 'a -> 'a
-  method visit_jmp : exp -> 'a -> 'a
-  method leave_jmp : exp -> 'a -> 'a
-
-  (** {4 [While (cond,bil)]}  *)
-  method enter_while : cond:exp -> bil -> 'a -> 'a
-  method visit_while : cond:exp -> bil -> 'a -> 'a
-  method leave_while : cond:exp -> bil -> 'a -> 'a
-
-  (** {4 [If (cond,yes,no)]}  *)
-  method enter_if : cond:exp -> yes:bil -> no:bil -> 'a -> 'a
-  method visit_if : cond:exp -> yes:bil -> no:bil -> 'a -> 'a
-  method leave_if : cond:exp -> yes:bil -> no:bil -> 'a -> 'a
-
-  (** {4 [CpuExn n]}  *)
-  method enter_cpuexn : int -> 'a -> 'a
-  method visit_cpuexn : int -> 'a -> 'a
-  method leave_cpuexn : int -> 'a -> 'a
-
-  (** {4 [Special string]}  *)
-  method enter_special : string -> 'a -> 'a
-  method visit_special : string -> 'a -> 'a
-  method leave_special : string -> 'a -> 'a
-
-  (** {3 Expressions}  *)
+class ['a] exp_visitor : object
+  inherit exp_state
   method enter_exp : exp -> 'a -> 'a
   method visit_exp : exp -> 'a -> 'a
   method leave_exp : exp -> 'a -> 'a
 
-  (** {4 [Load (src,addr,endian,size)]}  *)
   method enter_load : mem:exp -> addr:exp -> endian -> size -> 'a -> 'a
   method visit_load : mem:exp -> addr:exp -> endian -> size -> 'a -> 'a
   method leave_load : mem:exp -> addr:exp -> endian -> size -> 'a -> 'a
 
-  (** {4 [Store (dst,addr,src,endian,size)]}  *)
   method enter_store : mem:exp -> addr:exp -> exp:exp -> endian -> size -> 'a -> 'a
   method visit_store : mem:exp -> addr:exp -> exp:exp -> endian -> size -> 'a -> 'a
   method leave_store : mem:exp -> addr:exp -> exp:exp -> endian -> size -> 'a -> 'a
 
-  (** {4 [BinOp (op,e1,e2)]}  *)
   method enter_binop : binop -> exp -> exp -> 'a -> 'a
   method visit_binop : binop -> exp -> exp -> 'a -> 'a
   method leave_binop : binop -> exp -> exp -> 'a -> 'a
 
-  (** {4 [Unop (op,e)]}  *)
   method enter_unop : unop -> exp -> 'a -> 'a
   method visit_unop : unop -> exp -> 'a -> 'a
   method leave_unop : unop -> exp -> 'a -> 'a
 
-  (** {4 [Cast(kind,size,e)]}  *)
   method enter_cast : cast -> nat1 -> exp -> 'a -> 'a
   method visit_cast : cast -> nat1 -> exp -> 'a -> 'a
   method leave_cast : cast -> nat1 -> exp -> 'a -> 'a
 
-  (** {4 [Let (v,exp,body)]}  *)
   method enter_let : var -> exp:exp -> body:exp -> 'a -> 'a
   method visit_let : var -> exp:exp -> body:exp -> 'a -> 'a
   method leave_let : var -> exp:exp -> body:exp -> 'a -> 'a
 
-  (** {4 [Ite (cond,yes,no)]}  *)
   method enter_ite : cond:exp -> yes:exp -> no:exp -> 'a -> 'a
   method visit_ite : cond:exp -> yes:exp -> no:exp -> 'a -> 'a
   method leave_ite : cond:exp -> yes:exp -> no:exp -> 'a -> 'a
 
-  (** {4 [Extract (hi,lo,e)]}  *)
   method enter_extract : hi:nat1 -> lo:nat1 -> exp -> 'a -> 'a
   method visit_extract : hi:nat1 -> lo:nat1 -> exp -> 'a -> 'a
   method leave_extract : hi:nat1 -> lo:nat1 -> exp -> 'a -> 'a
 
-  (** {4 [Concat(e1,e2)]}  *)
   method enter_concat : exp -> exp -> 'a -> 'a
   method visit_concat : exp -> exp -> 'a -> 'a
   method leave_concat : exp -> exp -> 'a -> 'a
 
-  (** {3 [Leafs]} *)
-  (** {4 [Int w]}  *)
   method enter_int : word -> 'a -> 'a
   method visit_int : word -> 'a -> 'a
   method leave_int : word -> 'a -> 'a
 
-  (** {4 [Var v]}  *)
   method enter_var : var -> 'a -> 'a
   method visit_var : var -> 'a -> 'a
   method leave_var : var -> 'a -> 'a
 
-  (** {4 [Unknown (str,typ)]}  *)
   method enter_unknown : string -> typ -> 'a -> 'a
   method visit_unknown : string -> typ -> 'a -> 'a
   method leave_unknown : string -> typ -> 'a -> 'a
 end
 
 
-(** A visitor with shortcut.
-    Finder is a specialization of a visitor, that uses [return] as its
-    folding argument. At any time you can stop the traversing by
-    calling [return] function of the provided argument (which is by
-    itself is a record with one field - a function accepting argument
-    of type ['a option]).
+class ['a] bil_visitor : object
+  inherit ['a] exp_visitor
+  inherit stmt_state
 
-    For example, the following function will check whether [x]
-    variable is referenced in the provided scope.
-    {[
-      let is_referenced x = find (object(self)
-          inherit [unit] finder
-          method! enter_var y cc =
-            if Bap_var.(x = y) then cc.return (Some ()); cc
-        end)
-    ]}
+  method run : bil -> 'a -> 'a
+  method enter_stmt : stmt -> 'a -> 'a
+  method visit_stmt : stmt -> 'a -> 'a
+  method leave_stmt : stmt -> 'a -> 'a
+  method enter_move : var -> exp -> 'a -> 'a
+  method visit_move : var -> exp -> 'a -> 'a
+  method leave_move : var -> exp -> 'a -> 'a
 
-    Note: the example uses [find] function from the [Bap_helpers].
-*)
-class ['a] finder : object
-  inherit ['a option return] visitor
-  method find_in_bil : bil -> 'a option
-  method find_in_exp : exp -> 'a option
+  method enter_jmp : exp -> 'a -> 'a
+  method visit_jmp : exp -> 'a -> 'a
+  method leave_jmp : exp -> 'a -> 'a
+
+  method enter_while : cond:exp -> bil -> 'a -> 'a
+  method visit_while : cond:exp -> bil -> 'a -> 'a
+  method leave_while : cond:exp -> bil -> 'a -> 'a
+
+  method enter_if : cond:exp -> yes:bil -> no:bil -> 'a -> 'a
+  method visit_if : cond:exp -> yes:bil -> no:bil -> 'a -> 'a
+  method leave_if : cond:exp -> yes:bil -> no:bil -> 'a -> 'a
+
+  method enter_cpuexn : int -> 'a -> 'a
+  method visit_cpuexn : int -> 'a -> 'a
+  method leave_cpuexn : int -> 'a -> 'a
+
+  method enter_special : string -> 'a -> 'a
+  method visit_special : string -> 'a -> 'a
+  method leave_special : string -> 'a -> 'a
 end
 
-(** AST transformation.
-    mapper allows one to map AST, performing some limited
-    amount of transformations on it. Mapper provides extra
-    flexibility by mapping [stmt] to [stmt list], thus allowing
-    to remove statements from the output (by mapping to empty list) or
-    to map one statement to several. This is particularly useful when
-    you map [if] or [while] statements.
-*)
-class mapper : object
-  inherit state
+class ['a] bil_finder : object
+  inherit ['a option return] bil_visitor
+  method find : bil -> 'a option
+end
 
-  (** Default entry point.
-      But again, you can use any method as an entry  *)
-  method run : bil -> bil
+class ['a] exp_finder : object
+  inherit ['a option return] exp_visitor
+  method find : exp -> 'a option
+end
 
-  (** {3 Statements}  *)
-  method map_stmt : stmt -> bil
-  method map_move : var -> exp -> bil
-  method map_jmp : exp -> bil
-  method map_while : cond:exp -> bil -> bil
-  method map_if : cond:exp -> yes:bil -> no:bil -> bil
-  method map_cpuexn : int -> bil
-  method map_special : string -> bil
-
-  (** {3 Expressions}  *)
+class exp_mapper : object
+  inherit exp_state
   method map_exp : exp -> exp
   method map_load : mem:exp -> addr:exp -> endian -> size -> exp
   method map_store : mem:exp -> addr:exp -> exp:exp -> endian -> size -> exp
@@ -251,4 +131,19 @@ class mapper : object
   method map_var : var -> exp
   method map_sym : var -> var
   method map_unknown : string -> typ -> exp
+end
+
+
+class bil_mapper : object
+  inherit exp_mapper
+  inherit stmt_state
+  method run : bil -> bil
+
+  method map_stmt : stmt -> bil
+  method map_move : var -> exp -> bil
+  method map_jmp : exp -> bil
+  method map_while : cond:exp -> bil -> bil
+  method map_if : cond:exp -> yes:bil -> no:bil -> bil
+  method map_cpuexn : int -> bil
+  method map_special : string -> bil
 end

--- a/lib/microx/microx_concretizer.ml
+++ b/lib/microx/microx_concretizer.ml
@@ -11,7 +11,6 @@ type policy = [`Random | `Fixed of int64 | `Interval of int64 * int64 ]
 
 let rand64 lo hi = Int64.(Random.int64 (hi+(hi-lo)) + lo)
 
-let () = Random.self_init ()
 
 let rec generate = function
   | `Fixed x -> Word.of_int64 x
@@ -21,7 +20,12 @@ let rec generate = function
 class ['a] main ?(memory=fun _ -> None) ?(policy=def_policy) () =
   object(self)
     inherit ['a] expi as super
+
     method! eval_unknown _ t = self#emit t
+
+    initializer match policy with
+      | `Fixed _ -> ()
+      | _ -> Random.self_init ()
 
     method! lookup v =
       super#lookup v >>= fun r ->

--- a/plugins/phoenix/phoenix_helpers.ml
+++ b/plugins/phoenix/phoenix_helpers.ml
@@ -26,7 +26,7 @@ module Make(Env : sig
       | `r64 -> reg64_t in
     let make_var name =
       Bil.var (Var.create name jump_type) in
-    (object inherit Bil.mapper as super
+    (object inherit Stmt.mapper as super
       method! map_int addr =
         Symtab.owners syms addr |> List.hd |> function
         | Some (sym,entry,_) ->
@@ -40,7 +40,7 @@ module Make(Env : sig
 
   (** substitute loads with the value of corresponding memory *)
   let resolve_indirects =
-    Bil.map (object inherit Bil.mapper as super
+    Stmt.map (object inherit Stmt.mapper as super
       method! map_load ~mem ~addr endian scale =
         let exp = super#map_load ~mem ~addr endian scale in
         match addr with
@@ -55,7 +55,8 @@ module Make(Env : sig
     end)
 
   (* we're very conservative here *)
-  let has_side_effect e scope = (object inherit [bool] Bil.visitor
+  let has_side_effect e scope = (object
+    inherit [bool] Exp.visitor
     method! enter_load  ~mem:_ ~addr:_ _e _s _r = true
     method! enter_store ~mem:_ ~addr:_ ~exp:_ _e _s _r = true
     method! enter_var v r = r || Bil.is_assigned v scope


### PR DESCRIPTION
This PR introduces some breaking changes described in the Breaking
Changes section. See also corresponding PR to the bap-plugins
repository, that updates to this change.

Summary
-------

This PR adds the following features:

1. Term.visitor class
2. Term.mapper class
3. Three higher-order morphisms:
   - Term.switch
   - Term.proj
   - Term.cata
4. Splits Bil.visitor into:
    - Exp.visitor
    - Stmt.visitor
5. Splits Bil.mapper into:
    - Exp.mapper
    - Stmt.mapper

The `Term.visitor` class performs a deep visiting of the program in the
IR. It inherits `Exp.visitor`, so you can destruct your program to the
smallest possible atoms. The same is true for `Term.mapper`.

The `Term.switch` is used for pattern matching. `Term.proj` and
`Term.cata` are special cases of switch, that allow to omit some
branches.

All these additions (mapper,visitor and morphism) now allow one to write
an arbitrary transformation of ('a term).

Breaking changes
----------------

Other than splitting `Bil.{visitor,mapper}` into two classes, this PR
also removes corresponding morphisms from the `Bil` namespace. To fix
your program after this PR you need to do the following:

1. rename Bil.{visitor,mapper} to Stmt.{visitor,mapper}
   (or to Exp.{visitor,mapper} if you were only using `map_exp` method.)

2. rename `Bil.{fold,iter,map}` to `Stmt.{fold,iter,map}`