### PR TITLE
better taint propagation

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -5071,8 +5071,11 @@ module Std : sig
     class ['a] visitor : object
       inherit ['a] Exp.visitor
 
+      method enter_term : 't 'p . ('p,'t) cls -> 't term -> 'a -> 'a
       (** [visit_term cls t] dispatch term [t] to corresponding method  *)
-      method visit_term : 't 'p. ('p,'t) cls -> 't term -> 'a -> 'a
+      method visit_term : 't 'p . ('p,'t) cls -> 't term -> 'a -> 'a
+      method leave_term : 't 'p . ('p,'t) cls -> 't term -> 'a -> 'a
+
 
       method enter_program : program term -> 'a -> 'a
       method run           : program term -> 'a -> 'a
@@ -5318,7 +5321,8 @@ module Std : sig
     module Builder : sig
       type t
       (** initializes empty subroutine builder.  *)
-      val create : ?tid:tid -> ?args:int -> ?blks:int -> ?name:string -> unit -> t
+      val create : ?tid:tid -> ?args:int -> ?blks:int -> ?name:string ->
+        unit -> t
       (** appends a block to a subroutine  *)
       val add_blk : t -> blk term -> unit
       (** appends an argument  *)

--- a/lib/bap_types/bap_ir.ml
+++ b/lib/bap_types/bap_ir.ml
@@ -847,15 +847,21 @@ module Term = struct
 
   class ['a] visitor = object(self)
     inherit ['a] Bil.exp_visitor
+
+    method enter_term : 't 'p. ('p,'t) cls -> 't term -> 'a -> 'a = fun cls t x -> x
+    method leave_term : 't 'p. ('p,'t) cls -> 't term -> 'a -> 'a = fun cls t x -> x
     method visit_term : 't 'p. ('p,'t) cls -> 't term -> 'a -> 'a =
-      fun cls t x -> switch cls t
+      fun cls t x ->
+        let x = self#enter_term cls t x in
+        switch cls t
           ~program:(fun t -> self#run t x)
           ~sub:(fun t -> self#visit_sub t x)
           ~arg:(fun t -> self#visit_arg t x)
           ~blk:(fun t -> self#visit_blk t x)
           ~phi:(fun t -> self#visit_phi t x)
           ~def:(fun t -> self#visit_def t x)
-          ~jmp:(fun t -> self#visit_jmp t x)
+          ~jmp:(fun t -> self#visit_jmp t x) |>
+        self#leave_term cls t
 
     method enter_program p x = x
     method leave_program p x = x

--- a/lib/bap_types/bap_ir.mli
+++ b/lib/bap_types/bap_ir.mli
@@ -112,7 +112,10 @@ module Term : sig
 
   class ['a] visitor : object
     inherit ['a] exp_visitor
-    method visit_term : 't 'p. ('p,'t) cls -> 't term -> 'a -> 'a
+
+    method enter_term : 't 'p . ('p,'t) cls -> 't term -> 'a -> 'a
+    method visit_term : 't 'p . ('p,'t) cls -> 't term -> 'a -> 'a
+    method leave_term : 't 'p . ('p,'t) cls -> 't term -> 'a -> 'a
 
     method enter_program : program term -> 'a -> 'a
     method run           : program term -> 'a -> 'a

--- a/lib/microx/microx_concretizer.ml
+++ b/lib/microx/microx_concretizer.ml
@@ -4,8 +4,6 @@ open Bap.Std
 module SM = Monad.State
 open SM.Monad_infix
 
-let def_policy = `Fixed 0L
-
 type policy = [`Random | `Fixed of int64 | `Interval of int64 * int64 ]
 
 
@@ -17,38 +15,44 @@ let rec generate = function
   | `Random -> generate (`Interval (Int64.min_value, Int64.max_value))
   | `Interval (lo,hi) -> generate (`Fixed (rand64 lo hi))
 
-class ['a] main ?(memory=fun _ -> None) ?(policy=def_policy) () =
+class ['a] main
+    ?(memory=fun _ -> None)
+    ?(lookup=fun _ -> None)
+    ?random_seed
+    ?(reg_policy=`Random)
+    ?(mem_policy=`Random) () =
   object(self)
     inherit ['a] expi as super
+    initializer Option.iter random_seed ~f:Random.init
 
-    method! eval_unknown _ t = self#emit t
+    method! eval_unknown _ t = self#emit reg_policy t
 
-    initializer match policy with
-      | `Fixed _ -> ()
-      | _ -> Random.self_init ()
+    method private emit_word w =
+      SM.get () >>= fun ctxt ->
+      let ctxt,r = ctxt#create_word w in
+      SM.put ctxt >>= fun () ->
+      SM.return r
 
     method! lookup v =
       super#lookup v >>= fun r ->
       match Bil.Result.value r with
       | Bil.Imm _ | Bil.Mem _ -> SM.return r
-      | Bil.Bot -> self#emit (Var.typ v)
+      | Bil.Bot -> match lookup v with
+        | Some w -> self#emit_word w
+        | None -> self#emit reg_policy (Var.typ v)
 
     method! load s a =
       super#load s a >>= fun r -> match Bil.Result.value r with
       | Bil.Imm _ | Bil.Mem _ -> SM.return r
       | Bil.Bot -> match memory a with
-        | None -> self#emit_const 8
-        | Some w ->
-          SM.get () >>= fun ctxt ->
-          let ctxt,r = ctxt#create_word w in
-          SM.put ctxt >>= fun () ->
-          SM.return r
+        | None -> self#emit_const mem_policy 8
+        | Some w -> self#emit_word w
 
-    method private emit = function
-      | Type.Imm sz -> self#emit_const sz
+    method private emit policy = function
+      | Type.Imm sz -> self#emit_const policy sz
       | Type.Mem _  -> self#emit_empty
 
-    method private emit_const sz =
+    method private emit_const policy sz =
       SM.get () >>= fun ctxt ->
       let const = generate policy in
       let const = Word.extract_exn ~lo:0 ~hi:(sz-1) const in

--- a/lib/microx/microx_concretizer.mli
+++ b/lib/microx/microx_concretizer.mli
@@ -4,4 +4,7 @@ type policy = [`Random | `Fixed of int64 | `Interval of int64 * int64 ]
 
 class ['a] main :
   ?memory:(addr -> word option) ->
-  ?policy:policy -> unit -> ['a] expi
+  ?lookup:(var -> word option) ->
+  ?random_seed:int ->
+  ?reg_policy:policy ->
+  ?mem_policy:policy -> unit -> ['a] expi

--- a/plugins/api/api/posix
+++ b/plugins/api/api/posix
@@ -9,6 +9,8 @@ typedef int ldiv_t;
 typedef int lldiv_t;
 typedef int wchar_t;
 
+int main(int argc, const char *argv[]);
+
 // stdlib.h
 
 void          _Exit(int code)
@@ -93,6 +95,15 @@ int           wctomb(char *, wchar_t);
 
 // stdio.h
 typedef void * FILE;
+
+int printf(const char *format, ...) __attribute__((format(printf,1)));
+int fprintf(FILE *stream, const char *format, ...) __attribute__((format(printf,2)));
+int sprintf(char *str, const char *format, ...) __attribute__((format(printf,2)));
+int snprintf(char *str, size_t size, const char *format, ...) __attribute__((format(printf,3)));
+int scanf(const char *format, ...) __attribute__((format(scanf,1)));
+int fscanf(FILE *stream, const char *format, ...) __attribute__((format(scanf,2)));
+int sscanf(const char *str, const char *format, ...) __attribute__((format(scanf,2)));
+
 
 char *fgets(char * restrict s, int size, FILE * restrict stream)
     __attribute__((warn_unused_result));

--- a/plugins/api/api_main.ml
+++ b/plugins/api/api_main.ml
@@ -121,6 +121,7 @@ let id_of_attr = function
       | CONST_FLOAT id
       | CONST_CHAR id
       | CONST_STRING id) -> Some (unuglify id)
+  | GNU_ID id -> Some (unuglify id)
   | _ -> None
 
 let attr = function
@@ -238,7 +239,9 @@ let set_attr sub {attr_name; attr_args} =
     | s -> raise (Attr_type ("<lang>",s)) in
   let set_format = function
     | [l;n] -> Term.set_attr sub Sub.format (lang l, nth n)
-    | _ -> raise (Attr_arity "2") in
+    | ss ->
+      eprintf "Got: %s\n" @@ String.concat ss ~sep:",";
+      raise (Attr_arity "2") in
   match attr_name with
   | "const"    -> set Sub.const
   | "pure"     -> set Sub.pure

--- a/plugins/callsites/callsites_main.ml
+++ b/plugins/callsites/callsites_main.ml
@@ -74,10 +74,10 @@ let insert_defs prog sub =
   let insert intent blk jmp sub =
     Option.value_map (blk_with_def intent blk jmp sub)
       ~default:sub ~f:(Term.update blk_t sub) in
-  Term.enum blk_t sub |> Seq.fold ~init:sub ~f:(fun sub blk ->
-      Term.enum jmp_t blk |> Seq.fold ~init:sub ~f:(fun sub jmp ->
-          insert In  blk jmp sub |>
-          insert Out blk jmp))
+  List.fold [In;Out] ~init:sub ~f:(fun sub intent ->
+      Term.enum blk_t sub |> Seq.fold ~init:sub ~f:(fun sub blk ->
+          Term.enum jmp_t blk |> Seq.fold ~init:sub ~f:(fun sub jmp ->
+              insert intent blk jmp sub)))
 
 let fill_calls program =
   Term.map sub_t program ~f:(insert_defs program)

--- a/plugins/propagate_taint/propagator.mli
+++ b/plugins/propagate_taint/propagator.mli
@@ -14,7 +14,9 @@ val run :
   max_steps : int ->
   max_loop : int ->
   deterministic : bool ->
-  policy : Concretizer.policy ->
+  ?random_seed:int ->
+  reg_policy : Concretizer.policy ->
+  mem_policy : Concretizer.policy ->
   project -> [
     | `Name of string
     | `Term of tid] -> result

--- a/plugins/taint/taint_main.ml
+++ b/plugins/taint/taint_main.ml
@@ -111,6 +111,13 @@ let mark regs ptrs proj =
   Marker.run ~regs ~ptrs |>
   Project.with_program proj
 
+let main regs ptrs = match regs,ptrs with
+  | [],[] -> ()
+  | regs,ptrs ->
+    Project.register_pass ~deps:["callsites"] ~autorun:true
+      (mark regs ptrs)
+
+
 module Cmdline = struct
   open Cmdliner
 
@@ -158,13 +165,12 @@ language follows:";
 
   let info = Term.info ~doc ~man name
   let grammar =
-    Term.(pure mark $(taints "reg") $(taints "ptr"))
+    Term.(pure main $(taints "reg") $(taints "ptr"))
 
   let parse () = Term.eval ~argv (grammar,info)
 end
 
 let () = match Cmdline.parse () with
-  | `Ok pass ->
-    Project.register_pass ~deps:["callsites"] ~autorun:true pass
+  | `Ok () -> ()
   | `Version | `Help -> exit 0
   | `Error _ -> exit 1


### PR DESCRIPTION
This PR includes several improvements and bug fixes spread across
the code base, united by the main goal - improve taint propagation
framework. It is also found a necessary base for the upcoming movement
of Saluki to the new framework.

Main contribution
-----------------

It was observed, that a concretization to a single value will lead to
unwanted aliasing between arbitrary pointers. Consider the following
example:
```
000001dc: R0 := strcpy_dest
0000016d: R3 := mem[R11 - 0x34:32, el]:u32
```

Here `*strcpy_dest` and `*(R11-0x34)` a both unknown and will have the
same value. As a result `R0` and `R3` will point to the same memory
cell.

Note - this problem manifests itself with tainted pointers more often,
than with tainted immediates, mostly because for a tainted immediate
value we distinguish between different computations that results to the
same value. We cannot do this with pointers, as we will loose
precision.

This PR adds four more options to the concretizer class, three of them
are propagated to the command line interface:

- `lookup` function (not available on command line) - allows a user to
  provide concrete values for unknown variables. It is useful, for
  example, to resolve SP to a value close to the `stack_start`, that
  will reduce the probability of unwanted aliasing between heap memory
  and stack memory. The `propagate-taint` plugin is setting SP to some
  high constant be default.

- `reg_policy` - a policy for concertizing unknown register
  (defaults to `random`)

- `mem_policy` - a policy for concertizing memory loads
  (defaults to `random`)

- `random_seed` - a seed for RNG (useful to get predictable results)

Auxiliary stuff
---------------

- Added printf and scanf family of functions to the api/posix
- fixed parsing attributes, so that format attribute is now can be read
- added enter/leave term methods to the Term.visitor
- fixed few bugs in callsites plugin