### PR TITLE
abstract cache digest

### DIFF
--- a/lib/regular/regular.ml
+++ b/lib/regular/regular.ml
@@ -31,5 +31,4 @@ module Std = struct
   include Seq.Export
 
   type 'a seq = 'a Seq.t [@@deriving bin_io, compare, sexp]
-
 end

--- a/lib/regular/regular_cache.ml
+++ b/lib/regular/regular_cache.ml
@@ -1,5 +1,9 @@
 open Core_kernel.Std
 open Regular_data_intf
+open Format
+
+
+type key = string
 
 type 'a t = {
   load : string -> 'a option;
@@ -25,3 +29,27 @@ module Service = struct
   let provide new_service = service := new_service
   let request x y = !service.create x y
 end
+
+
+
+module Digest = struct
+  include String
+
+  let make s = s |> Digest.string |> Digest.to_hex
+
+  let format fmt =
+    let buf = Buffer.create 4096 in
+    let ppf = formatter_of_buffer buf in
+    let key ppf =
+      pp_print_flush ppf ();
+      Buffer.contents buf |> make in
+    kfprintf key ppf fmt
+
+  let add buf fmt = format ("%s"^^fmt) buf
+  let add_sexp d sexp_of x = add d "%a" Sexp.pp (sexp_of x)
+  let add_file d name = add d "%s" (Digest.file name)
+  let create ~namespace = make namespace
+end
+
+let digest ~namespace fmt =
+  Digest.format ("%s"^^fmt) namespace

--- a/lib/regular/regular_cache.mli
+++ b/lib/regular/regular_cache.mli
@@ -1,14 +1,18 @@
+open Core_kernel.Std
 open Regular_data_intf
+open Format
 
 type 'a t
 
 val create :
-  load:(string -> 'a option) ->
-  save:(string -> 'a -> unit) -> 'a t
+  load:(digest -> 'a option) ->
+  save:(digest -> 'a -> unit) -> 'a t
 
-val load : 'a t -> string -> 'a option
+val digest : namespace:string -> ('a,formatter,unit,digest) format4 -> 'a
 
-val save : 'a t -> string -> 'a -> unit
+val load : 'a t -> digest -> 'a option
+
+val save : 'a t -> digest -> 'a -> unit
 
 type service = {
   create : 'a . 'a reader -> 'a writer -> 'a t
@@ -17,4 +21,13 @@ type service = {
 module Service : sig
   val provide : service -> unit
   val request : 'a reader -> 'a writer -> 'a t
+end
+
+module Digest : sig
+  type t = digest
+  val create : namespace:string -> t
+  val add : t -> ('a,formatter,unit,t) format4 -> 'a
+  val add_sexp : t -> ('a -> Sexp.t) -> 'a -> t
+  val add_file : t -> string -> t
+  include Identifiable with type t := t
 end

--- a/lib/regular/regular_data_intf.ml
+++ b/lib/regular/regular_data_intf.ml
@@ -1,7 +1,8 @@
 open Core_kernel.Std
 open Regular_data_types
 
-type bytes = Regular_bytes.t
+type bytes = Regular_bytes.t [@@deriving bin_io, compare, sexp]
+type digest = string [@@deriving bin_io, compare, sexp]
 
 type 'a reader = 'a Regular_data_read.t
 type 'a writer = 'a Regular_data_write.t
@@ -30,8 +31,8 @@ module type Data = sig
     val print : ?ver:string -> ?fmt:string -> Format.formatter -> t -> unit
   end
   module Cache : sig
-    val load : string -> t option
-    val save : string -> t -> unit
+    val load : digest -> t option
+    val save : digest -> t -> unit
   end
   val add_reader : ?desc:string -> ver:string -> string -> t reader -> unit
   val add_writer : ?desc:string -> ver:string -> string -> t writer -> unit

--- a/plugins/cache/cache_main.ml
+++ b/plugins/cache/cache_main.ml
@@ -19,7 +19,7 @@ type config = {
 
 type index = {
   config  : config;
-  entries : entry String.Map.t;
+  entries : entry Data.Cache.Digest.Map.t;
 } [@@deriving bin_io, compare, sexp]
 
 let (/) = Filename.concat
@@ -32,11 +32,10 @@ module Index = struct
   }
   let empty = {
     config = default_config;
-    entries = String.Map.empty;
+    entries = Data.Cache.Digest.Map.empty;
   }
   let perm = 0o770
   let getenv opt = try Some (Sys.getenv opt) with Not_found -> None
-
 
   let rec mkdir path =
     let par = Filename.dirname path in
@@ -132,7 +131,7 @@ let size file =
 
 let cleanup () =
   Index.update ~f:(fun _ idx ->
-      {idx with entries = String.Map.empty});
+      {idx with entries = Data.Cache.Digest.Map.empty});
   exit 0
 
 let set_size size =

--- a/plugins/ida/ida_main.ml
+++ b/plugins/ida/ida_main.ml
@@ -26,7 +26,7 @@ let register ida =
     let ida = match ida with
       | None -> "default"
       | Some ida -> ida in
-    Digest.(to_hex (string(file path ^ string ida))) in
+    Data.Cache.digest ~namespace:"ida" "%s%s" (Digest.file path) ida in
   let syms_of_ida ida path =
     try Some Ida.(with_file ?ida path get_symbols) with
       exn ->

--- a/src/bap_main.ml
+++ b/src/bap_main.ml
@@ -1,5 +1,6 @@
 open Core_kernel.Std
 open Bap_plugins.Std
+open Regular.Std
 open Bap.Std
 open Or_error
 open Format
@@ -66,7 +67,9 @@ let print_formats_and_exit () =
   Bap_format_printer.run `writers (module Project);
   exit 0
 
-let args filename passes argv =
+let args filename argv =
+  let passes = Project.passes () |>
+               List.map ~f:Project.Pass.name in
   let transparent_args =
     "-d" :: "--dump" ::
     "-v" :: "--verbose" ::
@@ -91,9 +94,9 @@ let args filename passes argv =
   Sexp.to_string_mach
 
 let digest o =
-  let fs = Digest.file o.filename in
-  let os = Digest.string (args o.filename o.passes Sys.argv) in
-  Digest.(to_hex (string (fs ^ os)))
+  Data.Cache.digest ~namespace:"project" "%s%s"
+    (Digest.file o.filename)
+    (args o.filename Sys.argv)
 
 let process options project =
   let run_passes init = List.fold ~init ~f:(fun proj pass ->


### PR DESCRIPTION
This PR makes cache digests abstract. This will prevent users from
creating bad digests. As a compensation it provides an interface to
build digests. The interface uses variadic functions with `format`
parameters.