### PR TITLE
more accurate taint propagation

### DIFF
--- a/lib/bap_types/bap_ir.ml
+++ b/lib/bap_types/bap_ir.ml
@@ -14,6 +14,7 @@ module Bil = struct
 end
 
 module Exp = struct
+  type t = exp
   include Bap_exp
   include Exp
   include Bap_helpers.Exp
@@ -377,6 +378,28 @@ module Ir_arg = struct
   }
   let name arg = Var.name (lhs arg)
 
+
+  let warn_unused = Bap_value.Tag.register (module Unit)
+      ~name:"warn_unused"
+      ~uuid:"7aa17c89-cc9b-4ed2-8700-620cb9e09491"
+
+  let format = Bap_value.Tag.register (module String)
+      ~name:"format"
+      ~uuid:"d864c411-73eb-48b2-a7e9-33b51fa540c9"
+
+  let alloc_size = Bap_value.Tag.register (module Unit)
+      ~name:"alloc_size"
+      ~uuid:"b29905b3-4fb5-486e-8064-9b63cadc6174"
+
+  let restricted = Bap_value.Tag.register (module Unit)
+      ~name:"restricted"
+      ~uuid:"5ee30262-aed9-4aa8-a8e3-34a061104420"
+
+  let nonnull = Bap_value.Tag.register (module Unit)
+      ~name:"nonnull"
+      ~uuid:"3c0a6181-9a9c-4cf4-aa37-8ceebd773952"
+
+
   include Regular.Make(struct
       type t = arg term [@@deriving bin_io, compare, sexp]
       let module_name = Some "Bap.Std.Arg"
@@ -712,6 +735,18 @@ module Term = struct
   let dead = Bap_value.Tag.register (module Unit)
       ~name:"dead"
       ~uuid:"6009fb21-2a6c-4511-9aa4-92b2894debc7"
+
+  let precondition = Bap_value.Tag.register (module Exp)
+      ~name:"precondition"
+      ~uuid:"f08c88e1-56f5-4148-822a-ac2dff34bda5"
+
+  let invariant = Bap_value.Tag.register (module Exp)
+      ~name:"invariant"
+      ~uuid:"743d712b-7ee4-46da-b3b7-98d3ca5e618b"
+
+  let postcondition = Bap_value.Tag.register (module Exp)
+      ~name:"postcondition"
+      ~uuid:"f248e4c1-9efc-4c70-a864-e34706e2082b"
 
   let change t p tid f =
     Array.findi (t.get p.self) ~f:(fun _ x -> x.tid = tid) |> function
@@ -1159,15 +1194,6 @@ module Ir_sub = struct
   end
 
   module Aliases = Enum(String)
-  module Fmt = struct
-    type fmt =
-      [`printf | `scanf | `strftime | `strfmon]
-      [@@deriving bin_io, compare, sexp]
-    type t = fmt * arg term [@@deriving bin_io, compare, sexp]
-    let pp ppf (fmt,arg) =
-      Format.fprintf ppf "%a, %a"
-        Sexp.pp (sexp_of_fmt fmt) Ir_arg.pp arg
-  end
 
   module Args = struct
     type t = (arg term, arg term * arg term) Either.t
@@ -1182,10 +1208,6 @@ module Ir_sub = struct
   let aliases = Bap_value.Tag.register (module Aliases)
       ~name:"aliases"
       ~uuid:"ed73c040-d798-4fc9-96a0-d3c12a870955"
-
-  let alloc_size = Bap_value.Tag.register (module Args)
-      ~name:"alloc_size"
-      ~uuid:"74ab1380-3b35-42ee-a45e-ad29fd02d234"
 
   let const = Bap_value.Tag.register (module Unit)
       ~name:"const"
@@ -1222,14 +1244,6 @@ module Ir_sub = struct
   let returns_twice = Bap_value.Tag.register (module Unit)
       ~name:"return_twice"
       ~uuid:"40166004-ea98-431b-81b0-4e74a0b681ee"
-
-  let warn_unused_result = Bap_value.Tag.register (module Unit)
-      ~name:"warn_unused_result"
-      ~uuid:"094b53c8-d71a-4dc6-9bb1-83bdf27d1da9"
-
-  let format = Bap_value.Tag.register (module Fmt)
-      ~name:"format"
-      ~uuid:"8b954fbf-e6e4-43cd-8981-b7a0a524b525"
 
   module Builder = struct
     type t =

--- a/lib/bap_types/bap_ir.mli
+++ b/lib/bap_types/bap_ir.mli
@@ -97,6 +97,10 @@ module Term : sig
   val synthetic : unit tag
   val live : unit tag
   val dead : unit tag
+  val precondition : exp tag
+  val invariant : exp tag
+  val postcondition : exp tag
+
 
   class mapper : object
     inherit exp_mapper
@@ -206,7 +210,6 @@ module Ir_sub : sig
   end
 
   val aliases : string list tag
-  val alloc_size : (arg term, arg term * arg term) Either.t tag
   val const : unit tag
   val pure : unit tag
   val stub : unit tag
@@ -215,9 +218,7 @@ module Ir_sub : sig
   val malloc : unit tag
   val noreturn : unit tag
   val returns_twice : unit tag
-  val warn_unused_result : unit tag
   val nothrow : unit tag
-  val format : ([`printf | `scanf | `strftime | `strfmon] * arg term) tag
   include Regular with type t := t
 end
 
@@ -329,6 +330,13 @@ module Ir_arg : sig
   val intent : t -> intent option
   val with_intent : t -> intent -> t
   val with_unknown_intent : t -> t
+
+  val alloc_size : unit tag
+  val format : string tag
+  val warn_unused : unit tag
+  val restricted : unit tag
+  val nonnull : unit tag
+
   include Regular with type t := t
 end
 

--- a/oasis/propagate-taint
+++ b/oasis/propagate-taint
@@ -6,6 +6,6 @@ Library propagate_taint_plugin
   Build$:  flag(everything) || flag(propagate_taint)
   Path: plugins/propagate_taint
   FindlibName: bap-plugin-propagate_taint
-  BuildDepends: bap, bap-microx, cmdliner, text-tags
+  BuildDepends: bap, bap-microx, cmdliner
   InternalModules: Propagate_taint_main, Propagator
   XMETADescription: propagate taints through a program

--- a/plugins/api/.merlin
+++ b/plugins/api/.merlin
@@ -1,7 +1,10 @@
-PKG bap
+REC
 PKG FrontC
 PKG bap-x86-cpu
 PKG bap-arm
 PKG cmdliner
+
+B ../../_build/lib/arm
+B ../../_build/lib/x86_cpu
 
 FLG -short-paths

--- a/plugins/callsites/callsites_main.ml
+++ b/plugins/callsites/callsites_main.ml
@@ -15,14 +15,6 @@ let callee call prog = match Call.target call with
 let require x = Option.some_if x ()
 
 let def_of_arg arg =
-  let x = Bil.var (Arg.lhs arg) in
-  match Arg.rhs arg with
-  | Bil.Var var -> Some (Def.create var x)
-  | Bil.Load (Bil.Var m as mem,a,e,s) ->
-    Some (Def.create m (Bil.store ~mem ~addr:a x e s))
-  | _ -> None
-
-let use_of_arg arg =
   let x = Arg.lhs arg in
   let e = Arg.rhs arg in
   Some (Def.create x e)
@@ -51,10 +43,9 @@ let add_def intent blk def =
   else Term.append  def_t blk def
 
 let defs_of_args call intent args : def term seq =
-  let make_def = if intent = In then use_of_arg else def_of_arg in
   Seq.filter_map args ~f:(fun arg ->
       require (intent_matches arg intent) >>= fun () ->
-      make_def arg >>| transfer_attrs call)
+      def_of_arg arg >>| transfer_attrs call)
 
 let target intent sub blk call =
   if intent = Out

--- a/plugins/taint/taint_main.ml
+++ b/plugins/taint/taint_main.ml
@@ -6,7 +6,7 @@ open Format
 type strain =
   | Addr of int64
   | Tid of string
-  | Use of string
+  | Var of string
   [@@deriving variants]
 
 let grammar = {|
@@ -34,13 +34,13 @@ module Strain = struct
     try Ok (Int64.of_string s)
     with exn -> expect "0x<hex-digits>" ~got:s
 
-  let use  s = Ok (Use s)
+  let var  s = Ok (Var s)
   let term s = Ok (Tid s)
   let addr s = word s >>| addr
   let atom = function
     | Atom s when is_addr s -> addr s
     | Atom s when is_term s -> term s
-    | Atom s when is_var s  -> use s
+    | Atom s when is_var s  -> var s
     | s -> expect "<tid> | <var> | <addr>"
              ~got:(Sexp.to_string s)
 
@@ -57,7 +57,7 @@ module Strain = struct
 
   let to_string = function
     | Addr a -> sprintf "%0Lx" a
-    | Tid s | Use s -> s
+    | Tid s | Var s -> s
 
   let parser s = match parse s with
     | Ok r -> `Ok r
@@ -77,8 +77,7 @@ module Marker = struct
     let tid = Term.tid def in
     List.for_all strains ~f:(function
         | Tid name -> Tid.name tid = name
-        | Use name ->
-          Set.exists ~f:(fun v -> Var.name v = name) (Def.free_vars def)
+        | Var name -> Var.name (Def.lhs def) = name
         | Addr a -> match Term.get_attr def Disasm.insn_addr with
           | None -> false
           | Some addr -> match Addr.to_int64 addr with
@@ -140,7 +139,7 @@ definitions should be tainted. It can be either an address, a
 variable, a tid or a list of strains. If an address is passed then a
 definition is tainted if it corresponds to an instruction with the
 specified address. If a variable is passed, the the definition is
-tainted if it uses a variable with the given name. Finally, if tid
+tainted if it defines a variable with the given name. Finally, if tid
 is specified, then a definition must have the specified tid to be
 tainted. If several strains are specified, then all conditions must be
 satisfied. Consider ther following examples, |};
@@ -153,7 +152,7 @@ satisfied. Consider ther following examples, |};
 The first example will taint a value stored in a register
 defined by an instruction at address $(i,0xBAD). The second
 example will taint a value that is pointed by a variable
-$(i,strcpy_dst) that is used after each call to a $(i,strcpy). (Note:
+$(i,strcpy_dst) that is defined after each call to a $(i,strcpy). (Note:
 this functionality relies on API plugin, that is responsible for
 embedding this definitions at the call sites). The third example will
 taint values returned by a $(i,malloc) only at the specified call site


### PR DESCRIPTION
This PR is a bunch of fixes and reification, that in sum
leads to a better (more accurate) taint propagation and
analysis.

Move some attribute to arg module
---------------------------------

Some GNU attributes, that are defined on a function level, are actually
should be assigned to attributes. This attributes, are often use some
number to point on a positional parameter, like `format(printf,1)` show
that first parameter is a printf format string. Now, we attach such
arguments not to the function, but to the argument of subroutine. The
following attributes are affected:

  - alloc_size
  - format
  - nonnull (new)
  - restrict (new - in fact it is type qualifier)
  - warn_unused (previously known as warn_unused_result)

Also three new attributes are added:

  - precondition
  - invariant
  - postcondition

They can be attached to a term. An expression, associated with attribute
is a boolean `BIL` expression, that must be true at corresponding
positions.

A change in a taint introduction mechanism
------------------------------------

Now, if a term marked as tainted, then that means that all
values, produced in this term are for some reason tainted.

For example, previously if we had:
```
.tainted_reg %1
R0 := R1
```

Then we introduced taint into `R0`, leaving `R1` intact.

Now, in this definition we will mark `R1` as tainted, and the taint will
propagate into `R0` as a side-effect.

With this new approach it is possible now to fix callsites plugin. Now
all synthetic terms, that are used to fix dataflow from and out of the
function will have arguments on the left hand side. This is, first of
all, more intuitive, and, most important, will fix an issue, when an
inout argument killed return value. Consider the following example,
previously we put the following definitions around the call to `strcpy`

```
  strcpy_dst := R0
  strcpy_src := R0
  call @strcpy return %1
1:
  R0 := strcpy_result
  R0 := strcpy_dst
```

Beside that it is incorrect at all, it also has a nasty feature, that
the last definition kills the previous. But after this PR, the
following definitions are inserted:

```
  strcpy_dst := R0
  strcpy_src := R0
  call @strcpy return %1
1:
  strcpy_result := R0
  strcpy_dst := R0
```

Proper taint propagation from/to memory
---------------------------------------

- load to register will kill all taints stored in the register
  and propagate taints associated with the address
- store will kill all taints associated with address and substitute
  them with taints associated with a result stored in the register.

Note: previously it was a union of taints, that resulted in
overtainting.

Fix API parsing
---------------

- recognize restricted pointers
- recognize arrays
- make intent non-optional