### PR TITLE
spill out marking from the propagate taint plugin

### DIFF
--- a/lib/bap/bap_project.mli
+++ b/lib/bap/bap_project.mli
@@ -67,9 +67,6 @@ val set : t -> 'a tag -> 'a -> t
 val get : t -> 'a tag -> 'a option
 val has : t -> 'a tag -> bool
 
-val restore_state : t -> unit
-
-
 module Pass : sig
   type t = pass [@@deriving sexp_of]
 
@@ -87,12 +84,13 @@ module Pass : sig
   val autorun : t -> bool
 end
 
+
 val find_pass : string -> pass option
 
 val register_pass :
-  ?autorun:bool -> ?deps:string list -> ?name:string -> (t -> t) -> unit
+  ?autorun:bool -> ?runonce:bool -> ?deps:string list -> ?name:string -> (t -> t) -> unit
 val register_pass':
-  ?autorun:bool -> ?deps:string list -> ?name:string -> (t -> unit) -> unit
+  ?autorun:bool -> ?runonce:bool -> ?deps:string list -> ?name:string -> (t -> unit) -> unit
 
 val passes : unit -> pass list
 
@@ -103,4 +101,8 @@ module Factory : Source.Factory
          ?symbolizer:symbolizer ->
          ?rooter:rooter ->
          ?reconstructor:reconstructor -> unit -> t Or_error.t
+
+
+val restore_state : t -> unit
+
 include Data with type t := t

--- a/lib/bap_bml/bap_bml.ml
+++ b/lib/bap_bml/bap_bml.ml
@@ -1,0 +1,241 @@
+open Core_kernel.Std
+open Bap.Std
+
+
+exception Parse_error of string
+
+module type Registry = sig
+  type t
+  val register : string -> t -> unit
+  val find : string -> t option
+  val list : unit -> (string * t) list
+end
+
+module Registry(T : T) = struct
+  type t = T.t
+  let registered : t String.Table.t = String.Table.create ()
+  let register name v = Hashtbl.set registered ~key:name ~data:v
+  let find = Hashtbl.find registered
+  let list () = Hashtbl.to_alist registered
+end
+
+
+module type Ops = sig
+  type t
+  module Nullary  : Registry with type t = t
+  module Unary : Registry with type t = string -> t
+end
+
+module Ops(T : T) = struct
+  type t = T.t
+  module Nullary = Registry(T)
+  module Unary = Registry(struct type t = string -> T.t end)
+end
+
+module Predicates = Ops(struct type t = bool Term.visitor end)
+module Mappers = Ops(struct type t = Term.mapper end)
+
+
+let marker parse tag x =
+  let x = parse x in
+  object
+    inherit Term.mapper as super
+    method! map_term cls t =
+      Term.set_attr t tag x |> super#map_term cls
+  end
+
+let has tag = object
+  inherit [bool] Term.visitor
+  method! enter_term cls t _ = Term.has_attr t tag
+end
+
+module Cmp(T : Comparable) = struct
+  open T
+  let equal x t = x = t
+  let greater x t  = x > t
+  let lesser  x t  = x < t
+
+  let cmp test tag x cls t _ = match Term.get_attr t tag with
+    | None -> false
+    | Some y -> test x y
+
+  let make test parse tag x =
+    let x = parse x in
+    object inherit [bool] Term.visitor
+      method! enter_term = cmp test tag x
+    end
+  let equal = make equal
+  let greater = make greater
+  let lesser = make lesser
+end
+
+let (-) pref tag = pref ^ "-" ^ Value.Tag.name tag
+let (+) pref suf = if suf = "" then pref else pref^"-"^suf
+
+let unit suf set is tag =
+  Mappers.Nullary.register (set-tag+suf) (marker ident tag ());
+  Predicates.Nullary.register (is-tag+suf) (has tag)
+
+module Markers = struct
+  module Term = struct
+    include Term
+    let unit = unit "" "set" "is"
+
+    let () =
+      unit synthetic;
+      unit live;
+      unit dead;
+      unit visited;
+  end
+
+  module Sub = struct
+    include Sub
+    let unit = unit "sub" "set" "is"
+    let () =
+      unit const;
+      unit pure;
+      unit stub;
+      unit extern;
+      unit leaf;
+      unit malloc;
+      unit noreturn;
+      unit returns_twice;
+      unit nothrow
+  end
+
+  module Arg = struct
+    include Arg
+    let unit = unit "arg" "set" "is"
+
+    let () =
+      unit alloc_size;
+      unit restricted;
+      unit nonnull;
+  end
+
+  module Has = struct
+    let unit = unit "" "set" "has"
+  end
+
+  let () =
+    unit "" "set" "has" mark;
+end
+
+
+let expect exp got =
+  raise (Parse_error (sprintf "Expected %s got %S" exp got))
+
+
+module Color = struct
+  let colors = [
+    "black",   `black;
+    "red",     `red;
+    "green",   `green;
+    "yellow",  `yellow;
+    "blue",    `blue;
+    "magenta", `magenta;
+    "cyan",    `cyan;
+    "white",   `white;
+  ]
+
+  let grammar = List.map colors ~f:fst |> String.concat ~sep:" | "
+
+  let color_t s = match List.Assoc.find colors s with
+    | Some c -> c
+    | None -> expect grammar s
+
+
+
+  let () =
+    let (:=) = Mappers.Unary.register in
+    "foreground" := marker color_t foreground;
+    "background" := marker color_t background;
+    "color"      := marker color_t color
+
+  module Colors = struct
+    type t = color
+    include Comparable.Make(struct
+        type t = color [@@deriving bin_io, compare, sexp]
+      end)
+  end
+
+  include Cmp(Colors)
+
+  let () =
+    let (:=) = Predicates.Unary.register in
+    "has-foreground" := equal color_t foreground;
+    "has-background" := equal color_t background;
+    "has-color"      := equal color_t color
+end
+
+
+module Comment = struct
+  let () =
+    Mappers.Unary.register "comment" @@
+    marker ident comment;
+end
+
+module Python = struct
+  let () =
+    Mappers.Unary.register "python" @@
+    marker ident python;
+end
+
+module Taint = struct
+  let has_attr cmp kind s =
+    object inherit [bool] Term.visitor
+      method! enter_term cls t _ =
+        match Term.get_attr t kind with
+        | None -> false
+        | Some seed -> match Tid.from_string s with
+          | Error _ -> false
+          | Ok seed' -> cmp seed seed'
+    end
+
+  let either (x : bool Term.visitor) (y : bool Term.visitor) =
+    object inherit [bool] Term.visitor
+      method! enter_term cls t _ =
+        x#visit_term cls t false || y#visit_term cls t false
+    end
+
+  let seed tag =
+    object inherit Term.mapper as super
+      method! map_term cls t  =
+        Term.set_attr t tag (Term.tid t) |>
+        super#map_term cls
+    end
+
+
+  let has_seed tag  = has_attr Tid.equal tag
+  let has_taint tag = has_attr (fun taints taint ->
+      Map.exists taints ~f:(fun taints -> Set.mem taints taint)) tag
+
+  let () =
+    let (:=) = Predicates.Nullary.register in
+    "taints" := either (has Taint.reg) (has Taint.ptr);
+    "taints-reg" := has Taint.reg;
+    "taints-ptr" := has Taint.ptr;
+    "has-taints" := either (has Taint.ptrs) (has Taint.regs);
+    "has-tainted-ptr" := has Taint.ptrs;
+    "has-tainted-reg" := has Taint.regs
+
+  let () =
+    let (:=) = Predicates.Unary.register in
+    "taints-reg" := has_seed Taint.ptr;
+    "taints-ptr" := has_seed Taint.reg;
+    "has-tainted-ptr" := has_taint Taint.ptrs;
+    "has-tainted-reg" := has_taint Taint.regs
+
+  let () =
+    let (:=) = Mappers.Nullary.register in
+    "taint-ptr" := seed Taint.ptr;
+    "taint-reg" := seed Taint.reg
+end
+
+module True = struct
+  let yes = object inherit [bool] Term.visitor
+    method! enter_term cls t _ = true
+  end
+
+  let () = Predicates.Nullary.register "true" yes
+end

--- a/lib/bap_bml/bap_bml.mli
+++ b/lib/bap_bml/bap_bml.mli
@@ -1,0 +1,39 @@
+open Core_kernel.Std
+open Bap.Std
+
+(** BML - Bap Mapping Language.
+
+    A small DSL for mapping terms. See [bap --help-map] for full
+    language grammar and description. This library implements BML's
+    standard library and can be used to extend the language with new
+    predicates and mapper. Just implement them and register using
+    corresponding module.
+*)
+
+exception Parse_error of string
+
+(** Interface to a registry.
+    Registry is a key value storage.*)
+module type Registry = sig
+  type t
+
+  (** [register name value] register [value] with a given [name].
+      If [name] was already associated with some other value, then
+      it will be superseeded with the new binding.   *)
+  val register : string -> t -> unit
+
+  (** [find name] find a value associated with the given [value]  *)
+  val find : string -> t option
+
+  (** [list ()] list all bindings  *)
+  val list : unit -> (string * t) list
+end
+
+module type Ops = sig
+  type t
+  module Nullary  : Registry with type t = t
+  module Unary    : Registry with type t = string -> t
+end
+
+module Predicates : Ops with type t = bool Term.visitor
+module Mappers    : Ops with type t = Term.mapper

--- a/lib/bap_disasm/bap_disasm_basic.ml
+++ b/lib/bap_disasm/bap_disasm_basic.ml
@@ -72,22 +72,28 @@ module Table = struct
 end
 
 type dis = {
-  id : int;
+  dd : int;
   insn_table : Table.t;
   reg_table  : Table.t;
   asm : bool;
   kinds : bool;
+  mutable closed : bool;
 }
+
+let (!!) dis =
+  if dis.closed then
+    failwith "with_disasm: dis value leaked the scope";
+  dis.dd
 
 module Reg = struct
 
   let create dis ~insn ~oper : reg =
     let data =
-      let reg_code = C.insn_op_reg_code dis.id ~insn ~oper in
+      let reg_code = C.insn_op_reg_code !!dis ~insn ~oper in
       let reg_name =
         if reg_code = 0 then "Nil"
         else
-          let off = C.insn_op_reg_name dis.id ~insn ~oper in
+          let off = C.insn_op_reg_name !!dis ~insn ~oper in
           (Table.lookup dis.reg_table off) in
       {reg_code; reg_name} in
     {insn; oper; data}
@@ -97,7 +103,7 @@ module Reg = struct
 
   module T = struct
     type t = reg
-    [@@deriving bin_io, sexp, compare]
+      [@@deriving bin_io, sexp, compare]
 
     let module_name = Some "Bap.Std.Reg"
     let version = "0.1"
@@ -118,9 +124,9 @@ module Imm = struct
 
   let create dis ~insn ~oper =
     let data =
-      let imm_small = C.insn_op_imm_small_value dis.id ~insn ~oper in
+      let imm_small = C.insn_op_imm_small_value !!dis ~insn ~oper in
       let imm_large = if fits imm_small then None else
-          Some (C.insn_op_imm_value dis.id ~insn ~oper) in
+          Some (C.insn_op_imm_value !!dis ~insn ~oper) in
       {imm_small; imm_large} in
     {insn; oper; data}
 
@@ -140,7 +146,7 @@ module Imm = struct
 
   module T = struct
     type t = imm
-    [@@deriving bin_io, sexp, compare]
+      [@@deriving bin_io, sexp, compare]
     let module_name = Some "Bap.Std.Imm"
     let version = "0.1"
     let pp fmt t =
@@ -164,13 +170,13 @@ module Fmm = struct
 
   let create dis ~insn ~oper = {
     insn; oper;
-    data = C.insn_op_fmm_value dis.id ~insn ~oper
+    data = C.insn_op_fmm_value !!dis ~insn ~oper
   }
   let to_float x = x.data
 
   module T = struct
     type t = fmm
-    [@@deriving bin_io, sexp, compare]
+      [@@deriving bin_io, sexp, compare]
 
     let module_name = Some "Bap.Std.Fmm"
     let version = "0.1"
@@ -188,7 +194,7 @@ module Op = struct
       | Reg of reg
       | Imm of imm
       | Fmm of fmm
-    [@@deriving bin_io, compare, sexp]
+      [@@deriving bin_io, compare, sexp]
 
     let pr fmt = Format.fprintf fmt
     let pp fmt = function
@@ -239,7 +245,7 @@ module Op = struct
 end
 
 type op = Op.t
-[@@deriving bin_io, compare, sexp]
+  [@@deriving bin_io, compare, sexp]
 
 let cpred_of_pred : pred -> C.pred = function
   | `Valid -> C.Is_true
@@ -283,27 +289,27 @@ module Insn = struct
 
 
   let create ~asm ~kinds dis ~insn =
-    let code = C.insn_code dis.id ~insn in
+    let code = C.insn_code !!dis ~insn in
     let name =
-      let off = C.insn_name dis.id ~insn in
+      let off = C.insn_name !!dis ~insn in
       Table.lookup dis.insn_table off in
     let asm =
       if asm then
-        let data = String.create (C.insn_asm_size dis.id ~insn) in
-        C.insn_asm_copy dis.id ~insn data;
+        let data = String.create (C.insn_asm_size !!dis ~insn) in
+        C.insn_asm_copy !!dis ~insn data;
         data
       else "" in
     let kinds =
       if kinds then
         List.filter_map Kind.all ~f:(fun k ->
             let p = cpred_of_pred (k :> pred) in
-            if C.is_supported dis.id p
-            then Option.some_if (C.insn_satisfies dis.id ~insn p) k
+            if C.is_supported !!dis p
+            then Option.some_if (C.insn_satisfies !!dis ~insn p) k
             else None)
       else [] in
     let opers =
-      Array.init (C.insn_ops_size dis.id ~insn) ~f:(fun oper ->
-          match C.insn_op_type dis.id ~insn ~oper with
+      Array.init (C.insn_ops_size !!dis ~insn) ~f:(fun oper ->
+          match C.insn_op_type !!dis ~insn ~oper with
           | C.Reg -> Op.Reg Reg.(create dis ~insn ~oper)
           | C.Imm -> Op.Imm Imm.(create dis ~insn ~oper)
           | C.Fmm -> Op.Fmm Fmm.(create dis ~insn ~oper)
@@ -379,8 +385,8 @@ let create_state ?(backlog=8) ?(stop_on=[]) ?stopped ?invalid ?hit dis
 }
 
 let insn_mem s ~insn : mem =
-  let off = C.insn_offset s.dis.id ~insn in
-  let words = C.insn_size s.dis.id ~insn in
+  let off = C.insn_offset !!(s.dis) ~insn in
+  let words = C.insn_size !!(s.dis) ~insn in
   let from = Addr.(Mem.min_addr s.current.mem ++ off) in
   ok_exn (Mem.view s.current.mem ~from ~words)
 
@@ -392,7 +398,7 @@ let set_memory dis p : unit =
   let buf = Mem.to_buffer p.mem in
   let addr = Mem.min_addr p.mem in
   let addr = ok_exn (Addr.to_int64 addr) in
-  C.set_memory dis.id addr (base buf) ~off:(pos buf) ~len:(length buf)
+  C.set_memory !!dis addr (base buf) ~off:(pos buf) ~len:(length buf)
 
 let update_state s current = {
   s with
@@ -405,16 +411,16 @@ let memory s = s.current.mem
 let with_preds s (ps : pred list) =
   let add p =
     let p = cpred_of_pred p in
-    if C.is_supported s.dis.id p then
-      C.predicates_push s.dis.id p in
+    if C.is_supported !!(s.dis) p then
+      C.predicates_push !!(s.dis) p in
   let ps = Preds.of_list ps in
   let drop = Preds.diff s.current.preds ps in
   if not(Preds.is_empty drop) then
     Preds.iter (Preds.diff ps s.current.preds) ~f:add
   else begin
-    C.predicates_clear s.dis.id;
+    C.predicates_clear !!(s.dis);
     Preds.iter ps ~f:(add);
-    C.predicates_push s.dis.id C.Is_invalid;
+    C.predicates_push !!(s.dis) C.Is_invalid;
   end;
   {s with current = {s.current with preds = ps}}
 
@@ -431,20 +437,20 @@ let preds s = Preds.to_list s.current.preds
 let addr s = Addr.(Mem.min_addr s.current.mem ++ s.current.off)
 
 let step s data =
-  C.insns_clear s.dis.id;
+  C.insns_clear !!(s.dis);
   let rec loop s data =
-    C.run s.dis.id;
-    let off = C.offset s.dis.id in
+    C.run !!(s.dis);
+    let off = C.offset !!(s.dis) in
     let s = update_state s {s.current with off} in
-    let n = C.insns_size s.dis.id in
+    let n = C.insns_size !!(s.dis) in
     assert (n > 0);
     let insn = n - 1 in
-    let stop = C.insn_size s.dis.id ~insn = 0 in
+    let stop = C.insn_size !!(s.dis) ~insn = 0 in
     let n = if stop then max 0 (n - 1) else n in
     let {asm; kinds} = s.dis in
     let insns = Array.init n ~f:(fun insn -> begin
           let is_valid =
-            not(C.insn_satisfies s.dis.id ~insn C.Is_invalid) in
+            not(C.insn_satisfies !!(s.dis) ~insn C.Is_invalid) in
           insn_mem s ~insn,
           Option.some_if is_valid
             (Insn.create ~asm ~kinds s.dis ~insn)
@@ -453,7 +459,7 @@ let step s data =
     if stop then match s.stopped with
       | Some f -> f s data
       | None -> s.return data
-    else if C.insn_satisfies s.dis.id ~insn C.Is_invalid
+    else if C.insn_satisfies !!(s.dis) ~insn C.Is_invalid
     then match s.invalid with
       | Some f -> f s (insn_mem s ~insn) data
       | None -> loop s data
@@ -480,21 +486,24 @@ let back s data =
   step { s with current; history} data
 
 let create ?(debug_level=0) ?(cpu="") ~backend triple =
-  let id = match C.create ~backend ~triple ~cpu ~debug_level with
+  let dd = match C.create ~backend ~triple ~cpu ~debug_level with
     | n when n >= 0 -> Ok n
     | -2 -> errorf "Unknown backend: %s" backend
     | -3 -> errorf "Unsupported target: %s %s" triple cpu
     |  n -> errorf "Disasm.Basic: Unknown error %d" n in
-  id >>= fun id -> return {
-    id;
-    insn_table = Table.create (C.insn_table id);
-    reg_table = Table.create (C.reg_table id);
+  dd >>= fun dd -> return {
+    dd;
+    insn_table = Table.create (C.insn_table dd);
+    reg_table = Table.create (C.reg_table dd);
     asm = false;
     kinds = false;
+    closed = false;
   }
 
 
-let close dis = C.delete dis.id
+let close dis =
+  C.delete dis.dd;
+  dis.closed <- true
 
 let with_disasm ?debug_level ?cpu ~backend triple ~f =
   create ?debug_level ?cpu ~backend triple >>= fun dis ->
@@ -510,12 +519,12 @@ let run ?backlog ?(stop_on=[]) ?invalid ?stopped ?hit dis ~return ~init mem =
   jump state (memory state) init
 
 let store_kinds d =
-  C.store_predicates d.id true;
+  C.store_predicates !!d true;
   {d with kinds = true}
 
 
 let store_asm d =
-  C.store_asm_string d.id true;
+  C.store_asm_string !!d true;
   {d with asm = true}
 
 let insn_of_mem dis mem =

--- a/lib/bap_sema/bap_sema_taint.ml
+++ b/lib/bap_sema/bap_sema_taint.ml
@@ -16,12 +16,12 @@ type map = set Var.Map.t [@@deriving bin_io, compare, sexp]
 type 'a values = 'a Values.t
 
 let reg = Value.Tag.register
-    ~name:"tainted_reg"
+    ~name:"tainted-reg"
     ~uuid:"1ab9a363-db8f-4ab4-9fb4-5ff54de97c5c"
     (module Tid)
 
 let ptr = Value.Tag.register
-    ~name:"tainted_ptr"
+    ~name:"tainted-ptr"
     ~uuid:"ef2d20e5-b04d-41da-ab20-5d98ddc2f78e"
     (module Tid)
 
@@ -59,12 +59,12 @@ module Taint_map = struct
 end
 
 let regs : map tag = Value.Tag.register
-    ~name:"tainted_regs"
+    ~name:"tainted-regs"
     ~uuid:"03c90a60-e19f-43cc-8049-fdeb23973396"
     (module Taint_map)
 
 let ptrs : map tag = Value.Tag.register
-    ~name:"tainted_ptrs"
+    ~name:"tainted-ptrs"
     ~uuid:"ecf96df5-f706-4f95-a421-3fa9b91ad8bd"
     (module Taint_map)
 

--- a/lib/bap_trace/bap_trace_events.ml
+++ b/lib/bap_trace/bap_trace_events.ml
@@ -89,22 +89,22 @@ end
 
 let memory_load =
   Value.Tag.register (module Load)
-    ~name:"memory_load"
+    ~name:"memory-load"
     ~uuid:"9546a981-de85-4e5c-8d59-73a15bf5c7bd"
 
 let memory_store =
   Value.Tag.register (module Store)
-    ~name:"memory_store"
+    ~name:"memory-store"
     ~uuid:"d5995d83-76be-410d-94a9-b0cfcb91f2de"
 
 let register_read =
   Value.Tag.register (module Read)
-    ~name:"register_read"
+    ~name:"register-read"
     ~uuid:"ded5dc91-dafc-4316-9c6c-4dad4e40a273"
 
 let register_write =
   Value.Tag.register (module Write)
-    ~name:"register_write"
+    ~name:"register-write"
     ~uuid:"395f5f37-5aed-4bd2-a51f-1c7216b5cd7c"
 
 let timestamp =
@@ -114,17 +114,17 @@ let timestamp =
 
 let pc_update =
   Value.Tag.register (module Addr)
-    ~name:"pc_update"
+    ~name:"pc-update"
     ~uuid:"98ea397e-d726-43be-9ec5-bf226d67578f"
 
 let code_exec =
   Value.Tag.register (module Chunk)
-    ~name:"code_exec"
+    ~name:"code-exec"
     ~uuid:"b8b3af3a-d1aa-4bf0-a36f-4ea6d0dd2bbf"
 
 let context_switch =
   Value.Tag.register (module Int)
-    ~name:"context_switch"
+    ~name:"context-switch"
     ~uuid:"7f1d322a-d2cc-4e42-8e7a-081080751268"
 
 let syscall =

--- a/lib/bap_types/bap_attributes.ml
+++ b/lib/bap_types/bap_attributes.ml
@@ -73,19 +73,19 @@ let weight = register (module Float)
     ~uuid:"657366ea-9a28-4e5e-8341-c545d861732b"
 
 let target_addr = register (module Bap_bitvector)
-    ~name:"target_addr"
+    ~name:"target-addr"
     ~uuid:"7bcef7c0-0b37-4167-887a-eba0d68891fe"
 
 let target_name = register (module String)
-    ~name:"target_name"
+    ~name:"target-name"
     ~uuid:"35d9334f-7c17-46f7-8ff9-9430aa1293ac"
 
 let subroutine_addr = register (module Bap_bitvector)
-    ~name:"subroutine_addr"
+    ~name:"subroutine-addr"
     ~uuid:"76bfd31c-05fb-48af-bfc1-721720710f0f"
 
 let subroutine_name = register (module String)
-    ~name:"subroutine_name"
+    ~name:"subroutine-name"
     ~uuid:"86fe023d-2637-4d92-baac-a420f518f250"
 
 let filename = register (module String)

--- a/lib/bap_types/bap_common.ml
+++ b/lib/bap_types/bap_common.ml
@@ -18,9 +18,10 @@ module Trie      = Bap_trie
 module type Integer   = Integer.S
 module type Trie      = Bap_trie_intf.S
 
+
 type endian = Bitvector.endian =
     LittleEndian | BigEndian
-[@@deriving sexp, bin_io, compare]
+  [@@deriving sexp, bin_io, compare]
 
 
 module Size = struct
@@ -34,23 +35,23 @@ module Size = struct
     | `r256
   ] [@@deriving bin_io, compare, sexp, variants]
 
-  type 'a p = 'a constraint 'a = [< all]
-  [@@deriving bin_io, compare, sexp]
+  type 'a p =
+    'a constraint 'a = [< all] [@@deriving bin_io, compare, sexp]
 
   type t = all p
-  [@@deriving bin_io, compare, sexp]
+    [@@deriving bin_io, compare, sexp]
 end
 
 (** size of operand  *)
 type size = Size.t
-[@@deriving bin_io, compare, sexp]
+  [@@deriving bin_io, compare, sexp]
 
 (** size of address  *)
 type addr_size = [ `r32 | `r64 ] Size.p
-[@@deriving bin_io, compare, sexp]
+  [@@deriving bin_io, compare, sexp]
 
 type nat1 = int
-[@@deriving bin_io, compare, sexp]
+  [@@deriving bin_io, compare, sexp]
 
 (** The IR type of a BIL expression *)
 module Type = struct
@@ -59,11 +60,11 @@ module Type = struct
     | Imm of nat1
     (** [Mem (a,t)]memory with a specifed addr_size *)
     | Mem of addr_size * size
-  [@@deriving bin_io, compare, sexp, variants]
+    [@@deriving bin_io, compare, sexp, variants]
 end
 
 type typ = Type.t
-[@@deriving bin_io, compare, sexp]
+  [@@deriving bin_io, compare, sexp]
 
 
 (** Supported architectures  *)
@@ -106,14 +107,14 @@ module Arch = struct
     | `aarch64
     | `aarch64_be
   ]
-  [@@deriving bin_io, compare, enumerate, sexp]
+    [@@deriving bin_io, compare, enumerate, sexp]
 
   type ppc = [
     | `ppc
     | `ppc64
     | `ppc64le
   ]
-  [@@deriving bin_io, compare, enumerate, sexp]
+    [@@deriving bin_io, compare, enumerate, sexp]
 
   type mips = [
     | `mips
@@ -121,31 +122,31 @@ module Arch = struct
     | `mips64
     | `mips64el
   ]
-  [@@deriving bin_io, compare, enumerate, sexp]
+    [@@deriving bin_io, compare, enumerate, sexp]
 
   type sparc = [
     | `sparc
     | `sparcv9
   ]
-  [@@deriving bin_io, compare, enumerate, sexp]
+    [@@deriving bin_io, compare, enumerate, sexp]
 
   type nvptx = [
     | `nvptx
     | `nvptx64
   ]
-  [@@deriving bin_io, compare, enumerate, sexp]
+    [@@deriving bin_io, compare, enumerate, sexp]
 
   type hexagon = [`hexagon]
-  [@@deriving bin_io, compare, enumerate, sexp]
+    [@@deriving bin_io, compare, enumerate, sexp]
 
   type r600 = [`r600]
-  [@@deriving bin_io, compare, enumerate, sexp]
+    [@@deriving bin_io, compare, enumerate, sexp]
 
   type systemz = [`systemz]
-  [@@deriving bin_io, compare, enumerate, sexp]
+    [@@deriving bin_io, compare, enumerate, sexp]
 
   type xcore = [`xcore]
-  [@@deriving bin_io, compare, enumerate, sexp]
+    [@@deriving bin_io, compare, enumerate, sexp]
 
   type t = [
     | aarch64
@@ -170,10 +171,10 @@ end
 *)
 
 type arch = Arch.t
-[@@deriving bin_io, compare, sexp]
+  [@@deriving bin_io, compare, sexp]
 
 type word = Bap_bitvector.t
-[@@deriving bin_io, compare, sexp]
+  [@@deriving bin_io, compare, sexp]
 
 type addr = Bap_bitvector.t
-[@@deriving bin_io, compare, sexp]
+  [@@deriving bin_io, compare, sexp]

--- a/lib/bap_types/bap_ir.ml
+++ b/lib/bap_types/bap_ir.ml
@@ -380,7 +380,7 @@ module Ir_arg = struct
 
 
   let warn_unused = Bap_value.Tag.register (module Unit)
-      ~name:"warn_unused"
+      ~name:"warn-unused"
       ~uuid:"7aa17c89-cc9b-4ed2-8700-620cb9e09491"
 
   let format = Bap_value.Tag.register (module String)
@@ -388,7 +388,7 @@ module Ir_arg = struct
       ~uuid:"d864c411-73eb-48b2-a7e9-33b51fa540c9"
 
   let alloc_size = Bap_value.Tag.register (module Unit)
-      ~name:"alloc_size"
+      ~name:"alloc-size"
       ~uuid:"b29905b3-4fb5-486e-8064-9b63cadc6174"
 
   let restricted = Bap_value.Tag.register (module Unit)
@@ -735,6 +735,10 @@ module Term = struct
   let dead = Bap_value.Tag.register (module Unit)
       ~name:"dead"
       ~uuid:"6009fb21-2a6c-4511-9aa4-92b2894debc7"
+
+  let visited = Bap_value.Tag.register (module Unit)
+      ~name:"visited"
+      ~uuid:"0e162aa3-153f-44a3-88e7-6e42d876e760"
 
   let precondition = Bap_value.Tag.register (module Exp)
       ~name:"precondition"
@@ -1242,7 +1246,7 @@ module Ir_sub = struct
       ~uuid:"32058b19-95ca-46e3-bee0-d0a3694fd5b1"
 
   let returns_twice = Bap_value.Tag.register (module Unit)
-      ~name:"return_twice"
+      ~name:"returns-twice"
       ~uuid:"40166004-ea98-431b-81b0-4e74a0b681ee"
 
   module Builder = struct

--- a/lib/bap_types/bap_ir.mli
+++ b/lib/bap_types/bap_ir.mli
@@ -97,6 +97,7 @@ module Term : sig
   val synthetic : unit tag
   val live : unit tag
   val dead : unit tag
+  val visited : unit tag
   val precondition : exp tag
   val invariant : exp tag
   val postcondition : exp tag
@@ -178,7 +179,6 @@ module Term : sig
     ?def:(def term -> 'a) ->
     ?jmp:(jmp term -> 'a) ->
     't term -> 'a
-
 end
 
 module Ir_program : sig

--- a/lib/graphlib/.merlin
+++ b/lib/graphlib/.merlin
@@ -1,0 +1,2 @@
+REC
+PKG ocamlgraph

--- a/plugins/map_terms/.merlin
+++ b/plugins/map_terms/.merlin
@@ -1,0 +1,2 @@
+REC
+B ../../_build/lib/bap_bml

--- a/plugins/map_terms/map_terms_main.ml
+++ b/plugins/map_terms/map_terms_main.ml
@@ -1,0 +1,269 @@
+open Core_kernel.Std
+open Regular.Std
+open Bap.Std
+open Bap_bml
+open Format
+
+include Self()
+
+let grammar = {|
+    bml    ::= (<exps> <exps>)
+    exps   ::= <exp>  | (<exp>1 .. <exp>N)
+    exp    ::= (<id>) | (<id> <arg>)
+    arg    ::= <id> | ?quoted string?
+    id     ::= ?alphanumeric sequence?
+|}
+
+module Scheme = struct
+  open Sexp.O
+
+  type pred = bool Term.visitor
+  type mark = Term.mapper
+  type patt = pred list * mark list
+  type t = patt list
+
+  let error fmt = ksprintf (fun s -> Error s) fmt
+  let unbound_name name = error "Unbound name: %S" name
+  let expect_arg n name = error "Term %s has arity %d" name n
+
+  let lookup arity ns1 ns2 tag = match ns1 tag with
+    | Some exp -> Ok exp
+    | None -> match ns2 tag with
+      | None -> unbound_name tag
+      | Some exp -> expect_arg arity tag
+
+  let lookup0 nns uns = lookup 0 nns uns
+  let lookup1 nns uns = lookup 1 uns nns
+
+  let parse_exp0 = lookup0
+  let parse_exp1 uns nns tag v = match lookup1 uns nns tag with
+    | Error err -> Error err
+    | Ok parse_arg -> try Ok (parse_arg v) with
+      | Parse_error msg -> Error msg
+
+  let rec parse_exp nns uns = function
+    | List [Atom tag] -> parse_exp0 nns uns tag
+    | List [Atom tag; Atom v] -> parse_exp1 nns uns tag v
+    | list -> error "expected <exp> got %s" @@ Sexp.to_string list
+
+  let rec parse_exps nns uns = function
+    | List (Atom _ :: _) as exp -> [parse_exp nns uns exp]
+    | List exps ->
+      List.map exps ~f:(parse_exps nns uns) |> List.concat
+    | s -> [error "expected <expr> got %s" @@ Sexp.to_string s]
+
+  let parse_mappers s =
+    parse_exps Mappers.Nullary.find Mappers.Unary.find s |>
+    Result.all
+
+  let parse_preds s =
+    parse_exps Predicates.Nullary.find Predicates.Unary.find s |>
+    Result.all
+
+  let parse_marker ps ms = match parse_preds ps, parse_mappers ms with
+    | Ok ps, Ok ms -> Ok (ps,ms)
+    | Error e,_|_,Error e -> Error e
+
+  let parse : sexp -> (patt,string) Result.t = function
+    | Sexp.List [preds; marks] -> parse_marker preds marks
+    | _ -> Error {|expect "("<preds> <marks>")"|}
+
+  let sexp_error {Sexp.location; err_msg} =
+    Error (sprintf "Syntax error: %s - %s" location err_msg)
+
+  let parse_string s =
+    try parse (Sexp.of_string s)
+    with Sexp.Parse_error err -> sexp_error err
+       | exn -> Error "Malformed sexp"
+
+  let parse_file f =
+    try List.map ~f:parse (Sexp.load_sexps f) |> Result.all
+    with Sexp.Parse_error err -> sexp_error err
+       | Sys_error e -> Error e
+       | exn -> Error "Malformed sexp "
+
+  let parse_arg s = match parse_string s with
+    | Ok r -> `Ok r
+    | Error e -> `Error e
+
+  let arg = parse_arg, (fun ppf _ -> ())
+end
+
+class marker (patts : Scheme.t) = object(self)
+  inherit Term.mapper as super
+  method! map_term cls t =
+    List.fold patts ~init:t ~f:(fun t (preds,maps) ->
+        if List.for_all preds ~f:(fun p -> p#visit_term cls t false)
+        then List.fold maps ~init:t ~f:(fun t m -> m#map_term cls t)
+        else t) |>
+    super#map_term cls
+end
+
+let main patts file proj =
+  let patts = match file with
+    | None -> patts
+    | Some file -> match Scheme.parse_file file with
+      | Ok ps -> patts @ ps
+      | Error err -> raise (Parse_error err) in
+  let marker = new marker patts in
+  marker#run (Project.program proj) |>
+  Project.with_program proj
+
+module Cmdline = struct
+  open Cmdliner
+
+  let scheme : Scheme.t Term.t =
+    let doc = "Map terms according the $(docv)" in
+    Arg.(value & opt_all Scheme.arg [] &
+         info ["with"] ~doc ~docv:"PATTERN")
+
+  let file : string option Term.t =
+    let doc = "Read patterns from the $(docv)" in
+    Arg.(value & opt (some file) None &
+         info ["using"] ~doc ~docv:"FILE")
+
+  let bold = List.map ~f:(sprintf "$(b,%s)")
+
+
+  let term = ["synthetic"; "live"; "dead"; "visited"]
+  let sub = [
+    "const"; "pure"; "stub"; "extern"; "leaf"; "malloc";
+    "noreturn"; "return_twice"; "nothrow"
+  ]
+  let arg = ["alloc-size"; "restricted"; "nonnull"]
+
+  let enum xs = Arg.doc_alts ~quoted:false (bold xs)
+
+  let attr attrs name desc =
+    `I (sprintf "$(b,(%s))" name,
+        sprintf ("%s, where $(i,ATTR) must be one of %s.")
+          desc (enum attrs))
+
+  let colors = bold [
+      "black"; "red"; "green"; "yellow"; "blue"; "magenta"; "cyan"; "white"
+    ]
+
+  module Predicates = struct
+
+
+    let color attr =
+      `I (sprintf "$(b,(has-%s COLOR))" attr,
+          sprintf "Is satisfied when a term's
+    attribute $(b,%s) has the given value, where $(i,COLOR) must be
+    one of %s" attr (enum colors))
+
+    let section = [
+      `S "STANDARD PREDICATES";
+      `I ("$(b,(true))","Is always satisfied.");
+      attr term "is-ATTR"
+        "Is satisfied when a term has the given attribute";
+      attr sub "is-ATTR-sub"
+        "Is satisfied when a term is a subroutine with the given attribute";
+      attr arg "is-ATTR-arg"
+        "Is satisfied when a term is an argument with the given attribute";
+      `I ("$(b,(has-mark))", "Is satisfied when a term has an
+      attribute $(b,mark).");
+      color "color";
+      color "foreground";
+      color "background";
+      `I ("$(b,(taints))", "Is satisfied if a term is taint source, i.e., has
+      $(b,tainted-reg) or $(b,tainted-ptr) attributes.");
+      `I ("$(b,(taints-reg))", "Is satisfied if a term is taint source,
+      that taints a value stored in a register, i.e., has a
+      $(b,tainted-reg) attribute.");
+      `I ("$(b,(taints-ptr))", "Is satisfied if a term is taint source,
+      that taints a value pointed by a value stored in a register, i.e., has a
+      $(b,tainted-ptr) attribute.");
+      `I ("$(b,(has-taints))", "Is satisfied if a term is tainted, i.e., has
+      $(b,tainted-reg) or $(b,tainted-ptr) attributes.");
+      `I ("$(b,(has-tainted-reg))", "Is satisfied if a term uses a
+      tainted value stored in a register, i.e., has a
+      $(b,tainted-regs) attribute.");
+      `I ("$(b,(has-tainted-reg taint))", "Is satisfied if a term uses a
+      value tainted with $(i,taint) and stored in a register, where $(i,taint)
+      must be a valid taint identifier, e.g., $(b,%12).");
+      `I ("$(b,(has-tainted-ptr))", "Is satisfied if a term loads a
+      value from a tainted address, i.e., has a $(b,tainted-regs) attribute.");
+      `I ("$(b,(has-tainted-reg taint))", "Is satisfied if a term
+      loads a value from an address tainted by the give
+      $(i,taint). The $(i,taint) must be a valid taint identifier, e.g., $(b,%42).");
+    ]
+  end
+
+  module Mappers = struct
+    let color attr =
+      `I (sprintf "$(b,(%s COLOR))" attr,
+          sprintf "Set term's attribute $(b,%s) to the given value,
+          where $(i,COLOR) must be one of %s" attr (enum colors))
+
+    let section = [
+      `S "STANDARD MAPPERS";
+      attr term "set-ATTR" "Mark a term with the specified attribute";
+      attr sub "set-ATTR-sub" "Mark a term with the specified attribute";
+      attr arg "set-ATTR-arg" "Mark a term with the specified attribute";
+      `I ("$(b,(set-mark))", "Attch $(b,mark) attribute to a term");
+      color "color";
+      color "foreground";
+      color "background";
+      `I ("$(b,(taint-reg TID))", "Mark a term with the given $(b,TID)
+      as a taint source for register values.");
+      `I ("$(b,(taint-ptr TID))", "Mark a term with the given $(b,TID)
+      as a taint source for memory values.")
+    ]
+  end
+
+  let grammar = [
+    `S "LANGUAGE GRAMMAR";
+    `Pre grammar;
+  ]
+
+  let example = [
+    `S "EXAMPLES";
+    `P "$(b,bap) exe --$(mname)-pattern='((is-visited) (foreground green))'";
+    `P {|$(b,bap) exe --$(mname)-pattern='((taints-ptr %12) (comment "ha ha"))'|};
+  ]
+
+  let see_also = [
+    `S "SEE ALSO"; `P "$(b,bap-taint)(1), $(b, bap-bml)(3)"
+  ]
+
+  let man = [
+    `S "SYNOPSIS";
+    `P "$(b,bap) [$(b,--$(mname)-with)=$(i,SCHEME)]
+                 [$(b,--$(mname)-using)=$(i,FILE)] $(b,--$(mname))";
+    `S "DESCRIPTION";
+    `P "Transform terms using a domain specific pattern matching language.
+    The pass accepts a list of patterns via a command line argument
+    $(b,--)$(b,$(mname)-pattern) (that can be specified several times), or
+    via file, that contains a list of patterns. Each pattern is
+    represented by a pair $(b,(<condition> <action>)). The $(b,<action>) specifies
+    a transformation over a term, that is applied if a $(b,<condition>)
+    is satisfied. Both $(b,<condition>) and $(b,<action>) can be a
+    single $(b,<expression>) or a list of expressions, delimited with
+    parentheses. If there is a list of conditions, then all must be
+    satisfied. If there is a list of actions, then all actions are
+    applied in order. Each expression is either a nullary
+    function $(b,(<id>)) or an unary function $(b,(<id>
+    <arg>)). Where $(b,<id>) must be a valid predicate or mapper
+    name. There is a predefined set of standard functions, but it can
+    be extended by adding new mappers or predicates to the BML
+    language using $(bap-bml) library. ";
+  ] @
+    Predicates.section @
+    Mappers.section @
+    grammar @
+    example @
+    see_also
+
+  let info  = Term.info ~doc ~man name
+  let start = Term.(const main $scheme $file)
+  let parse () = Term.eval ~argv ~catch:false (start,info)
+end
+
+let () = match Cmdline.parse () with
+  | `Ok pass -> Project.register_pass pass
+  | `Version | `Help -> exit 0
+  | `Error _ -> exit 1
+  | exception Parse_error msg ->
+    eprintf "Parsing error: %s\n%!" msg;
+    exit 2

--- a/plugins/warn_unused/warn_unused_main.ml
+++ b/plugins/warn_unused/warn_unused_main.ml
@@ -31,8 +31,8 @@ let collect_seeds prog = (object
   inherit [Tid.Set.t] Term.visitor
   method! enter_term cls t seeds =
     match Term.get_attr t Taint.reg with
-    | None -> seeds
-    | Some seed -> Set.add seeds seed
+    | Some seed when Term.has_attr t Term.visited -> Set.add seeds seed
+    | _ -> seeds
 end)#run prog Tid.Set.empty
 
 


### PR DESCRIPTION
The marking infrastructure is moved away from the taint propagation
pass. Now we have a full fledged extensible term mapping DSL. But before
this few other changes (breaking changes are marked with `*`):

Don't warn about unvisited terms
--------------------------------

Resolves #398.

Removed term marking from propagate taint plugin*
------------------------------------------------

Now it is responsible only for propagating taint. It will mark
unconditionally terms with `visited`, `tainted-{reg,ptr}[s]`
attributes.

* This may break your scripts relying on `--propagate-taint-mark-*`
options that are no longer available. See below for a new `map-terms`
pass.

Renamed attribute names*
-----------------------

substituted underscore with a dash. We will stick to this convention,
starting from this commit.

* This may break your scripts, that used `--print-bir-attr` with these
names.

Added protection for disassembler
---------------------------------

Now we will throw an exception, if someone is trying to use a closed
disassembler. Instead of segfaulting.

Added `runonce` option to the pass
----------------------------------

This option prevents a pass from being run more than once. It is useful
for autorunned plugins, and for non idempotent passes.

Added `map-terms` plugin
------------------------

This is an evolution of marking facilities of `propagate-taint` plugin.
Now it also ships with a library, that allows add arbitrary predicates
and mappers. The DSL grammar is slightly changed, and now is closer to
scheme. See the full man page:

```
MAP-TERMS(1)                   Map-terms Manual                   MAP-TERMS(1)

NAME
       map-terms - map terms using BML DSL

SYNOPSIS
       bap [--map-terms-with=SCHEME] [--map-terms-using=FILE] map-terms

DESCRIPTION
       Transform terms using a domain specific pattern matching language. The
       pass accepts a list of patterns via a command line argument
       --map-terms-pattern (that can be specified several times), or via file,
       that contains a list of patterns. Each pattern is represented by a pair
       (<condition> <action>). The <action> specifies a transformation over a
       term, that is applied if a <condition> is satisfied. Both <condition>
       and <action> can be a single <expression> or a list of expressions,
       delimited with parentheses. If there is a list of conditions, then all
       must be satisfied. If there is a list of actions, then all actions are
       applied in order. Each expression is either a nullary function (<id>)
       or an unary function (<id> <arg>). Where <id> must be a valid predicate
       or mapper name. There is a predefined set of standard functions, but it
       can be extended by adding new mappers or predicates to the BML language
       using $(bap-bml) library.

OPTIONS
       --help[=FMT] (default=pager)
           Show this help in format FMT (pager, plain or groff).

       --using=FILE
           Read patterns from the FILE

       --with=PATTERN
           Map terms according the PATTERN

STANDARD PREDICATES
       (true)
           Is always satisfied.

       (is-ATTR)
           Is satisfied when a term has the given attribute, where ATTR must
           be one of one of synthetic, live, dead or visited.

       (is-ATTR-sub)
           Is satisfied when a term is a subroutine with the given attribute,
           where ATTR must be one of one of const, pure, stub, extern, leaf,
           malloc, noreturn, return_twice or nothrow.

       (is-ATTR-arg)
           Is satisfied when a term is an argument with the given attribute,
           where ATTR must be one of one of alloc-size, restricted or nonnull.

       (has-mark)
           Is satisfied when a term has an attribute mark.

       (has-color COLOR)
           Is satisfied when a term's attribute color has the given value,
           where COLOR must be one of one of black, red, green, yellow, blue,
           magenta, cyan or white

       (has-foreground COLOR)
           Is satisfied when a term's attribute foreground has the given
           value, where COLOR must be one of one of black, red, green, yellow,
           blue, magenta, cyan or white

       (has-background COLOR)
           Is satisfied when a term's attribute background has the given
           value, where COLOR must be one of one of black, red, green, yellow,
           blue, magenta, cyan or white

       (taints)
           Is satisfied if a term is taint source, i.e., has tainted-reg or
           tainted-ptr attributes.

       (taints-reg)
           Is satisfied if a term is taint source, that taints a value stored
           in a register, i.e., has a tainted-reg attribute.

       (taints-ptr)
           Is satisfied if a term is taint source, that taints a value pointed
           by a value stored in a register, i.e., has a tainted-ptr attribute.

       (has-taints)
           Is satisfied if a term is tainted, i.e., has tainted-reg or
           tainted-ptr attributes.

       (has-tainted-reg)
           Is satisfied if a term uses a tainted value stored in a register,
           i.e., has a tainted-regs attribute.

       (has-tainted-reg taint)
           Is satisfied if a term uses a value tainted with taint and stored
           in a register, where taint must be a valid taint identifier, e.g.,
           %12.

       (has-tainted-ptr)
           Is satisfied if a term loads a value from a tainted address, i.e.,
           has a tainted-regs attribute.

       (has-tainted-reg taint)
           Is satisfied if a term loads a value from an address tainted by the
           give taint. The taint must be a valid taint identifier, e.g., %42.

STANDARD MAPPERS
       (set-ATTR)
           Mark a term with the specified attribute, where ATTR must be one of
           one of synthetic, live, dead or visited.

       (set-ATTR-sub)
           Mark a term with the specified attribute, where ATTR must be one of
           one of const, pure, stub, extern, leaf, malloc, noreturn,
           return_twice or nothrow.

       (set-ATTR-arg)
           Mark a term with the specified attribute, where ATTR must be one of
           one of alloc-size, restricted or nonnull.

       (set-mark)
           Attch mark attribute to a term

       (color COLOR)
           Set term's attribute color to the given value, where COLOR must be
           one of one of black, red, green, yellow, blue, magenta, cyan or
           white

       (foreground COLOR)
           Set term's attribute foreground to the given value, where COLOR
           must be one of one of black, red, green, yellow, blue, magenta,
           cyan or white

       (background COLOR)
           Set term's attribute background to the given value, where COLOR
           must be one of one of black, red, green, yellow, blue, magenta,
           cyan or white

       (taint-reg TID)
           Mark a term with the given TID as a taint source for register
           values.

       (taint-ptr TID)
           Mark a term with the given TID as a taint source for memory values.

LANGUAGE GRAMMAR
           bml    ::= (<exps> <exps>)
           exps   ::= <exp>  | (<exp>1 .. <exp>N)
           exp    ::= (<id>) | (<id> <arg>)
           arg    ::= <id> | ?quoted string?
           id     ::= ?alphanumeric sequence?

EXAMPLES
       bap exe --map-terms-pattern='((is-visited) (foreground green))'

       bap exe --map-terms-pattern='((taints-ptr %12) (comment "ha ha"))'

SEE ALSO
       bap-taint(1),  bap-bml(3)
```