### PR TITLE
Disable usage of ppx-jane rewriter in bapbuild

### DIFF
--- a/lib/bap_build/bap_build.ml
+++ b/lib/bap_build/bap_build.ml
@@ -22,7 +22,6 @@ module Plugin_rules = struct
     "debug";
     "short_paths";
     "custom";
-    "ppx(ppx-bap)"
   ]
 
   let needs_threads pkgs =


### PR DESCRIPTION
It was used to enable ppx_inline tests in plugins, but it conflicts
with other ppx extensions.