### PR TITLE
Move --ida-path option to the configure script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ _oasis
 /man/bap-byteweight.1
 /man/bap.1
 /lib/bap_config/bap_config.ml
+/lib/bap_ida/bap_ida_config.ml

--- a/lib/bap_ida/bap_ida.ml
+++ b/lib/bap_ida/bap_ida.ml
@@ -1,6 +1,6 @@
 open Core_kernel.Std
 open Word_size
-
+open Result.Monad_infix
 
 type ida = {
   ida : string;
@@ -44,14 +44,13 @@ module Ida = struct
 
   let asm p = ext p "asm"
 
-
   (* Headless IDA on linux systems dlopens libcurses.so (sic).
      So, we need to find a 32-bit libcurses library, copy it
      to a temporary folder renaming to `libcurses.so`, as it
      can have different suffixes and prefixes. *)
-  let setup_env path =
+  let setup_headless_env path =
     let lib = Filename.temp_file "bap_" "lib" in
-    FileUtil.rm [lib];  (* yep, this is a vulnerability *)
+    FileUtil.rm [lib];
     FileUtil.mkdir lib;
     FileUtil.cp [path] (Filename.concat lib "libcurses.so");
     let var = "LD_LIBRARY_PATH" in
@@ -62,14 +61,13 @@ module Ida = struct
     Unix.putenv var new_path;
     fun () ->
       FileUtil.rm ~recurse:true [lib];
-      if old_path <> "" then
-        Unix.putenv var old_path
+      if old_path <> "" then Unix.putenv var old_path
 
   (* ida works fine only if everything is in the same folder  *)
   let run t cmd =
     let cwd = Unix.getcwd () in
     let clean = match t.curses with
-      | Some path -> setup_env path
+      | Some path -> setup_headless_env path
       | None -> fun () -> () in
     Sys.chdir (Filename.dirname t.exe);
     cmd ();
@@ -88,30 +86,36 @@ module Ida = struct
         | [_;path] -> Some (String.strip path)
         | _ -> None) |> List.filter ~f:Sys.file_exists |> List.hd
 
-  let find exe =
-    try FileUtil.which exe with Not_found -> exe
 
-  let is_headless ida =
-    Re.execp (Re_posix.re ".*/?idal(64)?" |> Re.compile) ida
+  let require req check =
+    if check then Ok () else Error (Error.of_string req)
 
-  let find_ida ?ida () =
-    let ida = match ida with
-      | Some path -> path
-      | None when Sys.win32 ->
-        failwithf "Don't know how to find files in Windows" ()
-      | None -> "idaq" in
-    let ida = if Filename.is_implicit ida then find ida else ida in
-    if Sys.file_exists ida then Some ida else None
+  let ida () =
+    let open Bap_ida_config in
+    let (/) = Filename.concat in
+    require "path must exist"
+      (Sys.file_exists ida_path) >>= fun () ->
+    require "path must be a folder"
+      (Sys.is_directory ida_path) >>= fun () ->
+    require "can't use headless on windows"
+      (is_headless ==> not Sys.win32) >>= fun () ->
+    require "idaq exists"
+      (Sys.file_exists (ida_path/"idaq")) >>= fun () ->
+    require "idaq64 exists"
+      (Sys.file_exists (ida_path/"idaq64")) >>= fun () ->
+    require "idal exists"
+      (Sys.file_exists (ida_path/"idal")) >>= fun () ->
+    require "idal64 exists"
+      (Sys.file_exists (ida_path/"idal64")) >>| fun () ->
+    if is_headless
+    then ida_path/"idal64"
+    else ida_path/"idaq64"
 
-  let exists ?ida () = find_ida ?ida () <> None
-
-  let create ?ida target =
+  let create target =
     if not (Sys.file_exists target)
     then invalid_argf "Can't find target executable" ();
-    let ida = match find_ida ?ida () with
-      | Some ida -> ida
-      | None -> raise Not_in_path in
-    let curses = if Sys.os_type = "Unix" && is_headless ida
+    let ida = ok_exn (ida ()) in
+    let curses = if Sys.os_type = "Unix" && Bap_ida_config.is_headless
       then find_curses () else None in
     let exe = Filename.temp_file "bap_" "_ida" in
     FileUtil.cp [target] exe;
@@ -151,8 +155,8 @@ module Ida = struct
   let close self =
     FileUtil.rm self.trash
 
-  let with_file ?ida target command =
-    let ida = create ?ida target in
+  let with_file target command =
+    let ida = create target in
     let f ida = exec ida command in
     protectx ~f ida ~finally:close
 

--- a/lib/bap_ida/bap_ida.mli
+++ b/lib/bap_ida/bap_ida.mli
@@ -15,7 +15,7 @@ module Std : sig
   (** Interaction with ida instance  *)
   module Ida : sig
     (** exception External_command_failed occurs when the external IDA
-        command is not executed successfully *)
+        command was not executed successfully *)
     exception Failed of string
 
     exception Not_in_path
@@ -24,13 +24,9 @@ module Std : sig
     (** IDA instance *)
     type t = ida
 
-    (** [create ?ida target] create an IDA instance that will work with
-        [target] executable. [ida] is an optional hint, that can be
-        either a full path to [ida] executable, or just an executable
-        name *)
-    val create : ?ida:string -> string -> t
-
-    val exists : ?ida:string -> unit -> bool
+    (** [create target] create an IDA instance that will work with
+        [target] executable. *)
+    val create : string -> t
 
     val exec : t -> 'a command -> 'a
 
@@ -38,9 +34,9 @@ module Std : sig
     val close : t -> unit
 
 
-    (** [with_file ?ida target analysis] creates ida instance on [target],
+    (** [with_file target analysis] creates ida instance on [target],
         perform [analysis] and close [ida] *)
-    val with_file : ?ida:string -> string -> 'a command -> 'a
+    val with_file : string -> 'a command -> 'a
 
 
     (** [Ida.exec ida get_symbols] extract symbols from binary *)

--- a/lib/bap_ida/bap_ida_config.ml.ab
+++ b/lib/bap_ida/bap_ida_config.ml.ab
@@ -1,0 +1,2 @@
+let ida_path = "$ida_path"
+let is_headless = $ida_headless

--- a/lib/bap_ida/bap_ida_scripts.mli
+++ b/lib/bap_ida/bap_ida_scripts.mli
@@ -19,3 +19,4 @@ val extract_symbols : string -> string
 *)
 
 val extract_script : value memmap -> string
+    x

--- a/oasis/ida
+++ b/oasis/ida
@@ -10,5 +10,6 @@ Library bap_ida
   CompiledObject:   best
   Build$:           flag(everything) || flag(ida)
   Modules:          Bap_ida
+  InternalModules:  Bap_ida_config
   BuildDepends:     fileutils, re.posix
   XMETADescription: make calls into IDA

--- a/oasis/ida.files.ab.in
+++ b/oasis/ida.files.ab.in
@@ -1,0 +1,1 @@
+        , lib/bap_ida/bap_ida_config.ml.ab

--- a/oasis/ida.setup.ml.in
+++ b/oasis/ida.setup.ml.in
@@ -1,0 +1,11 @@
+let define_headless = function
+  | Some "true" when BaseEnv.var_get "system" <> "linux" ->
+    invalid_arg "headless mode is supported only on linux"
+  | None -> "false"
+  | Some ("true"|"1"|"yes") -> "true"
+  | Some _ -> "false"
+
+let () =
+  add_variable ~doc:"A directory with IDA Pro" "ida_path";
+  add_variable ~define:define_headless
+    ~doc:"Run IDA in a headless mode" "ida_headless"

--- a/src/find_starts.ml
+++ b/src/find_starts.ml
@@ -14,8 +14,8 @@ let make_addr arch x =
   let width = Size.in_bits (Arch.addr_size arch) in
   Addr.of_int64 ~width x
 
-let with_ida ~which_ida bin : addr seq Or_error.t =
+let with_ida bin : addr seq Or_error.t =
   Image.create bin >>| fun (img, _warns) ->
   let addr = make_addr (Image.arch img) in
-  Ida.(with_file ~ida:which_ida bin get_symbols) |>
+  Ida.(with_file bin get_symbols) |>
   Seq.of_list |> Seq.map ~f:(fun (_,_,x) -> addr x)

--- a/src/find_starts.mli
+++ b/src/find_starts.mli
@@ -2,10 +2,9 @@ open Bap.Std
 open Core_kernel.Std
 
 
-(** [with_ida ~which_ida testbin] evaluates the IDA from [which_ida]
-    on the binary [testbin], and returns the function start address
-    sequence *)
-val with_ida: which_ida:string -> string -> addr seq Or_error.t
+(** [with_ida testbin] evaluates the IDA on the binary [testbin], and
+    returns the function start address sequence *)
+val with_ida: string -> addr seq Or_error.t
 
 (** [with_byteweight testbin] evaluates bap-byteweight on the binary
     [testbin], and returns the function start address sequence *)

--- a/src/func_start.ml
+++ b/src/func_start.ml
@@ -18,4 +18,4 @@ let of_truth truth ~testbin : addr seq Or_error.t =
 let of_tool tool ~testbin : addr seq Or_error.t =
   if tool = "bap-byteweight"
   then Find_starts.with_byteweight testbin
-  else Find_starts.with_ida ~which_ida:tool testbin
+  else Find_starts.with_ida testbin


### PR DESCRIPTION
Now we resolve ida on configuration time. And it is impossible
to install bap_ida library, without ida being installed on the
system. A comprehensive support from the opam side is added as
a separate push to the opam-repository.