### PR TITLE
detect binutils installation at configuration time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ _oasis
 /man/bap.1
 /lib/bap_config/bap_config.ml
 /lib/bap_ida/bap_ida_config.ml
+/plugins/objdump/objdump_config.ml

--- a/configure
+++ b/configure
@@ -35,5 +35,5 @@ ocaml tools/cat.ml '"\n# $name\n"' -- $SECTIONS $AB _oasis
 ocaml tools/cat.ml '"\n# $name\n"' -- $TAGS _tags.in _tags
 ocaml tools/cat.ml '"\n#1 \"$name\"\n"' -- $PLUGINS myocamlbuild.ml.in myocamlbuild.ml
 ocaml tools/cat.ml '"\n#1 \"$name\"\n"' -- $SETUPS setup.ml.in setup.ml
-oasis setup
-ocaml setup.ml -configure "$@"
+oasis -quiet setup
+ocaml setup.ml -quiet -configure "$@"

--- a/lib/bap_ida/bap_ida.ml
+++ b/lib/bap_ida/bap_ida.ml
@@ -88,7 +88,9 @@ module Ida = struct
 
 
   let require req check =
-    if check then Ok () else Error (Error.of_string req)
+    if check
+    then Ok ()
+    else Or_error.errorf "IDA configuration failure: %s" req
 
   let ida () =
     let open Bap_ida_config in

--- a/oasis/objdump
+++ b/oasis/objdump
@@ -8,5 +8,5 @@ Library objdump_plugin
   FindlibName:      bap-plugin-objdump
   CompiledObject:   best
   BuildDepends:     bap, cmdliner, re.pcre
-  Modules:          Objdump_main
+  InternalModules:  Objdump_main, Objdump_config
   XMETADescription: use objdump to provide a symbolizer

--- a/oasis/objdump.files.ab.in
+++ b/oasis/objdump.files.ab.in
@@ -1,0 +1,1 @@
+        , plugins/objdump/objdump_config.ml.ab

--- a/oasis/objdump.setup.ml.in
+++ b/oasis/objdump.setup.ml.in
@@ -1,0 +1,7 @@
+let define = function
+  | None | Some "#undefined" -> "[]"
+  | Some xs -> xs
+
+
+let () =
+  add_variable ~define ~doc:"A list (OCaml syntax) of supported targets" "objdump_targets"

--- a/plugins/objdump/objdump_config.ml.ab
+++ b/plugins/objdump/objdump_config.ml.ab
@@ -1,0 +1,1 @@
+let targets=$objdump_targets

--- a/plugins/objdump/objdump_main.ml
+++ b/plugins/objdump/objdump_main.ml
@@ -6,15 +6,17 @@ open Re_perl
 open Cmdliner
 open Format
 open Option.Monad_infix
+open Objdump_config
 include Self()
 
 let objdump_opts = "-rd --no-show-raw-insn"
-let version = "0.1"
 (* a list of common names for objdump *)
-let objdump_cmds = ["objdump"; (* default in general *)
-                    "x86_64-elf-objdump"; (* macports default *)
-                    "i386-elf-objdump" (*macports default *)
-                   ]
+let objdump_cmds =
+  "objdump" ::
+  List.map targets ~f:(fun p -> p^"-objdump") |>
+  String.Set.stable_dedup_list |>
+  List.map ~f:(fun cmd -> cmd ^ " " ^ objdump_opts)
+
 
 (* expected format: [num] <[name]>:
    Note the use of "^\s" to stop greedy globing of the re "+"
@@ -43,48 +45,37 @@ let parse_func_start l =
   else
     None
 
-let run_objdump cmd opts arch file : symbolizer =
-  let fullcmd = cmd ^ " " ^ opts ^ " " ^ file in
+let popen cmd =
+  let env = Unix.environment () in
+  let ic,oc,ec = Unix.open_process_full cmd env in
+  let r = In_channel.input_lines ic in
+  In_channel.iter_lines ec ~f:(fun msg -> debug "%s" msg);
+  match Unix.close_process_full (ic,oc,ec) with
+  | Unix.WEXITED 0 -> Some r
+  | Unix.WEXITED n ->
+    info "command `%s' terminated abnormally with exit code %d" cmd n;
+    None
+  | Unix.WSIGNALED _ | Unix.WSTOPPED _ ->
+    (* a signal number is internal to OCaml, so don't print it *)
+    info "command `%s' was terminated by a signal" cmd;
+    None
+
+let run_objdump arch file  =
+  let popen = fun cmd -> popen (cmd ^ " " ^ file) in
+  let lines = List.find_map objdump_cmds ~f:popen in
   let names = Addr.Table.create () in
-  let ic = Unix.open_process_in fullcmd in
   let width = Arch.addr_size arch |> Size.in_bits in
-  let add name addr =
+  let add (name,addr) =
     Hashtbl.set names ~key:(Addr.of_int64 ~width addr) ~data:name in
-  In_channel.iter_lines ~f:(fun line -> match parse_func_start line with
-      | None -> ()
-      | Some (name,addr) -> add name addr) ic;
-  In_channel.close ic;
+  Option.iter lines ~f:(List.iter ~f:(fun line ->
+      Option.iter (parse_func_start line) ~f:add));
   if Hashtbl.length names = 0
   then warning "failed to obtain symbols";
-  Symbolizer.create (Hashtbl.find names)
+  Ok (Symbolizer.create (Hashtbl.find names))
 
-let register opts cmd =
-  let symbolizer =
-    Stream.merge Project.Info.arch Project.Info.file ~f:(fun arch file ->
-        Or_error.try_with (fun () -> run_objdump cmd opts arch file)) in
-  Symbolizer.Factory.register name symbolizer
-
-let main cmd opts =
-  let is_executable exe =
-    try Some (FileUtil.which exe) with Not_found -> None in
-  let command = List.find_map ~f:is_executable in
-  match cmd with
-  | Some s -> register opts s (* a specific path to objdump  given *)
-  | None ->
-    (* no specific path; lets try to infer, and return () even if *)
-    (* we fail *)
-    match command objdump_cmds >>| register opts with
-    | _ -> ()
-
-let path : string option Term.t =
-  let doc = "Specify the path to objdump." in
-  Arg.(value & opt (some file) None & info ["path"] ~doc)
-
-let opts : string Term.t =
-  let doc = "Specify objdump options. \
-             Warning! We rely on *no* raw instructions, i.e., \
-             --no-show-raw-insn, during parsing." in
-  Arg.(value & opt string objdump_opts & info ["opts"] ~doc)
+let main () =
+  Stream.merge Project.Info.arch Project.Info.file ~f:run_objdump |>
+  Symbolizer.Factory.register name
 
 let info =
   let man = [
@@ -92,19 +83,6 @@ let info =
     `P "This plugin provides a symbolizer based on objdump. \
         Note that we parse objdump output, thus this symbolizer \
         is potentially fragile to changes in objdumps output.";
-    `S "DIAGNOSTICS";
-    `P  "This plugin makes several assumptions:";
-    `P  "1) objdump does not output raw instructions. This is \
-         currently fulfilled by the $(b,--no-show-raw-insn) default. \
-         Beware changing this without checking that you are getting \
-         the symbols you expect.";
-    `P  "2) objdump output lines for symbols are left flush as \
-         $(i,<number>: <name>) signify the start of a \
-         $(i,name) at address $(i,number). There is no \
-         command line option to change this currently.";
-    `P  "If you get the wrong output but objdump is running, \
-         you will likely need to edit the source (and submit a PR when\
-         working!) and change $(b,func_start_re).";
     `S  "EXAMPLES";
     `P  "To view the symbols after running the plugin:";
     `P  "$(b, bap --symbolizer=objdump --dump-symbols) $(i,executable)";
@@ -114,7 +92,7 @@ let info =
   Term.info ~man ~doc name ~version
 
 let () =
-  let run = Term.(const main $path $opts) in
+  let run = Term.(const main $const ()) in
   match Term.eval ~argv ~catch:false (run, info) with
   | `Ok () -> ()
   | `Help | `Version -> exit 0


### PR DESCRIPTION
Alike as IDA, objdump now expects a path to objdump to be passed
at configuration time. A corresponding `conf-binutils` package will
be added to opam and the dependency between them will be established.

As a consequence, `bap-objdump` package will not be installable, if
there is no objdump program, moreover, a corresponding external
dependency will be added and thus installed via depext.