### PR TITLE
added conf-{ida,objdump} dependency to opam/opam

### DIFF
--- a/opam/opam
+++ b/opam/opam
@@ -9,12 +9,18 @@ dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 build: [
   ["./configure"
-                 "--prefix=%{prefix}%"
-                 "--with-cxx=`which clang++`"
-                 "--mandir=%{man}%"
-                 "--enable-everything"
-                 "--enable-tests"
-                 ]
+  "--prefix=%{prefix}%"
+  "--with-cxx=`which clang++`"
+  "--mandir=%{man}%"
+  "--enable-everything"
+  "--enable-tests"
+  "--%{conf-ida:enable}%-ida"
+  "--ida-path=%{conf-ida:path}%" {conf-ida:installed}
+  "--ida-headless=%{conf-ida:headless}%" {conf-ida:installed}
+  "--%{conf-binutils:enable}%-objdump"
+  "--objdump-path=%{conf-binutils:objdump}%" {conf-binutils:installed}
+  "--objdump-targets=%{conf-binutils:targets}%" {conf-binutils:installed}
+  ]
   [make]
 ]
 
@@ -155,6 +161,11 @@ depexts: [
         "libzip"
      ]
     ]
+]
+
+depopts: [
+   "conf-ida"
+   "conf-binutils"
 ]
 
 available: [ocaml-version >= "4.02.3"]


### PR DESCRIPTION
Since someone may use this file for obtaining bap, I've added an
integration with `conf-ida` and `conf-objdump` packages. These
packages are only available in our opam-repository, so don't forget to
add it. To get working ida or objdump plugins on your box, make sure
that these packages are installed. To get proper objdump on your linux
or mac box, invoke `opam depext conf-objdump`.

Note -- after this PR is merged, ida and objdump will become unavailable
if conf-ida and, correspondingly, conf-objdump are not installed.