### PR TITLE
add ida powered file loader

### DIFF
--- a/lib/bap/bap_project.ml
+++ b/lib/bap/bap_project.ml
@@ -189,6 +189,10 @@ let pp_disasm_error ppf = function
     fprintf ppf "<%s>: %a"
       (Disasm_expert.Basic.Insn.asm insn) Error.pp err
 
+let union_memory m1 m2 =
+  Memmap.to_sequence m2 |> Seq.fold ~init:m1 ~f:(fun m1 (mem,v) ->
+      Memmap.add m1 mem v)
+
 let create_exn
     ?disassembler:backend
     ?brancher
@@ -256,7 +260,7 @@ let create_exn
       disasm = Disasm.create g;
       program = MVar.read program;
       symbols = MVar.read symtab;
-      arch; memory=data; storage; state; passes=[]
+      arch; memory=union_memory code data; storage; state; passes=[]
     } in
   loop ()
 

--- a/lib/bap_ida/bap_ida.mli
+++ b/lib/bap_ida/bap_ida.mli
@@ -47,7 +47,6 @@ module Std : sig
   module Command : sig
     type 'a t = 'a command
 
-    val create : script:string -> process:(string -> 'a) -> 'a t
-
+    val create : [`python | `idc] -> script:string -> process:(string -> 'a) -> 'a t
   end
 end


### PR DESCRIPTION
With the new loader it is possible to load all files, that are
supported by ida, including:

- kernel modules (closes #345)
- object files (closes #402)

Note - the default loader is still llvm, to switch to the ida loader,
pass --loader=ida to bap.

This PR also fixes a bug in the project construction function, we left
out the code segment in the final project.

Also, this PR adds support for writing ida scripts in IDC, and rewrites
symbols command in IDC.