### PR TITLE
Color updates

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -3379,6 +3379,7 @@ module Std : sig
     | `magenta
     | `cyan
     | `white
+    | `gray
   ] [@@deriving bin_io, compare, sexp]
 
 

--- a/lib/bap_bml/bap_bml.ml
+++ b/lib/bap_bml/bap_bml.ml
@@ -136,6 +136,7 @@ module Color = struct
     "magenta", `magenta;
     "cyan",    `cyan;
     "white",   `white;
+    "gray",    `gray;
   ]
 
   let grammar = List.map colors ~f:fst |> String.concat ~sep:" | "

--- a/lib/bap_types/bap_attributes.ml
+++ b/lib/bap_types/bap_attributes.ml
@@ -12,6 +12,7 @@ module Color = struct
     | `magenta
     | `cyan
     | `white
+    | `gray
   ] [@@deriving bin_io, compare, sexp]
   let pp ppf color =
     Format.fprintf ppf "%a" Sexp.pp (sexp_of_t color)
@@ -28,6 +29,7 @@ module Foreground = struct
     | `magenta -> "\x1b[35m"
     | `cyan    -> "\x1b[36m"
     | `white   -> "\x1b[37m"
+    | `gray    -> "\x1b[1;30m"
   let pp ppf c = Format.fprintf ppf "%s" @@ to_ascii c
 end
 
@@ -42,6 +44,7 @@ module Background = struct
     | `magenta -> "\x1b[45m"
     | `cyan    -> "\x1b[46m"
     | `white   -> "\x1b[47m"
+    | `gray    -> "\x1b[1;40m"
 
   let pp ppf c = Format.fprintf ppf "%s" @@ to_ascii c
 end

--- a/plugins/emit_ida_script/emit_ida_script_main.ml
+++ b/plugins/emit_ida_script/emit_ida_script_main.ml
@@ -13,6 +13,7 @@ let idacode_of_color = function
   | `magenta -> 0xFFB2FF
   | `cyan    -> 0xFFFFB2
   | `white   -> 0xFFFFFF
+  | `gray    -> 0xEAEAEA
   | _ -> invalid_arg "unexpected color"
 
 let string_of_color c = Sexp.to_string (sexp_of_color c)

--- a/plugins/emit_ida_script/emit_ida_script_main.ml
+++ b/plugins/emit_ida_script/emit_ida_script_main.ml
@@ -5,9 +5,14 @@ include Self()
 
 (** ida uses a strange color coding, bgr, IIRC  *)
 let idacode_of_color = function
-  | `green -> 0x99ff99
-  | `red -> 0xCCCCFF
-  | `yellow -> 0xC2FFFF
+  | `black   -> 0x000000
+  | `red     -> 0xCCCCFF
+  | `green   -> 0x99FF99
+  | `yellow  -> 0xC2FFFF
+  | `blue    -> 0xFFB2B2
+  | `magenta -> 0xFFB2FF
+  | `cyan    -> 0xFFFFB2
+  | `white   -> 0xFFFFFF
   | _ -> invalid_arg "unexpected color"
 
 let string_of_color c = Sexp.to_string (sexp_of_color c)

--- a/plugins/map_terms/map_terms_main.ml
+++ b/plugins/map_terms/map_terms_main.ml
@@ -140,7 +140,8 @@ module Cmdline = struct
           desc (enum attrs))
 
   let colors = bold [
-      "black"; "red"; "green"; "yellow"; "blue"; "magenta"; "cyan"; "white"
+      "black"; "red"; "green"; "yellow"; "blue"; "magenta"; "cyan";
+      "white"; "gray"
     ]
 
   module Predicates = struct


### PR DESCRIPTION
Make sure `emit-ida-script` plugin can use all colors that BAP supports

Add gray to the list of colors supported by BAP