### PR TITLE
IDA Python Plugin to propagate taint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ _oasis
 /lib/bap_config/bap_config.ml
 /lib/bap_ida/bap_ida_config.ml
 /plugins/objdump/objdump_config.ml
+/plugins/ida/python/bap_propagate_taint.py

--- a/oasis/ida-plugin
+++ b/oasis/ida-plugin
@@ -10,6 +10,7 @@ Library ida_plugin
   BuildDepends:     bap, bap-ida, cmdliner
   Modules:          Ida_main
   XMETADescription: use ida to provide rooter, symbolizer and reconstructor
+  DataFiles:        python/bap_propagate_taint.py ($ida_plugin_path)
 
 Library emit_ida_script_plugin
   Build$:           flag(everything) || flag(ida_plugin)

--- a/oasis/ida-plugin.files.ab.in
+++ b/oasis/ida-plugin.files.ab.in
@@ -1,0 +1,1 @@
+        , plugins/ida/python/bap_propagate_taint.py.ab

--- a/oasis/ida-plugin.setup.ml.in
+++ b/oasis/ida-plugin.setup.ml.in
@@ -1,0 +1,11 @@
+let (/) = Filename.concat
+
+let define = function
+  | Some thing -> thing
+  | None ->
+    try Sys.getenv "IDAUSR" / "plugins"
+    with Not_found -> try Sys.getenv "HOME" / ".idapro" / "plugins"
+      with Not_found -> failwith "Please specify path for IDA plugin"
+
+let () =
+  add_variable ~define ~doc:"A directory with IDA plugins" "ida_plugin_path"

--- a/plugins/ida/python/bap_propagate_taint.py
+++ b/plugins/ida/python/bap_propagate_taint.py
@@ -1,0 +1,66 @@
+import idautils
+import tempfile
+
+
+def taint_and_color(ptr_or_reg):
+
+    args = {
+        'input_file_path': idc.GetInputFilePath(),
+        'taint_location': idc.ScreenEA(),
+        'ida_script_location': tempfile.mkstemp(suffix='.py',
+                                                prefix='ida-bap-')[1],
+        'ptr_or_reg': ptr_or_reg
+    }
+
+    idc.Message('-------- STARTING TAINT ANALYSIS --------------\n')
+    idc.SetStatus(IDA_STATUS_WAITING)
+
+    idaapi.refresh_idaview_anyway()
+
+    # TODO : Figure out how to get rid of the opam dependency here
+    idc.Exec(
+        "\
+        eval `opam config env`; \
+        bap \"{input_file_path}\" \
+        --taint-{ptr_or_reg}=0x{taint_location:X} \
+        --taint \
+        --propagate-taint \
+        --map-terms-with='((true) (color gray))' \
+        --map-terms-with='((is-visited) (color white))' \
+        --map-terms-with='((has-taints) (color red))' \
+        --map-terms-with='((taints) (color yellow))' \
+        --map-terms \
+        --emit-ida-script-attr=color \
+        --emit-ida-script-file={ida_script_location} \
+        --emit-ida-script \
+        ".format(**args)
+    )
+
+    idc.Message('-------- DONE WITH TAINT ANALYSIS -------------\n\n')
+    idc.SetStatus(IDA_STATUS_READY)
+
+    idaapi.IDAPython_ExecScript(args['ida_script_location'], globals())
+
+    idc.Exec("rm -f {ida_script_location}".format(**args))  # Cleanup
+
+    idc.Refresh()  # Force the color information to show up
+
+
+def taint_reg_and_color():
+    taint_and_color('reg')
+
+
+def taint_ptr_and_color():
+    taint_and_color('ptr')
+
+
+def add_hotkey(hotkey, func):
+    hotkey_ctx = idaapi.add_hotkey(hotkey, func)
+    if hotkey_ctx is None:
+        print("Failed to register {} for {}".format(hotkey, func))
+    else:
+        print("Registered {} for {}".format(hotkey, func))
+
+
+add_hotkey("Shift-A", taint_reg_and_color)
+add_hotkey("Ctrl-Shift-A", taint_ptr_and_color)

--- a/plugins/ida/python/bap_propagate_taint.py.ab
+++ b/plugins/ida/python/bap_propagate_taint.py.ab
@@ -17,11 +17,9 @@ def taint_and_color(ptr_or_reg):
 
     idaapi.refresh_idaview_anyway()
 
-    # TODO : Figure out how to get rid of the opam dependency here
     idc.Exec(
         "\
-        eval `opam config env`; \
-        bap \"{input_file_path}\" \
+        $(bindir)/bap \"{input_file_path}\" \
         --taint-{ptr_or_reg}=0x{taint_location:X} \
         --taint \
         --propagate-taint \


### PR DESCRIPTION
This PR adds an IDA Python Plugin to be able to select any arbitrary line in Graph/Text view in IDA, and be able to taint that line and propagate taint information and see it visually.

### Keybindings
- Shift-A : Equivalent to `--taint-reg` in BAP
- Ctrl-Shift-A : Equivalent to `--taint-ptr` in BAP

The plugin is loaded automatically into IDA for usage, after installation.

### Testing
```
./configure --prefix=`opam config var prefix` --enable-ida-plugin
make && make reinstall
```

Then, just select some line by placing your cursor over it in IDA, and press Shift-A or Ctrl-Shift-A.

### Color Scheme
- "Nasty" Yellow : Taint source
- "Affected" Red : Lines that got tainted
- "Ignored" Gray : Lines that were not visited by propagate-taint
- "Normal" White : Lines that were visited, but didn't get tainted

### Screenshots

#### Taint Source, and Tainted Locations

![screenshot](https://cloud.githubusercontent.com/assets/5683582/15433217/6a8b84b4-1e7f-11e6-90d1-6d28d7ecf67f.png)

#### Unvisited Regions

![gray](https://cloud.githubusercontent.com/assets/5683582/15433216/6a8b3b6c-1e7f-11e6-80d0-e3dea3789934.png)

