### PR TITLE
fix filter_map function in trace

### DIFF
--- a/lib/bap_traces/bap_trace.ml
+++ b/lib/bap_traces/bap_trace.ml
@@ -162,10 +162,13 @@ let supports_by_proto t tag = match t.proto with
 let supports t tag = supports_by_tool t tag && supports_by_proto t tag
 
 let read_events t : event seq =
+  let map e = match t.mapper e with
+    | None -> Seq.Step.Skip ()
+    | Some e -> Seq.Step.Yield (e,()) in
   Seq.unfold_step ~init:() ~f:(fun () ->
       match t.reader.next () with
       | None -> Seq.Step.Done
-      | Some (Ok e) -> Seq.Step.Yield (e,())
+      | Some (Ok e) -> map e
       | Some Error e -> match t.monitor e with
         | `Stop -> Seq.Step.Done
         | `Fail -> Error.raise e


### PR DESCRIPTION
The Trace.filter_map was relying on a mapper function,
that were never applied. Should be fixed now, although
the design is still rather fragile.