### PR TITLE
Add MOVPCLR to the ARM Lifter

### DIFF
--- a/lib/arm/arm_lifter.ml
+++ b/lib/arm/arm_lifter.ml
@@ -35,6 +35,9 @@ let lift_move mem ops (insn : move_insn) : stmt list =
   | `MOVsi, [|dest; src; shift_imm; cond; _; wflag|] ->
     lift ~dest src `MOV ~simm:shift_imm mem cond ~wflag
 
+  | `MOVPCLR, [|cond; wflag|] ->
+    lift ~dest:(`Reg `PC) (`Reg `LR) `MOV mem cond ~wflag
+
   | `MVNi, [|dest; src; cond; _; wflag|]
   | `MVNr, [|dest; src; cond; _; wflag|] ->
     lift ~dest src `MVN mem cond ~wflag

--- a/lib/arm/arm_types.ml
+++ b/lib/arm/arm_types.ml
@@ -106,6 +106,7 @@ type move_insn = [
   | `MOVr
   | `MOVsi
   | `MOVsr
+  | `MOVPCLR
   | `MVNi
   | `MVNr
   | `MVNsi

--- a/python/arm.py
+++ b/python/arm.py
@@ -74,6 +74,7 @@ class MOVi16(Move) : pass
 class MOVr(Move) : pass
 class MOVsi(Move) : pass
 class MOVsr(Move) : pass
+class MOVPCLR(Move) : pass
 class MVNi(Move) : pass
 class MVNr(Move) : pass
 class MVNsi(Move) : pass


### PR DESCRIPTION
I noticed issue #117 which said that the ARM lifter doesn't handle `mov pc, lr`, so I decided to look into the ARM lifter. Here's a PR that adds MOVPCLR to the lifter.


---

Since I've never written code for a lifter before, please let me know if I made any mistakes (or any style errors etc), and I will correct them.

---

### Testing it

Running the following code:

```bash
echo '0e f0 a0 e1' | bap-mc --arch=arm --show-insn=pretty --show-bil=pretty --show-bir=pretty
```

We get the output as

```
MOVPCLR(0xe,Nil)
{
  jmp LR
}
00000004: 
00000005: return LR
```