### PR TITLE
Restructure IDA Plugins

### DIFF
--- a/oasis/ida
+++ b/oasis/ida
@@ -13,3 +13,12 @@ Library bap_ida
   InternalModules:  Bap_ida_config
   BuildDepends:     fileutils, re.posix
   XMETADescription: make calls into IDA
+
+Library bap_ida_rsr
+  Build$:           flag(everything) || flag(ida)
+  Path:             plugins/ida
+  FindlibName:      bap-plugin-ida_rsr
+  CompiledObject:   best
+  BuildDepends:     bap, bap-ida, cmdliner
+  Modules:          Ida_main
+  XMETADescription: use ida to provide rooter, symbolizer and reconstructor

--- a/oasis/ida-plugin
+++ b/oasis/ida-plugin
@@ -2,16 +2,6 @@ Flag ida_plugin
   Description: Build IDA plugin
   Default: false
 
-Library ida_plugin
-  Build$:           flag(everything) || flag(ida_plugin)
-  Path:             plugins/ida
-  FindlibName:      bap-plugin-ida
-  CompiledObject:   best
-  BuildDepends:     bap, bap-ida, cmdliner
-  Modules:          Ida_main
-  XMETADescription: use ida to provide rooter, symbolizer and reconstructor
-  DataFiles:        python/*.py ($ida_plugin_path)
-
 Library emit_ida_script_plugin
   Build$:           flag(everything) || flag(ida_plugin)
   Path:             plugins/emit_ida_script
@@ -19,3 +9,11 @@ Library emit_ida_script_plugin
   BuildDepends:     bap, cmdliner
   Modules:          Emit_ida_script_main
   XMETADescription: extract a python script from the project data type
+
+Library ida_python_plugins
+  Build$:           flag(everything) || flag(ida_plugin)
+  Path:             plugins/ida/python
+  FindlibName:      bap-plugin-ida-python
+  BuildDepends:     bap, bap-plugin-taint, bap-plugin-propagate_taint, bap-plugin-map_terms
+  XMETADescription: IDA python plugin scripts
+  DataFiles:        *.py ($ida_plugin_path)

--- a/oasis/ida-plugin.setup.ml.in
+++ b/oasis/ida-plugin.setup.ml.in
@@ -5,7 +5,7 @@ let define = function
   | None ->
     try Sys.getenv "IDAUSR" / "plugins"
     with Not_found -> try Sys.getenv "HOME" / ".idapro" / "plugins"
-      with Not_found -> failwith "Please specify path for IDA plugin"
+      with Not_found -> failwith "Please specify path for IDA plugins"
 
 let () =
-  add_variable ~define ~doc:"A directory with IDA plugins" "ida_plugin_path"
+  add_variable ~define ~doc:"A directory for IDA plugins" "ida_plugin_path"

--- a/opam/opam
+++ b/opam/opam
@@ -134,7 +134,7 @@ depends: [
     "ocurl" {<= "0.7.1"}
     "optcomp"
     "re"
-    "uri"
+    "uri" {>= "1.9.0"}
     "utop"
     "zarith"
     "uuidm"


### PR DESCRIPTION
This PR restructures IDA Plugins in BAP to move the rooter, symbolizer and reconstructor into `bap-ida`, and keep the rest of the plugins in `bap-ida-plugins` to remove the `bap-ida` dependency. A further PR that I'll be making in the [BAP opam repository](https://github.com/BinaryAnalysisPlatform/opam-repository) will fix up the build process in opam.

### Advantages

+ Users can now use BAP along with IDA Demo (after [installing IDA Python onto it](https://gist.github.com/jaybosamiya/951193ae774dfc127b513a93795a46c7))
+ `bap-ida` now means "all integrations for BAP with IDA (that need IDA Pro)"
+ `bap-ida-plugins` now means "BAP/IDA plugins which work with both IDA Pro and IDA Demo"