### PR TITLE
Add aspcud to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
     - ocaml-native-compilers
     - ocaml-nox
     - time
+    - aspcud
 
 env:
   - FORK_USER=talex5 FORK_BRANCH=containers OPAMYES=true PACKAGE=bap OCAML_VERSION=latest TESTS=false


### PR DESCRIPTION
In Travis builds, to prevent issues with opam messing up with the constraints (as we noticed recently), we can use the recommended external dependency solver `aspcud`. This PR adds it.