### PR TITLE
PEP Standardization and Documentation for IDAPython Plugins

### DIFF
--- a/plugins/ida/python/bap_propagate_taint.py.ab
+++ b/plugins/ida/python/bap_propagate_taint.py.ab
@@ -1,24 +1,45 @@
+"""
+IDA Python Plugin to use BAP to propagate taint information.
+
+Allows user to select any arbitrary line in Graph/Text view in IDA,
+and be able to taint that line and propagate taint information.
+
+Keybindings:
+    Shift-A      : Equivalent to `--taint-reg` in BAP
+    Ctrl-Shift-A : Equivalent to `--taint-ptr` in BAP
+
+Color Scheme:
+    "Nasty" Yellow : Taint source
+    "Affected" Red : Lines that got tainted
+    "Ignored" Gray : Lines that were not visited by propagate-taint
+    "Normal" White : Lines that were visited, but didn't get tainted
+"""
 import idautils
 
 
 class BAP_Taint(idaapi.plugin_t):
+    """
+    Plugin to use BAP to propagate taint information.
 
-    callbacks = {
+    Also supports installation of callbacks using install_callback()
+    """
+
+    _callbacks = {
         'ptr': [],
         'reg': []
     }
 
     @classmethod
-    def do_callbacks(cls, ptr_or_reg):
+    def _do_callbacks(cls, ptr_or_reg):
         assert(ptr_or_reg == 'reg' or ptr_or_reg == 'ptr')
         data = {
             'ea': idc.ScreenEA(),
             'ptr_or_reg': ptr_or_reg
         }
-        for callback in cls.callbacks[ptr_or_reg]:
+        for callback in cls._callbacks[ptr_or_reg]:
             callback(data)
 
-    def taint_and_color(self, ptr_or_reg):
+    def _taint_and_color(self, ptr_or_reg):
         import tempfile
 
         args = {
@@ -60,15 +81,15 @@ class BAP_Taint(idaapi.plugin_t):
 
         idc.Refresh()  # Force the color information to show up
 
-        self.do_callbacks(ptr_or_reg)
+        self._do_callbacks(ptr_or_reg)
 
-    def taint_reg_and_color(self):
-        self.taint_and_color('reg')
+    def _taint_reg_and_color(self):
+        self._taint_and_color('reg')
 
-    def taint_ptr_and_color(self):
-        self.taint_and_color('ptr')
+    def _taint_ptr_and_color(self):
+        self._taint_and_color('ptr')
 
-    def add_hotkey(self, hotkey, func):
+    def _add_hotkey(self, hotkey, func):
         hotkey_ctx = idaapi.add_hotkey(hotkey, func)
         if hotkey_ctx is None:
             print("Failed to register {} for {}".format(hotkey, func))
@@ -82,25 +103,42 @@ class BAP_Taint(idaapi.plugin_t):
     wanted_hotkey = ""
 
     def init(self):
-        self.add_hotkey("Shift-A", self.taint_reg_and_color)
-        self.add_hotkey("Ctrl-Shift-A", self.taint_ptr_and_color)
+        """Initialize Plugin."""
+        self._add_hotkey("Shift-A", self._taint_reg_and_color)
+        self._add_hotkey("Ctrl-Shift-A", self._taint_ptr_and_color)
 
     def term(self):
+        """Terminate Plugin."""
         pass
 
     def run(self, arg):
+        """
+        Run Plugin.
+
+        Ignored since keybindings are installed.
+        """
         pass
 
     @classmethod
     def install_callback(cls, callback_fn, ptr_or_reg=None):
+        """
+        Install callback to be run when the user calls for taint propagation.
+
+        Callback must take a dict and must return nothing.
+
+        Dict is guaranteed to get the following keys:
+            'ea': The value of EA at point where user propagated taint from.
+            'ptr_or_reg': Either 'ptr' or 'reg' depending on user selection.
+        """
         if ptr_or_reg is None:
             cls.install_callback(callback_fn, 'ptr')
             cls.install_callback(callback_fn, 'reg')
         elif ptr_or_reg == 'ptr' or ptr_or_reg == 'reg':
-            cls.callbacks[ptr_or_reg].append(callback_fn)
+            cls._callbacks[ptr_or_reg].append(callback_fn)
         else:
             print "Invalid ptr_or_reg value passed {}".format(repr(ptr_or_reg))
 
 
 def PLUGIN_ENTRY():
+    """Install BAP_Taint upon entry."""
     return BAP_Taint()

--- a/plugins/ida/python/bap_propagate_taint.py.ab
+++ b/plugins/ida/python/bap_propagate_taint.py.ab
@@ -92,7 +92,7 @@ class BAP_Taint(idaapi.plugin_t):
         pass
 
     @classmethod
-    def install_callback(cls, callback_fn, ptr_or_reg = None):
+    def install_callback(cls, callback_fn, ptr_or_reg=None):
         if ptr_or_reg is None:
             cls.install_callback(callback_fn, 'ptr')
             cls.install_callback(callback_fn, 'reg')
@@ -100,6 +100,7 @@ class BAP_Taint(idaapi.plugin_t):
             cls.callbacks[ptr_or_reg].append(callback_fn)
         else:
             print "Invalid ptr_or_reg value passed {}".format(repr(ptr_or_reg))
+
 
 def PLUGIN_ENTRY():
     return BAP_Taint()

--- a/plugins/ida/python/propagate_taint_bap_hexrays.py
+++ b/plugins/ida/python/propagate_taint_bap_hexrays.py
@@ -1,13 +1,13 @@
 bap_color = {
-    'black'  : 0x000000,
-    'red'    : 0xCCCCFF,
-    'green'  : 0x99FF99,
-    'yellow' : 0xC2FFFF,
-    'blue'   : 0xFFB2B2,
+    'black':   0x000000,
+    'red':     0xCCCCFF,
+    'green':   0x99FF99,
+    'yellow':  0xC2FFFF,
+    'blue':    0xFFB2B2,
     'magenta': 0xFFB2FF,
-    'cyan'   : 0xFFFFB2,
-    'white'  : 0xFFFFFF,
-    'gray'   : 0xEAEAEA,
+    'cyan':    0xFFFFB2,
+    'white':   0xFFFFFF,
+    'gray':    0xEAEAEA,
 }
 
 


### PR DESCRIPTION
This PR adds docstrings (following PEP257) to both IDAPython plugins. It also ensures that they follow PEP8. Additionally, it makes some members of both classes private, since they are not expected to be called directly.

@maverickwoo thanks for letting me know about PEP257 :)