### PR TITLE
Take care of older versions of IDA

### DIFF
--- a/lib/bap_ida/bap_ida.ml
+++ b/lib/bap_ida/bap_ida.ml
@@ -171,8 +171,16 @@ module Ida = struct
 from idautils import *
 from idaapi import *
 
+try:
+      from idaapi import get_func_name2 as get_func_name
+      # Since get_func_name is deprecated (at least from IDA 6.9)
+except ImportError:
+      pass
+      # Older versions of IDA don't have get_func_name2
+      # so we just use the older name get_func_name
+
 def func_name_propagate_thunk(ea):
-    current_name = get_func_name2(ea)
+    current_name = get_func_name(ea)
     if current_name[0].isalpha():
         return current_name
     func = get_func(ea)
@@ -182,7 +190,7 @@ def func_name_propagate_thunk(ea):
         ea_new = calc_thunk_func_target(func, temp_ptr.cast())
     if ea_new != BADADDR:
         ea = ea_new
-    propagated_name = get_func_name2(ea)
+    propagated_name = get_func_name(ea)
     if len(current_name) > len(propagated_name) > 0:
         return propagated_name
     else:

--- a/oasis/ida
+++ b/oasis/ida
@@ -14,10 +14,10 @@ Library bap_ida
   BuildDepends:     fileutils, re.posix
   XMETADescription: make calls into IDA
 
-Library bap_ida_rsr
+Library bap_ida_plugin
   Build$:           flag(everything) || flag(ida)
   Path:             plugins/ida
-  FindlibName:      bap-plugin-ida_rsr
+  FindlibName:      bap-plugin-ida
   CompiledObject:   best
   BuildDepends:     bap, bap-ida, cmdliner
   Modules:          Ida_main

--- a/oasis/ida-plugin
+++ b/oasis/ida-plugin
@@ -15,5 +15,5 @@ Library ida_python_plugins
   Path:             plugins/ida/python
   FindlibName:      bap-plugin-ida-python
   BuildDepends:     bap, bap-plugin-taint, bap-plugin-propagate_taint, bap-plugin-map_terms
-  XMETADescription: IDA python plugin scripts
+  XMETADescription: call bap from IDA Pro
   DataFiles:        *.py ($ida_plugin_path)


### PR DESCRIPTION
Newer versions of IDA have deprecated `get_func_name` but older versions don't have `get_func_name2`. This PR allows for using the latest available one among the two.

This PR also fixes some `oasis` naming and description.