### PR TITLE
Plugin for Hex-Rays Decompiler (BAP comments + abstract base plugin + refactor)

### DIFF
--- a/plugins/ida/python/bap_propagate_taint.py.ab
+++ b/plugins/ida/python/bap_propagate_taint.py.ab
@@ -106,6 +106,7 @@ class BAP_Taint(idaapi.plugin_t):
         """Initialize Plugin."""
         self._add_hotkey("Shift-A", self._taint_reg_and_color)
         self._add_hotkey("Ctrl-Shift-A", self._taint_ptr_and_color)
+        return idaapi.PLUGIN_KEEP
 
     def term(self):
         """Terminate Plugin."""

--- a/plugins/ida/python/bap_utils.py
+++ b/plugins/ida/python/bap_utils.py
@@ -7,19 +7,22 @@ def sexp2list(s):
     """Convert S-Expression to List."""
     sexp = [[]]
     word = ''
+    in_str = False
     for c in s:
-        if c == '(':
+        if c == '(' and not in_str:
             sexp.append([])
-        elif c == ')':
+        elif c == ')' and not in_str:
             if word:
                 sexp[-1].append(word)
                 word = ''
             temp = sexp.pop()
             sexp[-1].append(temp)
-        elif c == ' ':
+        elif c in (' ', '\n', '\t') and not in_str:
             if word:
                 sexp[-1].append(word)
             word = ''
+        elif c == '\"':
+            in_str = not in_str
         else:
             word += c
     return sexp[0]
@@ -28,6 +31,9 @@ def sexp2list(s):
 def list2sexp(l):
     """Convert List to S-Expression."""
     if isinstance(l, str):
+        for special_char in (' ', '\n', '\t', '(', ')', '\"'):
+            if special_char in l:
+                return '\"' + l + '\"'
         return l
     return '(' + ' '.join(list2sexp(e) for e in l) + ')'
 

--- a/plugins/ida/python/bap_utils.py
+++ b/plugins/ida/python/bap_utils.py
@@ -88,6 +88,15 @@ def add_to_comment_string(comm, key, value):
     return comm[:start_loc] + list2sexp(kv) + comm[end_loc:]
 
 
+def cfunc_from_ea(ea):
+    """Get cfuncptr_t from EA."""
+    func = idaapi.get_func(ea)
+    if func is None:
+        return None
+    cfunc = idaapi.decompile(func)
+    return cfunc
+
+
 class DoNothing(idaapi.plugin_t):
     """
     Do Nothing.

--- a/plugins/ida/python/bap_utils.py
+++ b/plugins/ida/python/bap_utils.py
@@ -32,8 +32,15 @@ def list2sexp(l):
     return '(' + ' '.join(list2sexp(e) for e in l) + ')'
 
 
-def add_to_comment_string(comm, key, value):
-    """Add key:value to comm string."""
+def get_bap_comment(comm):
+    """
+    Get '(BAP )' style comment from given string.
+
+    Returns tuple (BAP_dict, start_loc, end_loc)
+        BAP_dict: The '(BAP )' style comment
+        start_loc: comm[:start_loc] was before the BAP comment
+        end_loc: comm[end_loc:] was after the BAP comment
+    """
     if '(BAP ' in comm:
         start_loc = comm.index('(BAP ')
         bracket_count = 0
@@ -57,8 +64,21 @@ def add_to_comment_string(comm, key, value):
         end_loc = len(comm)
         BAP_dict = '(BAP )'
 
+    return (BAP_dict, start_loc, end_loc)
+
+
+def get_bap_list(BAP_dict):
+    """Return a list containing all the values in the BAP comment."""
+    outer_removed = BAP_dict[5:-1]  # Remove outermost '(BAP', ')'
+    return sexp2list(outer_removed)
+
+
+def add_to_comment_string(comm, key, value):
+    """Add key:value to comm string."""
+    BAP_dict, start_loc, end_loc = get_bap_comment(comm)
+
     kv = ['BAP', [key, value]]
-    for e in sexp2list(BAP_dict[5:-1]):  # Remove outermost '(BAP', ')'
+    for e in get_bap_list(BAP_dict):
         if isinstance(e, list) and len(e) == 2:  # It is of the '(k v)' type
             if e[0] != key:  # Don't append if same as required key
                 kv.append(e)

--- a/plugins/ida/python/bap_utils.py
+++ b/plugins/ida/python/bap_utils.py
@@ -1,0 +1,66 @@
+"""Commonly used utilities for BAP IDAPython plugins to use."""
+
+
+def sexp2list(s):
+    """Convert S-Expression to List"""
+    sexp = [[]]
+    word = ''
+    for c in s:
+        if c == '(':
+            sexp.append([])
+        elif c == ')':
+            if word:
+                sexp[-1].append(word)
+                word = ''
+            temp = sexp.pop()
+            sexp[-1].append(temp)
+        elif c == ' ':
+            if word:
+                sexp[-1].append(word)
+            word = ''
+        else:
+            word += c
+    return sexp[0]
+
+
+def list2sexp(l):
+    """Convert List to S-Expression"""
+    if isinstance(l, str):
+        return l
+    return '(' + ' '.join(list2sexp(e) for e in l) + ')'
+
+
+def add_to_comment_string(comm, key, value):
+    """Add key:value to comm string"""
+    if '(BAP ' in comm:
+        start_loc = comm.index('(BAP ')
+        bracket_count = 0
+        for i in range(start_loc, len(comm)):
+            if comm[i] == '(':
+                bracket_count += 1
+            elif comm[i] == ')':
+                bracket_count -= 1
+                if bracket_count == 0:
+                    end_loc = i + 1
+                    BAP_dict = comm[start_loc:end_loc]
+                    break
+        else:
+            # Invalid bracketing.
+            # Someone messed up the dict.
+            # Correct by inserting enough close brackets.
+            end_loc = len(comm)
+            BAP_dict = comm[start_loc:end_loc] + (')' * bracket_count)
+    else:
+        start_loc = len(comm)
+        end_loc = len(comm)
+        BAP_dict = '(BAP )'
+
+    kv = ['BAP', [key, value]]
+    for e in sexp2list(BAP_dict[5:-1]):  # Remove outermost '(BAP', ')'
+        if isinstance(e, list) and len(e) == 2:  # It is of the '(k v)' type
+            if e[0] != key:  # Don't append if same as required key
+                kv.append(e)
+        else:
+            kv.append(e)
+
+    return comm[:start_loc] + list2sexp(kv) + comm[end_loc:]

--- a/plugins/ida/python/bap_utils.py
+++ b/plugins/ida/python/bap_utils.py
@@ -1,5 +1,7 @@
 """Commonly used utilities for BAP IDAPython plugins to use."""
 
+import idaapi
+
 
 def sexp2list(s):
     """Convert S-Expression to List"""
@@ -64,3 +66,45 @@ def add_to_comment_string(comm, key, value):
             kv.append(e)
 
     return comm[:start_loc] + list2sexp(kv) + comm[end_loc:]
+
+
+class DoNothing(idaapi.plugin_t):
+    """
+    Do Nothing.
+
+    This plugin does absolutely nothing. It is created for the sole purpose of
+    being able to keep multiple non-plugin Python files which may then be used
+    as utilities by other plugins.
+
+    Usage:
+        import bap_utils
+
+        class DoNothing<SomeUniqueIdentifier>(bap_utils.DoNothing):
+            pass
+
+        def PLUGIN_ENTRY():
+            return DoNothing<SomeUniqueIdentifier>()
+    """
+
+    flags = idaapi.PLUGIN_UNL
+    comment = "Does Nothing"
+    help = "Does Nothing"
+    wanted_name = "Do Nothing"
+    wanted_hotkey = ""
+
+    def init(self):
+        """Skip plugin."""
+        return idaapi.PLUGIN_OK
+
+    def term(self):
+        """Do nothing."""
+        pass
+
+    def run(self, arg):
+        """Do nothing."""
+        pass
+
+
+def PLUGIN_ENTRY():
+    """Do not count this file as a plugin."""
+    return DoNothing()

--- a/plugins/ida/python/bap_utils.py
+++ b/plugins/ida/python/bap_utils.py
@@ -50,15 +50,18 @@ def get_bap_comment(comm):
     if '(BAP ' in comm:
         start_loc = comm.index('(BAP ')
         bracket_count = 0
+        in_str = False
         for i in range(start_loc, len(comm)):
-            if comm[i] == '(':
+            if comm[i] == '(' and not in_str:
                 bracket_count += 1
-            elif comm[i] == ')':
+            elif comm[i] == ')' and not in_str:
                 bracket_count -= 1
                 if bracket_count == 0:
                     end_loc = i + 1
                     BAP_dict = comm[start_loc:end_loc]
                     break
+            elif comm[i] == '\"':
+                in_str = not in_str
         else:
             # Invalid bracketing.
             # Someone messed up the dict.

--- a/plugins/ida/python/bap_utils.py
+++ b/plugins/ida/python/bap_utils.py
@@ -4,7 +4,7 @@ import idaapi
 
 
 def sexp2list(s):
-    """Convert S-Expression to List"""
+    """Convert S-Expression to List."""
     sexp = [[]]
     word = ''
     for c in s:
@@ -26,14 +26,14 @@ def sexp2list(s):
 
 
 def list2sexp(l):
-    """Convert List to S-Expression"""
+    """Convert List to S-Expression."""
     if isinstance(l, str):
         return l
     return '(' + ' '.join(list2sexp(e) for e in l) + ')'
 
 
 def add_to_comment_string(comm, key, value):
-    """Add key:value to comm string"""
+    """Add key:value to comm string."""
     if '(BAP ' in comm:
         start_loc = comm.index('(BAP ')
         bracket_count = 0

--- a/plugins/ida/python/propagate_comments_bap_hexrays.py
+++ b/plugins/ida/python/propagate_comments_bap_hexrays.py
@@ -17,9 +17,9 @@ class BAP_Comment_Pseudocode(SimpleLine_Modifier_Hexrays):
                 continue
             ea_BAP_dict, _, _ = bap_utils.get_bap_comment(ea_comm)
             for e in bap_utils.get_bap_list(ea_BAP_dict):
-                if isinstance(e, list) and len(e) == 2:  # i.e. '(k v)' type
+                if isinstance(e, list) and len(e) >= 2:  # i.e. '(k v)' type
                     val_list = sl_dict.get(e[0], [])
-                    val_list.append(['0x%x' % ea, e[1]])
+                    val_list.append(['0x%x' % ea] + e[1:])
                     sl_dict[e[0]] = val_list
 
         if len(sl_dict) > 0:

--- a/plugins/ida/python/propagate_comments_bap_hexrays.py
+++ b/plugins/ida/python/propagate_comments_bap_hexrays.py
@@ -28,7 +28,9 @@ class BAP_Comment_Pseudocode(SimpleLine_Modifier_Hexrays):
             BAP_dict = ['BAP']
             for k, v in sl_dict.items():
                 BAP_dict += [[k] + v]
-            sl.line += ' // ' + bap_utils.list2sexp(BAP_dict)
+            sl.line += '\x01\x0c // \x01\x0c'  # start comment coloring
+            sl.line += bap_utils.list2sexp(BAP_dict)
+            sl.line += '\x02\x0c\x02\x0c'  # stop comment coloring
 
     comment = "BAP Comment on Pseudocode"
     help = "BAP Comment on Pseudocode"

--- a/plugins/ida/python/propagate_comments_bap_hexrays.py
+++ b/plugins/ida/python/propagate_comments_bap_hexrays.py
@@ -19,8 +19,9 @@ class BAP_Comment_Pseudocode(SimpleLine_Modifier_Hexrays):
             for e in bap_utils.get_bap_list(ea_BAP_dict):
                 if isinstance(e, list) and len(e) >= 2:  # i.e. '(k v)' type
                     val_list = sl_dict.get(e[0], [])
-                    if e[1:] not in val_list:
-                        val_list.append(e[1:])
+                    sexp = bap_utils.list2sexp(e[1:])
+                    if sexp not in val_list:
+                        val_list.append(sexp)
                     sl_dict[e[0]] = val_list
 
         if len(sl_dict) > 0:
@@ -28,15 +29,6 @@ class BAP_Comment_Pseudocode(SimpleLine_Modifier_Hexrays):
             for k, v in sl_dict.items():
                 BAP_dict += [[k] + v]
             sl.line += ' // ' + bap_utils.list2sexp(BAP_dict)
-            # A cleaner way might be to use
-            #   idaapi.get_user_cmt()
-            #   idaapi.set_user_cmt()
-            #   idaapi.restore_user_cmts()
-            # and related functions
-            #
-            # Current technique might require refreshing the view for
-            # propagating the changes properly (without repetitively saying
-            # "// (BAP ...)" )
 
     comment = "BAP Comment on Pseudocode"
     help = "BAP Comment on Pseudocode"

--- a/plugins/ida/python/propagate_comments_bap_hexrays.py
+++ b/plugins/ida/python/propagate_comments_bap_hexrays.py
@@ -1,0 +1,47 @@
+"""Hex-Rays Plugin to propagate comments to Pseudocode View."""
+
+from simpleline_modifier_hexrays import SimpleLine_Modifier_Hexrays
+import bap_utils
+
+
+class BAP_Comment_Pseudocode(SimpleLine_Modifier_Hexrays):
+    """Propagate comments from Text/Graph view to Pseudocode view."""
+
+    @classmethod
+    def _simpleline_modify(cls, cfunc, sl):
+        sl_dict = {}
+
+        for ea in set(cls.get_ea_list(cfunc, sl)):
+            ea_comm = GetCommentEx(ea, repeatable=0)
+            if ea_comm is None:
+                continue
+            ea_BAP_dict, _, _ = bap_utils.get_bap_comment(ea_comm)
+            for e in bap_utils.get_bap_list(ea_BAP_dict):
+                if isinstance(e, list) and len(e) == 2:  # i.e. '(k v)' type
+                    val_list = sl_dict.get(e[0], [])
+                    val_list.append(['0x%x' % ea, e[1]])
+                    sl_dict[e[0]] = val_list
+
+        if len(sl_dict) > 0:
+            BAP_dict = ['BAP']
+            for k, v in sl_dict.items():
+                BAP_dict += [[k] + v]
+            sl.line += ' // ' + bap_utils.list2sexp(BAP_dict)
+            # A cleaner way might be to use
+            #   idaapi.get_user_cmt()
+            #   idaapi.set_user_cmt()
+            #   idaapi.restore_user_cmts()
+            # and related functions
+            #
+            # Current technique might require refreshing the view for
+            # propagating the changes properly (without repetitively saying
+            # "// (BAP ...)" )
+
+    comment = "BAP Comment on Pseudocode"
+    help = "BAP Comment on Pseudocode"
+    wanted_name = "BAP Comment on Pseudocode"
+
+
+def PLUGIN_ENTRY():
+    """Install BAP_Comment_Pseudocode upon entry."""
+    return BAP_Comment_Pseudocode()

--- a/plugins/ida/python/propagate_comments_bap_hexrays.py
+++ b/plugins/ida/python/propagate_comments_bap_hexrays.py
@@ -19,7 +19,8 @@ class BAP_Comment_Pseudocode(SimpleLine_Modifier_Hexrays):
             for e in bap_utils.get_bap_list(ea_BAP_dict):
                 if isinstance(e, list) and len(e) >= 2:  # i.e. '(k v)' type
                     val_list = sl_dict.get(e[0], [])
-                    val_list.append(['0x%x' % ea] + e[1:])
+                    if e[1:] not in val_list:
+                        val_list.append(e[1:])
                     sl_dict[e[0]] = val_list
 
         if len(sl_dict) > 0:

--- a/plugins/ida/python/propagate_comments_bap_hexrays.py
+++ b/plugins/ida/python/propagate_comments_bap_hexrays.py
@@ -11,9 +11,7 @@ class BAP_Comment_Pseudocode(SimpleLine_Modifier_Hexrays):
     def _simpleline_modify(cls, cfunc, sl):
         sl_dict = {}
 
-        ea_set = set(cls.get_ea_list(cfunc, sl))
-
-        for ea in ea_set:
+        for ea in set(cls.get_ea_list(cfunc, sl)):
             ea_comm = GetCommentEx(ea, repeatable=0)
             if ea_comm is None:
                 continue
@@ -29,18 +27,16 @@ class BAP_Comment_Pseudocode(SimpleLine_Modifier_Hexrays):
             BAP_dict = ['BAP']
             for k, v in sl_dict.items():
                 BAP_dict += [[k] + v]
-            BAP_comment = bap_utils.list2sexp(BAP_dict)
-
-            t = idaapi.treeloc_t()
-            t.ea = max(ea_set)
-            t.itp = idaapi.ITP_BLOCK1  # Block comment before the statement
-            cfunc.set_user_cmt(t, BAP_comment)
-            cfunc.save_user_cmts()
-
-            # TODO: Currently, the plugin requires you to refresh to be able
-            #       to see the added BAP comments. Might be nice if it
-            #       internally did that, thought it might be hard since
-            #       the plugin installs itself as a refresh text callback
+            sl.line += ' // ' + bap_utils.list2sexp(BAP_dict)
+            # A cleaner way might be to use
+            #   idaapi.get_user_cmt()
+            #   idaapi.set_user_cmt()
+            #   idaapi.restore_user_cmts()
+            # and related functions
+            #
+            # Current technique might require refreshing the view for
+            # propagating the changes properly (without repetitively saying
+            # "// (BAP ...)" )
 
     comment = "BAP Comment on Pseudocode"
     help = "BAP Comment on Pseudocode"

--- a/plugins/ida/python/propagate_taint_bap_hexrays.py
+++ b/plugins/ida/python/propagate_taint_bap_hexrays.py
@@ -130,6 +130,8 @@ class BAP_Taint_Pseudocode(idaapi.plugin_t):
         except AttributeError:
             print "init_hexrays_plugin() not found. Skipping Hex-Rays plugin."
 
+        return idaapi.PLUGIN_KEEP
+
     def term(self):
         """Terminate Plugin."""
         try:

--- a/plugins/ida/python/propagate_taint_bap_hexrays.py
+++ b/plugins/ida/python/propagate_taint_bap_hexrays.py
@@ -16,25 +16,30 @@ bap_color = {
     'gray':    0xEAEAEA,
 }
 
+from simpleline_modifier_hexrays import SimpleLine_Modifier_Hexrays
 
-class BAP_Taint_Pseudocode(idaapi.plugin_t):
+
+class BAP_Taint_Pseudocode(SimpleLine_Modifier_Hexrays):
     """Propagate taint information from Text/Graph view to Pseudocode view."""
 
-    def _autocolorize_function(self, cfunc):
-        simplelinevec = cfunc.get_pseudocode()
+    comment = "BAP Taint Plugin for Pseudocode View"
+    help = "BAP Taint Plugin for Pseudocode View"
+    wanted_name = "BAP Taint Pseudocode"
 
-        def ea_from_addr_tag(addr_tag):
-            return cfunc.treeitems.at(addr_tag).ea
+    @classmethod
+    def _simpleline_modify(cls, cfunc, sl):
+        cls._color_line(sl, bap_color['gray'])
+        # Ready to be painted over by other colors
+        for ea in cls.get_ea_list(cfunc, sl):
+            new_color = cls._get_new_color(sl.bgcolor, ea)
+            cls._color_line(sl, new_color)
 
-        for simpleline in simplelinevec:
-            self._color_line(simpleline, bap_color['gray'])
-                # Ready to be painted over by other colors
-            self._autocolorize_line(simpleline, ea_from_addr_tag)
+    @staticmethod
+    def _color_line(sl, color):
+        sl.bgcolor = color
 
-    def _color_line(self, simpleline, color):
-        simpleline.bgcolor = color
-
-    def _get_new_color(self, current_color, ea):
+    @staticmethod
+    def _get_new_color(current_color, ea):
         coloring_order = [
             bap_color[c] for c in [
                 'gray',
@@ -62,47 +67,10 @@ class BAP_Taint_Pseudocode(idaapi.plugin_t):
         else:
             return current_color
 
-    def _autocolorize_line(self, simpleline, ea_from_tag):
-        anchor = idaapi.ctree_anchor_t()
-        line = simpleline.line[:]  # Copy
-
-        def is_addr_code(l):
-            return (l[0] == idaapi.COLOR_ON and
-                    l[1] == chr(idaapi.COLOR_ADDR))
-
-        while len(line) > 0:
-            skipcode_index = idaapi.tag_skipcode(line)
-            if skipcode_index == 0:  # No code found
-                line = line[1:]  # Skip one character ahead
-            else:
-                if is_addr_code(line):
-                    addr_tag = int(line[2:skipcode_index], 16)
-                    anchor.value = addr_tag
-                    if anchor.is_citem_anchor():
-                        line_ea = ea_from_tag(addr_tag)
-                        if line_ea != idaapi.BADADDR:
-                            new_color = self._get_new_color(simpleline.bgcolor,
-                                                            line_ea)
-                            self._color_line(simpleline, new_color)
-                line = line[skipcode_index:]  # Skip the colorcodes
-
-    flags = idaapi.PLUGIN_FIX
-    comment = "BAP Taint Plugin for Pseudocode View"
-    help = "BAP Taint Plugin for Pseudocode View"
-    wanted_name = "BAP Taint Pseudocode"
-    wanted_hotkey = ""
-
     def init(self):
         """Initialize Plugin."""
         try:
             if idaapi.init_hexrays_plugin():
-                def hexrays_event_callback(event, *args):
-                    if event == idaapi.hxe_text_ready:
-                        vu, = args
-                        self._autocolorize_function(vu.cfunc)
-                    return 0
-
-                idaapi.install_hexrays_callback(hexrays_event_callback)
 
                 def cfunc_from_ea(ea):
                     func = idaapi.get_func(ea)
@@ -116,7 +84,7 @@ class BAP_Taint_Pseudocode(idaapi.plugin_t):
                     cfunc = cfunc_from_ea(ea)
                     if cfunc is None:
                         return
-                    self._autocolorize_function(cfunc)
+                    self.run_over_cfunc(cfunc)
 
                 idaapi.load_and_run_plugin('bap_propagate_taint.py', 0)
                 BAP_Taint.install_callback(autocolorize_callback)
@@ -130,22 +98,7 @@ class BAP_Taint_Pseudocode(idaapi.plugin_t):
         except AttributeError:
             print "init_hexrays_plugin() not found. Skipping Hex-Rays plugin."
 
-        return idaapi.PLUGIN_KEEP
-
-    def term(self):
-        """Terminate Plugin."""
-        try:
-            idaapi.term_hexrays_plugin()
-        except AttributeError:
-            pass
-
-    def run(self, arg):
-        """
-        Run Plugin.
-
-        Ignored since callbacks are installed.
-        """
-        pass
+        return SimpleLine_Modifier_Hexrays.init(self)  # Call superclass init()
 
 
 def PLUGIN_ENTRY():

--- a/plugins/ida/python/propagate_taint_bap_hexrays.py
+++ b/plugins/ida/python/propagate_taint_bap_hexrays.py
@@ -87,7 +87,7 @@ class BAP_Taint_Pseudocode(SimpleLine_Modifier_Hexrays):
                        " in Hex-Rays")
 
             else:
-                print "Hex-Rays not loaded"
+                return idaapi.PLUGIN_SKIP
 
         except AttributeError:
             print "init_hexrays_plugin() not found. Skipping Hex-Rays plugin."

--- a/plugins/ida/python/propagate_taint_bap_hexrays.py
+++ b/plugins/ida/python/propagate_taint_bap_hexrays.py
@@ -17,6 +17,7 @@ bap_color = {
 }
 
 from simpleline_modifier_hexrays import SimpleLine_Modifier_Hexrays
+import bap_utils
 
 
 class BAP_Taint_Pseudocode(SimpleLine_Modifier_Hexrays):
@@ -72,16 +73,9 @@ class BAP_Taint_Pseudocode(SimpleLine_Modifier_Hexrays):
         try:
             if idaapi.init_hexrays_plugin():
 
-                def cfunc_from_ea(ea):
-                    func = idaapi.get_func(ea)
-                    if func is None:
-                        return None
-                    cfunc = idaapi.decompile(func)
-                    return cfunc
-
                 def autocolorize_callback(data):
                     ea = data['ea']
-                    cfunc = cfunc_from_ea(ea)
+                    cfunc = bap_utils.cfunc_from_ea(ea)
                     if cfunc is None:
                         return
                     self.run_over_cfunc(cfunc)

--- a/plugins/ida/python/propagate_taint_bap_hexrays.py
+++ b/plugins/ida/python/propagate_taint_bap_hexrays.py
@@ -118,11 +118,11 @@ class BAP_Taint_Pseudocode(idaapi.plugin_t):
                         return
                     self._autocolorize_function(cfunc)
 
-                idaapi.load_and_run_plugin('bap_propagate_taint', 0)
+                idaapi.load_and_run_plugin('bap_propagate_taint.py', 0)
                 BAP_Taint.install_callback(autocolorize_callback)
 
-                print "Finished installing callbacks for Taint Analysis \
-                       in Hex-Rays"
+                print ("Finished installing callbacks for Taint Analysis" +
+                       " in Hex-Rays")
 
             else:
                 print "Hex-Rays not loaded"

--- a/plugins/ida/python/simpleline_modifier_hexrays.py
+++ b/plugins/ida/python/simpleline_modifier_hexrays.py
@@ -20,6 +20,8 @@ Note: You will need to add a PLUGIN_ENTRY() function, to your plugin code,
 that returns an object of your plugin, which uses this Class as a super class.
 """
 
+import idaapi
+
 
 class SimpleLine_Modifier_Hexrays(idaapi.plugin_t):
     """Modifies each simpleline_t in Pseudocode view."""
@@ -108,3 +110,16 @@ class SimpleLine_Modifier_Hexrays(idaapi.plugin_t):
         Ignored since callbacks are installed.
         """
         pass
+
+import bap_utils
+
+
+class DoNothingSLM(bap_utils.DoNothing):
+    """Do Nothing. Subclassed to prevent IDA from complaining."""
+
+    pass
+
+
+def PLUGIN_ENTRY():
+    """Do not count this file as a plugin."""
+    return DoNothingSLM()

--- a/plugins/ida/python/simpleline_modifier_hexrays.py
+++ b/plugins/ida/python/simpleline_modifier_hexrays.py
@@ -96,6 +96,8 @@ class SimpleLine_Modifier_Hexrays(idaapi.plugin_t):
         except AttributeError:
             print "init_hexrays_plugin() not found. Skipping Hex-Rays plugin."
 
+        return idaapi.PLUGIN_KEEP
+
     def term(self):
         """Terminate Plugin."""
         try:

--- a/plugins/ida/python/simpleline_modifier_hexrays.py
+++ b/plugins/ida/python/simpleline_modifier_hexrays.py
@@ -41,7 +41,7 @@ class SimpleLine_Modifier_Hexrays(idaapi.plugin_t):
                     s[1] == chr(idaapi.COLOR_ADDR))
 
         anchor = idaapi.ctree_anchor_t()
-        line = simpleline.line[:]  # Copy
+        line = sl.line[:]  # Copy
         ea_list = []
 
         while len(line) > 0:
@@ -53,7 +53,7 @@ class SimpleLine_Modifier_Hexrays(idaapi.plugin_t):
                     addr_tag = int(line[2:skipcode_index], 16)
                     anchor.value = addr_tag
                     if anchor.is_citem_anchor():
-                        line_ea = ea_from_tag(addr_tag)
+                        line_ea = ea_from_addr_tag(addr_tag)
                         if line_ea != idaapi.BADADDR:
                             ea_list.append(line_ea)
                 line = line[skipcode_index:]  # Skip the colorcodes
@@ -85,7 +85,7 @@ class SimpleLine_Modifier_Hexrays(idaapi.plugin_t):
                 def hexrays_event_callback(event, *args):
                     if event == idaapi.hxe_text_ready:
                         vu, = args
-                        self._run_over_cfunc(vu.cfunc)
+                        self.run_over_cfunc(vu.cfunc)
                     return 0
 
                 idaapi.install_hexrays_callback(hexrays_event_callback)

--- a/plugins/ida/python/simpleline_modifier_hexrays.py
+++ b/plugins/ida/python/simpleline_modifier_hexrays.py
@@ -52,7 +52,10 @@ class SimpleLine_Modifier_Hexrays(idaapi.plugin_t):
                 if is_addr_code(line):
                     addr_tag = int(line[2:skipcode_index], 16)
                     anchor.value = addr_tag
-                    if anchor.is_citem_anchor():
+                    if (
+                        anchor.is_citem_anchor() and
+                        not anchor.is_blkcmt_anchor()
+                    ):
                         line_ea = ea_from_addr_tag(addr_tag)
                         if line_ea != idaapi.BADADDR:
                             ea_list.append(line_ea)

--- a/plugins/ida/python/simpleline_modifier_hexrays.py
+++ b/plugins/ida/python/simpleline_modifier_hexrays.py
@@ -1,0 +1,110 @@
+"""
+Abstract Base Plugin Class to modify simplelines in Pseudocode View.
+
+This plugin should be subclassed and the following members should be
+implemented before being usable:
+    - simpleline_modify(cls, cfunc, sl)
+        - Accepts a simpleline_t (sl) and modifies it
+        - cfunc and class cls are provided for use if necessary
+    - comment
+        - string to describe your plugin
+    - help
+        - string for any help information
+    - wanted_name
+        - string for what you want your plugin to be named
+
+Methods that might be useful while implementing above methods:
+    - get_ea_list(cls, cfunc, sl)
+
+Note: You will need to add a PLUGIN_ENTRY() function, to your plugin code,
+that returns an object of your plugin, which uses this Class as a super class.
+"""
+
+
+class SimpleLine_Modifier_Hexrays(idaapi.plugin_t):
+    """Modifies each simpleline_t in Pseudocode view."""
+
+    @classmethod
+    def _simpleline_modify(cls, cfunc, sl):
+        raise NotImplementedError("Please implement this method")
+
+    @classmethod
+    def get_ea_list(cls, cfunc, sl):
+        """Get a list of EAs that are in a simpleline_t."""
+        def ea_from_addr_tag(addr_tag):
+            return cfunc.treeitems.at(addr_tag).ea
+
+        def is_addr_code(s):
+            return (s[0] == idaapi.COLOR_ON and
+                    s[1] == chr(idaapi.COLOR_ADDR))
+
+        anchor = idaapi.ctree_anchor_t()
+        line = simpleline.line[:]  # Copy
+        ea_list = []
+
+        while len(line) > 0:
+            skipcode_index = idaapi.tag_skipcode(line)
+            if skipcode_index == 0:  # No code found
+                line = line[1:]  # Skip one character ahead
+            else:
+                if is_addr_code(line):
+                    addr_tag = int(line[2:skipcode_index], 16)
+                    anchor.value = addr_tag
+                    if anchor.is_citem_anchor():
+                        line_ea = ea_from_tag(addr_tag)
+                        if line_ea != idaapi.BADADDR:
+                            ea_list.append(line_ea)
+                line = line[skipcode_index:]  # Skip the colorcodes
+
+        return ea_list
+
+    @classmethod
+    def run_over_cfunc(cls, cfunc):
+        """Run the plugin over the given cfunc."""
+        simplelinevec = cfunc.get_pseudocode()
+
+        for simpleline in simplelinevec:
+            cls._simpleline_modify(cfunc, simpleline)
+
+    flags = idaapi.PLUGIN_FIX
+    wanted_hotkey = ""
+
+    def init(self):
+        """
+        Ensure plugin's line modification function is called whenever needed.
+
+        If Hex-Rays is not installed, or is not initialized yet, then plugin
+        will not load. To ensure that the plugin loads after Hex-Rays, please
+        name your plugin's .py file with a name that starts lexicographically
+        after "hexx86f"
+        """
+        try:
+            if idaapi.init_hexrays_plugin():
+                def hexrays_event_callback(event, *args):
+                    if event == idaapi.hxe_text_ready:
+                        vu, = args
+                        self._run_over_cfunc(vu.cfunc)
+                    return 0
+
+                idaapi.install_hexrays_callback(hexrays_event_callback)
+
+            else:
+                print "Hex-Rays not loaded"
+
+        except AttributeError:
+            print "init_hexrays_plugin() not found. Skipping Hex-Rays plugin."
+
+    def term(self):
+        """Terminate Plugin."""
+        try:
+            idaapi.term_hexrays_plugin()
+        except AttributeError:
+            pass
+
+    def run(self, arg):
+        """
+        Run Plugin.
+
+        Ignored since callbacks are installed.
+        """
+        pass

--- a/plugins/ida/python/simpleline_modifier_hexrays.py
+++ b/plugins/ida/python/simpleline_modifier_hexrays.py
@@ -94,7 +94,7 @@ class SimpleLine_Modifier_Hexrays(idaapi.plugin_t):
                 idaapi.install_hexrays_callback(hexrays_event_callback)
 
             else:
-                print "Hex-Rays not loaded"
+                return idaapi.PLUGIN_SKIP
 
         except AttributeError:
             print "init_hexrays_plugin() not found. Skipping Hex-Rays plugin."


### PR DESCRIPTION
This PR does quite a few changes:

+ Add a `bap_utils` library for usage in IDAPython
    + This adds functions like `sexp2list`, `list2sexp`, `cfunc_from_ea` etc, which are extremely useful when writing plugins for IDA, especially for standardizing to using s-expressions.  
    + This also adds a `DoNothing` plugin which can be used to build further libraries, or for making abstract plugins (used later)
+ Add the `SimpleLine_Modifier_Hexrays` abstract base class plugin which is useful  for implementing HexRays (decompiler) plugins by abstracting away a large part of the implementation details
+ Refactor the `BAP_Taint_Pseudocode` plugin to use the abstract base class `SimpleLine_Modifier_Hexrays`.
+ Add a Hex-Rays plugin to propagate BAP comments from Text/Graph View to pseudocode view
+ Ensure that the `BAP_Taint` plugin does not unnecessarily re-initialize itself upon opening a new binary in the same window.

### Test/Screenshots

If we were to add BAP comments (i.e. using the s-expression style) in the text view (here, it is done manually, for testing, but otherwise, the `--emit-ida-script-attr` is a useful way to add BIR attribute information), then we propagate the information to all the related lines in decompilation view.

![screenshot1](https://cloud.githubusercontent.com/assets/5683582/15683766/f7bed858-2731-11e6-9216-2e4eb92733fb.png)
![screenshot2](https://cloud.githubusercontent.com/assets/5683582/15683767/f7c2f23a-2731-11e6-8deb-8c50202b8ce5.png)
