### PR TITLE
BAP_BIR_Attr IDA Python Plugin

### DIFF
--- a/plugins/ida/python/bap_bir_attr.py
+++ b/plugins/ida/python/bap_bir_attr.py
@@ -35,6 +35,12 @@ class BAP_BIR_Attr(idaapi.plugin_t):
 
     @classmethod
     def run_bap(cls):
+        """
+        Ask user for BAP args to pass, BIR attributes to print; and run BAP.
+
+        Allows users to also use {screen_ea} in the BAP args to get the
+        address at the location pointed to by the cursor.
+        """
         import tempfile
         from bap_utils import run_bap_with
 
@@ -43,15 +49,18 @@ class BAP_BIR_Attr(idaapi.plugin_t):
             'ida_script_location': tempfile.mkstemp(suffix='.py',
                                                     prefix='ida-bap-')[1],
             'args_from_user': idaapi.askstr(0, '', 'Args to pass to BAP'),
-            'bir_attr': idaapi.askstr(0, 'comment', 'BIR Attributes')
+            'bir_attr': idaapi.askstr(0, 'comment',
+                                      'BIR Attributes (comma separated)')
         }
 
         if args['args_from_user'] is None:
             args['args_from_user'] = ''
 
         if args['bir_attr'] is not None:
+            for attr in args['bir_attr'].split(','):
+                attr = attr.strip()  # For users who prefer "x, y, z" style
+                args['args_from_user'] += " --emit-ida-script-attr=" + attr
             args['args_from_user'] += "\
-            --emit-ida-script-attr={bir_attr} \
             --emit-ida-script-file={ida_script_location} \
             --emit-ida-script \
             ".format(**args)

--- a/plugins/ida/python/bap_bir_attr.py
+++ b/plugins/ida/python/bap_bir_attr.py
@@ -68,7 +68,7 @@ class BAP_BIR_Attr(idaapi.plugin_t):
         idc.SetStatus(IDA_STATUS_WAITING)
         idaapi.refresh_idaview_anyway()
 
-        run_bap_with(args['args_from_user'].format(args))
+        run_bap_with(args['args_from_user'].format(**args))
 
         idc.SetStatus(IDA_STATUS_READY)
 

--- a/plugins/ida/python/bap_bir_attr.py
+++ b/plugins/ida/python/bap_bir_attr.py
@@ -43,7 +43,7 @@ class BAP_BIR_Attr(idaapi.plugin_t):
             'ida_script_location': tempfile.mkstemp(suffix='.py',
                                                     prefix='ida-bap-')[1],
             'args_from_user': idaapi.askstr(0, '', 'Args to pass to BAP'),
-            'bir_attr': idaapi.askstr(0, '', 'BIR Attributes')
+            'bir_attr': idaapi.askstr(0, 'comment', 'BIR Attributes')
         }
 
         if args['args_from_user'] is None:

--- a/plugins/ida/python/bap_bir_attr.py
+++ b/plugins/ida/python/bap_bir_attr.py
@@ -1,0 +1,112 @@
+"""
+IDA Python Plugin to get BIR attributes from an arbitrary BAP execution.
+
+Allows user to run any BAP plugins and get information from BIR attributes,
+into comments in IDA. Use the selected line's address in the command using
+"{screen_ea}".
+
+Keybindings:
+    Shift-S  : Open up a window to accept arbitrary BAP commands,
+                and select arbitrary BIR attributes to output to IDA comments
+
+Comment Format:
+    Comments in the Text/Graph Views are added using a key-value storage
+    with the format (BAP (k1 v1) (k2 v2) ...)
+"""
+import idautils
+
+
+class BAP_BIR_Attr(idaapi.plugin_t):
+    """
+    Plugin to get BIR attributes from arbitrary BAP executions.
+
+    Also supports installation of callbacks using install_callback()
+    """
+
+    _callbacks = []
+
+    @classmethod
+    def _do_callbacks(cls):
+        data = {
+            'ea': idc.ScreenEA(),
+        }
+        for callback in cls._callbacks:
+            callback(data)
+
+    @classmethod
+    def run_bap(cls):
+        import tempfile
+        from bap_utils import run_bap_with
+
+        args = {
+            'screen_ea': "0x{:X}".format(idc.ScreenEA()),
+            'ida_script_location': tempfile.mkstemp(suffix='.py',
+                                                    prefix='ida-bap-')[1],
+            'args_from_user': idaapi.askstr(0, '', 'Args to pass to BAP'),
+            'bir_attr': idaapi.askstr(0, '', 'BIR Attributes')
+        }
+
+        args['args_from_user'] = args['args_from_user'].format(**args)
+
+        idc.SetStatus(IDA_STATUS_WAITING)
+        idaapi.refresh_idaview_anyway()
+
+        run_bap_with(
+            "\
+            {args_from_user} \
+            --emit-ida-script-attr={bir_attr} \
+            --emit-ida-script-file={ida_script_location} \
+            --emit-ida-script \
+            ".format(**args)
+        )
+
+        idc.SetStatus(IDA_STATUS_READY)
+
+        idaapi.IDAPython_ExecScript(args['ida_script_location'], globals())
+
+        idc.Exec("rm -f \"{ida_script_location}\"".format(**args))  # Cleanup
+
+        idc.Refresh()  # Force the updated information to show up
+
+        cls._do_callbacks()
+
+    flags = idaapi.PLUGIN_FIX
+    comment = "BAP BIR Attr Plugin"
+    help = "BAP BIR Attr Plugin"
+    wanted_name = "BAP BIR Attr Plugin"
+    wanted_hotkey = ""
+
+    def init(self):
+        """Initialize Plugin."""
+        from bap_utils import add_hotkey
+        add_hotkey("Shift-S", self.run_bap)
+        return idaapi.PLUGIN_KEEP
+
+    def term(self):
+        """Terminate Plugin."""
+        pass
+
+    def run(self, arg):
+        """
+        Run Plugin.
+
+        Ignored since keybindings are installed.
+        """
+        pass
+
+    @classmethod
+    def install_callback(cls, callback_fn):
+        """
+        Install callback to be run when the user calls for BAP execution.
+
+        Callback must take a dict and must return nothing.
+
+        Dict is guaranteed to get the following keys:
+            'ea': The value of EA at point where user propagated taint from.
+        """
+        cls._callbacks[ptr_or_reg].append(callback_fn)
+
+
+def PLUGIN_ENTRY():
+    """Install BAP_BIR_Attr upon entry."""
+    return BAP_BIR_Attr()

--- a/plugins/ida/python/bap_bir_attr.py
+++ b/plugins/ida/python/bap_bir_attr.py
@@ -46,19 +46,20 @@ class BAP_BIR_Attr(idaapi.plugin_t):
             'bir_attr': idaapi.askstr(0, '', 'BIR Attributes')
         }
 
-        args['args_from_user'] = args['args_from_user'].format(**args)
+        if args['args_from_user'] is None:
+            args['args_from_user'] = ''
 
-        idc.SetStatus(IDA_STATUS_WAITING)
-        idaapi.refresh_idaview_anyway()
-
-        run_bap_with(
-            "\
-            {args_from_user} \
+        if args['bir_attr'] is not None:
+            args['args_from_user'] += "\
             --emit-ida-script-attr={bir_attr} \
             --emit-ida-script-file={ida_script_location} \
             --emit-ida-script \
             ".format(**args)
-        )
+
+        idc.SetStatus(IDA_STATUS_WAITING)
+        idaapi.refresh_idaview_anyway()
+
+        run_bap_with(args['args_from_user'].format(args))
 
         idc.SetStatus(IDA_STATUS_READY)
 

--- a/plugins/ida/python/bap_propagate_taint.py
+++ b/plugins/ida/python/bap_propagate_taint.py
@@ -88,13 +88,6 @@ class BAP_Taint(idaapi.plugin_t):
     def _taint_ptr_and_color(self):
         self._taint_and_color('ptr')
 
-    def _add_hotkey(self, hotkey, func):
-        hotkey_ctx = idaapi.add_hotkey(hotkey, func)
-        if hotkey_ctx is None:
-            print("Failed to register {} for {}".format(hotkey, func))
-        else:
-            print("Registered {} for {}".format(hotkey, func))
-
     flags = idaapi.PLUGIN_FIX
     comment = "BAP Taint Plugin"
     help = "BAP Taint Plugin"
@@ -103,8 +96,9 @@ class BAP_Taint(idaapi.plugin_t):
 
     def init(self):
         """Initialize Plugin."""
-        self._add_hotkey("Shift-A", self._taint_reg_and_color)
-        self._add_hotkey("Ctrl-Shift-A", self._taint_ptr_and_color)
+        from bap_utils import add_hotkey
+        add_hotkey("Shift-A", self._taint_reg_and_color)
+        add_hotkey("Ctrl-Shift-A", self._taint_ptr_and_color)
         return idaapi.PLUGIN_KEEP
 
     def term(self):

--- a/plugins/ida/python/bap_utils.py.ab
+++ b/plugins/ida/python/bap_utils.py.ab
@@ -212,6 +212,20 @@ def run_bap_with(argument_string):
     idc.Exec("rm -f \"{symbol_file_location}\"".format(**args))  # Cleanup
 
 
+def add_hotkey(hotkey, func):
+    """
+    Assign hotkey to run func.
+
+    If a pre-existing action for the hotkey exists, then this function will
+    remove that action and replace it with func.
+    """
+    hotkey_ctx = idaapi.add_hotkey(hotkey, func)
+    if hotkey_ctx is None:
+        print("Failed to register {} for {}".format(hotkey, func))
+    else:
+        print("Registered {} for {}".format(hotkey, func))
+
+
 class DoNothing(idaapi.plugin_t):
     """
     Do Nothing.


### PR DESCRIPTION
This PR adds a plugin to IDA that
+ Allows execution of arbitrary (user-supplied) BAP commands/plugins
+ Pulls arbitrary (user-supplied) BIR attributes into IDA as comments

This PR leverages changes made in PR #449 to ensure that BAP gets the latest symbols as well, using `run_bap_with(argument_string)` :snake: 

### Keybindings

+ Shift-S : Open up a window to accept arbitrary BAP commands, and select arbitrary BIR attributes to output to IDA comments

The plugin is loaded automatically into IDA for usage, after installation.

### Testing

The following tests help demonstrate this plugin's use:

#### Test using Taint

Args to pass to BAP: `--taint-reg={screen_ea} --taint --propagate-taint`
BIR Attributes (comma separated): `tainted-reg, tainted-regs`

#### Test using Saluki

Args to pass to BAP: `--saluki`
BIR Attributes (comma separated): `comments`

Note: This specifically requires that you have [this version](https://github.com/BinaryAnalysisPlatform/bap-plugins/commit/08c89ffa2b594668fc8636e1c0e938beb3b4c79a) of saluki that outputs to BIR comment attribute

### Screenshots

In Text View:
![screenshot1](https://cloud.githubusercontent.com/assets/5683582/15724678/2d829dbe-2816-11e6-996c-e676584b5a81.png)

In Pseudocode View
![screenshot2](https://cloud.githubusercontent.com/assets/5683582/15724682/2f779426-2816-11e6-89a4-b8bf5189f8fc.png)
