### PR TITLE
Allow disabling certain plugins/features when enabling everything

### DIFF
--- a/configure
+++ b/configure
@@ -25,7 +25,8 @@ for i in "$@"; do
   esac
 done
 
-SECTIONS=`ocaml tools/oasis_sections.ml $@`
+SECTIONS=`ocaml tools/oasis_sections.ml --sections $@`
+ARGS=`ocaml tools/oasis_sections.ml --args $@`
 TAGS=`ocaml tools/collect.ml tags $SECTIONS`
 PLUGINS=`ocaml tools/collect.ml ocamlbuild.ml $SECTIONS`
 SETUPS=`ocaml tools/collect.ml setup.ml $SECTIONS`
@@ -36,4 +37,4 @@ ocaml tools/cat.ml '"\n# $name\n"' -- $TAGS _tags.in _tags
 ocaml tools/cat.ml '"\n#1 \"$name\"\n"' -- $PLUGINS myocamlbuild.ml.in myocamlbuild.ml
 ocaml tools/cat.ml '"\n#1 \"$name\"\n"' -- $SETUPS setup.ml.in setup.ml
 oasis -quiet setup
-ocaml setup.ml -quiet -configure "$@"
+ocaml setup.ml -quiet -configure $ARGS

--- a/configure
+++ b/configure
@@ -27,6 +27,7 @@ done
 
 SECTIONS=`ocaml tools/oasis_sections.ml --sections $@`
 ARGS=`ocaml tools/oasis_sections.ml --args $@`
+ARGS=$(eval 'echo' $ARGS)  # Workaround to expand unexpanded arguments
 TAGS=`ocaml tools/collect.ml tags $SECTIONS`
 PLUGINS=`ocaml tools/collect.ml ocamlbuild.ml $SECTIONS`
 SETUPS=`ocaml tools/collect.ml setup.ml $SECTIONS`

--- a/opam/opam
+++ b/opam/opam
@@ -17,6 +17,7 @@ build: [
   "--%{conf-ida:enable}%-ida"
   "--ida-path=%{conf-ida:path}%" {conf-ida:installed}
   "--ida-headless=%{conf-ida:headless}%" {conf-ida:installed}
+  "--%{conf-ida:enable}%-fsi-benchmark"
   "--%{conf-binutils:enable}%-objdump"
   "--objdump-path=%{conf-binutils:objdump}%" {conf-binutils:installed}
   "--objdump-targets=%{conf-binutils:targets}%" {conf-binutils:installed}

--- a/tools/oasis_sections.ml
+++ b/tools/oasis_sections.ml
@@ -5,13 +5,11 @@ let header = "common"
 let has_extension name =
   String.contains name '.'
 
-let everything =
-  Sys.readdir "oasis" |> Array.to_list |>
-  List.filter (fun sec -> sec <> header && not (has_extension sec))
+let enabled = "--enable-"
+let disabled = "--disable-"
 
-let enable_feature arg =
+let feature enable arg =
   let length = String.length arg in
-  let enable = "--enable-" in
   let prefix = String.length enable in
   try
     if String.sub arg 0 prefix = enable
@@ -19,17 +17,22 @@ let enable_feature arg =
     else None
   with exn -> None
 
-let selected args =
+let everything_except disabled_args =
+  Sys.readdir "oasis" |> Array.to_list |>
+  List.filter (fun sec -> sec <> header && not (has_extension sec)
+                          && not (List.mem sec disabled_args) )
+
+let selected enable args =
   args |> List.fold_left (fun fs arg ->
-      match enable_feature arg with
+      match feature enable arg with
       | Some f when Sys.file_exists ("oasis" / f) -> f :: fs
       | _ -> fs) []
 
-
 let features args =
+  let disabled_args = (selected disabled args) in
   if List.(mem "--enable-everything" args || mem "--help" args)
-  then header :: everything
-  else header :: selected args
+  then header :: everything_except disabled_args
+  else header :: selected enabled args
 
 let main args =
   features args |>

--- a/tools/oasis_sections.ml
+++ b/tools/oasis_sections.ml
@@ -29,14 +29,31 @@ let selected enable args =
       | _ -> fs) []
 
 let features args =
-  let disabled_args = (selected disabled args) in
+  let disabled_args = selected disabled args in
   if List.(mem "--enable-everything" args || mem "--help" args)
   then header :: everything_except disabled_args
   else header :: selected enabled args
 
+let filtered args =
+  let enabled_args = selected enabled args in
+  let disabled_args = selected disabled args in
+  List.(filter (fun arg -> not (mem arg (
+      map (fun f -> enabled^f) enabled_args @
+      map (fun f -> disabled^f) disabled_args))) args)
+
 let main args =
-  features args |>
-  List.map (fun s -> "oasis" / s) |>
-  String.concat " " |> print_endline
+  let output_list =
+    match args with
+    | _ :: h :: args when h = "--args" ->
+      if List.(mem "--enable-everything" args || mem "--help" args)
+      then filtered args
+      else args
+    | _ :: h :: args when h = "--sections" ->
+      features args |>
+      List.map (fun s -> "oasis" / s)
+    | _ ->
+      assert false
+  in
+  output_list |> String.concat " " |> print_endline
 
 let () = main (Array.to_list Sys.argv)


### PR DESCRIPTION
This PR allows us to specifically disable certain plugins/features when we enable everything, for example, if we run `./configure --enable-everything --disable-ida`, then it will enable every plugin/feature except for `ida`