### PR TITLE
fix microx backtracking

### DIFF
--- a/lib/microx/microx_conqueror.mli
+++ b/lib/microx/microx_conqueror.mli
@@ -10,7 +10,7 @@ class context :
     method visited : int Tid.Map.t
 
     method add_checkpoint : tid -> 's
-    method checkpoints : (tid * 's) list Tid.Map.t
+    method checkpoints : 's Tid.Map.t Tid.Map.t
     method backtrack : 's option
     method merge : 's -> 's
 


### PR DESCRIPTION
The backtracking point was registered on the entry to a block,
as a result, when we were backtracking all updates to the context
made in the last block were ignored.

A better way would be to store the context just before the first
jump. To simplify the implementation we will store context actually on
every jump (since usually there one or two jumps on a block, this
wouldn't have a big impact). Also, for performance consideration, an
associative list was substituted with a real Tid.Map.