### PR TITLE
Enable caching of built dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: c
 script: bash -ex .travis-opam.sh
 sudo: false
+cache:
+  directories:
+    - $HOME/.opam
+  before_cache:
+    - opam remove bap -y
+    - rm -rf $HOME/.opam/log
 addons:
   apt:
     sources:


### PR DESCRIPTION
Similar to #333 by @maurer, this caches the contents of the `~/.opam` folder which should speed up the build by skipping rebuild of dependencies when unnecessary.

#333 was reverted in https://github.com/BinaryAnalysisPlatform/bap/commit/93ee72c0768a9a3692e48e599f1a72431d129e58 because, as @ivg said, sometimes bap would get cached as well. This PR takes care of that by removing bap before placing things into cache. This ensures that the dependencies are stored, but bap is not.

*Note:* It might take a while after this PR is merged for caching to start showing significant improvements (since the merge will cause the cache to be generated, and subsequent PRs/commits will use the cache whenever possible)