### PR TITLE
BAP to the Future | Config update

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -589,11 +589,11 @@ module Std : sig
 
           (* ... *)
 
-          let on_config_ready {Config.get=(!)} =
-            do_stuff !path !debug (* ... *)
-
           let main () =
-            Config.request on_config_ready
+            Config.when_ready
+              (fun {Config.get=(!)} ->
+                 do_stuff !path !debug (* ... *)
+              )
         ]}
     *)
     module Config : sig

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -589,11 +589,11 @@ module Std : sig
 
           (* ... *)
 
-          let configured {Config.get=(!)} =
+          let on_config_ready {Config.get=(!)} =
             do_stuff !path !debug (* ... *)
 
           let main () =
-            Config.parse configured
+            Config.request on_config_ready
         ]}
     *)
     module Config : sig
@@ -637,9 +637,9 @@ module Std : sig
       (** A witness that can read configured params *)
       type reader = {get : 'a. 'a param -> 'a}
 
-      (** [parse configured] parses configuration and command line
-          arguments and calls [configured (reader:Config.reader)] *)
-      val parse : (reader -> unit) -> unit
+      (** [request on_config_ready] parses configuration and command line
+          arguments and calls [on_config_ready (reader:Config.reader)] *)
+      val request : (reader -> unit) -> unit
 
       (** The type for a block of man page text.
 

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -640,9 +640,11 @@ module Std : sig
       (** A witness that can read configured params *)
       type reader = {get : 'a. 'a param -> 'a}
 
-      (** [request on_config_ready] parses configuration and command line
-          arguments and calls [on_config_ready (reader:Config.reader)] *)
-      val request : (reader -> unit) -> unit
+      (** [when_ready f] requests the system to call function [f] once
+          configuration parameters are  established and stabilized. An
+          access function will be passed to the function [f],  that can be
+          used to safely dereference parameters.  *)
+      val when_ready : (reader -> unit) -> unit
 
       (** The type for a block of man page text.
 

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -634,6 +634,9 @@ module Std : sig
       val flag :
         ?docv:string -> ?doc:string -> name:string -> bool param
 
+      (** Provides a future determined on when the config can be read *)
+      val determined : 'a param -> 'a future
+
       (** A witness that can read configured params *)
       type reader = {get : 'a. 'a param -> 'a}
 

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -589,9 +589,11 @@ module Std : sig
 
           (* ... *)
 
-          let main () =
-            let (!) = Config.parse () in
+          let configured {Config.get=(!)} =
             do_stuff !path !debug (* ... *)
+
+          let main () =
+            Config.parse configured
         ]}
     *)
     module Config : sig
@@ -632,11 +634,12 @@ module Std : sig
       val flag :
         ?docv:string -> ?doc:string -> name:string -> bool param
 
-      (** Reads a value from a parameter *)
-      type 'a reader = 'a param -> 'a
+      (** A witness that can read configured params *)
+      type reader = {get : 'a. 'a param -> 'a}
 
-      (** Parse command line arguments and return a param reader *)
-      val parse : unit -> 'a reader
+      (** [parse configured] parses configuration and command line
+          arguments and calls [configured (reader:Config.reader)] *)
+      val parse : (reader -> unit) -> unit
 
       (** The type for a block of man page text.
 

--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -159,10 +159,10 @@ module Create() = struct
     let determined (p:'a param) : 'a future = p
 
     type reader = {get : 'a. 'a param -> 'a}
-    let request on_config_ready : unit =
+    let when_ready f : unit =
       match Term.eval (!main, !term_info) with
       | `Error _ -> exit 1
-      | `Ok _ -> on_config_ready {get = (fun p -> Future.peek_exn p)}
+      | `Ok _ -> f {get = (fun p -> Future.peek_exn p)}
       | `Version | `Help -> exit 0
 
     let bool = Arg.bool

--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -151,11 +151,11 @@ module Create() = struct
     let manpage (man:manpage_block list) : unit =
       term_info := Term.info ~doc ~man plugin_name
 
-    type 'a reader = 'a param -> 'a
-    let parse () : 'a reader =
+    type reader = {get : 'a. 'a param -> 'a}
+    let parse configured : unit =
       match Term.eval (!main, !term_info) with
       | `Error _ -> exit 1
-      | `Ok _ -> (fun p -> !p)
+      | `Ok _ -> configured {get = (fun p -> !p)}
       | `Version | `Help -> exit 0
 
     let bool = Arg.bool

--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -156,6 +156,8 @@ module Create() = struct
     let manpage (man:manpage_block list) : unit =
       term_info := Term.info ~doc ~man plugin_name
 
+    let determined (p:'a param) : 'a future = p
+
     type reader = {get : 'a. 'a param -> 'a}
     let request on_config_ready : unit =
       match Term.eval (!main, !term_info) with

--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -157,10 +157,10 @@ module Create() = struct
       term_info := Term.info ~doc ~man plugin_name
 
     type reader = {get : 'a. 'a param -> 'a}
-    let parse configured : unit =
+    let request on_config_ready : unit =
       match Term.eval (!main, !term_info) with
       | `Error _ -> exit 1
-      | `Ok _ -> configured {get = (fun p -> Future.peek_exn p)}
+      | `Ok _ -> on_config_ready {get = (fun p -> Future.peek_exn p)}
       | `Version | `Help -> exit 0
 
     let bool = Arg.bool

--- a/lib/bap/bap_self.mli
+++ b/lib/bap/bap_self.mli
@@ -1,5 +1,6 @@
 open Format
 open Core_kernel.Std
+open Bap_future.Std
 
 module Create() : sig
   val name : string
@@ -30,6 +31,8 @@ module Create() : sig
 
     val flag :
       ?docv:string -> ?doc:string -> name:string -> bool param
+
+    val determined : 'a param -> 'a future
 
     type reader = {get : 'a. 'a param -> 'a}
     val on_config_ready : (reader -> unit) -> unit

--- a/lib/bap/bap_self.mli
+++ b/lib/bap/bap_self.mli
@@ -31,8 +31,8 @@ module Create() : sig
     val flag :
       ?docv:string -> ?doc:string -> name:string -> bool param
 
-    type 'a reader = 'a param -> 'a
-    val parse : unit -> 'a reader
+    type reader = {get : 'a. 'a param -> 'a}
+    val parse : (reader -> unit) -> unit
 
     type manpage_block = [
       | `I of string * string

--- a/lib/bap/bap_self.mli
+++ b/lib/bap/bap_self.mli
@@ -32,7 +32,7 @@ module Create() : sig
       ?docv:string -> ?doc:string -> name:string -> bool param
 
     type reader = {get : 'a. 'a param -> 'a}
-    val parse : (reader -> unit) -> unit
+    val on_config_ready : (reader -> unit) -> unit
 
     type manpage_block = [
       | `I of string * string

--- a/lib/bap/bap_self.mli
+++ b/lib/bap/bap_self.mli
@@ -35,7 +35,7 @@ module Create() : sig
     val determined : 'a param -> 'a future
 
     type reader = {get : 'a. 'a param -> 'a}
-    val on_config_ready : (reader -> unit) -> unit
+    val when_ready : (reader -> unit) -> unit
 
     type manpage_block = [
       | `I of string * string


### PR DESCRIPTION
I just _had_ to make a reference to that iconic movie here. :zap: :metal: :zap:
This PR is one from a series of PRs that will transition our `Config` interface into being able to work in a much better way. The point is to simplify the interface that plugin developers use for command line parsing. Over time, we aim to consolidate all the information from different plugins and produce a much nicer and more coherent command line parsing structure (compared to the hacky method we had earlier with Cmdliner being used in all plugins).

This PR does the following:
+ Updates the type of `reader` to a record with a `get` function
    + Turns out, the implementation from #468 guaranteed a truly polymorphic `get` function, but the interface did not guarantee it at the time and thus OCaml made it weakly polymorphic. This fixes it.
+ Updates the interface of `Config` to instead use a callback function
    + This is in preparation for further PRs to come which will update the implementation for the transitions outlined above
+ Uses `Bap_future.future` in implementation of `param`
    + This is because actually, parameters are only set once during execution, and thereafter are not updated. Hence, they have a timeline that spans from undefined to defined, and are hence more better understood as `future`s rather than as `ref`s
+ Updated documentation to for newer interface usage
