### PR TITLE
Update emit-ida-script to use Config instead of Cmdliner + Minor changes in Config

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -629,6 +629,10 @@ module Std : sig
         'a converter -> default:'a ->
         ?docv:string -> ?doc:string -> name:string -> 'a param
 
+      val param_all :
+        'a converter -> default:'a list ->
+        ?docv:string -> ?doc:string -> name:string -> 'a list param
+
       (** Create a boolean parameter that is set to true if user
           mentions it in the command line arguments *)
       val flag :

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -584,7 +584,7 @@ module Std : sig
 
         {[
           let path = Config.(param string ~doc:"a path to file"
-                               ~default:"input.txt" ~name:"path")
+                               ~default:"input.txt" "path")
           let debug = Config.(flag (* ... *) )
 
           (* ... *)
@@ -627,20 +627,19 @@ module Std : sig
       (** Create a parameter *)
       val param :
         'a converter -> default:'a ->
-        ?docv:string -> ?doc:string -> name:string -> 'a param
+        ?docv:string -> ?doc:string -> string -> 'a param
 
       (** Create a parameter which accepts a list at command line by
-          repetition of argument [name]. Behaves the same as
-          [param (list 'a) ...] in all other respects. Defaults to an
-          empty list if unspecified. *)
+          repetition of argument. Similar to [param (list 'a) ...]
+          in all other respects. Defaults to an empty list if unspecified. *)
       val param_all :
         'a converter -> ?default:'a list ->
-        ?docv:string -> ?doc:string -> name:string -> 'a list param
+        ?docv:string -> ?doc:string -> string -> 'a list param
 
       (** Create a boolean parameter that is set to true if user
           mentions it in the command line arguments *)
       val flag :
-        ?docv:string -> ?doc:string -> name:string -> bool param
+        ?docv:string -> ?doc:string -> string -> bool param
 
       (** Provides a future determined on when the config can be read *)
       val determined : 'a param -> 'a future

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -745,6 +745,12 @@ module Std : sig
       val t4 : ?sep:char -> 'a converter -> 'b converter -> 'c converter ->
         'd converter -> ('a * 'b * 'c * 'd) converter
 
+      (** [some none c] is like the converter [c] except it returns
+          [Some] value. It is used for command line arguments
+          that default to [None] when absent. [none] is what to print to
+          document the absence (defaults to [""]). *)
+      val some : ?none:string -> 'a converter -> 'a option converter
+
     end
 
   end

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -629,8 +629,12 @@ module Std : sig
         'a converter -> default:'a ->
         ?docv:string -> ?doc:string -> name:string -> 'a param
 
+      (** Create a parameter which accepts a list at command line by
+          repetition of argument [name]. Behaves the same as
+          [param (list 'a) ...] in all other respects. Defaults to an
+          empty list if unspecified. *)
       val param_all :
-        'a converter -> default:'a list ->
+        'a converter -> ?default:'a list ->
         ?docv:string -> ?doc:string -> name:string -> 'a list param
 
       (** Create a boolean parameter that is set to true if user

--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -135,7 +135,7 @@ module Create() = struct
           Promise.fulfill promise x) $ t $ (!main));
       future
 
-    let param_all converter ~default ?(docv="VAL")
+    let param_all converter ?(default=[]) ?(docv="VAL")
         ?(doc="Uncodumented") ~name : 'a list param =
       let future, promise = Future.create () in
       let param = get_param ~converter:(Arg.list converter) ~default ~name in

--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -135,6 +135,16 @@ module Create() = struct
           Promise.fulfill promise x) $ t $ (!main));
       future
 
+    let param_all converter ~default ?(docv="VAL")
+        ?(doc="Uncodumented") ~name : 'a list param =
+      let future, promise = Future.create () in
+      let param = get_param ~converter:(Arg.list converter) ~default ~name in
+      let t =
+        Arg.(value @@ opt_all converter param @@ info [name] ~doc ~docv) in
+      main := Term.(const (fun x () ->
+          Promise.fulfill promise x) $ t $ (!main));
+      future
+
     let flag ?(docv="VAL") ?(doc="Undocumented") ~name : bool param =
       let future, promise = Future.create () in
       let param = get_param ~converter:Arg.bool ~default:false ~name in

--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -126,7 +126,7 @@ module Create() = struct
         | None -> value in
       value
 
-    let param converter ~default ?(docv="VAL") ?(doc="Undocumented") ~name =
+    let param converter ~default ?(docv="VAL") ?(doc="Undocumented") name =
       let future, promise = Future.create () in
       let param = get_param ~converter ~default ~name in
       let t =
@@ -136,7 +136,7 @@ module Create() = struct
       future
 
     let param_all converter ?(default=[]) ?(docv="VAL")
-        ?(doc="Uncodumented") ~name : 'a list param =
+        ?(doc="Uncodumented") name : 'a list param =
       let future, promise = Future.create () in
       let param = get_param ~converter:(Arg.list converter) ~default ~name in
       let t =
@@ -145,7 +145,7 @@ module Create() = struct
           Promise.fulfill promise x) $ t $ (!main));
       future
 
-    let flag ?(docv="VAL") ?(doc="Undocumented") ~name : bool param =
+    let flag ?(docv="VAL") ?(doc="Undocumented") name : bool param =
       let future, promise = Future.create () in
       let param = get_param ~converter:Arg.bool ~default:false ~name in
       let t =

--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -172,7 +172,7 @@ module Create() = struct
     type reader = {get : 'a. 'a param -> 'a}
     let when_ready f : unit =
       let evaluate_cmdline_args () =
-        match Term.eval (!main, !term_info) with
+        match Term.eval ~argv (!main, !term_info) with
         | `Error _ -> exit 1
         | `Ok _ -> f {get = (fun p -> Future.peek_exn p)}
         | `Version | `Help -> exit 0 in

--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -193,6 +193,7 @@ module Create() = struct
     let t2 = Arg.t2
     let t3 = Arg.t3
     let t4 = Arg.t4
+    let some = Arg.some
 
   end
 

--- a/lib/bap/bap_self.mli
+++ b/lib/bap/bap_self.mli
@@ -29,6 +29,10 @@ module Create() : sig
       'a converter -> default:'a ->
       ?docv:string -> ?doc:string -> name:string -> 'a param
 
+    val param_all :
+      'a converter -> default:'a list ->
+      ?docv:string -> ?doc:string -> name:string -> 'a list param
+
     val flag :
       ?docv:string -> ?doc:string -> name:string -> bool param
 

--- a/lib/bap/bap_self.mli
+++ b/lib/bap/bap_self.mli
@@ -27,14 +27,14 @@ module Create() : sig
 
     val param :
       'a converter -> default:'a ->
-      ?docv:string -> ?doc:string -> name:string -> 'a param
+      ?docv:string -> ?doc:string -> string -> 'a param
 
     val param_all :
       'a converter -> ?default:'a list ->
-      ?docv:string -> ?doc:string -> name:string -> 'a list param
+      ?docv:string -> ?doc:string -> string -> 'a list param
 
     val flag :
-      ?docv:string -> ?doc:string -> name:string -> bool param
+      ?docv:string -> ?doc:string -> string -> bool param
 
     val determined : 'a param -> 'a future
 

--- a/lib/bap/bap_self.mli
+++ b/lib/bap/bap_self.mli
@@ -67,6 +67,7 @@ module Create() : sig
       ('a * 'b * 'c) converter
     val t4 : ?sep:char -> 'a converter -> 'b converter -> 'c converter ->
       'd converter -> ('a * 'b * 'c * 'd) converter
+    val some : ?none:string -> 'a converter -> 'a option converter
 
   end
 

--- a/lib/bap/bap_self.mli
+++ b/lib/bap/bap_self.mli
@@ -30,7 +30,7 @@ module Create() : sig
       ?docv:string -> ?doc:string -> name:string -> 'a param
 
     val param_all :
-      'a converter -> default:'a list ->
+      'a converter -> ?default:'a list ->
       ?docv:string -> ?doc:string -> name:string -> 'a list param
 
     val flag :


### PR DESCRIPTION
This PR does the following
+ Updates `emit-ida-script` to use the `Config` interface
+ Updates the `Config` interface to
    + Allow `param_all` for taking lists through repetition at command line
    + Adds the standard `some` converter
    + Makes `name` a non named-argument in `param`, `flag` to prevent dangling optional argument problem
+ Update `Config` implementation to
    + Account for above changes
    + Ensure that the filtered arguments are passed to a plugin (Note: In future PRs, as we slowly combine information from different plugin config, we will instead be calling `Term.eval` only once globally, rather than once every plugin.)