### PR TITLE
Update multiple plugins to use the Config interface instead of Cmdliner

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -629,6 +629,10 @@ module Std : sig
         'a converter -> default:'a ->
         ?docv:string -> ?doc:string -> name:string -> 'a param
 
+      val param_all :
+        'a converter -> default:'a list ->
+        ?docv:string -> ?doc:string -> name:string -> 'a list param
+
       (** Create a boolean parameter that is set to true if user
           mentions it in the command line arguments *)
       val flag :

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -584,7 +584,7 @@ module Std : sig
 
         {[
           let path = Config.(param string ~doc:"a path to file"
-                               ~default:"input.txt" ~name:"path")
+                               ~default:"input.txt" "path")
           let debug = Config.(flag (* ... *) )
 
           (* ... *)
@@ -627,20 +627,19 @@ module Std : sig
       (** Create a parameter *)
       val param :
         'a converter -> default:'a ->
-        ?docv:string -> ?doc:string -> name:string -> 'a param
+        ?docv:string -> ?doc:string -> string -> 'a param
 
       (** Create a parameter which accepts a list at command line by
-          repetition of argument [name]. Behaves the same as
-          [param (list 'a) ...] in all other respects. Defaults to an
-          empty list if unspecified. *)
+          repetition of argument. Similar to [param (list 'a) ...]
+          in all other respects. Defaults to an empty list if unspecified. *)
       val param_all :
         'a converter -> ?default:'a list ->
-        ?docv:string -> ?doc:string -> name:string -> 'a list param
+        ?docv:string -> ?doc:string -> string -> 'a list param
 
       (** Create a boolean parameter that is set to true if user
           mentions it in the command line arguments *)
       val flag :
-        ?docv:string -> ?doc:string -> name:string -> bool param
+        ?docv:string -> ?doc:string -> string -> bool param
 
       (** Provides a future determined on when the config can be read *)
       val determined : 'a param -> 'a future

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -745,6 +745,12 @@ module Std : sig
       val t4 : ?sep:char -> 'a converter -> 'b converter -> 'c converter ->
         'd converter -> ('a * 'b * 'c * 'd) converter
 
+      (** [some none c] is like the converter [c] except it returns
+          [Some] value. It is used for command line arguments
+          that default to [None] when absent. [none] is what to print to
+          document the absence (defaults to [""]). *)
+      val some : ?none:string -> 'a converter -> 'a option converter
+
     end
 
   end

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -629,8 +629,12 @@ module Std : sig
         'a converter -> default:'a ->
         ?docv:string -> ?doc:string -> name:string -> 'a param
 
+      (** Create a parameter which accepts a list at command line by
+          repetition of argument [name]. Behaves the same as
+          [param (list 'a) ...] in all other respects. Defaults to an
+          empty list if unspecified. *)
       val param_all :
-        'a converter -> default:'a list ->
+        'a converter -> ?default:'a list ->
         ?docv:string -> ?doc:string -> name:string -> 'a list param
 
       (** Create a boolean parameter that is set to true if user

--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -135,7 +135,7 @@ module Create() = struct
           Promise.fulfill promise x) $ t $ (!main));
       future
 
-    let param_all converter ~default ?(docv="VAL")
+    let param_all converter ?(default=[]) ?(docv="VAL")
         ?(doc="Uncodumented") ~name : 'a list param =
       let future, promise = Future.create () in
       let param = get_param ~converter:(Arg.list converter) ~default ~name in

--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -135,6 +135,16 @@ module Create() = struct
           Promise.fulfill promise x) $ t $ (!main));
       future
 
+    let param_all converter ~default ?(docv="VAL")
+        ?(doc="Uncodumented") ~name : 'a list param =
+      let future, promise = Future.create () in
+      let param = get_param ~converter:(Arg.list converter) ~default ~name in
+      let t =
+        Arg.(value @@ opt_all converter param @@ info [name] ~doc ~docv) in
+      main := Term.(const (fun x () ->
+          Promise.fulfill promise x) $ t $ (!main));
+      future
+
     let flag ?(docv="VAL") ?(doc="Undocumented") ~name : bool param =
       let future, promise = Future.create () in
       let param = get_param ~converter:Arg.bool ~default:false ~name in

--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -126,7 +126,7 @@ module Create() = struct
         | None -> value in
       value
 
-    let param converter ~default ?(docv="VAL") ?(doc="Undocumented") ~name =
+    let param converter ~default ?(docv="VAL") ?(doc="Undocumented") name =
       let future, promise = Future.create () in
       let param = get_param ~converter ~default ~name in
       let t =
@@ -136,7 +136,7 @@ module Create() = struct
       future
 
     let param_all converter ?(default=[]) ?(docv="VAL")
-        ?(doc="Uncodumented") ~name : 'a list param =
+        ?(doc="Uncodumented") name : 'a list param =
       let future, promise = Future.create () in
       let param = get_param ~converter:(Arg.list converter) ~default ~name in
       let t =
@@ -145,7 +145,7 @@ module Create() = struct
           Promise.fulfill promise x) $ t $ (!main));
       future
 
-    let flag ?(docv="VAL") ?(doc="Undocumented") ~name : bool param =
+    let flag ?(docv="VAL") ?(doc="Undocumented") name : bool param =
       let future, promise = Future.create () in
       let param = get_param ~converter:Arg.bool ~default:false ~name in
       let t =

--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -172,7 +172,7 @@ module Create() = struct
     type reader = {get : 'a. 'a param -> 'a}
     let when_ready f : unit =
       let evaluate_cmdline_args () =
-        match Term.eval (!main, !term_info) with
+        match Term.eval ~argv (!main, !term_info) with
         | `Error _ -> exit 1
         | `Ok _ -> f {get = (fun p -> Future.peek_exn p)}
         | `Version | `Help -> exit 0 in

--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -193,6 +193,7 @@ module Create() = struct
     let t2 = Arg.t2
     let t3 = Arg.t3
     let t4 = Arg.t4
+    let some = Arg.some
 
   end
 

--- a/lib/bap/bap_self.mli
+++ b/lib/bap/bap_self.mli
@@ -29,6 +29,10 @@ module Create() : sig
       'a converter -> default:'a ->
       ?docv:string -> ?doc:string -> name:string -> 'a param
 
+    val param_all :
+      'a converter -> default:'a list ->
+      ?docv:string -> ?doc:string -> name:string -> 'a list param
+
     val flag :
       ?docv:string -> ?doc:string -> name:string -> bool param
 

--- a/lib/bap/bap_self.mli
+++ b/lib/bap/bap_self.mli
@@ -27,14 +27,14 @@ module Create() : sig
 
     val param :
       'a converter -> default:'a ->
-      ?docv:string -> ?doc:string -> name:string -> 'a param
+      ?docv:string -> ?doc:string -> string -> 'a param
 
     val param_all :
       'a converter -> ?default:'a list ->
-      ?docv:string -> ?doc:string -> name:string -> 'a list param
+      ?docv:string -> ?doc:string -> string -> 'a list param
 
     val flag :
-      ?docv:string -> ?doc:string -> name:string -> bool param
+      ?docv:string -> ?doc:string -> string -> bool param
 
     val determined : 'a param -> 'a future
 

--- a/lib/bap/bap_self.mli
+++ b/lib/bap/bap_self.mli
@@ -67,6 +67,7 @@ module Create() : sig
       ('a * 'b * 'c) converter
     val t4 : ?sep:char -> 'a converter -> 'b converter -> 'c converter ->
       'd converter -> ('a * 'b * 'c * 'd) converter
+    val some : ?none:string -> 'a converter -> 'a option converter
 
   end
 

--- a/lib/bap/bap_self.mli
+++ b/lib/bap/bap_self.mli
@@ -30,7 +30,7 @@ module Create() : sig
       ?docv:string -> ?doc:string -> name:string -> 'a param
 
     val param_all :
-      'a converter -> default:'a list ->
+      'a converter -> ?default:'a list ->
       ?docv:string -> ?doc:string -> name:string -> 'a list param
 
     val flag :

--- a/plugins/callsites/callsites_main.ml
+++ b/plugins/callsites/callsites_main.ml
@@ -78,10 +78,8 @@ let main proj =
   let prog = Project.program proj in
   Project.with_program proj (fill_calls prog)
 
-module Cmdline = struct
-  open Cmdliner
-
-  let man = [
+let () =
+  Config.manpage [
     `S "DESCRIPTION";
     `P "This pass will inject artifical definitions of a subroutine
       arguments at call sites. Consider function $(b,malloc) that has
@@ -97,18 +95,9 @@ module Cmdline = struct
       000001c3: malloc_size := R0
       0000015b: call @malloc with return %0000015c";
     `P "And prepend another to the block to which malloc will return:";
-
     `Pre "
       0000015c:
       000001c4: R0 := malloc_result
       ...";
-  ]
-
-  let info = Term.info ~man ~doc name
-  let run () = Term.eval ~argv (Term.const main,info)
-end
-
-let () = match Cmdline.run () with
-  | `Ok pass -> Project.register_pass pass
-  | `Version | `Help -> exit 0
-  | `Error _ -> exit 1
+  ];
+  Config.when_ready (fun _ -> Project.register_pass main)

--- a/plugins/ida/ida_main.ml
+++ b/plugins/ida/ida_main.ml
@@ -135,17 +135,29 @@ let main () =
   register_source (module Reconstructor);
   Project.Input.register_loader name loader
 
-let () =
-  let () = Config.manpage [
-      `S "DESCRIPTION";
-      `P "This plugin provides rooter, symbolizer and reconstuctor services.";
-      `P "If IDA instance is found on the machine, or specified by a
-        user, it will be queried for the specified information."
-    ] in
-  let path = Config.(param (some string) "path" ~default:None
-                       ~doc:"Use IDA to extract symbols from file. \
-                             You can optionally provide path to IDA \
-                             executable, or executable name.") in
-  Config.when_ready (fun {Config.get=(!)} ->
-      (* TODO: Use [path] when calling IDA. *)
-      main () )
+module Main = struct
+  open Cmdliner
+  let man = [
+    `S "DESCRIPTION";
+    `P "This plugin provides rooter, symbolizer and reconstuctor services.";
+    `P "If IDA instance is found on the machine, or specified by a
+  user, it will be queried for the specified information."
+
+  ]
+
+
+  let path : string option Term.t =
+    let doc = "Use IDA to extract symbols from file. \
+               You can optionally provide path to IDA executable,\
+               or executable name." in
+    Arg.(value & opt (some string) None & info ["path"] ~doc)
+
+  let info = Term.info name ~version ~doc ~man
+
+  let () =
+    let run = Term.(const main $ const ()) in
+    match Term.eval ~argv ~catch:false (run,info) with
+    | `Ok () -> ()
+    | `Help | `Version -> exit 0
+    | `Error _ -> exit 1
+end

--- a/plugins/ida/ida_main.ml
+++ b/plugins/ida/ida_main.ml
@@ -135,29 +135,17 @@ let main () =
   register_source (module Reconstructor);
   Project.Input.register_loader name loader
 
-module Main = struct
-  open Cmdliner
-  let man = [
-    `S "DESCRIPTION";
-    `P "This plugin provides rooter, symbolizer and reconstuctor services.";
-    `P "If IDA instance is found on the machine, or specified by a
-  user, it will be queried for the specified information."
-
-  ]
-
-
-  let path : string option Term.t =
-    let doc = "Use IDA to extract symbols from file. \
-               You can optionally provide path to IDA executable,\
-               or executable name." in
-    Arg.(value & opt (some string) None & info ["path"] ~doc)
-
-  let info = Term.info name ~version ~doc ~man
-
-  let () =
-    let run = Term.(const main $ const ()) in
-    match Term.eval ~argv ~catch:false (run,info) with
-    | `Ok () -> ()
-    | `Help | `Version -> exit 0
-    | `Error _ -> exit 1
-end
+let () =
+  let () = Config.manpage [
+      `S "DESCRIPTION";
+      `P "This plugin provides rooter, symbolizer and reconstuctor services.";
+      `P "If IDA instance is found on the machine, or specified by a
+        user, it will be queried for the specified information."
+    ] in
+  let path = Config.(param (some string) "path" ~default:None
+                       ~doc:"Use IDA to extract symbols from file. \
+                             You can optionally provide path to IDA \
+                             executable, or executable name.") in
+  Config.when_ready (fun {Config.get=(!)} ->
+      (* TODO: Use [path] when calling IDA. *)
+      main () )

--- a/plugins/objdump/objdump_main.ml
+++ b/plugins/objdump/objdump_main.ml
@@ -3,7 +3,6 @@ open Bap_future.Std
 open Bap.Std
 open Regular.Std
 open Re_perl
-open Cmdliner
 open Format
 open Option.Monad_infix
 open Objdump_config
@@ -77,8 +76,8 @@ let main () =
   Stream.merge Project.Info.arch Project.Info.file ~f:run_objdump |>
   Symbolizer.Factory.register name
 
-let info =
-  let man = [
+let () =
+  Config.manpage [
     `S "DESCRIPTION";
     `P "This plugin provides a symbolizer based on objdump. \
         Note that we parse objdump output, thus this symbolizer \
@@ -88,12 +87,5 @@ let info =
     `P  "$(b, bap --symbolizer=objdump --dump-symbols) $(i,executable)";
     `P  "To use the internal extractor and *not* this plugin:";
     `P  "$(b, bap --symbolizer=internal --dump-symbols) $(i,executable)";
-  ] in
-  Term.info ~man ~doc name ~version
-
-let () =
-  let run = Term.(const main $const ()) in
-  match Term.eval ~argv ~catch:false (run, info) with
-  | `Ok () -> ()
-  | `Help | `Version -> exit 0
-  | `Error _ -> exit 1
+  ];
+  Config.when_ready (fun _ -> main ())

--- a/plugins/read_symbols/read_symbols_main.ml
+++ b/plugins/read_symbols/read_symbols_main.ml
@@ -34,25 +34,16 @@ let register syms =
   register (module Symbolizer);
   register (module Reconstructor)
 
-let man = [
-  `S "DESCRIPTION";
-  `P "Read symbol information from a file and provide rooter,
+let () =
+  let () = Config.manpage [
+      `S "DESCRIPTION";
+      `P "Read symbol information from a file and provide rooter,
     symbolizer and a reconstructor, based on this information."
-]
-
-module Main = struct
-  open Cmdliner
-  let info = Term.info name ~version ~doc ~man
-
-  let symsfile : string option Term.t =
-    let doc = "Use this file as symbols source" in
-    Arg.(value & opt (some non_dir_file) None &
-         info ["from";] ~doc ~docv:"SYMS")
-
-  let () =
-    match Term.eval ~argv (symsfile,info) with
-    | `Ok (Some file) -> register file
-    | `Ok None -> ()
-    | `Help | `Version -> exit 0
-    | `Error _ -> exit 1
-end
+    ] in
+  let symsfile = Config.(param (some non_dir_file) "from"
+                           ~default:None ~docv:"SYMS"
+                           ~doc:"Use this file as symbols source") in
+  Config.when_ready (fun {Config.get=(!)} ->
+      match !symsfile with
+      | Some file -> register file
+      | None -> () )

--- a/plugins/trace/trace_main.ml
+++ b/plugins/trace/trace_main.ml
@@ -83,8 +83,8 @@ module Cmdline = struct
       err_formatter fmt
 
   let () =
-    Future.upon Plugins.loaded (fun () ->
-        Config.when_ready (fun {Config.get=(!)} ->
+    Config.when_ready (fun {Config.get=(!)} ->
+        Future.upon Plugins.loaded (fun () ->
             match main !dump !load with
             | Ok `Done -> ()
             | Ok `Exit -> exit 0

--- a/plugins/trace/trace_main.ml
+++ b/plugins/trace/trace_main.ml
@@ -83,20 +83,21 @@ module Cmdline = struct
       err_formatter fmt
 
   let () =
-    Config.when_ready (fun {Config.get=(!)} ->
-        match main !dump !load with
-        | Ok `Done -> ()
-        | Ok `Exit -> exit 0
-        | Error e -> match e with
-          | `Protocol_error err ->
-            exitf "Protocol error: %a" Error.pp err
-          | `System_error err ->
-            exitf "System error: %s" @@ Unix.error_message err
-          | `No_provider ->
-            exitf "No provider for the given URI"
-          | `Ambiguous_uri ->
-            exitf "More than one provider for a given URI"
-          | exception Incompatibe_args ->
-            exitf "Incompatible arguments, see usage SYNOPSIS" )
+    Future.upon Plugins.loaded (fun () ->
+        Config.when_ready (fun {Config.get=(!)} ->
+            match main !dump !load with
+            | Ok `Done -> ()
+            | Ok `Exit -> exit 0
+            | Error e -> match e with
+              | `Protocol_error err ->
+                exitf "Protocol error: %a" Error.pp err
+              | `System_error err ->
+                exitf "System error: %s" @@ Unix.error_message err
+              | `No_provider ->
+                exitf "No provider for the given URI"
+              | `Ambiguous_uri ->
+                exitf "More than one provider for a given URI"
+              | exception Incompatibe_args ->
+                exitf "Incompatible arguments, see usage SYNOPSIS" ))
 
 end

--- a/plugins/trace/trace_main.ml
+++ b/plugins/trace/trace_main.ml
@@ -45,7 +45,21 @@ let main dump_uri loads =
   | None,loads -> load loads
 
 module Cmdline = struct
-  open Cmdliner
+  let man = [
+    `S "SYNOPSIS";
+    `Pre "
+        $(b,bap) --$(b,$mname-dump)=$(i,URI)
+        $(b,bap) $(i,BINARY) --$(b,$mname-load)=$(i,URI)...
+       ";
+    `S "DESCRIPTION";
+    `P "Loads and prints traces. The plugin can be used in two
+       modes. When called as $(b,--$mname-dump) it will just dump the
+       specified trace and exit. In the second mode, it will load
+       specified traces, so that they can be used by
+       analysis. The loaded traces must be runs of the analyzed
+       $(i,BINARY). The loaded traces are accessible via the
+       $(b,Traces) of the traces library."
+  ]
 
   let uri_of_string str =
     let uri = Uri.of_string str in
@@ -55,55 +69,34 @@ module Cmdline = struct
 
   let uri = (fun s -> `Ok (uri_of_string s)), Uri.pp_hum
 
-  let dump : Uri.t option Term.t =
+  let dump : Uri.t option Config.param =
     let doc = "Dump a trace specified by $(docv)" in
-    Arg.(value & opt (some uri) None & info ["dump"] ~doc ~docv:"URI")
+    Config.(param (some uri) "dump" ~default:None ~docv:"URI" ~doc)
 
-  let load : Uri.t list Term.t =
+  let load : Uri.t list Config.param =
     let doc = "Load trace from the specified $(docv). The option maybe
     used many times to load several traces" in
-    Arg.(value & opt_all uri [] & info ["load"] ~doc ~docv:"URI")
-
-  let cmd =
-    let man = [
-      `S "SYNOPSIS";
-      `Pre "
-        $(b,bap) --$(b,$mname-dump)=$(i,URI)
-        $(b,bap) $(i,BINARY) --$(b,$mname-load)=$(i,URI)...
-       ";
-      `S "DESCRIPTION";
-      `P "Loads and prints traces. The plugin can be used in two
-       modes. When called as $(b,--$mname-dump) it will just dump the
-       specified trace and exit. In the second mode, it will load
-       specified traces, so that they can be used by
-       analysis. The loaded traces must be runs of the analyzed
-       $(i,BINARY). The loaded traces are accessible via the
-       $(b,Traces) of the traces library."
-    ] in
-    Term.(pure main $dump $load),
-    Term.info name ~doc ~man ~version:Config.version
+    Config.(param_all uri "load" ~docv:"URI" ~doc)
 
   let exitf fmt =
     kfprintf (fun ppf -> pp_print_newline ppf (); exit 1)
       err_formatter fmt
 
-  let run () =
-    match Term.eval ~catch:false ~argv cmd with
-    | `Error _ -> exit 1
-    | `Version | `Help -> exit 0
-    | `Ok (Ok `Done) -> ()
-    | `Ok (Ok `Exit) -> exit 0
-    | `Ok (Error e) -> match e with
-      | `Protocol_error err ->
-        exitf "Protocol error: %a" Error.pp err
-      | `System_error err ->
-        exitf "System error: %s" @@ Unix.error_message err
-      | `No_provider ->
-        exitf "No provider for the given URI"
-      | `Ambiguous_uri ->
-        exitf "More than one provider for a given URI"
-      | exception Incompatibe_args ->
-        exitf "Incompatible arguments, see usage SYNOPSIS"
+  let () =
+    Config.when_ready (fun {Config.get=(!)} ->
+        match main !dump !load with
+        | Ok `Done -> ()
+        | Ok `Exit -> exit 0
+        | Error e -> match e with
+          | `Protocol_error err ->
+            exitf "Protocol error: %a" Error.pp err
+          | `System_error err ->
+            exitf "System error: %s" @@ Unix.error_message err
+          | `No_provider ->
+            exitf "No provider for the given URI"
+          | `Ambiguous_uri ->
+            exitf "More than one provider for a given URI"
+          | exception Incompatibe_args ->
+            exitf "Incompatible arguments, see usage SYNOPSIS" )
 
-  let () = Future.upon Plugins.loaded run
 end

--- a/plugins/warn_unused/warn_unused_main.ml
+++ b/plugins/warn_unused/warn_unused_main.ml
@@ -119,7 +119,6 @@ module Cmdline = struct
   ]
 
   let passes = [name; "--taint"; "--mark"; "--print"]
-  let not_a_pass s = not (List.mem passes s)
 
   let pass name =
     let doc = sprintf "run $mname-%s pass" name in
@@ -132,12 +131,8 @@ module Cmdline = struct
   let passes {Config.get=(!)} = ignore !taint_p, !print_p, !mark_p
 
   let () =
-    let check_passes () = match Array.find argv ~f:not_a_pass with
-      | None -> ()
-      | Some pass -> eprintf "Unknown pass: %s" pass; exit 1 in
     Config.manpage man;
     Config.when_ready (fun {Config.get=(!)} ->
-        check_passes ();
         Project.register_pass ~deps:["callsites"] ~name:"taint" taint;
         Project.register_pass' ~name:"print" (run print);
         Project.register_pass  ~name:"mark" (run mark);

--- a/plugins/warn_unused/warn_unused_main.ml
+++ b/plugins/warn_unused/warn_unused_main.ml
@@ -129,8 +129,7 @@ module Cmdline = struct
   let print_p = pass "print"
   let mark_p  = pass "mark"
 
-  let ignore_args _ _ _ = ()
-  let passes {Config.get=(!)} = ignore_args !taint_p !print_p !mark_p
+  let passes {Config.get=(!)} = ignore !taint_p, !print_p, !mark_p
 
   let () =
     let check_passes () = match Array.find argv ~f:not_a_pass with


### PR DESCRIPTION
This PR does the following
+ Updates multiple plugins to use the `Config` interface
    + `cache`
    + `callsites`
    + `dump_symbols`
    + `emit_ida_script`
    + `ida`
    + `objdump`
    + `propagate_taint`
    + `read_symbols`
    + `taint`
    + `trace`
    + `warn_unused`
+ Updates the `Config` interface to
    + Allow `param_all` for taking lists through repetition at command line
    + Adds the standard `some` converter
    + Makes `name` a non named-argument in `param`, `flag` to prevent dangling optional argument problem
+ Update `Config` implementation to
    + Account for above changes
    + Ensure that the filtered arguments are passed to a plugin (Note: In future PRs, as we slowly combine information from different plugin config, we will instead be calling `Term.eval` only once globally, rather than once every plugin.)