### PR TITLE
Moved the logger into the library.

### DIFF
--- a/lib/bap/bap.ml
+++ b/lib/bap/bap.ml
@@ -9,6 +9,7 @@ module Std = struct
   module Event = Bap_event
   module Project = Bap_project
   module Self = Bap_self.Create
+  module Log = Bap_log
   type project = Project.t
   type event = Event.t = ..
 end

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -6871,4 +6871,11 @@ module Std : sig
     val restore_state : t -> unit
     (**/**)
   end
+
+  module Log : sig
+
+    (** Start logging events. Only events of type [Event.Log] are
+        logged.  *)
+    val start : unit -> unit
+  end
 end

--- a/lib/bap/bap_log.mli
+++ b/lib/bap/bap_log.mli
@@ -1,0 +1,1 @@
+val start : unit -> unit

--- a/oasis/bap-std
+++ b/oasis/bap-std
@@ -17,7 +17,7 @@ Library bap
                    bap-future,
                    cmdliner
   Modules:         Bap
-  InternalModules: Bap_event, Bap_project, Bap_self
+  InternalModules: Bap_event, Bap_log, Bap_project, Bap_self
 
 
 Library types

--- a/src/bap_main.ml
+++ b/src/bap_main.ml
@@ -241,7 +241,7 @@ let () =
     try if Sys.getenv "BAP_DEBUG" <> "0" then
         Printexc.record_backtrace true
     with Not_found -> () in
-  Bap_log.start ();
+  Log.start ();
   at_exit (pp_print_flush err_formatter);
   let argv,passes = run_loader () in
   try main (parse passes argv); exit 0 with

--- a/src/bap_mc.ml
+++ b/src/bap_mc.ml
@@ -280,6 +280,7 @@ let start options =
   Program.main ()
 
 let _main : unit =
+  Log.start ();
   let argv = Bap_plugin_loader.run Sys.argv in
   try match Cmdline.parse argv >>= start with
     | Ok _ -> exit 0


### PR DESCRIPTION
Otherwise a standalone program, that lives out of the source tree, will
not have an access to logging and will require a user to re-implement
it.

In order to enable logging in a standalone program use `Log.start`
function.