### PR TITLE
Allow a frontend to link with internal libraries.

### DIFF
--- a/lib/bap_plugins/bap_plugins.ml
+++ b/lib/bap_plugins/bap_plugins.ml
@@ -47,7 +47,11 @@ module Plugin = struct
           let key = Findlib.package_property preds pkg "archive" |>
                     Filename.chop_extension in
           Hashtbl.set units ~key ~data:`In_core
-        with exn -> ())
+        with exn -> ());
+    Findlib.recorded_predicates () |> List.iter ~f:(fun pred ->
+        match String.chop_prefix pred ~prefix:"used_" with
+        | None -> ()
+        | Some lib -> Hashtbl.set units ~key:lib ~data:`In_core)
   end
 
   let of_path path =

--- a/myocamlbuild.ml.in
+++ b/myocamlbuild.ml.in
@@ -54,7 +54,10 @@ let pr_6184_hack = function
   | After_rules ->
     (* Pass -predicates to ocamldep *)
     pflag ["ocaml"; "ocamldep"] "predicate" (fun s -> S [A "-predicates"; A s]);
-
+    package_default.MyOCamlbuildBase.lib_ocaml |>
+    List.iter (fun (lib,_,_) ->
+        flag ["ocaml"; "link"; "use_"^lib]
+          (S [A "-predicates"; A ("used_"^lib)]));
   | _ -> ()
 
 

--- a/oasis/byteweight
+++ b/oasis/byteweight
@@ -2,7 +2,7 @@ Flag byteweight
   Description: Build byteweight library
   Default: false
 
-Library byteweight
+Library bap_byteweight
   Path:            lib/bap_byteweight
   FindLibName:     bap-byteweight
   Build$:          flag(everything) || flag(byteweight)

--- a/oasis/byteweight-frontend
+++ b/oasis/byteweight-frontend
@@ -5,9 +5,9 @@ Flag byteweight_frontend
 
 Executable "bap-byteweight"
   Path:           src
-  MainIs:         byteweight_main.ml
+  MainIs:         bap_byteweight_main.ml
   Build$:         flag(everything) || flag(byteweight_frontend)
   Install:        true
   CompiledObject: best
   BuildDepends:   bap, bap-byteweight,
-                  cmdliner, curl, fileutils, re.posix
+                  cmdliner, curl, fileutils, re.posix, findlib.dynload

--- a/oasis/frontend
+++ b/oasis/frontend
@@ -2,22 +2,6 @@ Flag frontend
   Description: Build BAP frontend
   Default: false
 
-# !!!! READ THE FOLLOWING NOTE !!!
-# Frontends that are capable of loading plugins, aka hosts
-# programs, can only depend on the two internal libraries:
-# bap and bap.plugins. They may, however, depend on an arbitrary
-# amount of findlib libraries.
-# The internal library is a library declared with the Library section
-# in the _oasis file.
-# Clarification. We use `findlib.dynload` to track libraries, with which
-# a binary is linked. Unfortunately, internal libraries bypass this mechanism
-# so if some plugin will try to load the same internal library, then it
-# will be loaded as dependency, that will lead to a corruption and
-# hopefully to a segfault.
-# If your frontend needs some internal library, then consider moving
-# the functionality that needs this into a plugin, as frontends are intended
-# only for parsing command-line arguments and dispatching them to bap.
-
 Executable "bap"
   Path:           src
   MainIs:         bap_main.ml

--- a/opam/opam
+++ b/opam/opam
@@ -72,7 +72,7 @@ install: [
   ["ocamlfind" "remove" "bap-api"]
   ["ocamlfind" "remove" "bap-bml"]
   [make "reinstall"]
-  ["bap-byteweight" "update"]
+  ["bap-byteweight" "update" "--url=https://github.com/BinaryAnalysisPlatform/bap/releases/download/v0.9.9/sigs.zip"]
   [make "test"]
 ]
 

--- a/src/bap_byteweight_main.ml
+++ b/src/bap_byteweight_main.ml
@@ -303,8 +303,12 @@ module Cmdline = struct
 end
 
 let () =
-  match Cmdline.eval Sys.argv with
+  Log.start ();
+  let args = Bap_plugin_loader.run Sys.argv in
+  match Cmdline.eval args with
   | `Ok Ok () -> ()
-  | `Ok Error err -> eprintf "Program failed: %s\n"
-                       Error.(to_string_hum err)
+  | `Ok Error err ->
+    eprintf "Program failed: %s\n%!"
+      Error.(to_string_hum err);
+    exit 2
   | _ -> exit 1

--- a/src/bap_plugin_loader.ml
+++ b/src/bap_plugin_loader.ml
@@ -117,14 +117,3 @@ let run_and_get_passes argv =
   Array.(to_list @@ filter_map argv ~f:to_pass)
 
 let run argv = fst (run_and_get_passes argv)
-
-
-let () = Stream.observe Plugins.events (function
-    | `Loaded p ->
-      info "Loaded %s from %S" (Plugin.name p) (Plugin.path p)
-    | `Loading p ->
-      debug "Loading %s from %S" (Plugin.name p) (Plugin.path p)
-    | `Opening p -> debug "Opening bundle %s" p
-    | `Errored (path,err) ->
-      error "Failed to load plugin %S: %a" path Error.pp err
-    | `Linking lib -> debug "Linking library %s" lib)


### PR DESCRIPTION
Previously it was disallowed, see the big fat warning in the
`oasis/fronted` (removed by this PR).

This PR will now track both internal and external libraries. We leverage
the predicate mechanism of ocamlfind, and for each internal library
`LIB` thatis linked with a host program, we record a predicated
`used_LIB`. Later, we can extract the names of linked libraries and
record them in the registry of linked libraries.

This PR also revives the byteweight frontend, that was broken due to a
dependency on the internal library byteweight (the problem manifested
itself only if it was installed from the source tree, it worked ok from
the opam-repository).