### PR TITLE
Change the evaluation context of plugins events

### DIFF
--- a/lib/bap_plugins/bap_plugins.ml
+++ b/lib/bap_plugins/bap_plugins.ml
@@ -151,10 +151,10 @@ module Plugin = struct
       set_main_bundle (bundle plugin);
       load_entries plugin reqs >>= fun () ->
       load_entry ~don't_register:true plugin main >>| fun () ->
-      let reason = `Provided_by plugin.name in
-      set_main_bundle old_bundle;
       Promise.fulfill plugin.finish ();
       notify (`Loaded plugin);
+      set_main_bundle old_bundle;
+      let reason = `Provided_by plugin.name in
       List.iter mains ~f:(fun unit ->
           Hashtbl.set units ~key:unit ~data:reason)
 


### PR DESCRIPTION
So far the evaluation context was switched just after the plugin loaded
to the context of the host program, and only afterwards the events were
fired. As a result, the `Config.when_ready` evaluated its argument
function under the context of the host program, so the `register_pass`
function was registering passes with the name `bap` instead of the name
of a plugin.

This PR will fix this particular issue, and the callback will be
evaluated at the correct context. But, the issue will fire up again,
when we will switch to the one grammar/one parsing scheme. So we should
think a little bit more about how we can ensure, that events are called
under the proper context.