### PR TITLE
union all rooters if no one is preferred by a user

### DIFF
--- a/src/bap_cmdline_terms.ml
+++ b/src/bap_cmdline_terms.ml
@@ -44,8 +44,10 @@ let rooters () : string list Term.t =
   | names ->
     let doc = sprintf "Use a rooter with a given $(docv) . If an
     option is specified several times, then rooters are
-    merged. Possible values: %s." @@ Arg.doc_alts_enum names in
-    Arg.(value & opt_all (enum names) ["internal"] &
+    merged. If not specified, then all available rooters will be
+    merged together. Possible values: %s." @@ Arg.doc_alts_enum names in
+    let default = List.map names ~f:fst in
+    Arg.(value & opt_all (enum names) default &
          info ["rooter"] ~doc ~docv:"NAME")
 
 let reconstructor () : string option Term.t =


### PR DESCRIPTION
We've tried several default values for the rooter:

1. internal
2. the first one
3. nothing

The had their caveats:

1. internal doesn't work at all for stripped binaries, so it
   has a very negative user experience, basically bap doesn't
   work out of box on anything other than toy examples, compiled
   with -g.

2. the first one, is very non-deterministic, it can be `internal`,
   so we have the same set of problems as in `1`. It can be any
   other and the results are hard to predict.

3. nothing means bap will output nothing unless you specify a rooter,
   definitely not an option.

This PR introduces the new default, if no rooter is specified, then
that means, that a user doesn't have any particular preferences, so
we will use all available information, i.e., we will take all registered
rooters and merge them. It looks like this strategy allows us to
recover, more code, that just using one or another rooter, for example,
taking `/bin/ls` as an example, we have the following results:

```
  75121 bw+ida
  69205 bw
  41878 ida
```

where numbers on the left is the total amount of terms in a program. The
results say, that both rooters allow us to recover more information,
then each rooter alone, and that byteweight allows us to recover nearly
twice as more information, as IDA alone.

This PR still allows a user to be specific, about which rooter to use,
i.e., if an option `--rooter=A` then only rooter `A` will be used. To
specify several rooters, uses `--rooter=A --rooter=B` or a more
convenient `--rooter={A,B}`.