### PR TITLE
Few warning fixes etc

### DIFF
--- a/plugins/ida/bap_ida_service.ml
+++ b/plugins/ida/bap_ida_service.ml
@@ -150,5 +150,5 @@ let register ida_path is_headless : unit =
     let self = create config target in
     let exec cmd = exec self cmd in
     let close () = close self in
-    { exec; close } in
+    Service.{ exec; close } in
   Service.provide create

--- a/plugins/ida/bap_ida_service.ml
+++ b/plugins/ida/bap_ida_service.ml
@@ -1,8 +1,5 @@
-open Core_kernel.Std
-open Bap.Std
+open! Core_kernel.Std
 open Bap_ida.Std
-open Word_size
-open Result.Monad_infix
 
 type ida = {
   ida : string;

--- a/plugins/ida/bap_ida_service.ml
+++ b/plugins/ida/bap_ida_service.ml
@@ -12,12 +12,15 @@ type ida = {
   debug : int;
 } [@@deriving sexp]
 
-type config = {
-  ida : string;
-  curses : string option;
-  idb : string -> string;
-  debug : int;
-}
+module Config = struct
+  type t = {
+    ida : string;
+    curses : string option;
+    idb : string -> string;
+    debug : int;
+  }
+end
+type config = Config.t
 
 type 'a command = 'a Command.t
 
@@ -70,15 +73,11 @@ let run (t:ida) cmd =
   clean ();
   Sys.chdir cwd
 
-let create config target =
+let create {Config.ida; idb; debug; curses} target =
   if not (Sys.file_exists target)
   then invalid_argf "Can't find target executable" ();
   let exe = Filename.temp_file "bap_" "_ida" in
   FileUtil.cp [target] exe;
-  let ida = config.ida in
-  let curses = config.curses in
-  let idb = config.idb in
-  let debug = config.debug in
   let self = {
     ida;
     exe;
@@ -141,7 +140,7 @@ let register ida_path is_headless : unit =
   let debug =
     try Int.of_string (Sys.getenv "BAP_IDA_DEBUG") with exn -> 0 in
   let config = {
-    ida;
+    Config.ida;
     curses;
     idb;
     debug

--- a/plugins/ida/ida_main.ml
+++ b/plugins/ida/ida_main.ml
@@ -153,15 +153,15 @@ let checked ida_path is_headless =
     (Sys.is_directory ida_path) >>= fun () ->
   require "can't use headless on windows"
     (is_headless ==> not Sys.win32) >>= fun () ->
-  require "idaq exists"
+  require "idaq must exist"
     (Sys.file_exists (ida_path/"idaq")) >>= fun () ->
-  require "idaq64 exists"
+  require "idaq64 must exist"
     (Sys.file_exists (ida_path/"idaq64")) >>= fun () ->
-  require "idal exists"
+  require "idal must exist"
     (Sys.file_exists (ida_path/"idal")) >>= fun () ->
-  require "idal64 exists"
+  require "idal64 must exist"
     (Sys.file_exists (ida_path/"idal64")) >>= fun () ->
-  require "bap-ida-python installed"
+  require "bap-ida-python must be installed"
     (Sys.file_exists
        (ida_path/"plugins"/"plugin_loader_bap.py"))  >>| fun () ->
   ida_path


### PR DESCRIPTION
This PR does the following
+ Improves warning messages shown to user
+ Prevent warning messages related to the `Service` on compilation
+ Prevent possible name clashing of the `ida` and `config` records
+ Remove unnecessary `open`s (artifact of previous implementation)
+ Prevent warning due to `Core_kernel.Std` shadowing `&&`