### PR TITLE
Config defaults

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -527,6 +527,9 @@ module Std : sig
       access to permission information.  *)
 
 
+  (** Converts an 'a to a string *)
+  type 'a printer = Format.formatter -> 'a -> unit
+
 
   (** {1:api BAP API}  *)
 
@@ -617,9 +620,6 @@ module Std : sig
 
       (** Parse a string to an 'a *)
       type 'a parser = string -> [ `Ok of 'a | `Error of string ]
-
-      (** Converts an 'a to a string *)
-      type 'a printer = Format.formatter -> 'a -> unit
 
       (** Type for converting [string] <-> ['a]. Also defines a default
           value for the ['a] type. *)
@@ -776,8 +776,6 @@ module Std : sig
     end
 
   end
-
-  type 'a printer = Format.formatter -> 'a -> unit
 
   (** Signature for integral type.  *)
   module type Integer = sig

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -621,8 +621,11 @@ module Std : sig
       (** Converts an 'a to a string *)
       type 'a printer = Format.formatter -> 'a -> unit
 
-      (** Interconversion between string and 'a type, along with a default *)
-      type 'a converter = 'a parser * 'a printer * 'a
+      (** Type for converting [string] <-> ['a]. Also defines a default
+          value for the ['a] type. *)
+      type 'a converter
+
+      val converter : 'a parser -> 'a printer -> 'a -> 'a converter
 
       (** [param conv ~default ~docv ~doc name] creates a parameter
           which is referred to on the command line, environment

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -701,7 +701,7 @@ module Std : sig
       (** [string] converts values with the identity function. *)
       val string : string converter
 
-      (** [enum l p] converts values such that unambiguous prefixes of
+      (** [enum l] converts values such that unambiguous prefixes of
           string names in [l] map to the corresponding value of type ['a].
 
           {b Warning.} The type ['a] must be comparable with

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -621,12 +621,12 @@ module Std : sig
       (** Converts an 'a to a string *)
       type 'a printer = Format.formatter -> 'a -> unit
 
-      (** Interconversion between string and 'a type *)
-      type 'a converter = 'a parser * 'a printer
+      (** Interconversion between string and 'a type, along with a default *)
+      type 'a converter = 'a parser * 'a printer * 'a
 
       (** Create a parameter *)
       val param :
-        'a converter -> default:'a ->
+        'a converter -> ?default:'a ->
         ?docv:string -> ?doc:string -> string -> 'a param
 
       (** Create a parameter which accepts a list at command line by

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -624,7 +624,19 @@ module Std : sig
       (** Interconversion between string and 'a type, along with a default *)
       type 'a converter = 'a parser * 'a printer * 'a
 
-      (** Create a parameter *)
+      (** [param conv ~default ~docv ~doc name] creates a parameter
+          which is referred to on the command line, environment
+          variable, and config file using the value of [name], with
+          the type defined by [conv], using the [default] value if
+          unspecified by user.
+
+          The [default] is optional, and falls back to the
+          default defined by [conv].
+
+          [doc] is the man page information of the argument. The
+          variable ["$(docv)"] can be used to refer to the value of
+          [docv]. [docv] is a variable name used in the man page to
+          stand for their value. *)
       val param :
         'a converter -> ?default:'a ->
         ?docv:string -> ?doc:string -> string -> 'a param

--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -200,8 +200,6 @@ module Create() = struct
     let converter : 'a Arg.converter -> 'a -> 'a converter =
       fun (parser, printer) default -> parser, printer, default
 
-    let unspecified_default = invalid_arg "default unspecified"
-
     let bool = converter Arg.bool false
     let char = converter Arg.char '\x00'
     let int = converter Arg.int 0
@@ -210,10 +208,12 @@ module Create() = struct
     let int64 = converter Arg.int64 Int64.zero
     let float = converter Arg.float 0.
     let string = converter Arg.string ""
-    let enum x = converter (Arg.enum x) unspecified_default
-    let file = converter Arg.file unspecified_default
-    let dir = converter Arg.dir unspecified_default
-    let non_dir_file = converter Arg.non_dir_file unspecified_default
+    let enum x =
+      let _, default = List.hd_exn x in
+      converter (Arg.enum x) default
+    let file = converter Arg.file ""
+    let dir = converter Arg.dir ""
+    let non_dir_file = converter Arg.non_dir_file ""
     let list ?sep x = converter (Arg.list ?sep (get_conv x)) []
     let array ?sep x = converter (Arg.array ?sep (get_conv x)) (Array.empty ())
     let pair ?sep x y =

--- a/lib/bap/bap_self.mli
+++ b/lib/bap/bap_self.mli
@@ -23,10 +23,10 @@ module Create() : sig
 
     type 'a parser = string -> [ `Ok of 'a | `Error of string ]
     type 'a printer = Format.formatter -> 'a -> unit
-    type 'a converter = 'a parser * 'a printer
+    type 'a converter = 'a parser * 'a printer * 'a
 
     val param :
-      'a converter -> default:'a ->
+      'a converter -> ?default:'a ->
       ?docv:string -> ?doc:string -> string -> 'a param
 
     val param_all :

--- a/lib/bap/bap_self.mli
+++ b/lib/bap/bap_self.mli
@@ -23,7 +23,9 @@ module Create() : sig
 
     type 'a parser = string -> [ `Ok of 'a | `Error of string ]
     type 'a printer = Format.formatter -> 'a -> unit
-    type 'a converter = 'a parser * 'a printer * 'a
+    type 'a converter
+
+    val converter : 'a parser -> 'a printer -> 'a -> 'a converter
 
     val param :
       'a converter -> ?default:'a ->

--- a/plugins/cache/cache_main.ml
+++ b/plugins/cache/cache_main.ml
@@ -188,11 +188,11 @@ let () =
       `P "Provide caching service for all data types."
     ] in
   let clean = Config.(flag "clean" ~doc:"Cleanup all caches") in
-  let set_size = Config.(param (some int64) "size" ~default:None ~docv:"N"
+  let set_size = Config.(param (some int64) "size" ~docv:"N"
                            ~doc:"Set maximum total size of cached data to
                                  $(docv) MB. The option value will persist
                                  between different runs of the program") in
-  let dir = Config.(param (some string) "dir" ~default:None ~docv:"DIR"
+  let dir = Config.(param (some string) "dir" ~docv:"DIR"
                       ~doc:"Use $(docv) as a cache directory") in
   let print_info = Config.(flag "info" ~doc:"Print information about the
                                              cache and exit") in

--- a/plugins/dump_symbols/dump_symbols_main.ml
+++ b/plugins/dump_symbols/dump_symbols_main.ml
@@ -31,7 +31,7 @@ let () =
           `(<symbol name> <symbol start address> <symbol end address>)', e.g.,
           `(malloc 0x11034 0x11038)'"
     ] in
-  let file = Config.(param (some string) "file" ~default:None ~docv:"FILE"
+  let file = Config.(param (some string) "file" ~docv:"FILE"
                        ~doc:"Dump symbols to the specified $(docv)") in
   Config.when_ready (fun {Config.get=(!)} ->
       let main = main !file in

--- a/plugins/emit_ida_script/emit_ida_script_main.ml
+++ b/plugins/emit_ida_script/emit_ida_script_main.ml
@@ -127,7 +127,7 @@ let () =
       loaded into IDA. The special `color' tag causes the
       respective address to be colored."
     ] in
-  let dst = Config.(param (some string) "file" ~default:None ~docv:"NAME"
+  let dst = Config.(param (some string) "file" ~docv:"NAME"
                       ~doc:"Dump annotations to the specified file $(docv). If
                             not specified, then the script will dumped into the
                             standard output") in

--- a/plugins/propagate_taint/propagate_taint_main.ml
+++ b/plugins/propagate_taint/propagate_taint_main.ml
@@ -251,7 +251,7 @@ module Cmdline = struct
                            ~default:10 ~docv:"N"
                            ~doc:"Limit loop to $(docv) iterations")
 
-  let interesting = Config.(param (list string) "interesting" ~default:[]
+  let interesting = Config.(param (list string) "interesting"
                               ~doc:"Look only at specified functions")
 
   let deterministic = Config.(flag "deterministic"
@@ -299,7 +299,7 @@ module Cmdline = struct
   let random_seed : int option Config.param =
     let doc =
       "Initialize random number generator with the given seed" in
-    Config.(param (some int) "random-seed" ~default:None ~doc)
+    Config.(param (some int) "random-seed" ~doc)
 
   let create
       max_trace max_loop deterministic

--- a/plugins/propagate_taint/propagate_taint_main.ml
+++ b/plugins/propagate_taint/propagate_taint_main.ml
@@ -283,8 +283,8 @@ module Cmdline = struct
       | `Fixed n -> fprintf ppf "%Ld" n
       | `Interval (n,m) -> fprintf ppf "(%Ld %Ld)" n m
 
-    let t : t Config.converter =
-      parser,printer,invalid_arg "Unspecified default"
+    let t default : t Config.converter =
+      parser,printer,default
   end
 
   let policy key name default : policy Config.param =
@@ -294,7 +294,7 @@ module Cmdline = struct
       be randomly picked from this interval (boundaries including).
       If set to `random', then values will be picked randomly from a
       domain, defined by a type of value." name in
-    Config.(param Policy.t (sprintf "%s-value" key) ~default ~doc)
+    Config.(param (Policy.t default) (sprintf "%s-value" key) ~doc)
 
   let random_seed : int option Config.param =
     let doc =

--- a/plugins/propagate_taint/propagate_taint_main.ml
+++ b/plugins/propagate_taint/propagate_taint_main.ml
@@ -283,7 +283,8 @@ module Cmdline = struct
       | `Fixed n -> fprintf ppf "%Ld" n
       | `Interval (n,m) -> fprintf ppf "(%Ld %Ld)" n m
 
-    let t : t Config.converter = parser,printer
+    let t : t Config.converter =
+      parser,printer,invalid_arg "Unspecified default"
   end
 
   let policy key name default : policy Config.param =

--- a/plugins/propagate_taint/propagate_taint_main.ml
+++ b/plugins/propagate_taint/propagate_taint_main.ml
@@ -284,7 +284,7 @@ module Cmdline = struct
       | `Interval (n,m) -> fprintf ppf "(%Ld %Ld)" n m
 
     let t default : t Config.converter =
-      parser,printer,default
+      Config.converter parser printer default
   end
 
   let policy key name default : policy Config.param =

--- a/plugins/read_symbols/read_symbols_main.ml
+++ b/plugins/read_symbols/read_symbols_main.ml
@@ -40,8 +40,7 @@ let () =
       `P "Read symbol information from a file and provide rooter,
     symbolizer and a reconstructor, based on this information."
     ] in
-  let symsfile = Config.(param (some non_dir_file) "from"
-                           ~default:None ~docv:"SYMS"
+  let symsfile = Config.(param (some non_dir_file) "from" ~docv:"SYMS"
                            ~doc:"Use this file as symbols source") in
   Config.when_ready (fun {Config.get=(!)} ->
       match !symsfile with

--- a/plugins/taint/taint_main.ml
+++ b/plugins/taint/taint_main.ml
@@ -68,7 +68,7 @@ module Strain = struct
     String.concat ~sep:" " |>
     Format.fprintf ppf "(%s)"
 
-  let t = parser,pp
+  let t = parser,pp,invalid_arg "Undefined default"
 end
 
 

--- a/plugins/taint/taint_main.ml
+++ b/plugins/taint/taint_main.ml
@@ -68,7 +68,7 @@ module Strain = struct
     String.concat ~sep:" " |>
     Format.fprintf ppf "(%s)"
 
-  let t = parser,pp,invalid_arg "Undefined default"
+  let t = parser,pp,[]
 end
 
 

--- a/plugins/taint/taint_main.ml
+++ b/plugins/taint/taint_main.ml
@@ -68,7 +68,7 @@ module Strain = struct
     String.concat ~sep:" " |>
     Format.fprintf ppf "(%s)"
 
-  let t = parser,pp,[]
+  let t = Config.converter parser pp []
 end
 
 

--- a/plugins/trace/trace_main.ml
+++ b/plugins/trace/trace_main.ml
@@ -67,7 +67,8 @@ module Cmdline = struct
     | None -> Uri.with_scheme uri (Some "file")
     | Some _ -> uri
 
-  let uri = (fun s -> `Ok (uri_of_string s)), Uri.pp_hum
+  let uri = (fun s -> `Ok (uri_of_string s)), Uri.pp_hum,
+            invalid_arg "Unspecified default"
 
   let dump : Uri.t option Config.param =
     let doc = "Dump a trace specified by $(docv)" in

--- a/plugins/trace/trace_main.ml
+++ b/plugins/trace/trace_main.ml
@@ -67,7 +67,8 @@ module Cmdline = struct
     | None -> Uri.with_scheme uri (Some "file")
     | Some _ -> uri
 
-  let uri = (fun s -> `Ok (uri_of_string s)), Uri.pp_hum, Uri.empty
+  let uri =
+    Config.converter (fun s -> `Ok (uri_of_string s)) Uri.pp_hum Uri.empty
 
   let dump : Uri.t option Config.param =
     let doc = "Dump a trace specified by $(docv)" in

--- a/plugins/trace/trace_main.ml
+++ b/plugins/trace/trace_main.ml
@@ -72,7 +72,7 @@ module Cmdline = struct
 
   let dump : Uri.t option Config.param =
     let doc = "Dump a trace specified by $(docv)" in
-    Config.(param (some uri) "dump" ~default:None ~docv:"URI" ~doc)
+    Config.(param (some uri) "dump" ~docv:"URI" ~doc)
 
   let load : Uri.t list Config.param =
     let doc = "Load trace from the specified $(docv). The option maybe

--- a/plugins/trace/trace_main.ml
+++ b/plugins/trace/trace_main.ml
@@ -67,8 +67,7 @@ module Cmdline = struct
     | None -> Uri.with_scheme uri (Some "file")
     | Some _ -> uri
 
-  let uri = (fun s -> `Ok (uri_of_string s)), Uri.pp_hum,
-            invalid_arg "Unspecified default"
+  let uri = (fun s -> `Ok (uri_of_string s)), Uri.pp_hum, Uri.empty
 
   let dump : Uri.t option Config.param =
     let doc = "Dump a trace specified by $(docv)" in


### PR DESCRIPTION
Make the defaults a bit more easier to use. Now, defaults are optional for most converters (which actually hold the defaults now).

For example, one can just say `Config.(param string "x")` instead of the older `Config.(param string "x" ~default:"")`

Fixed up issues that might have come up in #493 