### PR TITLE
Add doc_enum

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -725,6 +725,13 @@ module Std : sig
           @raise Invalid_argument if [l] is empty. *)
       val enum : (string * 'a) list -> 'a converter
 
+      (** [doc_enum l] documents the possible string names in the [l]
+          map according to the number of alternatives. If [quoted] is
+          [true] (default), the tokens are quoted. The resulting
+          string can be used in sentences of the form ["$(docv) must
+          be %s"]. *)
+      val doc_enum : ?quoted:bool -> (string * 'a) list -> string
+
       (** [file] converts a value with the identity function and
           checks with {!Sys.file_exists} that a file with that name exists. *)
       val file : string converter

--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -204,6 +204,8 @@ module Create() = struct
             Stream.unsubscribe Plugins.events subscription
           | _ -> () )
 
+    let doc_enum = Arg.doc_alts_enum
+
     let of_arg : 'a Arg.converter -> 'a -> 'a converter =
       fun (parser, printer) default -> converter parser printer default
 

--- a/lib/bap/bap_self.mli
+++ b/lib/bap/bap_self.mli
@@ -62,6 +62,7 @@ module Create() : sig
     val float : float converter
     val string : string converter
     val enum : (string * 'a) list -> 'a converter
+    val doc_enum : ?quoted:bool -> (string * 'a) list -> string
     val file : string converter
     val dir : string converter
     val non_dir_file : string converter


### PR DESCRIPTION
This PR introduces the `Config.doc_enum` function that will make it easier to write documentation for plugins that use enums.

Sample usage:
```
# Config.doc_enum;;
- : ?quoted:bool -> (string * 'a) list -> string = <fun>
# Config.doc_enum ["a", 1; "b", 2;];;
- : string = either `a' or `b'
# Config.doc_enum ["a", 1];;
- : string = `a'
# Config.doc_enum ["a", 1; "b", 2; "c", 3];;
- : string = one of `a', `b' or `c'
```