### PR TITLE
remove symbols option from the frontend

### DIFF
--- a/src/bap_main.ml
+++ b/src/bap_main.ml
@@ -124,11 +124,6 @@ let main o =
       Project.restore_state proj;
       proj
     | None ->
-      let o = {
-        o with
-        symbolizers = o.symbols @ o.symbolizers;
-        rooters = o.symbols @ o.rooters;
-      } in
       let rooter = rooter o
       and brancher = brancher o
       and reconstructor = reconstructor o
@@ -200,8 +195,8 @@ let program_info =
   Term.info "bap" ~version:Config.version ~doc ~man
 let program source =
   let create
-      a b c d e f g i j k l = Bap_options.Fields.create
-      a b c d e f g i j k l [] in
+      a b c d e f g i j k = Bap_options.Fields.create
+      a b c d e f g i j k [] in
   let open Bap_cmdline_terms in
   Term.(const create
         $filename
@@ -213,7 +208,6 @@ let program source =
         $(brancher ())
         $(symbolizers ())
         $(rooters ())
-        $(symbols ())
         $(reconstructor ())),
   program_info
 

--- a/src/bap_options.ml
+++ b/src/bap_options.ml
@@ -14,7 +14,6 @@ type t = {
   brancher        : string option;
   symbolizers     : string list;
   rooters         : string list;
-  symbols         : string list;
   reconstructor   : string option;
   passes          : string list;
 } [@@deriving sexp, fields]


### PR DESCRIPTION
There're several reasons:

1. symbolizer and rooter are orthogonal
2. there is no practical reason to restrict rooter, so the default
   behavior is to say `--symbolizer=ida` without concertizing rooters,
   i.e., to use all available information.
3. with symbols option it is not possible to implement the all default
   option for the rooter, so it will fix #496.
4. the option is fragile and was broken most of its lifetime, mostly
   because it breaks the SPOT rule.