### PR TITLE
Allow disabling certain plugins/features when enabling everything

### DIFF
--- a/configure
+++ b/configure
@@ -32,13 +32,15 @@ SETUPS=`ocaml tools/collect.ml setup.ml $SECTIONS`
 AB=`ocaml tools/collect.ml files.ab $SECTIONS`
 
 # Correct for "--disable" type of arguments
-ARGS=`ocaml tools/oasis_sections.ml --args "$@"`
-set --
-while read -r arg; do
-    set -- "$@" "$arg"
-done <<EOF
+if ! $FST; then
+    ARGS=`ocaml tools/oasis_sections.ml --args "$@"`
+    set --
+    while read -r arg; do
+        set -- "$@" "$arg"
+    done <<EOF
     $ARGS
 EOF
+fi
 
 ocaml tools/cat.ml '"\n# $name\n"' -- $SECTIONS $AB _oasis
 ocaml tools/cat.ml '"\n# $name\n"' -- $TAGS _tags.in _tags

--- a/configure
+++ b/configure
@@ -25,11 +25,18 @@ for i in "$@"; do
   esac
 done
 
-SECTIONS=`ocaml tools/oasis_sections.ml $@`
+SECTIONS=`ocaml tools/oasis_sections.ml --sections $@`
 TAGS=`ocaml tools/collect.ml tags $SECTIONS`
 PLUGINS=`ocaml tools/collect.ml ocamlbuild.ml $SECTIONS`
 SETUPS=`ocaml tools/collect.ml setup.ml $SECTIONS`
 AB=`ocaml tools/collect.ml files.ab $SECTIONS`
+
+# Correct for "--disable" type of arguments
+ARGS=`ocaml tools/oasis_sections.ml --args "$@"`
+set --
+while read -r arg; do
+    set -- "$@" "$arg"
+done <<< "$ARGS"
 
 ocaml tools/cat.ml '"\n# $name\n"' -- $SECTIONS $AB _oasis
 ocaml tools/cat.ml '"\n# $name\n"' -- $TAGS _tags.in _tags

--- a/configure
+++ b/configure
@@ -25,7 +25,7 @@ for i in "$@"; do
   esac
 done
 
-SECTIONS=`ocaml tools/oasis_sections.ml --sections $@`
+SECTIONS=`ocaml tools/oasis_sections.ml --sections "$@"`
 TAGS=`ocaml tools/collect.ml tags $SECTIONS`
 PLUGINS=`ocaml tools/collect.ml ocamlbuild.ml $SECTIONS`
 SETUPS=`ocaml tools/collect.ml setup.ml $SECTIONS`
@@ -36,7 +36,9 @@ ARGS=`ocaml tools/oasis_sections.ml --args "$@"`
 set --
 while read -r arg; do
     set -- "$@" "$arg"
-done <<< "$ARGS"
+done <<EOF
+    $ARGS
+EOF
 
 ocaml tools/cat.ml '"\n# $name\n"' -- $SECTIONS $AB _oasis
 ocaml tools/cat.ml '"\n# $name\n"' -- $TAGS _tags.in _tags

--- a/opam/opam
+++ b/opam/opam
@@ -17,6 +17,7 @@ build: [
   "--%{conf-ida:enable}%-ida"
   "--ida-path=%{conf-ida:path}%" {conf-ida:installed}
   "--ida-headless=%{conf-ida:headless}%" {conf-ida:installed}
+  "--%{conf-ida:enable}%-fsi-benchmark"
   "--%{conf-binutils:enable}%-objdump"
   "--objdump-path=%{conf-binutils:objdump}%" {conf-binutils:installed}
   "--objdump-targets=%{conf-binutils:targets}%" {conf-binutils:installed}

--- a/tools/oasis_sections.ml
+++ b/tools/oasis_sections.ml
@@ -5,13 +5,11 @@ let header = "common"
 let has_extension name =
   String.contains name '.'
 
-let everything =
-  Sys.readdir "oasis" |> Array.to_list |>
-  List.filter (fun sec -> sec <> header && not (has_extension sec))
+let enabled = "--enable-"
+let disabled = "--disable-"
 
-let enable_feature arg =
+let feature enable arg =
   let length = String.length arg in
-  let enable = "--enable-" in
   let prefix = String.length enable in
   try
     if String.sub arg 0 prefix = enable
@@ -19,21 +17,44 @@ let enable_feature arg =
     else None
   with exn -> None
 
-let selected args =
+let everything_except disabled_args =
+  Sys.readdir "oasis" |> Array.to_list |>
+  List.filter (fun sec -> sec <> header && not (has_extension sec)
+                          && not (List.mem sec disabled_args) )
+
+let selected enable args =
   args |> List.fold_left (fun fs arg ->
-      match enable_feature arg with
+      match feature enable arg with
       | Some f when Sys.file_exists ("oasis" / f) -> f :: fs
       | _ -> fs) []
 
-
 let features args =
+  let disabled_args = selected disabled args in
   if List.(mem "--enable-everything" args || mem "--help" args)
-  then header :: everything
-  else header :: selected args
+  then header :: everything_except disabled_args
+  else header :: selected enabled args
+
+let filtered args =
+  let enabled_args = selected enabled args in
+  let disabled_args = selected disabled args in
+  List.(filter (fun arg -> not (mem arg (
+      map (fun f -> enabled^f) enabled_args @
+      map (fun f -> disabled^f) disabled_args))) args)
 
 let main args =
-  features args |>
-  List.map (fun s -> "oasis" / s) |>
-  String.concat " " |> print_endline
+  match args with
+  | _ :: h :: args when h = "--args" ->
+    let args =
+      if List.(mem "--enable-everything" args || mem "--help" args)
+      then filtered args
+      else args in
+    args |>
+    String.concat "\n" |> print_endline
+  | _ :: h :: args when h = "--sections" ->
+    features args |>
+    List.map (fun s -> "oasis" / s) |>
+    String.concat " " |> print_endline
+  | _ ->
+    assert false
 
 let () = main (Array.to_list Sys.argv)


### PR DESCRIPTION
This PR allows us to specifically disable certain plugins/features when we enable everything, for example, if we run `./configure --enable-everything --disable-ida`, then it will enable every plugin/feature except for `ida`

All of the issues that were there in the previous PR that tried to do this (i.e. #454) have been handled here. Expansions, quotes, empty strings, strings with spaces -- all are handled now.

### Tests

All of the following have passed (i.e. work as expected).

#### On personal machine

+ [x] Without parameters
```
./configure
```

+ [X] With lots of paramenters (including `opam config var conf-binutils:targets` which has spaces)
```
./configure --prefix=`opam config var prefix` --with-cxx=`which clang++` --mandir=`opam config var man` --enable-everything --enable-tests --enable-ida --ida-path=`opam config var conf-ida:path` --enable-objdump --objdump-path=`opam config var conf-binutils:objdump` --objdump-targets="`opam config var conf-binutils:targets`"
```

+ [X] Disabling some things (specifically, `objdump`)
```
./configure --prefix=`opam config var prefix` --with-cxx=`which clang++` --mandir=`opam config var man` --enable-everything --enable-tests --enable-ida --ida-path=`opam config var conf-ida:path` --disable-objdump
```

+ [X] Help!
```
./configure --help
```

+ [X] Passing weird parameters (to check if error checking works as expected)
```
./configure --trollol
```

+ [X] Passing weird parameters (to check if error checking works as expected)
```
./configure "--this is SPARTA"
```

#### On Travis CI

+ [X] Disabling `ida`, `fsi-benchmark`, `objdump`
```
./configure "--prefix=/home/travis/.opam/system" "--with-cxx=`which clang++`" "--mandir=/home/travis/.opam/system/man" "--enable-everything" "--enable-tests" "--disable-ida" "--disable-fsi-benchmark" "--disable-objdump"
```