### PR TITLE
Extending Config

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -650,23 +650,31 @@ module Std : sig
           usable as normal, but will emit a warning to the user if they
           try to use it.
           Example usage: [Config.(param ~deprecated int "--old")].
+
+          Additionally, [synonyms] can be added to allow multiple
+          arguments referring to the same parameters. However, this is
+          usually discouraged, and considered proper usage only in rare
+          scenarios.
       *)
       val param :
         'a converter -> ?deprecated:string -> ?default:'a ->
-        ?docv:string -> ?doc:string -> string -> 'a param
+        ?docv:string -> ?doc:string -> ?synonyms:string list ->
+        string -> 'a param
 
       (** Create a parameter which accepts a list at command line by
           repetition of argument. Similar to [param (list 'a) ...]
           in all other respects. Defaults to an empty list if unspecified. *)
       val param_all :
         'a converter -> ?deprecated:string -> ?default:'a list ->
-        ?docv:string -> ?doc:string -> string -> 'a list param
+        ?docv:string -> ?doc:string -> ?synonyms:string list ->
+        string -> 'a list param
 
       (** Create a boolean parameter that is set to true if user
           mentions it in the command line arguments *)
       val flag :
         ?deprecated:string ->
-        ?docv:string -> ?doc:string -> string -> bool param
+        ?docv:string -> ?doc:string -> ?synonyms:string list ->
+        string -> bool param
 
       (** Provides a future determined on when the config can be read *)
       val determined : 'a param -> 'a future

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -655,9 +655,27 @@ module Std : sig
           arguments referring to the same parameters. However, this is
           usually discouraged, and considered proper usage only in rare
           scenarios.
+
+          Also, a developer can use the [~as_flag] to specify a
+          default value that the argument takes if it is used like a
+          flag. This behaviour can be understood better through the
+          following example.
+
+              Consider [Config.(param (some int) ~as_flag:(Some 10) "x")].
+
+              This results in 3 possible command line invocations:
+
+              1. No [--x] - Results in [default] value (specifically
+                            here, [None]).
+
+              2. Only [--x] - This causes it to have the value [as_flag]
+                              (specifically here,[Some 10]).
+
+              3. [--x=20] - This causes it to have the value from the
+                            command line (specifically here, [Some 20]).
       *)
       val param :
-        'a converter -> ?deprecated:string -> ?default:'a ->
+        'a converter -> ?deprecated:string -> ?default:'a -> ?as_flag:'a ->
         ?docv:string -> ?doc:string -> ?synonyms:string list ->
         string -> 'a param
 
@@ -666,8 +684,8 @@ module Std : sig
           in all other respects. Defaults to an empty list if unspecified. *)
       val param_all :
         'a converter -> ?deprecated:string -> ?default:'a list ->
-        ?docv:string -> ?doc:string -> ?synonyms:string list ->
-        string -> 'a list param
+        ?as_flag:'a -> ?docv:string -> ?doc:string ->
+        ?synonyms:string list ->  string -> 'a list param
 
       (** Create a boolean parameter that is set to true if user
           mentions it in the command line arguments *)

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -627,6 +627,10 @@ module Std : sig
 
       val converter : 'a parser -> 'a printer -> 'a -> 'a converter
 
+      (** Default deprecation warning message, for easy deprecation of
+          parameters. *)
+      val deprecated : string
+
       (** [param conv ~default ~docv ~doc name] creates a parameter
           which is referred to on the command line, environment
           variable, and config file using the value of [name], with
@@ -639,21 +643,29 @@ module Std : sig
           [doc] is the man page information of the argument. The
           variable ["$(docv)"] can be used to refer to the value of
           [docv]. [docv] is a variable name used in the man page to
-          stand for their value. *)
+          stand for their value.
+
+          A user can optionally add [deprecated] to a parameter that
+          is to be deprecated soon. This will cause the parameter to be
+          usable as normal, but will emit a warning to the user if they
+          try to use it.
+          Example usage: [Config.(param ~deprecated int "--old")].
+      *)
       val param :
-        'a converter -> ?default:'a ->
+        'a converter -> ?deprecated:string -> ?default:'a ->
         ?docv:string -> ?doc:string -> string -> 'a param
 
       (** Create a parameter which accepts a list at command line by
           repetition of argument. Similar to [param (list 'a) ...]
           in all other respects. Defaults to an empty list if unspecified. *)
       val param_all :
-        'a converter -> ?default:'a list ->
+        'a converter -> ?deprecated:string -> ?default:'a list ->
         ?docv:string -> ?doc:string -> string -> 'a list param
 
       (** Create a boolean parameter that is set to true if user
           mentions it in the command line arguments *)
       val flag :
+        ?deprecated:string ->
         ?docv:string -> ?doc:string -> string -> bool param
 
       (** Provides a future determined on when the config can be read *)

--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -154,7 +154,7 @@ module Create() = struct
       | Some _ -> "DEPRECATED. " ^ doc
       | None -> doc
 
-    let param converter ?deprecated ?default ?(docv="VAL")
+    let param converter ?deprecated ?default ?as_flag ?(docv="VAL")
         ?(doc="Undocumented") ?(synonyms=[]) name =
       let warn_if_deprecated () = warn_if_deprecated name deprecated in
       let doc = check_deprecated doc deprecated in
@@ -166,21 +166,25 @@ module Create() = struct
       let converter = Converter.to_arg converter in
       let param = get_param ~converter ~default ~name in
       let t =
-        Arg.(value @@ opt converter param @@ info (name::synonyms) ~doc ~docv) in
+        Arg.(value
+             @@ opt ?vopt:as_flag converter param
+             @@ info (name::synonyms) ~doc ~docv) in
       main := Term.(const (fun x () ->
           warn_if_deprecated ();
           Promise.fulfill promise x) $ t $ (!main));
       future
 
-    let param_all (converter:'a converter) ?deprecated ?(default=[]) ?(docv="VAL")
-        ?(doc="Uncodumented") ?(synonyms=[]) name : 'a list param =
+    let param_all (converter:'a converter) ?deprecated ?(default=[]) ?as_flag
+        ?(docv="VAL") ?(doc="Uncodumented") ?(synonyms=[]) name : 'a list param =
       let warn_if_deprecated () = warn_if_deprecated name deprecated in
       let doc = check_deprecated doc deprecated in
       let future, promise = Future.create () in
       let converter = Converter.to_arg converter in
       let param = get_param ~converter:(Arg.list converter) ~default ~name in
       let t =
-        Arg.(value @@ opt_all converter param @@ info (name::synonyms) ~doc ~docv) in
+        Arg.(value
+             @@ opt_all ?vopt:as_flag converter param
+             @@ info (name::synonyms) ~doc ~docv) in
       main := Term.(const (fun x () ->
           warn_if_deprecated ();
           Promise.fulfill promise x) $ t $ (!main));

--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -155,7 +155,7 @@ module Create() = struct
       | None -> doc
 
     let param converter ?deprecated ?default ?(docv="VAL")
-        ?(doc="Undocumented") name =
+        ?(doc="Undocumented") ?(synonyms=[]) name =
       let warn_if_deprecated () = warn_if_deprecated name deprecated in
       let doc = check_deprecated doc deprecated in
       let future, promise = Future.create () in
@@ -166,33 +166,34 @@ module Create() = struct
       let converter = Converter.to_arg converter in
       let param = get_param ~converter ~default ~name in
       let t =
-        Arg.(value @@ opt converter param @@ info [name] ~doc ~docv) in
+        Arg.(value @@ opt converter param @@ info (name::synonyms) ~doc ~docv) in
       main := Term.(const (fun x () ->
           warn_if_deprecated ();
           Promise.fulfill promise x) $ t $ (!main));
       future
 
     let param_all (converter:'a converter) ?deprecated ?(default=[]) ?(docv="VAL")
-        ?(doc="Uncodumented") name : 'a list param =
+        ?(doc="Uncodumented") ?(synonyms=[]) name : 'a list param =
       let warn_if_deprecated () = warn_if_deprecated name deprecated in
       let doc = check_deprecated doc deprecated in
       let future, promise = Future.create () in
       let converter = Converter.to_arg converter in
       let param = get_param ~converter:(Arg.list converter) ~default ~name in
       let t =
-        Arg.(value @@ opt_all converter param @@ info [name] ~doc ~docv) in
+        Arg.(value @@ opt_all converter param @@ info (name::synonyms) ~doc ~docv) in
       main := Term.(const (fun x () ->
           warn_if_deprecated ();
           Promise.fulfill promise x) $ t $ (!main));
       future
 
-    let flag ?deprecated ?(docv="VAL") ?(doc="Undocumented") name : bool param =
+    let flag ?deprecated ?(docv="VAL") ?(doc="Undocumented")
+        ?(synonyms=[]) name : bool param =
       let warn_if_deprecated () = warn_if_deprecated name deprecated in
       let doc = check_deprecated doc deprecated in
       let future, promise = Future.create () in
       let param = get_param ~converter:Arg.bool ~default:false ~name in
       let t =
-        Arg.(value @@ flag @@ info [name] ~doc ~docv) in
+        Arg.(value @@ flag @@ info (name::synonyms) ~doc ~docv) in
       main := Term.(const (fun x () ->
           warn_if_deprecated ();
           Promise.fulfill promise (param || x)) $ t $ (!main));

--- a/lib/bap/bap_self.mli
+++ b/lib/bap/bap_self.mli
@@ -27,15 +27,19 @@ module Create() : sig
 
     val converter : 'a parser -> 'a printer -> 'a -> 'a converter
 
+    val deprecated : string
+
+
     val param :
-      'a converter -> ?default:'a ->
+      'a converter -> ?deprecated:string -> ?default:'a ->
       ?docv:string -> ?doc:string -> string -> 'a param
 
     val param_all :
-      'a converter -> ?default:'a list ->
+      'a converter -> ?deprecated:string -> ?default:'a list ->
       ?docv:string -> ?doc:string -> string -> 'a list param
 
     val flag :
+      ?deprecated:string ->
       ?docv:string -> ?doc:string -> string -> bool param
 
     val determined : 'a param -> 'a future

--- a/lib/bap/bap_self.mli
+++ b/lib/bap/bap_self.mli
@@ -31,14 +31,14 @@ module Create() : sig
 
 
     val param :
-      'a converter -> ?deprecated:string -> ?default:'a ->
+      'a converter -> ?deprecated:string -> ?default:'a -> ?as_flag:'a ->
       ?docv:string -> ?doc:string -> ?synonyms:string list ->
       string -> 'a param
 
     val param_all :
       'a converter -> ?deprecated:string -> ?default:'a list ->
-      ?docv:string -> ?doc:string -> ?synonyms:string list ->
-      string -> 'a list param
+      ?as_flag:'a -> ?docv:string -> ?doc:string ->
+      ?synonyms:string list ->  string -> 'a list param
 
     val flag :
       ?deprecated:string ->

--- a/lib/bap/bap_self.mli
+++ b/lib/bap/bap_self.mli
@@ -32,15 +32,18 @@ module Create() : sig
 
     val param :
       'a converter -> ?deprecated:string -> ?default:'a ->
-      ?docv:string -> ?doc:string -> string -> 'a param
+      ?docv:string -> ?doc:string -> ?synonyms:string list ->
+      string -> 'a param
 
     val param_all :
       'a converter -> ?deprecated:string -> ?default:'a list ->
-      ?docv:string -> ?doc:string -> string -> 'a list param
+      ?docv:string -> ?doc:string -> ?synonyms:string list ->
+      string -> 'a list param
 
     val flag :
       ?deprecated:string ->
-      ?docv:string -> ?doc:string -> string -> bool param
+      ?docv:string -> ?doc:string -> ?synonyms:string list ->
+      string -> bool param
 
     val determined : 'a param -> 'a future
 


### PR DESCRIPTION
This PR does the following to extend `Config`:

+ Allows plugins to specify that a `config` `param` is deprecated. The reason for adding this is so that if/when developers decide that a certain option is no longer going to be used, then they can mark it as deprecated for a few releases, along with instructions to the alternative that was added, and then once the users have updated their plugins, these options can be phased out smoothly.
    + This addition prints a helpful warning message anytime the user uses this parameter
    + Plugin developers can also customize the message to point towards a better/alternative usage if they want
    + Help page (i.e. the `--help` manpage) clearly shows the parameter as deprecated

+ Allow plugins to specify synonyms for parameters. This, while discouraged, is necessary under some very specific scenarios, which is why we are adding it.

+ Allow plugins to say `as_flag` for a param, which allows usage of the param like a flag as well, specifying defaults.
    + For example, consider `Config.(param (some int) ~as_flag:(Some 10) "x")`. This results in 3 possible command line invocations:
        1. No `--x` - Results in `default` value (specifically here, `None`).
        2. Only `--x` - This causes it to have the value `as_flag` (specifically here, `Some 10`).
        3. `--x=20` - This causes it to have the value from the command line (specifically here, `Some 20`).