### PR TITLE
llvm-config-3.8 --system-libs

### DIFF
--- a/setup.ml.in
+++ b/setup.ml.in
@@ -73,8 +73,13 @@ let llvm var () : unit =
     ("llvm_"^var)
     (fun () ->
        let llvm_config = BaseEnv.var_get "llvm_config" in
-       OASISExec.run_read_one_line ~ctxt llvm_config ["--"^var]) |>
-  definition_end
+       let llvm_version = BaseEnv.var_get "llvm_version" in
+       let extract v =
+	 OASISExec.run_read_one_line ~ctxt llvm_config ["--"^v] in 
+       if llvm_version > "3.4" && var = "ldflags"
+       then extract var ^ extract "system-libs"
+       else extract var) |>
+    definition_end
 
 let cxx_flags () : unit =
   BaseEnv.var_define


### PR DESCRIPTION
Adds support for `llvm-config-3.5+` flags (namely `--system-libs`)