### PR TITLE
fix possible use-after-free in llvm_binary plugin

### DIFF
--- a/plugins/llvm/llvm_binary.hpp
+++ b/plugins/llvm/llvm_binary.hpp
@@ -436,7 +436,7 @@ struct objectfile_image : image {
         , segments_(seg::read(obj))
         , symbols_(sym::read(obj))
         , sections_(sec::read(obj))
-	, binary_(std::move(binary))
+        , binary_(std::move(binary))
         {}
     Triple::ArchType arch() const { return arch_; }
     uint64_t entry() const { return entry_; }

--- a/plugins/llvm/llvm_binary.hpp
+++ b/plugins/llvm/llvm_binary.hpp
@@ -430,7 +430,7 @@ uint64_t image_entry(const COFFObjectFile* obj) {
 
 template <typename T>
 struct objectfile_image : image {
-    explicit objectfile_image(const T* obj)
+    explicit objectfile_image(const T* obj, std::unique_ptr<object::Binary> binary)
         : arch_(image_arch(obj))
         , entry_(image_entry(obj))
         , segments_(seg::read(obj))
@@ -490,9 +490,9 @@ image* create_image(const Archive* arch, std::unique_ptr<object::Binary> binary)
 
 image* create_image(std::unique_ptr<object::Binary> binary) {
     const Binary* b = binary.get();
-    if (const Archive *arch = dyn_cast<Archive>(binary))
+    if (const Archive *arch = dyn_cast<Archive>(b))
         return create_image(arch, std::move(binary));
-    if (const ObjectFile *obj = dyn_cast<ObjectFile>(binary))
+    if (const ObjectFile *obj = dyn_cast<ObjectFile>(b))
         return create_image(obj, std::move(binary));
     llvm_binary_fail("Unrecognized binary format");
 }


### PR DESCRIPTION
*** This pull request is independent of LLVM 3.8 support.

• In `plugins/llvm/llvm_binary.hpp`, there is a `Binary` smart pointer that is improperly handled due to the fact that the pointer to the binary has a shorter lifetime than the image.

• To resolve this issue, we can make the binary smart pointer a part of `image`.