### PR TITLE
Onward to a single grammar config

### DIFF
--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -70,6 +70,14 @@ end = struct
         | `Ok () -> Promise.fulfill front_end_promise ()
         | `Version | `Help -> exit 0)
 
+  (* Ensures that all plugins can get their options while the front
+     ends are still being updated. _Must_ be removed after plugins are updated. *)
+  let temporary_workaround =
+    Future.upon Plugins.loaded (fun () ->
+        match Term.eval_peek_opts !global with
+        | _, `Error _ -> exit 1
+        | _, `Ok () -> Promise.fulfill front_end_promise ()
+        | _, `Version | _, `Help -> exit 0)
 end
 
 module Create() = struct

--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -21,17 +21,13 @@ end = struct
   let global = ref Term.(const ())
 
   let plugin_help plugin_name terminfo grammar : unit Term.t =
-    let formats = ["pager", `Pager;
-                   "plain", `Plain;
-                   "groff", `Groff;] in
-    let format_to_str fmt = List.Assoc.find (
-        List.map ~f:(fun (a,b) -> (b,a)) formats) fmt in
+    let formats = List.map ~f:(fun x -> x,x) ["pager"; "plain"; "groff"] in
     let name = plugin_name ^ "-help" in
     let doc = "Show help for " ^
               plugin_name ^
               " plugin in format $(docv), (pager, plain or groff)" in
     let help = Arg.(value @@
-                    opt ~vopt:(Some `Pager) (some (enum formats)) None @@
+                    opt ~vopt:(Some "pager") (some (enum formats)) None @@
                     info [name] ~doc ~docv:"FMT") in
     Term.(const (fun h () ->
         match h with
@@ -39,7 +35,7 @@ end = struct
         | Some v ->
           match eval ~argv:[|plugin_name;
                              "--help";
-                             Option.value_exn (format_to_str v)
+                             v
                            |] (grammar, terminfo) with
           | `Error _ -> exit 1
           | `Ok _ -> assert false


### PR DESCRIPTION
This PR does the following things:

+ Makes sure full config names are used at command line. 
This basically ensures that the complete name of argument shows up
everywhere, rather than stripped with plugin name (for example,
`--taint-ptr` shows up now, rather than `--ptr` in the manpage).
+ Allows plugins to register their grammars into the global grammar, along with code to fix up the manpage issues (basically, the previous change would have prevented `--<plugin>-help` from working, but after the changes, it will work even in the single grammar system).
+ Adds a `front_end` method which will be exposed to front ends (with a more clear interface, which abstracts `Cmdliner` away) in order to be able to set up the front end information (i.e. the default `--help` manpage etc).
+ A temporary workaround is added in order to have the plugins working correctly even while front ends are not moved to the new grammar. However, once the front ends are moved to the new grammar (in a future PR), this workaround will be removed.