### PR TITLE
Resolve x86-abi issues

### DIFF
--- a/plugins/api/api/c/posix
+++ b/plugins/api/api/c/posix
@@ -9,7 +9,7 @@ typedef int ldiv_t;
 typedef int lldiv_t;
 typedef int wchar_t;
 
-int main(int argc, const char *argv[]);
+int main(int argc, const char **argv);
 
 // stdlib.h
 


### PR DESCRIPTION
This PR resolves several x86 abi issues that were found by a new
testsuite:

1. Currently x86 abi don't know how to pass arrays of unknown sizes.
   Different ABI allows to pass them via registers, if certain condition
   holds and size is known, if the size is unknown, then they are
   usually passed as a pointer. Since, currently the support for x86 ABI
   is preliminary I fixed this locally in the `c/posix`.

2. Added ABI autodetection. This is a heuristics that may detect that a
   binary has MS ABI. A better approach would be to store the
   information about original file format. Knowing that the file is in
   PE32 or PE32+ format is a much better heuristic to guess that it is
   for Windows.

3. Added demangling for Win32 files.

As a result, now Saluki is able to work on MS binaries out of box, and
even without the IDA help, as PE32 binaries usually have much more
symbolic information.