### PR TITLE
Issue #516: Corrected COFF Section virtual address

### DIFF
--- a/plugins/llvm/llvm_binary.cpp
+++ b/plugins/llvm/llvm_binary.cpp
@@ -46,31 +46,31 @@ extern "C" {
 
 
     const char* segment_name(const seg::segment* s) {
-        return s->name().c_str();
+        return s->name.c_str();
     }
 
     uint64_t segment_offset(const seg::segment* s) {
-        return s->offset();
+        return s->offset;
     }
 
     uint64_t segment_addr(const seg::segment* s) {
-        return s->addr();
+        return s->addr;
     }
 
     uint64_t segment_size(const seg::segment* s) {
-        return s->size();
+        return s->size;
     }
 
     bool segment_is_readable(const seg::segment* s) {
-        return s->is_readable();
+        return s->is_readable;
     }
 
     bool segment_is_writable(const seg::segment* s) {
-        return s->is_writable();
+        return s->is_writable;
     }
 
     bool segment_is_executable(const seg::segment* s) {
-        return s->is_executable();
+        return s->is_executable;
     }
 
     const char* section_name(const sec::section* s) {

--- a/plugins/llvm/llvm_binary.cpp
+++ b/plugins/llvm/llvm_binary.cpp
@@ -74,15 +74,15 @@ extern "C" {
     }
 
     const char* section_name(const sec::section* s) {
-        return s->name().c_str();
+        return s->name.c_str();
     }
 
     uint64_t section_addr(const sec::section* s) {
-        return s->addr();
+        return s->addr;
     }
 
     uint64_t section_size(const sec::section* s) {
-        return s->size();
+        return s->size;
     }
 
     const char* symbol_name(const sym::symbol* s) {

--- a/plugins/llvm/llvm_binary.hpp
+++ b/plugins/llvm/llvm_binary.hpp
@@ -132,9 +132,9 @@ std::vector<segment> read(const ELFObjectFile<T>& obj) {
 			begin->p_offset,
 			begin->p_vaddr, 
 			begin->p_filesz, 
-			begin->p_flags & ELF::PF_R, 
-			begin->p_flags & ELF::PF_W, 
-			begin->p_flags & ELF::PF_X});
+			static_cast<bool>(begin->p_flags & ELF::PF_R), 
+			static_cast<bool>(begin->p_flags & ELF::PF_W), 
+			static_cast<bool>(begin->p_flags & ELF::PF_X)});
 	}
     }
     return segments;
@@ -143,9 +143,9 @@ std::vector<segment> read(const ELFObjectFile<T>& obj) {
 template <typename S>
 segment make_segment(const S &s) {
     return segment{s.segname, s.fileoff, s.vmaddr, s.filesize,
-	    s.initprot & MachO::VM_PROT_READ,
-	    s.initprot & MachO::VM_PROT_WRITE,
-	    s.initprot & MachO::VM_PROT_EXECUTE};
+	    static_cast<bool>(s.initprot & MachO::VM_PROT_READ),
+	    static_cast<bool>(s.initprot & MachO::VM_PROT_WRITE),
+	    static_cast<bool>(s.initprot & MachO::VM_PROT_EXECUTE)};
 }
 
 std::vector<segment> read(const MachOObjectFile& obj) {
@@ -168,12 +168,12 @@ segment make_segment(T image_base, const coff_section &s) {
 	    static_cast<T>(s.PointerToRawData),
 	    static_cast<T>(s.VirtualAddress + image_base),
 	    static_cast<T>(s.SizeOfRawData),
-	    static_cast<T>(s.Characteristics) &
-	    COFF::IMAGE_SCN_MEM_READ,
-	    static_cast<T>(s.Characteristics) &
-	    COFF::IMAGE_SCN_MEM_WRITE,
-	    static_cast<T>(s.Characteristics) &
-	    COFF::IMAGE_SCN_MEM_EXECUTE};
+	    static_cast<bool>((s.Characteristics) &
+			      COFF::IMAGE_SCN_MEM_READ),
+	    static_cast<bool>((s.Characteristics) &
+			      COFF::IMAGE_SCN_MEM_WRITE),
+	    static_cast<bool>((s.Characteristics) &
+			      COFF::IMAGE_SCN_MEM_EXECUTE)};
 }
 
 template <typename T>


### PR DESCRIPTION
Furthermore, `section` namespace is refactored to adhere to same format as `segment`