### PR TITLE
Introduce -p, --pass, --passes

### DIFF
--- a/src/bap_cmdline_terms.ml
+++ b/src/bap_cmdline_terms.ml
@@ -203,7 +203,10 @@ let options_for_passes = [
   `I begin
     "$(b,--)$(i,PASS)",
     "Runs a program $(i,PASS). The $(i,PASS) should be registered in the
-         system, usually by loading or installing corresponding plugin."
+         system, usually by loading or installing corresponding
+         plugin. DEPRECATED. This option will be removed in the near
+         future. Instead, it is advisable to use the $(b,-p) option to
+         specify passes."
   end;
   `I begin
     "$(b,--)$(i,PASS)-$(i,OPTION)",

--- a/src/bap_main.ml
+++ b/src/bap_main.ml
@@ -200,7 +200,10 @@ let program source =
                                a b c d e f g i j k []), passopt in
   let open Bap_cmdline_terms in
   let passopt : string list Term.t =
-    let doc = "Runs passes (comma separated)" in
+    let doc =
+      "Runs passes (comma separated). This option replaces the \
+       previously existing $(b,--)$(i,PASS) options which are now \
+       deprecated and will soon be removed." in
     Arg.(value & opt (list string) [] &
          info ["p"; "pass"; "passes"] ~doc ~docv:"PASS") in
   Term.(const create

--- a/src/bap_main.ml
+++ b/src/bap_main.ml
@@ -195,10 +195,16 @@ let program_info =
   Term.info "bap" ~version:Config.version ~doc ~man
 let program source =
   let create
-      a b c d e f g i j k = Bap_options.Fields.create
-      a b c d e f g i j k [] in
+      passopt
+      a b c d e f g i j k = (Bap_options.Fields.create
+                               a b c d e f g i j k []), passopt in
   let open Bap_cmdline_terms in
+  let passopt : string list Term.t =
+    let doc = "Runs passes (comma separated)" in
+    Arg.(value & opt (list string) [] &
+         info ["p"; "pass"; "passes"] ~doc ~docv:"PASS") in
   Term.(const create
+        $passopt
         $filename
         $(disassembler ())
         $(loader ())
@@ -228,7 +234,9 @@ let run_loader () =
 
 let parse passes argv =
   match Cmdliner.Term.eval ~argv ~catch:false (program source) with
-  | `Ok opts -> { opts with Bap_options.passes }
+  | `Ok (opts, passopt) ->
+    let passes = passopt @ passes in
+    { opts with Bap_options.passes }
   | _ -> exit 0
 
 let error fmt =


### PR DESCRIPTION
This PR introduces `-p`, `--pass`, `--passes` as command line options for specifying passes. It does **not** remove `--PASS` though.

The reason that this is done as a quick temporary fix to the code (in a separate PR from #512) is so that the test suite can be updated to work with master (after this is merged) and the transition is smoothened, and we are more confident of the changes.