### PR TITLE
Merge prefixes in llvm backend

### DIFF
--- a/lib/bap_disasm/disasm.cpp
+++ b/lib/bap_disasm/disasm.cpp
@@ -82,7 +82,7 @@ class disassembler {
     vector<string>  asms;
     string asm_cache;
     vector<predicates> insn_preds;
-    int64_t base;
+    uint64_t base;
     int off;
     bool store_preds, store_asms;
 
@@ -124,7 +124,7 @@ public:
         };
     }
 
-    void set_memory(int64_t addr, const char *data, int offset, int length) {
+    void set_memory(uint64_t addr, const char *data, int offset, int length) {
         this->base = addr;
         this->off  = 0;
         dis->set_memory({data, addr, {offset, length}});
@@ -315,7 +315,7 @@ static inline shared_ptr<disassembler> get(int d) {
 }
 
 
-void bap_disasm_set_memory(int d, int64_t base, const char *data, int off, int len) {
+void bap_disasm_set_memory(int d, uint64_t base, const char *data, int off, int len) {
     get(d)->set_memory(base, data, off, len);
 }
 

--- a/lib/bap_disasm/disasm.h
+++ b/lib/bap_disasm/disasm.h
@@ -144,7 +144,7 @@ const char* bap_disasm_backend_name(int i);
  * */
 void bap_disasm_set_memory(
     bap_disasm_type disasm,
-    int64_t base,
+    uint64_t base,
     const char *data,
     int off,
     int len);

--- a/lib/bap_disasm/disasm.hpp
+++ b/lib/bap_disasm/disasm.hpp
@@ -35,7 +35,7 @@ struct operand;
 // to disassembler, that involves the instruction are undefined.
 struct disassembler_interface {
     // disassemble one instruction, starting from addres \a pc.
-    virtual void step(int64_t pc) = 0;
+    virtual void step(uint64_t pc) = 0;
 
     // directs disassembler to a specifed memory region
     virtual void set_memory(memory) = 0;
@@ -97,7 +97,7 @@ struct insn {
 
 struct memory {
     const char *data;
-    int64_t     base;
+    uint64_t     base;
     location    loc;
 };
 

--- a/lib/bap_disasm/disasm_stubs.c
+++ b/lib/bap_disasm/disasm_stubs.c
@@ -4,6 +4,8 @@
 #include <caml/alloc.h>
 #include <assert.h>
 
+#include <stdint.h>
+
 #include "disasm.h"
 
 

--- a/plugins/llvm/llvm_disasm.cpp
+++ b/plugins/llvm/llvm_disasm.cpp
@@ -309,7 +309,14 @@ public:
                 current = valid_insn(loc);
                 if (is_prefix() && size != 0) {
                     step(pc+size);
-                    if (is_valid()) {
+
+                    // a standalone prefix is not a valid instruction
+                    if (current.loc.len == 0) {
+                        current = invalid_insn(loc);
+                    }
+
+                    // a prefix to invalid instruction is invalid instruction
+                    if (current.code != 0) {
                         location ext = {loc.off, loc.len + current.loc.len};
                         current = valid_insn(ext);
                     }
@@ -342,10 +349,10 @@ public:
 
     // invalid instruction doesn't satisfy any predicate except is_invalid.
     bool satisfies(bap_disasm_insn_p_type p) const {
-        bool current_invalid = current.code == 0;
+        auto current_is_invalid = current.code == 0;
         if (p == is_invalid) {
-            return is_valid();
-        } else if (current_invalid) {
+            return current_is_invalid;
+        } else if (current_is_invalid) {
             return false;
         } else if (p == is_true) {
             return true;
@@ -394,10 +401,6 @@ private:
 
     insn invalid_insn(location loc) const {
         return {0, 0L, loc};
-    }
-
-    bool is_valid() const {
-        return current.code == 0;
     }
 
     operand create_operand(llvm::MCOperand mcop, location loc) const {


### PR DESCRIPTION
LLVM-MC disassembler treats instruction prefixes as separate instruction. In fact, situation is even worse, as several prefixes are sometimes merged into instruction and sometimes it can survive as a standalone. An examples for this is REX prefix. 

In any case, this behavior is very specific to LLVM-MC, and is not conforming to any standard. So a lifter, shouldn't depend or fix this behavior. Moreover, our current lifter, doesn't expect such behavior, and all instructions with prefixes other then REX are handled incorrectly. 

This PR will normalize LLVM behavior with respect to prefixes. They are now glued back to the instruction, and can't ever escape from the disassembler as a separate instruction. 

The testsuite is correspondingly updated.