### PR TITLE
add dejagnu dependency

### DIFF
--- a/opam/opam
+++ b/opam/opam
@@ -172,6 +172,7 @@ depexts: [
         "clang"
         "llvm"
         "m4"
+        "dejagnu"
      ]]
      [["osx" "macports"] [
         "gmp"


### PR DESCRIPTION
Although the package is optional, we need to add it to opam/opam file,
since it includes a non-optional `make check` call. Another option would
be to make the `check` rule to check the presence of the dejagnu (that
it already does), and ignore the testsuite, if it is not present. But,
it looks like, that such option will only increase the entropy, so I
would better add the package as dependency.

This will resolve #537.