### PR TITLE
publish create/close functions for basic disasm

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -4535,19 +4535,29 @@ module Std : sig
       *)
       type (+'a,+'k,'s,'r) state
 
-      (** [with_disasm ?debug_level ?cpu ~backend target] creates a
+      (** [with_disasm ?debug_level ?cpu ~backend ~f target] creates a
+          disassembler passing all options to [create] function and
+          applies function [f] to it. Once [f] is evaluated the
+          disassembler is closed with [close] function.  *)
+      val with_disasm :
+        ?debug_level:int -> ?cpu:string -> backend:string -> string ->
+        f:((empty, empty) t -> 'a Or_error.t) -> 'a Or_error.t
+
+      (** [create ?debug_level ?cpu ~backend target] creates a
           disassembler for the specified [target]. All parameters are
           backend specific, consult the concrete backend for more
           information. In general, the greater [debug_level] is, the
           more debug information will be outputed by a backend. To
           silent backend set it [0]. This is a default value. Example:
 
-          [with_disasm ~debug_level:3 ~backend:"llvm" "x86_64" ~f:process]
+          [create ~debug_level:3 ~backend:"llvm" "x86_64" ~f:process]
       *)
-      val with_disasm :
-        ?debug_level:int -> ?cpu:string -> backend:string -> string ->
-        f:((empty, empty) t -> 'a Or_error.t) -> 'a Or_error.t
+      val create : ?debug_level:int -> ?cpu:string -> backend:string -> string ->
+        (empty, empty) t Or_error.t
 
+
+      (** [close d] closes a disassembler [d].   *)
+      val close : (_,_) t -> unit
 
       (** enables storing assembler information  *)
       val store_asm : (_,'k) t -> (asm,'k) t

--- a/lib/bap_disasm/bap_disasm_basic.mli
+++ b/lib/bap_disasm/bap_disasm_basic.mli
@@ -27,6 +27,11 @@ val with_disasm :
   ?debug_level:int -> ?cpu:string -> backend:string -> string ->
   f:((empty, empty) t -> 'a Or_error.t) -> 'a Or_error.t
 
+val create : ?debug_level:int -> ?cpu:string -> backend:string -> string ->
+  (empty, empty) t Or_error.t
+
+val close : (_,_) t -> unit
+
 val store_asm : (_,'k) t -> (asm,'k) t
 
 val store_kinds : ('a,_) t -> ('a,kinds) t


### PR DESCRIPTION
Previously a basic disassembler could be only accessed by `with_disasm`
function, that is safe but not very versatile. There is at least one use
case, where the CPS style is not enough, as we may need to have a pool
of disassemblers. For example in bap-server.

This PR adds this functions to the module interface, however they are
discouraged, and `with_disasm` function should be considered whenever
it is possible.