### PR TITLE
Add space before output from --system-libs

### DIFF
--- a/setup.ml.in
+++ b/setup.ml.in
@@ -81,7 +81,7 @@ let llvm var () : unit =
        let extract v =
 	 OASISExec.run_read_one_line ~ctxt llvm_config ["--"^v] in
        if strip_patch llvm_version > "3.4" && var = "ldflags"
-       then extract var ^ extract "system-libs"
+       then extract var ^ " " ^ extract "system-libs"
        else extract var) |>
     definition_end
 


### PR DESCRIPTION
Fix building with LLVM 3.8

Ensure a space between the outputs of `llvm-config --ldflags` and `llvm-config --system-libs`.