### PR TITLE
constraint ocurl version to 0.7.7

### DIFF
--- a/opam/opam
+++ b/opam/opam
@@ -151,7 +151,7 @@ depends: [
     "ounit" {build}
     "ocamlgraph"
     "ocamlfind" {>= "1.5.6" & < "2.0"}
-    "ocurl" {>= "0.7.7"}
+    "ocurl" {= "0.7.7"}
     "optcomp"
     "re"
     "uri" {>= "1.9.0"}


### PR DESCRIPTION
It looks like that ocurl.0.7.8 doesn't compile on Ubuntu Precise,
although it works fine at least on the Trusty.