### PR TITLE
Dehackify cxx and llvm building

### DIFF
--- a/lib/bap_build/bap_build.ml
+++ b/lib/bap_build/bap_build.ml
@@ -153,6 +153,7 @@ module Plugin_rules = struct
                    make_list_option "-provides" in
     Cmd (S [
         A "bapbundle"; A "pack";
+        T (Tags.of_list ["bundle"; "library"; "plugin"]);
         A "-name"; A (dashify (env "%"));
         A "-main"; A (env "%.cmxs");
         A "-main"; A (env "%.cma");

--- a/myocamlbuild.ml.in
+++ b/myocamlbuild.ml.in
@@ -1,46 +1,20 @@
-let nonempty = function (A s) -> String.length s <> 0 | _ -> true
-
-(* the piqi support is rather fragile *)
-let piqic_rule () : unit =
-  rule "piqic: piqi -> .ml & _ext.ml"
-    ~prods:["%_piqi.ml"; "%_piqi_ext.ml"]
-    ~deps:["%.piqi"]
-    (fun env _ ->
-       Cmd (S (List.filter nonempty [
-           A (expand "${piqic}");
-           A (expand "${piqic_flags}");
-           A "-C";
-           A "lib/bap_piqi";
-           A "-I";
-           A "../lib/bap_piqi";
-           A (env "%.piqi");
-           A"--multi-format"])));;
-
 let cxx_rule () =
   let deps = ["%.hpp"; "%.cpp"; "%.h"] and prod = "%.o" in
-  let action env _ = Cmd (S [
-      Sh (expand "${cxx} ${cxxflags} ${llvm_cxxflags}");
-      A "-c"; P (env "%.cpp"); A "-o"; P (env "%.o")]) in
+  let action env _ =
+    let src = env "%.cpp" and obj = env "%.o" in
+    let cxx = expand "${cxx} ${cc_optimization} ${cxxflags}" in
+    let tags = tags_of_pathname src ++ "c++" ++ "compile" in
+    Cmd (S [Sh cxx; T tags; A "-c"; P src; A "-o"; Px obj]) in
   rule "cxx: hpp & cpp & h -> o" ~deps ~prod action
 
-let dispatch = function
-  | Before_rules ->
-    piqic_rule ();
-    cxx_rule ();
-  | After_rules ->
-    List.iter
-      (fun tag ->
-         pflag ["ocaml"; tag] "pa_ounit_lib"
-           (fun s -> S[A"-ppopt"; A"-pa-ounit-lib"; A"-ppopt"; A s]))
-      ["ocamldep"; "compile"; "doc"];
-  | _ -> ()
+let () = Rules.add cxx_rule
 
-module Ocamlbuild_compat = struct
-  let mark_tag_used = ignore
-  include Ocamlbuild_plugin
-end
 
 let mark_tags () =
+  let module Ocamlbuild_compat = struct
+    let mark_tag_used = ignore
+    include Ocamlbuild_plugin
+  end in
   let open Ocamlbuild_compat in
   List.iter mark_tag_used [
     "pkg_core_bench";
@@ -54,17 +28,24 @@ let pr_6184_hack = function
   | After_rules ->
     (* Pass -predicates to ocamldep *)
     pflag ["ocaml"; "ocamldep"] "predicate" (fun s -> S [A "-predicates"; A s]);
+  | _ -> ()
+
+
+let predicate_used_libs = function
+  | After_rules ->
     package_default.MyOCamlbuildBase.lib_ocaml |>
     List.iter (fun (lib,_,_) ->
         flag ["ocaml"; "link"; "use_"^lib]
-          (S [A "-predicates"; A ("used_"^lib)]));
+          (S [A "-predicates"; A ("used_"^lib)]))
   | _ -> ()
+
 
 
 let () =
   mark_tags ();
-  Ocamlbuild_plugin.dispatch (fun hook ->
-      dispatch hook;
-      dispatch_default hook;
-      pr_6184_hack hook;
-      Ppx_driver_ocamlbuild.dispatch hook)
+  Ocamlbuild_plugin.dispatch (fun stage ->
+      Rules.dispatch stage;
+      dispatch_default stage;
+      pr_6184_hack stage;
+      predicate_used_libs stage;
+      Ppx_driver_ocamlbuild.dispatch stage)

--- a/oasis/common.ocamlbuild.ml.in
+++ b/oasis/common.ocamlbuild.ml.in
@@ -1,8 +1,21 @@
 (* OASIS_START *)
 (* OASIS_STOP *)
-#4 "oasis/common.ocamlbuild.ml.in"
+
 let oasis_env =
   BaseEnvLight.load
     ~allow_empty:true
     ()
 let expand s = BaseEnvLight.var_expand s oasis_env
+
+type rule = unit -> unit
+
+module Rules : sig
+  val add : rule -> unit
+  val dispatch : hook -> unit
+end = struct
+  let rules : (unit -> unit) list ref  = ref []
+  let add rule = rules := rule :: !rules
+  let dispatch = function
+    | Before_rules -> !rules |> List.iter (fun rule -> rule ())
+    | _ -> ()
+end

--- a/oasis/common.setup.ml.in
+++ b/oasis/common.setup.ml.in
@@ -3,6 +3,9 @@
 (* OASIS_STOP *)
 #5 "oasis/common.setup.ml.in"
 let definition_end = BaseEnv.var_ignore
+let define definitions =
+  List.iter (fun f -> try f () with exn -> ()) definitions
+
 
 let ctxt = !BaseContext.default
 
@@ -47,3 +50,11 @@ let is_undefined var : bool = not (is_defined var)
 
 let is_set_to var value : bool =
   is_defined var && BaseEnv.var_get var = value
+
+
+let rec find_map xs ~f =
+  match xs with
+  | [] -> None
+  | x :: xs -> match f x with
+    | None -> find_map xs ~f
+    | yay -> yay

--- a/oasis/ida.setup.ml.in
+++ b/oasis/ida.setup.ml.in
@@ -1,3 +1,4 @@
+
 let define_headless = function
   | Some "true" when BaseEnv.var_get "system" <> "linux" ->
     invalid_arg "headless mode is supported only on linux"

--- a/oasis/llvm.ocamlbuild.ml.in
+++ b/oasis/llvm.ocamlbuild.ml.in
@@ -1,0 +1,2 @@
+let () =
+  flag ["c++"; "compile"; "use_libllvm"] (Sh (expand "${llvm_cxxflags}"))

--- a/oasis/llvm.setup.ml.in
+++ b/oasis/llvm.setup.ml.in
@@ -1,0 +1,88 @@
+let strip_patch ver =
+  if String.length ver <> 5 then ver
+  else String.sub ver 0 3
+
+
+let llvm var () : unit =
+  BaseEnv.var_define
+    ~hide:true
+    ~dump:true
+    ~short_desc:(fun () -> "llvm-config --"^var)
+    ("llvm_"^var)
+    (fun () ->
+       let llvm_config = BaseEnv.var_get "llvm_config" in
+       let llvm_version = BaseEnv.var_get "llvm_version" in
+       let extract v =
+	 OASISExec.run_read_one_line ~ctxt llvm_config ["--"^v] in
+       if strip_patch llvm_version > "3.4" && var = "ldflags"
+       then extract var ^ extract "system-libs"
+       else extract var) |>
+    definition_end
+
+let llvm_version () : unit =
+  BaseEnv.var_define
+    ~hide:false
+    ~dump:true
+    ~cli:BaseEnv.CLIWith
+    ~short_desc:(fun () -> "llvm version (e.g., 3.4)")
+    "llvm_version"
+    (fun () ->
+       OASISExec.run_read_one_line ~ctxt "llvm-config" ["--version"]) |>
+  definition_end
+
+let llvm_config () : unit =
+  BaseEnv.var_define
+    ~hide:false
+    ~dump:true
+    ~cli:BaseEnv.CLIWith
+    ~short_desc:(fun () -> "llvm-config executable")
+    "llvm_config"
+    (fun () ->
+       (* default macports if we're on mac os x *)
+       let macosx = BaseEnv.var_get "system" = "macosx" in
+       let vers = match BaseEnv.var_get "llvm_version" with
+         | "" -> []
+         | ver when macosx -> ["-mp-" ^ ver; "-" ^ ver]
+         | ver -> ["-" ^ ver; "-" ^ strip_patch ver] in
+       find_map vers ~f:(fun ver ->
+           try Some (OASISFileUtil.which ~ctxt ("llvm-config" ^ ver))
+           with Not_found -> None) |> function
+       | Some path -> path
+       | None -> raise Not_found) |>
+  definition_end
+
+let llvm_mainlib () : unit =
+  BaseEnv.var_define
+    ~hide:true
+    ~dump:true
+    ~short_desc:(fun () -> "main LLVM library")
+    "llvm_mainlib"
+    (fun () -> "-lLLVM-"^BaseEnv.var_get "llvm_version") |>
+  definition_end
+
+
+let llvm_lib () : unit =
+  BaseEnv.var_define
+    ~hide:true
+    ~dump:true
+    ~short_desc:(fun () -> "LLVM library(ies) to link with")
+    "llvm_lib"
+    (fun () ->
+       let llvm_static = BaseEnv.var_get "llvm_static" in
+       let lib = if llvm_static = "true"
+         then "llvm_libs"
+         else "llvm_mainlib" in
+       BaseEnv.var_get lib) |>
+  definition_end
+
+let () =
+  define [
+    llvm_version;
+    llvm_config;
+    llvm_mainlib;
+    llvm "cxxflags";
+    llvm "ldflags";
+    llvm "cflags";
+    llvm "libs";
+    llvm_lib
+  ]

--- a/oasis/llvm.setup.ml.in
+++ b/oasis/llvm.setup.ml.in
@@ -27,7 +27,10 @@ let llvm_version () : unit =
     ~short_desc:(fun () -> "llvm version (e.g., 3.4)")
     "llvm_version"
     (fun () ->
-       OASISExec.run_read_one_line ~ctxt "llvm-config" ["--version"]) |>
+       try
+         ignore @@ OASISFileUtil.which ~ctxt "llvm-config";
+         OASISExec.run_read_one_line ~ctxt "llvm-config" ["--version"]
+       with Not_found -> "3.4") |>
   definition_end
 
 let llvm_config () : unit =
@@ -42,7 +45,7 @@ let llvm_config () : unit =
        let macosx = BaseEnv.var_get "system" = "macosx" in
        let vers = match BaseEnv.var_get "llvm_version" with
          | "" -> []
-         | ver when macosx -> ["-mp-" ^ ver; "-" ^ ver]
+         | ver when macosx -> ["-mp-" ^ strip_patch ver; "-" ^ strip_patch ver]
          | ver -> ["-" ^ ver; "-" ^ strip_patch ver] in
        find_map vers ~f:(fun ver ->
            try Some (OASISFileUtil.which ~ctxt ("llvm-config" ^ ver))

--- a/oasis/llvm.tags.in
+++ b/oasis/llvm.tags.in
@@ -1,0 +1,1 @@
+<plugins/llvm/llvm_*.cpp>: use_libllvm

--- a/oasis/objdump.setup.ml.in
+++ b/oasis/objdump.setup.ml.in
@@ -1,5 +1,3 @@
-
-
 let () =
   add_variable  ~doc:"A list (OCaml syntax) of supported targets" "objdump_targets"
     ~define:(function

--- a/oasis/piqi.ocamlbuild.ml.in
+++ b/oasis/piqi.ocamlbuild.ml.in
@@ -1,0 +1,19 @@
+let nonempty = function (A s) -> String.length s <> 0 | _ -> true
+
+(* the piqi support is rather fragile *)
+let piqic_rule () : unit =
+  rule "piqic: piqi -> .ml & _ext.ml"
+    ~prods:["%_piqi.ml"; "%_piqi_ext.ml"]
+    ~deps:["%.piqi"]
+    (fun env _ ->
+       Cmd (S (List.filter nonempty [
+           A (expand "${piqic}");
+           A (expand "${piqic_flags}");
+           A "-C";
+           A "lib/bap_piqi";
+           A "-I";
+           A "../lib/bap_piqi";
+           A (env "%.piqi");
+           A"--multi-format"])));;
+
+let () = Rules.add piqic_rule

--- a/oasis/piqi.setup.ml.in
+++ b/oasis/piqi.setup.ml.in
@@ -1,0 +1,22 @@
+let piqic () : unit =
+  let chop str = try
+      Filename.chop_extension str
+    with _ -> str in
+  let piqic_path = BaseCheck.prog_best "piqic_path" ["piqic-ocaml"; "piqic"] () in
+  BaseEnv.var_define "piqic_flags" (fun () ->
+      if chop (Filename.basename (BaseEnv.var_get "piqic")) = "piqic"
+      then "ocaml"
+      else "") |>
+  definition_end;
+  BaseEnv.var_define "piqic" (fun () ->
+      if List.mem (BaseStandardVar.os_type ()) ["Cygwin"; "Win32"]
+      then
+        String.concat " "
+          (OASISExec.run_read_output ~ctxt "cygpath" [piqic_path])
+      else piqic_path) |>
+  definition_end
+
+
+
+
+let () = define [piqic]

--- a/setup.ml.in
+++ b/setup.ml.in
@@ -1,20 +1,3 @@
-let piqic () : unit =
-  let chop str = try
-      Filename.chop_extension str
-    with _ -> str in
-  let piqic_path = BaseCheck.prog_best "piqic_path" ["piqic-ocaml"; "piqic"] () in
-  BaseEnv.var_define "piqic_flags" (fun () ->
-      if chop (Filename.basename (BaseEnv.var_get "piqic")) = "piqic"
-      then "ocaml"
-      else "") |>
-  definition_end;
-  BaseEnv.var_define "piqic" (fun () ->
-      if List.mem (BaseStandardVar.os_type ()) ["Cygwin"; "Win32"]
-      then
-        String.concat " "
-          (OASISExec.run_read_output ~ctxt "cygpath" [piqic_path])
-      else piqic_path) |>
-  definition_end
 
 let cxx () : unit =
   BaseEnv.var_define
@@ -26,72 +9,13 @@ let cxx () : unit =
     (fun () -> OASISFileUtil.which ~ctxt "c++") |>
   definition_end
 
-let llvm_version () : unit =
-  BaseEnv.var_define
-    ~hide:false
-    ~dump:true
-    ~cli:BaseEnv.CLIWith
-    ~short_desc:(fun () -> "llvm version (e.g., 3.4)")
-    "llvm_version"
-    (fun () ->
-       OASISExec.run_read_one_line ~ctxt "llvm-config" ["--version"]) |>
-  definition_end
-
-let rec find_map xs ~f =
-  match xs with
-  | [] -> None
-  | x :: xs -> match f x with
-    | None -> find_map xs ~f
-    | yay -> yay
-
-let strip_patch ver =
-  if String.length ver <> 5 then ver
-  else String.sub ver 0 3
-
-let llvm_config () : unit =
-  BaseEnv.var_define
-    ~hide:false
-    ~dump:true
-    ~cli:BaseEnv.CLIWith
-    ~short_desc:(fun () -> "llvm-config executable")
-    "llvm_config"
-    (fun () ->
-       (* default macports if we're on mac os x *)
-       let macosx = BaseEnv.var_get "system" = "macosx" in
-       let vers = match BaseEnv.var_get "llvm_version" with
-         | "" -> []
-         | ver when macosx -> ["-mp-" ^ ver; "-" ^ ver]
-         | ver -> ["-" ^ ver; "-" ^ strip_patch ver] in
-       find_map vers ~f:(fun ver ->
-           try Some (OASISFileUtil.which ~ctxt ("llvm-config" ^ ver))
-           with Not_found -> None) |> function
-       | Some path -> path
-       | None -> raise Not_found) |>
-  definition_end
-
-let llvm var () : unit =
-  BaseEnv.var_define
-    ~hide:true
-    ~dump:true
-    ~short_desc:(fun () -> "llvm-config --"^var)
-    ("llvm_"^var)
-    (fun () ->
-       let llvm_config = BaseEnv.var_get "llvm_config" in
-       let llvm_version = BaseEnv.var_get "llvm_version" in
-       let extract v =
-	 OASISExec.run_read_one_line ~ctxt llvm_config ["--"^v] in
-       if strip_patch llvm_version > "3.4" && var = "ldflags"
-       then extract var ^ extract "system-libs"
-       else extract var) |>
-    definition_end
-
 let cxx_flags () : unit =
   BaseEnv.var_define
     ~hide:true
     ~dump:true
     ~short_desc:(fun () -> "c++ flags")
     "cxxflags"
-    (fun () -> "-std=c++11 -I$standard_library -I$libdir/bap -Ilib/bap_disasm") |>
+    (fun () -> "-std=c++11 -fPIC -I$standard_library -I$libdir/bap -Ilib/bap_disasm") |>
   definition_end
 
 let cxx_libs () : unit =
@@ -104,14 +28,6 @@ let cxx_libs () : unit =
     (fun () -> if BaseEnv.var_get "system" = "macosx" then "-lc++" else "-lstdc++") |>
   definition_end
 
-let llvm_mainlib () : unit =
-  BaseEnv.var_define
-    ~hide:true
-    ~dump:true
-    ~short_desc:(fun () -> "main LLVM library")
-    "llvm_mainlib"
-    (fun () -> "-lLLVM-"^BaseEnv.var_get "llvm_version") |>
-  definition_end
 
 let cc_optimization () : unit =
   BaseEnv.var_define
@@ -122,22 +38,6 @@ let cc_optimization () : unit =
     "cc_optimization"
     (fun () -> "-O2") |>
   definition_end
-
-let llvm_lib () : unit =
-  BaseEnv.var_define
-    ~hide:true
-    ~dump:true
-    ~short_desc:(fun () -> "LLVM library(ies) to link with")
-    "llvm_lib"
-    (fun () ->
-       let llvm_static = BaseEnv.var_get "llvm_static" in
-       let lib = if llvm_static = "true"
-         then "llvm_libs"
-         else "llvm_mainlib" in
-       BaseEnv.var_get lib) |>
-  definition_end
-
-
 
 let check =
   let open OASISMessage in
@@ -155,8 +55,6 @@ let install_headers hdrs =
       | Some "bap" -> (cs, bs, lib, dirs, hdrs)
       | _ -> (cs, bs, lib, dirs, [])
 
-let define definitions =
-  List.iter (fun f -> try f () with exn -> ()) definitions
 
 let () =
 
@@ -164,19 +62,10 @@ let () =
   BaseEnv.var_get "standard_library";
 
   define [
-    piqic;
     cxx;
     cxx_flags;
     cxx_libs;
     cc_optimization;
-    llvm_version;
-    llvm_config;
-    llvm_mainlib;
-    llvm "cxxflags";
-    llvm "ldflags";
-    llvm "cflags";
-    llvm "libs";
-    llvm_lib;
   ];
 
   install_headers [


### PR DESCRIPTION
This PR makes our build system less hackish and, hopefully, more robust. To summarize:

* remove hardcoded llvm flags from the c++ rules (prevented building bap without llvm)
* give each module its own configuration (removes abstraction leaks between modules)
* use tags in the new rules (allows further extension)
* don't panic when llvm-config is not found (indeed why should we)
