### PR TITLE
added pretty printers for some events in bap-traces

### DIFF
--- a/lib/bap_traces/bap_trace_events.ml
+++ b/lib/bap_traces/bap_trace_events.ml
@@ -87,6 +87,23 @@ module Modload = struct
     Format.fprintf fmt "%s: %a - %a" t.name Addr.pp t.low Addr.pp t.high
 end
 
+let ppv name pp fmt t = Format.fprintf fmt "%s: %a" name pp t
+
+module Context_switch = struct
+  type t = int [@@deriving bin_io, compare, sexp]
+  let pp = ppv "context-switch" Int.pp
+end
+
+module Time_stamp = struct
+  type t = int64 [@@deriving bin_io, compare, sexp]
+  let pp = ppv "timestamp" Int64.pp
+end
+
+module Pc_update = struct
+  type t = addr [@@deriving bin_io, compare, sexp]
+  let pp = ppv "pc-update" Word.pp
+end
+
 let memory_load =
   Value.Tag.register (module Load)
     ~name:"memory-load"
@@ -108,12 +125,12 @@ let register_write =
     ~uuid:"395f5f37-5aed-4bd2-a51f-1c7216b5cd7c"
 
 let timestamp =
-  Value.Tag.register (module Int64)
+  Value.Tag.register (module Time_stamp)
     ~name:"timestamp"
     ~uuid:"0feea5c2-b471-48e4-a10f-c7e18cbf21a9"
 
 let pc_update =
-  Value.Tag.register (module Addr)
+  Value.Tag.register (module Pc_update)
     ~name:"pc-update"
     ~uuid:"98ea397e-d726-43be-9ec5-bf226d67578f"
 
@@ -123,7 +140,7 @@ let code_exec =
     ~uuid:"b8b3af3a-d1aa-4bf0-a36f-4ea6d0dd2bbf"
 
 let context_switch =
-  Value.Tag.register (module Int)
+  Value.Tag.register (module Context_switch)
     ~name:"context-switch"
     ~uuid:"7f1d322a-d2cc-4e42-8e7a-081080751268"
 

--- a/lib/bap_traces/bap_trace_events.mli
+++ b/lib/bap_traces/bap_trace_events.mli
@@ -20,7 +20,23 @@ val register_read : var move tag
 (** a value is written to the specified register  *)
 val register_write : var move tag
 
-(** this event can used to synchronize traces  *)
+(** this event can used to synchronize traces.
+    The semantics is unspecified and remains open, so that a particular
+    user can define its own meaning. But, the idea behind it, is that
+    this event introduces a countable ordering. Basically, one can
+    define a timeline, based on its own definition of a timescale.
+    To keep it more concrete, here are the examples of different time
+    scales:
+    1. every new event (except the timestamp itself) increments the
+       clock (basically all events are interleaved with the timestamp events)
+    2. every new instruction increments the clock (e.g., timestamp is
+       inserted after each `code_exec` event)
+    3. the clock is incremented every cpu cycle (e.g., timestamps are
+       incremented after each `code_exec` for the number of cpu cycles,
+       that the executed instruction took)
+    4. the clock is incremented every realtime second (e.g., obvious)
+    5. the clock is incremented every realtime second,  and is initialized
+       with the number of second that has passed since the start of the Epoch. *)
 val timestamp : int64 tag
 
 (** CPU PC register changed its value  *)


### PR DESCRIPTION
this PR adds pretty printers for next events in `bap-traces`: `timestamp`, `pc_update` and `context_switch`.