### PR TITLE
fixed segfault in llvm stubs

### DIFF
--- a/plugins/llvm/llvm_binary.hpp
+++ b/plugins/llvm/llvm_binary.hpp
@@ -302,11 +302,11 @@ image* create_image_elf(std::unique_ptr<object::Binary> binary) {
 
 image* create_image_obj(std::unique_ptr<object::Binary> binary) {
     if (binary->isCOFF())
-	return create_image<COFFObjectFile>(move(binary));
+        return create_image<COFFObjectFile>(move(binary));
     if (binary->isELF())
-	return create_image_elf(move(binary));
+        return create_image_elf(move(binary));
     if (binary->isMachO())
-	return create_image<MachOObjectFile>(move(binary));
+        return create_image<MachOObjectFile>(move(binary));
     std::cerr << "Unrecognized object format\n";
     return NULL;
 }
@@ -317,10 +317,12 @@ image* create_image_arch(std::unique_ptr<object::Binary> binary) {
 }
 
 image* create(std::unique_ptr<object::Binary> binary) {
+    if (!binary)
+        return NULL;
     if (isa<Archive>(*binary))
-	return create_image_arch(move(binary));
+        return create_image_arch(move(binary));
     if (isa<ObjectFile>(*binary))
-	return create_image_obj(move(binary));
+        return create_image_obj(move(binary));
     std::cerr << "Unrecognized binary format\n";
     return NULL;
 }

--- a/plugins/llvm/llvm_binary_34.hpp
+++ b/plugins/llvm/llvm_binary_34.hpp
@@ -371,11 +371,12 @@ std::unique_ptr<object::Binary> get_binary(const char* data, std::size_t size) {
     MemoryBuffer* buff(MemoryBuffer::getMemBufferCopy(data_ref, "binary"));
     OwningPtr<object::Binary> bin;
     if (error_code ec = createBinary(buff, bin)) {
-	std::cerr << ec << "\n";
+        std::cerr << ec.message() << std::endl;
         return NULL;
     }
     std::unique_ptr<object::Binary> binary(bin.take());
     return move(binary);
+
 }
 
 } //namespace img

--- a/plugins/llvm/llvm_binary_38.hpp
+++ b/plugins/llvm/llvm_binary_38.hpp
@@ -236,7 +236,7 @@ std::unique_ptr<object::Binary> get_binary(const char* data, std::size_t size) {
     MemoryBufferRef buf(data_ref, "binary");
     auto binary = createBinary(buf);
     if (error_code ec = binary.getError()) {
-	std::cerr << ec << "\n";
+        std::cerr << ec.message() << std::endl;
         return NULL;
     }
     return move(*binary);

--- a/plugins/llvm/llvm_binary_stubs.c
+++ b/plugins/llvm/llvm_binary_stubs.c
@@ -6,7 +6,7 @@
 #include <caml/compatibility.h>
 #include <inttypes.h>
 #include <stdbool.h>
-
+#include <stdio.h>
 #include "llvm_binary_stubs.h"
 #include "llvm_binary.h"
 
@@ -126,8 +126,12 @@ CAMLprim value llvm_binary_create_stub(value arg) {
     const struct caml_ba_array* array = Caml_ba_array_val(arg);
     if (array->num_dims != 1)
         caml_invalid_argument("invalid bigarray dimension");
+    if (!array->dim[0])
+        caml_invalid_argument("Unexpected EOF");
     const struct image* obj =
         image_create((const char*)(array->data), array->dim[0]);
+    if (!obj) 
+        caml_failwith("Bad file format");
     CAMLreturn(image_to_value(obj));
 }
 


### PR DESCRIPTION
fix https://github.com/BinaryAnalysisPlatform/bap/issues/571

Although segfault could happen with every type of files, because `llvm` just can't guess a magic, as it is for example given in the issue.
