### PR TITLE
added two env variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ addons:
     - dejagnu
 
 env:
-  - FORK_USER=talex5 FORK_BRANCH=containers OPAMYES=true PACKAGE=bap OCAML_VERSION=latest TESTS=false
+  - FORK_USER=talex5 FORK_BRANCH=containers OPAMYES=true PACKAGE=bap OCAML_VERSION=latest TESTS=false BAP_RUN_TEST=true BAP_RUN_CHECK=true

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,6 @@ build: setup.ml
 doc:
 	make -C doc
 
-test: build
-	$(SETUP) -test $(BAPTESTFLAGS)
-
 all:
 	$(SETUP) -all $(BAPALLFLAGS)
 
@@ -32,7 +29,19 @@ distclean:
 
 .PHONY: clean disclean reinstall
 
+.PHONY: test
+
 .PHONY: check
+
+test: build
+ifeq ("$(BAP_RUN_TEST)","true")
+	$(SETUP) -test $(BAPTESTFLAGS)
+endif
+
 check:
-	if [ -d .git ]; then git submodule init; git submodule update; fi
+ifeq ("$(BAP_RUN_CHECK)","true")
+	if [ -d .git ]; then git submodule init; git submodule update; 	fi
 	make -C testsuite
+endif
+
+


### PR DESCRIPTION
This PR introduce two environment variables, `BAP_RUN_TEST` and `BAP_RUN_CHECK`. So users have more control over install process, and all tests and check could be done only with setting this variables to `true`.