### PR TITLE
fix an extract function for x86 pshufd/pshufb insns

### DIFF
--- a/plugins/x86/x86_utils.ml
+++ b/plugins/x86/x86_utils.ml
@@ -36,7 +36,7 @@ let int_exp n width = BV.of_int n ~width |> Bil.int
  * so that we can avoid calling Typecheck.infer_ast *)
 let extract_element_symbolic_with_width t e n et =
   let t = !!t in
-  Bil.(cast low t (e lsl (n * (int_exp t et))))
+  Bil.(cast low t (e lsr (n * (int_exp t et))))
 
 let extract_byte_symbolic_with_width e n et =
   extract_element_symbolic_with_width (Type.imm 8) e n et


### PR DESCRIPTION
this expression `Bil.(cast low t (e lsl (n * (int_exp t et))))`
means to take `low t` bits from an `e lsl (n * (int_exp t et))`,
where the expression from the right of `lsl` actually
evaluates to a start bit, where to start extaction. so doing a
left shift and taking low bits is wrong approach

those changes influences on instructions: `PSHUFB` and `PSHUFD`