### PR TITLE
use bapbundle with plugins without specifying extension

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@
 ### Bug fixes
 1. PR#586 fixed segfault with short or damaged files fed to bap.
 2. PR#590 fixed llvm 3.8 specific issues
+3. PR#592 fixed a bug in lifting x86 PSHUFD/PSHUFB instructions
+
+### Features
+1. PR#593 bapbundle: it is no longer needed to specify the .plugin extension
+
 
 1.0.0
 =====


### PR DESCRIPTION
fix https://github.com/BinaryAnalysisPlatform/bap/issues/381

allows to install/remove bap plugins without specifying extensions, e.g.
 `bapbundle install mycode` instead of `bapbundle install mycode.plugin`. 
The latter version is still available. The same is for `update` and `show` commands.