### PR TITLE
fixed a bap exit status for unknown files, options and passes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 1. PR#586 fixed segfault with short or damaged files fed to bap.
 2. PR#590 fixed llvm 3.8 specific issues
 3. PR#592 fixed a bug in lifting x86 PSHUFD/PSHUFB instructions
+4. PR#595 fixed bap exit status
 
 ### Features
 1. PR#593 bapbundle: it is no longer needed to specify the .plugin extension


### PR DESCRIPTION
fix https://github.com/BinaryAnalysisPlatform/bap/issues/591

`bap` exits abnormally on unknown pass or option, or if file doesn't exist
