### PR TITLE
fixed some compilation warnings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 2. PR#590 fixed llvm 3.8 specific issues
 3. PR#592 fixed a bug in lifting x86 PSHUFD/PSHUFB instructions
 4. PR#595 fixed bap exit status
+5. PR#596 fixed most of compilation warnings
 
 ### Features
 1. PR#593 bapbundle: it is no longer needed to specify the .plugin extension

--- a/lib/bap_disasm/bap_disasm_prim.ml
+++ b/lib/bap_disasm/bap_disasm_prim.ml
@@ -42,7 +42,7 @@ type op =
   | Insn
 [@@deriving compare, sexp]
 
-
+[@@@ocaml.warning "-3"]
 
 external create
   : backend:string

--- a/lib/bap_types/bap_exp.ml
+++ b/lib/bap_types/bap_exp.ml
@@ -162,6 +162,8 @@ module PP = struct
     let a e = format_of_string
         (if is_imm e then "%a" else "(%a)") in
     let pr s = fprintf fmt s in
+    let is_b0 x = Bitvector.(x = b0) in
+    let is_b1 x = Bitvector.(x = b1) in
     match exp with
     | Load (Var _ as mem, idx, edn, s) ->
       pr "%a[%a, %a]:%a" pp mem pp idx pp_edn edn Bap_size.pp s
@@ -176,11 +178,10 @@ module PP = struct
       pr "extract: %d:%d[%a]" hi lo pp exp
     | Concat (le, re) ->
       pr (a le ^^ "." ^^ a re) pp le pp re
-    | BinOp (EQ,e, Int x) | BinOp (EQ,Int x, e)
-      when Bitvector.(x = b1) -> pr ("%a") pp e
-    | BinOp (EQ,e, Int x) | BinOp (EQ,Int x, e)
-      when Bitvector.(x = b0) ->
-      pr ("%a(%a)") pp_unop Unop.NOT pp e
+    | BinOp (EQ,e, Int x) when is_b1 x -> pr ("%a") pp e
+    | BinOp (EQ,Int x, e) when is_b1 x -> pr ("%a") pp e
+    | BinOp (EQ,e, Int x) when is_b0 x -> pr ("%a(%a)") pp_unop Unop.NOT pp e
+    | BinOp (EQ,Int x, e) when is_b0 x -> pr ("%a(%a)") pp_unop Unop.NOT pp e
     | BinOp (op, le, re) ->
       pr (a le ^^ " %a " ^^ a re) pp le pp_binop op pp re
     | UnOp (NOT, BinOp(LE,le,re)) ->

--- a/lib/bap_types/bap_helpers.ml
+++ b/lib/bap_types/bap_helpers.ml
@@ -137,11 +137,12 @@ module Constant_folder = struct
       | NEQ, e1, e2 when equal e1 e2 -> Int Word.b0
       | (LT|SLT), e1, e2 when equal e1 e2 -> Int Word.b0
       | (PLUS|LSHIFT|RSHIFT|ARSHIFT|OR|XOR), Int v, e
+        when Word.is_zero v -> e
       | (PLUS|MINUS|LSHIFT|RSHIFT|ARSHIFT|OR|XOR), e, Int v
         when Word.is_zero v -> e
-      | (TIMES|AND),e,Int v
+      | (TIMES|AND),e,Int v when Word.is_one v -> e
       | (TIMES|AND), Int v, e when Word.is_one v -> e
-      | (TIMES|AND), e, Int v
+      | (TIMES|AND), e, Int v when Word.is_zero v -> Int v
       | (TIMES|AND), Int v, e when Word.is_zero v -> Int v
       | (OR|AND), v1, v2 when equal v1 v2 -> v1
       | (XOR), v1, v2 when equal v1 v2 -> zero v1 v2

--- a/lib/regular/regular.mli
+++ b/lib/regular/regular.mli
@@ -1113,8 +1113,12 @@ module Std : sig
       (** The following is for system use only. Do not call directly. *)
       external get  : t -> int -> char = "%string_unsafe_get"
       external set  : t -> int -> char -> unit = "%string_unsafe_set"
+
+      [@@@ocaml.warning "-3"]
+
       external blit : t -> int -> t -> int -> int -> unit = "caml_blit_string" "noalloc"
       external fill : t -> int -> int -> char -> unit = "caml_fill_string" "noalloc"
+
       (**/**)
     end
   end

--- a/lib/regular/regular_bytes.ml
+++ b/lib/regular/regular_bytes.ml
@@ -1,4 +1,3 @@
-
 module Std_bytes = Bytes
 
 open Core_kernel.Std
@@ -94,6 +93,8 @@ include Identifiable.Make(struct
   end)
 
 module Unsafe = struct
+  [@@@ocaml.warning "-3"]
+
   let of_string = T.unsafe_of_string
   let to_string = T.unsafe_to_string
 

--- a/lib/regular/regular_bytes.mli
+++ b/lib/regular/regular_bytes.mli
@@ -1,4 +1,3 @@
-
 open Core_kernel.Std
 
 type t = Bytes.t [@@deriving bin_io, compare, sexp]
@@ -41,6 +40,8 @@ val capitalize : t -> t
 val uncapitalize : t -> t
 
 module Unsafe : sig
+  [@@@ocaml.warning "-3"]
+
   val to_string : t -> string
   val of_string : string -> t
   external get  : t -> int -> char = "%string_unsafe_get"
@@ -48,4 +49,3 @@ module Unsafe : sig
   external blit : t -> int -> t -> int -> int -> unit = "caml_blit_string" "noalloc"
   external fill : t -> int -> int -> char -> unit = "caml_fill_string" "noalloc"
 end
-

--- a/plugins/llvm/llvm_disasm.cpp
+++ b/plugins/llvm/llvm_disasm.cpp
@@ -482,7 +482,7 @@ private:
     insn valid_insn(location loc) const {
         insn ins;
 
-        for (int i = 0; i < mcinst.getNumOperands(); ++i) {
+        for (std::size_t i = 0; i < mcinst.getNumOperands(); ++i) {
             const llvm::MCOperand &op = mcinst.getOperand(i);
             if (!op.isValid() || op.isExpr()) {
                 if (debug_level > 0) {
@@ -579,7 +579,7 @@ private:
     }
 
     void init_prefixes() {
-        for (int i = 0; i < ins_info->getNumOpcodes(); i++) {
+        for (std::size_t i = 0; i < ins_info->getNumOpcodes(); i++) {
             if (ends_with(ins_info->getName(i), "_PREFIX")) {
                 prefixes.push_back(i);
             }

--- a/plugins/llvm/llvm_main.ml
+++ b/plugins/llvm/llvm_main.ml
@@ -2,6 +2,8 @@ open Core_kernel.Std
 open Bap.Std
 include Self()
 
+[@@@ocaml.warning "-3"]
+
 external init : unit -> int = "disasm_llvm_init_stub" "noalloc"
 
 let () =

--- a/plugins/phoenix/phoenix_printing.ml
+++ b/plugins/phoenix/phoenix_printing.ml
@@ -33,13 +33,12 @@ module Make(Env : sig val project : project end) = struct
 
   let pp_bil : bil pp = Bil.pp
 
-
   let pp_insn_line fmt (mem,insn) =
     pp_print_cut fmt ();
     pp_print_tab fmt ();
     Memory.pp fmt mem;
     pp_print_tab fmt ();
-    Insn.pp fmt insn
+    Insn.pp fmt insn [@ocaml.warning "-3"]
 
   let pp_nothing _ () = ()
   let pp_insns = pp_list ~sep:pp_nothing pp_insn_line
@@ -82,7 +81,7 @@ module Make(Env : sig val project : project end) = struct
     pp_print_as fmt 25 "";
     pp_set_tab fmt ();
     pp_print_as fmt 20 "";
-    pp_set_tab fmt ()
+    pp_set_tab fmt ()  [@ocaml.warning "-3"]
 
   (** prints a code as html document  *)
   let pp_code pp fmt v =
@@ -97,5 +96,5 @@ module Make(Env : sig val project : project end) = struct
        (href ../../../css/code-panel.css))>@}@}@{<body>%a@;@}@}" pp v;
     pp_close_tbox fmt ();
     pp_close_box fmt ();
-    pp_print_flush fmt ()
+    pp_print_flush fmt () [@ocaml.warning "-3"]
 end

--- a/plugins/print/print_main.ml
+++ b/plugins/print/print_main.ml
@@ -233,7 +233,7 @@ let pp_addr ppf addr =
 
 let setup_tabs ppf =
   pp_print_as ppf 50 "";
-  pp_set_tab ppf ()
+  pp_set_tab ppf () [@ocaml.warning "-3"]
 
 let print_disasm pp_insn subs secs ppf proj =
   let memory = Project.memory proj in
@@ -256,7 +256,7 @@ let print_disasm pp_insn subs secs ppf proj =
                   let mem = Block.memory blk in
                   fprintf ppf "%a:@\n" pp_addr (Memory.min_addr mem);
                   Block.insns blk |> List.iter ~f:(pp_insn ppf))));
-  pp_close_tbox ppf ()
+  pp_close_tbox ppf () [@ocaml.warning "-3"]
 
 let pp_bil fmt ppf (mem,insn) =
   let pp_bil ppf = Bil.Io.print ~fmt ppf in
@@ -268,7 +268,7 @@ let pp_insn fmt ppf (mem,insn) =
   Memory.pp ppf mem;
   pp_print_tab ppf ();
   Insn.Io.print ~fmt ppf insn;
-  fprintf ppf "@\n"
+  fprintf ppf "@\n" [@ocaml.warning "-3"]
 
 let main attrs ansi_colors demangle symbol_fmts subs secs =
   let ver = version in


### PR DESCRIPTION
fixed https://github.com/BinaryAnalysisPlatform/bap/issues/572

next warnings were silenced with `ocaml.warning` attribute:
```
Warning 3: deprecated: [@@noalloc] should be used instead of "noalloc"
Warning 3: deprecated: Format.pp_close_tbox
Warning 3: deprecated: Format.pp_open_tbox
Warning 3: deprecated: Format.pp_print_tab
Warning 3: deprecated: Format.pp_set_tab
```
next warnings were fixed by code edition
`Warning 57: Ambiguous or-pattern variables under guard`

next warnings weren't fixed and still appears during compilation:
```
Warning 58: no cmx file was found in path for module Clexer, and its interface was not compiled with -opaque
Warning 58: no cmx file was found in path for module Cparser, and its interface was not compiled with -opaque
Warning 58: no cmx file was found in path for module Topdirs, and its interface was not compiled with -opaque
Warning 58: no cmx file was found in path for module Z, and its interface was not compiled with -opaque
Warning: -pp overrides the effect of -syntax partly
```