### PR TITLE
api plugin stops processing in case of failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
 3. PR#592 fixed a bug in lifting x86 PSHUFD/PSHUFB instructions
 4. PR#595 fixed bap exit status
 5. PR#596 fixed most of compilation warnings
+6. PR#597 fixed api plugin exit status
+
 
 ### Features
 1. PR#593 bapbundle: it is no longer needed to specify the .plugin extension

--- a/plugins/api/api_main.ml
+++ b/plugins/api/api_main.ml
@@ -37,7 +37,7 @@ let main proj =
   Result.all |> function
   | Error e ->
     error "api wasn't applied: %a" Error.pp e;
-    proj
+    exit 1
   | Ok mappers ->
     let prog = Project.program proj in
     List.fold mappers ~init:prog ~f:(fun prog map -> map#run prog) |>


### PR DESCRIPTION
fix https://github.com/BinaryAnalysisPlatform/bap/issues/589

Api plugin stops with `exit 1` and emitting error message.