### PR TITLE
propagate backtraces from passes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,16 +2,17 @@
 =====
 
 ### Bug fixes
-1. PR#586 fixed segfault with short or damaged files fed to bap.
-2. PR#590 fixed llvm 3.8 specific issues
-3. PR#592 fixed a bug in lifting x86 PSHUFD/PSHUFB instructions
-4. PR#595 fixed bap exit status
-5. PR#596 fixed most of compilation warnings
-6. PR#597 fixed api plugin exit status
+1. PR#586 segfault with short or damaged files fed to bap.
+2. PR#590 llvm 3.8 specific issues
+3. PR#592 a bug in lifting x86 PSHUFD/PSHUFB instructions
+4. PR#595 bap exit status
+5. PR#596 most of the compilation warnings
 
 
 ### Features
 1. PR#593 bapbundle: it is no longer needed to specify the .plugin extension
+2. PR#597 API pass will stop processing in case of the error
+7. PR#599 print backtraces from passes
 
 
 1.0.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,49 +2,36 @@
 =====
 
 ### Bug fixes
-1. PR#586 segfault with short or damaged files fed to bap.
-2. PR#590 llvm 3.8 specific issues
-3. PR#592 a bug in lifting x86 PSHUFD/PSHUFB instructions
-4. PR#595 bap exit status
-5. PR#596 most of the compilation warnings
+- PR#586 segfault with short or damaged files fed to bap.
+- PR#590 llvm 3.8 specific issues
+- PR#592 a bug in lifting x86 PSHUFD/PSHUFB instructions
+- PR#595 bap exit status
+- PR#596 most of the compilation warnings
 
 
 ### Features
-1. PR#593 bapbundle: it is no longer needed to specify the .plugin extension
-2. PR#597 API pass will stop processing in case of the error
-7. PR#599 print backtraces from passes
+- PR#593 bapbundle: it is no longer needed to specify the .plugin extension
+- PR#597 API pass will stop processing in case of the error
+- PR#599 print backtraces from passes
 
 
 1.0.0
 =====
 
-1. A more powerful plugin system
-
-2. Split Bap.Std into several libraries.
-
-3. The disassembler layer is severly rewritten
-
-4. Made project storable and loadable
-
-5. Added new injection points
-
-6. Added BIL interpreters
-
-7. Removed bap-server
-
-8. New python interface (see https://BinaryAnalysisPlatform/bap-python)
-
-9. New ida integration, that works in both directions
-
-10. Multipass disassembling
-
-11. llvm-3.8 support (#546)
-
-12. new x86 lifter (#549)
-
-13. new testsuite with functional tests (#520)
-
-14. extensible API/ABI (#448)
+- A powerful plugin system
+- Split Bap.Std into several libraries.
+- The disassembler layer is severly rewritten
+- Made project storable and loadable
+- Added new injection points
+- Added BIL interpreters
+- Removed bap-server
+- New python interface (see https://BinaryAnalysisPlatform/bap-python)
+- New ida integration, that works in both directions
+- Multipass disassembling
+- llvm-3.8 support (#546)
+- new x86 lifter (#549)
+- new testsuite with functional tests (#520)
+- extensible API/ABI (#448)
 
 0.9.9
 =====

--- a/lib/bap/bap_project.ml
+++ b/lib/bap/bap_project.ml
@@ -442,7 +442,12 @@ module Pass = struct
     DList.find passes ~f:(fun p -> p.name = name)
 
   exception Failed of error [@@deriving sexp]
-  let fail error = raise (Failed error)
+
+  let fail = function
+    | Unsat_dep _ as err -> raise (Failed err)
+    | Runtime_error (pass,exn) ->
+      let backtrace = Caml.Printexc.get_backtrace () in
+      raise (Failed (Runtime_error (pass, Exn.Reraised (backtrace, exn))))
 
   let is_evaled pass proj =
     List.exists proj.passes ~f:(fun name -> name = pass.name)

--- a/src/bap_main.ml
+++ b/src/bap_main.ml
@@ -248,10 +248,11 @@ let () =
   | Project.Pass.Failed (Project.Pass.Unsat_dep (p,n)) ->
     error "Dependency `%s' of pass `%s' is not loaded"
       n (Project.Pass.name p)
-  | Project.Pass.Failed (Project.Pass.Runtime_error (p,exn)) ->
-    error "Pass `%s' failed at runtime with: %a"
-      (Project.Pass.name p) Exn.pp exn
   | Pass_not_found p -> error "Failed to find pass: %s" p
+  | Project.Pass.Failed
+      (Project.Pass.Runtime_error (p, Exn.Reraised (backtrace, exn))) ->
+    error "Pass `%s' failed at runtime with: %a\nBacktrace:\n%s"
+      (Project.Pass.name p) Exn.pp exn backtrace
   | exn ->
     error "Failed with an unexpected exception: %a\nBacktrace:\n%s"
       Exn.pp exn


### PR DESCRIPTION
Allow users to see a backtrace when an exception is thrown
from a pass.

The backtraces are printed for any exceptions, including Failure and
Invalid_arg (i.e., special handlers for these exceptions are disabled).

Resolve #598.

The problem
===========

The pass runner is capturing exceptions that are thrown by a pass, and
rethows it wrapped into the `Pass.Failed` exception. Since the newly
thrown exception is physically (and structurally) different from the
caught exception the backtraces is erased and is not propagated any
further. As a result, the printed backtrace shows only the path from the
pass runner to the entry point of the frontend. That is always the same
and does't really bear any information.

Obstacles
=========

Since the BAP API is fronzen, we can't change the `Pass.error` type, or
the `Failed` exception.

Solution
========

The backtraces is extraced by the pass runner at the place where it is
caught and translated into a string, then it is attached to the
`Exn.Reraised` exception, and reraised. There is a room for improvement,
however. First of all, we're sort of abusing the `Exn.Reraised`
exception. However, the abuse is local, and other solutions, would not
be anymore safe or robust (other then an api-breaking change, that will
affect the representation of the exception or the error type). Second,
the propagated backtraces still has few slots, that are specific to the
pass runner and do not bear any interesting information. It should be
nice, to trime them away, to get a clean trace, that starts from the
user plugin.