### PR TITLE
fix silenced warnings

### DIFF
--- a/plugins/phoenix/phoenix_printing.ml
+++ b/plugins/phoenix/phoenix_printing.ml
@@ -35,10 +35,10 @@ module Make(Env : sig val project : project end) = struct
 
   let pp_insn_line fmt (mem,insn) =
     pp_print_cut fmt ();
-    pp_print_tab fmt ();
+    pp_print_tab fmt () [@ocaml.warning "-3"];
     Memory.pp fmt mem;
-    pp_print_tab fmt ();
-    Insn.pp fmt insn [@ocaml.warning "-3"]
+    pp_print_tab fmt () [@ocaml.warning "-3"];
+    Insn.pp fmt insn
 
   let pp_nothing _ () = ()
   let pp_insns = pp_list ~sep:pp_nothing pp_insn_line
@@ -77,24 +77,24 @@ module Make(Env : sig val project : project end) = struct
 
   let setup_tab_stops fmt =
     pp_print_as fmt 6 "";
-    pp_set_tab fmt ();
+    pp_set_tab fmt () [@ocaml.warning "-3"];
     pp_print_as fmt 25 "";
-    pp_set_tab fmt ();
+    pp_set_tab fmt () [@ocaml.warning "-3"];
     pp_print_as fmt 20 "";
-    pp_set_tab fmt ()  [@ocaml.warning "-3"]
+    pp_set_tab fmt () [@ocaml.warning "-3"]
 
   (** prints a code as html document  *)
   let pp_code pp fmt v =
     pp_print_cut fmt ();
     pp_open_vbox fmt 0;
-    pp_open_tbox fmt ();
+    pp_open_tbox fmt () [@ocaml.warning "-3"];
     setup_tab_stops fmt;
     fprintf fmt
       "@;@{<html>@{<head>@{<(link
        (rel stylesheet)
        (type css)
        (href ../../../css/code-panel.css))>@}@}@{<body>%a@;@}@}" pp v;
-    pp_close_tbox fmt ();
+    pp_close_tbox fmt () [@ocaml.warning "-3"];
     pp_close_box fmt ();
-    pp_print_flush fmt () [@ocaml.warning "-3"]
+    pp_print_flush fmt ()
 end

--- a/plugins/print/print_main.ml
+++ b/plugins/print/print_main.ml
@@ -238,8 +238,8 @@ let setup_tabs ppf =
 let print_disasm pp_insn subs secs ppf proj =
   let memory = Project.memory proj in
   let syms = Project.symbols proj in
-  pp_open_tbox ppf ();
-  setup_tabs ppf;
+  pp_open_tbox ppf () [@ocaml.warning "-3"];
+  setup_tabs ppf [@ocaml.warning "-3"];
   Memmap.filter_map memory ~f:(Value.get Image.section) |>
   Memmap.to_sequence |> Seq.iter ~f:(fun (mem,sec) ->
       Symtab.intersecting syms mem |>
@@ -266,9 +266,9 @@ let pp_bil fmt ppf (mem,insn) =
 
 let pp_insn fmt ppf (mem,insn) =
   Memory.pp ppf mem;
-  pp_print_tab ppf ();
+  pp_print_tab ppf ()  [@ocaml.warning "-3"];
   Insn.Io.print ~fmt ppf insn;
-  fprintf ppf "@\n" [@ocaml.warning "-3"]
+  fprintf ppf "@\n"
 
 let main attrs ansi_colors demangle symbol_fmts subs secs =
   let ver = version in


### PR DESCRIPTION
silence warnings, that were improperly silenced before, because of wrong
`[@ocaml.warning]` position
