### PR TITLE
update to the new IDA integration interface

### DIFF
--- a/plugins/ida/bap_ida_service.ml
+++ b/plugins/ida/bap_ida_service.ml
@@ -1,6 +1,7 @@
 open! Core_kernel.Std
 open Bap_ida.Std
 
+
 type ida = {
   ida : string;
   exe : string;


### PR DESCRIPTION
This PR makes BAP compatible with the new bap-ida-python package.

It also introduces few improvements, like a proper handling of the
special characters in the generated output, and ignoring attributes
that do not have an address.