### PR TITLE
force Docker to build master branch

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN sed -i.bkp -e \
 USER bap
 WORKDIR /home/bap
 RUN opam init --auto-setup --comp=4.02.3 --yes
-RUN opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository
+RUN opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
 RUN opam update
 RUN opam depext --install bap --yes
 RUN sudo pip install bap


### PR DESCRIPTION
fix https://github.com/BinaryAnalysisPlatform/bap/issues/607

Forced Docker to build last `bap` version, from `master` branch.