### PR TITLE
support for Debian 8

### DIFF
--- a/vagrant/jessie64/Vagrantfile
+++ b/vagrant/jessie64/Vagrantfile
@@ -1,0 +1,21 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "debian/jessie64"
+  config.vm.provider "virtualbox" do |vb|
+      vb.memory = "4096"
+  end
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+sudo apt-get update
+sudo apt-get --yes install clang
+sudo apt-get --yes install opam
+opam init --auto-setup --comp=4.02.3 --yes
+eval `opam config env`
+opam install depext --yes
+opam depext conf-llvm.3.4 --install --yes
+opam depext bap --install --yes
+sudo apt-get install python-pip --yes
+sudo pip install bap
+SHELL
+end


### PR DESCRIPTION
As a followup to the #614 I've added a Vagrant file that provisions
jessie with BAP. There are few issues:

- jessie has an old opam that doesn't support plugin autoinstallation
  (`opam install depext` solves this issue);
- jessie has llvm-3.4 and our magic for picking the right version didn't
  work as expected due to the old opam, so one need to explicitly
  install the required version, e.g.,
  `opam depext conf-llvm.3.4 --install`

- bap silently uses clang for compiling C++ parts, that is not available
  by default on jessie, so an explicit  `sudo apt-get install clang` is
  needed (see #617)

Basically, the following script should work on a fresh jessie box:

```shell
sudo apt-get update
sudo apt-get --yes install clang
sudo apt-get --yes install opam
opam init --auto-setup --comp=4.02.3 --yes
eval `opam config env`
opam install depext
opam depext conf-llvm.3.4 --install --yes
opam depext bap --install --yes
sudo apt-get install python-pip --yes
sudo pip install bap
```