### PR TITLE
removed a dependency from cmdliner in plugins

### DIFF
--- a/oasis/api
+++ b/oasis/api
@@ -16,7 +16,7 @@ Library api_plugin
   Path:             plugins/api
   FindlibName:      bap-plugin-api
   CompiledObject:   best
-  BuildDepends:     bap, bap-api, cmdliner, fileutils
+  BuildDepends:     bap, bap-api, fileutils
   InternalModules:  Api_main, Api_config
   XMETADescription: add parameters to subroutines based on known API
   DataFiles:        api/c/posix ($datadir/bap-api/c)

--- a/oasis/beagle
+++ b/oasis/beagle
@@ -6,7 +6,7 @@ Library beagle_plugin
   Build$: flag(everything) || flag(beagle)
   Path: plugins/beagle
   FindlibName: bap-plugin-beagle
-  BuildDepends: bap, cmdliner, bap-microx, bap-beagle-prey
+  BuildDepends: bap, bap-microx, bap-beagle-prey
   InternalModules: Beagle_main, Beagle_trapper
   XMETADescription: microx powered obfuscated string solver
 

--- a/oasis/byteweight
+++ b/oasis/byteweight
@@ -15,6 +15,6 @@ Library byteweight_plugin
   FindlibName:      bap-plugin-byteweight
   Build$:           flag(everything) || flag(byteweight)
   CompiledObject:   best
-  BuildDepends:     bap, bap-byteweight, cmdliner
+  BuildDepends:     bap, bap-byteweight
   InternalModules:  Byteweight_main
   XMETADescription: find function starts using Byteweight algorithm

--- a/oasis/cache
+++ b/oasis/cache
@@ -6,6 +6,6 @@ Library cache_plugin
   Build$:           flag(everything) || flag(cache)
   Path:             plugins/cache
   FindlibName:      bap-plugin-cache
-  BuildDepends:     bap, cmdliner
+  BuildDepends:     bap
   InternalModules:  Cache_main
   XMETADescription: provide caching services

--- a/oasis/callsites
+++ b/oasis/callsites
@@ -7,6 +7,6 @@ Library callsites_plugin
   Path:             plugins/callsites
   FindlibName:      bap-plugin-callsites
   CompiledObject:   best
-  BuildDepends:     bap, cmdliner
+  BuildDepends:     bap
   Modules:          Callsites_main
   XMETADescription: annotate callsites with subroutine's arguments

--- a/oasis/demangle
+++ b/oasis/demangle
@@ -15,6 +15,6 @@ Library "demangle_plugin"
   Build$: flag(everything) || flag(demangle)
   FindlibName: bap-plugin-demangle
   CompiledObject: best
-  BuildDepends: core_kernel, bap-demangle, bap, cmdliner
+  BuildDepends: core_kernel, bap-demangle, bap
   InternalModules: Demangle_main
   XMETADescription: demangle subroutine names

--- a/oasis/dump-symbols
+++ b/oasis/dump-symbols
@@ -7,6 +7,6 @@ Library dump_symbols_plugin
   Path:             plugins/dump_symbols
   FindlibName:      bap-plugin-dump_symbols
   CompiledObject:   best
-  BuildDepends:     bap, cmdliner
+  BuildDepends:     bap
   InternalModules:  Dump_symbols_main
   XMETADescription: dump symbol information as a list of blocks

--- a/oasis/ida
+++ b/oasis/ida
@@ -18,7 +18,7 @@ Library bap_ida_plugin
   Path:             plugins/ida
   FindlibName:      bap-plugin-ida
   CompiledObject:   best
-  BuildDepends:     bap, bap-ida, cmdliner
+  BuildDepends:     bap, bap-ida
   Modules:          Ida_main
   InternalModules:  Bap_ida_config, Bap_ida_service
   XMETADescription: use ida to provide rooter, symbolizer and reconstructor

--- a/oasis/ida-plugin
+++ b/oasis/ida-plugin
@@ -6,6 +6,6 @@ Library emit_ida_script_plugin
   Build$:           flag(everything) || flag(ida_plugin)
   Path:             plugins/emit_ida_script
   FindlibName:      bap-plugin-emit_ida_script
-  BuildDepends:     bap, cmdliner
+  BuildDepends:     bap
   Modules:          Emit_ida_script_main
   XMETADescription: extract a IDA python script from bap

--- a/oasis/llvm
+++ b/oasis/llvm
@@ -35,6 +35,6 @@ Library llvm_plugin
   XMETADescription: provide loader and disassembler using LLVM library
   Path:          plugins/llvm
   Build$:        flag(everything) || flag(llvm)
-  BuildDepends:  bap, cmdliner, bap-llvm
+  BuildDepends:  bap, bap-llvm
   FindlibName:   bap-plugin-llvm
   InternalModules: Llvm_main

--- a/oasis/map-terms
+++ b/oasis/map-terms
@@ -14,6 +14,6 @@ Library map_terms_plugin
   Build$: flag(everything) || flag(map_terms)
   Path: plugins/map_terms
   FindlibName: bap-plugin-map_terms
-  BuildDepends: bap, bap-bml, cmdliner
+  BuildDepends: bap, bap-bml
   InternalModules: Map_terms_main
   XMETADescription: map terms using BML DSL

--- a/oasis/objdump
+++ b/oasis/objdump
@@ -7,6 +7,6 @@ Library objdump_plugin
   Path:             plugins/objdump
   FindlibName:      bap-plugin-objdump
   CompiledObject:   best
-  BuildDepends:     bap, cmdliner, re.pcre
+  BuildDepends:     bap, re.pcre
   InternalModules:  Objdump_main, Objdump_config
   XMETADescription: use objdump to provide a symbolizer

--- a/oasis/phoenix
+++ b/oasis/phoenix
@@ -6,7 +6,7 @@ Library phoenix_plugin
   Build$:           flag(everything) || flag(phoenix)
   Path:             plugins/phoenix
   FindlibName:      bap-plugin-phoenix
-  BuildDepends:     bap, cmdliner, text-tags, ocamlgraph, ezjsonm
+  BuildDepends:     bap, text-tags, ocamlgraph, ezjsonm
   InternalModules:  Phoenix_main,
                     Phoenix_dot,
                     Phoenix_helpers,

--- a/oasis/print
+++ b/oasis/print
@@ -8,6 +8,6 @@ Library print_plugin
   Build$:           flag(everything) || flag(print)
   Path:             plugins/print
   FindlibName:      bap-plugin-print
-  BuildDepends:     bap, cmdliner, text-tags, bap-demangle
+  BuildDepends:     bap, text-tags, bap-demangle
   InternalModules:  Print_main
   XMETADescription: print project in various formats

--- a/oasis/propagate-taint
+++ b/oasis/propagate-taint
@@ -6,6 +6,6 @@ Library propagate_taint_plugin
   Build$:  flag(everything) || flag(propagate_taint)
   Path: plugins/propagate_taint
   FindlibName: bap-plugin-propagate_taint
-  BuildDepends: bap, bap-microx, cmdliner
+  BuildDepends: bap, bap-microx
   InternalModules: Propagate_taint_main, Propagator
   XMETADescription: propagate taints through a program

--- a/oasis/symbol-reader
+++ b/oasis/symbol-reader
@@ -6,6 +6,6 @@ Library read_symbols_plugin
   Build$:           flag(everything) || flag(symbol_reader)
   Path:             plugins/read_symbols
   FindlibName:      bap-plugin-read_symbols
-  BuildDepends:     bap, cmdliner
+  BuildDepends:     bap
   Modules:          Read_symbols_main
   XMETADescription: read symbol information from file

--- a/oasis/taint
+++ b/oasis/taint
@@ -6,6 +6,6 @@ Library taint_plugin
   Build$:  flag(everything) || flag(taint)
   Path: plugins/taint
   FindlibName: bap-plugin-taint
-  BuildDepends: bap, cmdliner
+  BuildDepends: bap
   InternalModules: Taint_main
   XMETADescription: taint specified terms

--- a/oasis/trace
+++ b/oasis/trace
@@ -8,5 +8,5 @@ Library trace_plugin
   FindlibName:    bap-plugin-trace
   CompiledObject: best
   Modules: Trace_main
-  BuildDepends:   bap, cmdliner, bap-traces
+  BuildDepends:   bap, bap-traces
   XMETADescription: manage execution traces

--- a/oasis/warn-unused
+++ b/oasis/warn-unused
@@ -6,6 +6,6 @@ Library warn_unused_plugin
   Build$:  flag(everything) || flag(warn_unused)
   Path: plugins/warn_unused
   FindlibName: bap-plugin-warn_unused
-  BuildDepends: bap, cmdliner
+  BuildDepends: bap
   InternalModules: Warn_unused_main
   XMETADescription: warn about unused results of certain functions

--- a/oasis/x86
+++ b/oasis/x86
@@ -17,7 +17,7 @@ Library x86_plugin
  XMETADescription: provide x86 lifter
  Path:             plugins/x86
  FindlibName:      bap-plugin-x86
- BuildDepends:     bap, bap-abi, bap-c, bap-x86-cpu, bap-llvm, cmdliner
+ BuildDepends:     bap, bap-abi, bap-c, bap-x86-cpu, bap-llvm
  Modules:          X86_backend, X86_prefix
  InternalModules:  X86_abi,
                    X86_asm,

--- a/opam/opam
+++ b/opam/opam
@@ -28,6 +28,7 @@ build: [
 install: [
   ["ocamlfind" "remove" "bap"]
   ["ocamlfind" "remove" "bap-arm"]
+  ["ocamlfind" "remove" "bap-beagle-prey"]
   ["ocamlfind" "remove" "bap-build"]
   ["ocamlfind" "remove" "bap-byteweight"]
   ["ocamlfind" "remove" "bap-demangle"]
@@ -38,6 +39,7 @@ install: [
   ["ocamlfind" "remove" "bap-piqi"]
   ["ocamlfind" "remove" "bap-plugin-arm"]
   ["ocamlfind" "remove" "bap-plugin-api"]
+  ["ocamlfind" "remove" "bap-plugin-beagle"]
   ["ocamlfind" "remove" "bap-plugin-byteweight"]
   ["ocamlfind" "remove" "bap-plugin-cache"]
   ["ocamlfind" "remove" "bap-plugin-dump_symbols"]
@@ -81,6 +83,7 @@ install: [
 remove: [
   ["ocamlfind" "remove" "bap"]
   ["ocamlfind" "remove" "bap-arm"]
+  ["ocamlfind" "remove" "bap-beagle-prey"]
   ["ocamlfind" "remove" "bap-build"]
   ["ocamlfind" "remove" "bap-byteweight"]
   ["ocamlfind" "remove" "bap-demangle"]
@@ -91,6 +94,7 @@ remove: [
   ["ocamlfind" "remove" "bap-piqi"]
   ["ocamlfind" "remove" "bap-plugin-arm"]
   ["ocamlfind" "remove" "bap-plugin-api"]
+  ["ocamlfind" "remove" "bap-plugin-beagle"]
   ["ocamlfind" "remove" "bap-plugin-byteweight"]
   ["ocamlfind" "remove" "bap-plugin-cache"]
   ["ocamlfind" "remove" "bap-plugin-dump_symbols"]
@@ -142,7 +146,7 @@ depends: [
     "base-unix"
     "bitstring"
     "camlzip"
-    "cmdliner" {>= "0.9.6"}
+    "cmdliner" {= "0.9.8"}
     "ppx_jane" {>= "113.33.00" & < "113.34.00"}
     "core_kernel" {>= "113.33.00" & < "113.34.00"}
     "ezjsonm"


### PR DESCRIPTION
removed a dependency from `cmdliner` in plugins, since they actually depends from `bap-std`, but not directly from `cmdliner`