### PR TITLE
removed displacement checking in modern x86-lifter

### DIFF
--- a/plugins/x86/x86_tools_mem.ml
+++ b/plugins/x86/x86_tools_mem.ml
@@ -70,10 +70,8 @@ module Make (CPU : X86CPU) (RR : RR) (IM : IM) : MM = struct
       Option.map ~f:(fun s -> Word.of_int ~width:2 s |> Bil.int) shift
 
     let make_disp disp =
-      Option.some_if (disp <> 0) disp |>
-      Option.map ~f:(fun disp ->
-          Word.of_int ~width:(Size.in_bits addr_size) disp |>
-          Bil.int)
+      Option.some @@ Bil.int @@
+      Word.of_int ~width:(Size.in_bits addr_size) disp
 
     let addr {seg; base; scale; index; disp} =
       let seg = Option.map ~f:(fun seg -> make_value seg) seg in


### PR DESCRIPTION
fix https://github.com/BinaryAnalysisPlatform/bap/issues/640
fix https://github.com/BinaryAnalysisPlatform/bap/issues/642

Lifter should not perform any checks over operands, just use them as they are.

Fix prevent project fails with bytes sequences like `8b 04 25 00 00 00 00`, where source memory operand is defined by zero segment, base and index values.
