### PR TITLE
fixed macho dynamic symbols error when compiling with llvm 3.4

### DIFF
--- a/lib/bap_llvm/llvm_binary_34.hpp
+++ b/lib/bap_llvm/llvm_binary_34.hpp
@@ -218,6 +218,13 @@ error_or<symbols_sizes> getSymbolSizes(const ObjectFile &obj) {
     return success(std::move(sizes));
 }
 
+error_or<symbols_sizes> getSymbolSizes(const MachOObjectFile& obj) {
+    symbols_sizes sizes;
+    error_code ec;
+    fill_symbols(obj.begin_symbols(), obj.end_symbols(), sizes, ec);
+    return success(std::move(sizes));
+}
+
 } //namespace sym
 
 namespace sec {


### PR DESCRIPTION
fix https://github.com/BinaryAnalysisPlatform/bap/issues/645

`llvm 3.4` doesn't support dynamic symbols for macho files, as it could be seen from code snippet below. 
```
symbol_iterator MachOObjectFile::begin_dynamic_symbols() const {
  // TODO: implement
  report_fatal_error("Dynamic symbols unimplemented in MachOObjectFile");
}

symbol_iterator MachOObjectFile::end_dynamic_symbols() const {
  // TODO: implement
  report_fatal_error("Dynamic symbols unimplemented in MachOObjectFile");
}
```