### PR TITLE
fixes bap segfaults with *.o files

### DIFF
--- a/lib/bap_llvm/llvm_binary.hpp
+++ b/lib/bap_llvm/llvm_binary.hpp
@@ -80,7 +80,6 @@ error_or<segments> read(const ELFObjectFile<T>& obj) {
     auto begin = elf_header_begin(obj.getELFFile());
     auto end   = elf_header_end(obj.getELFFile());
     segments s;
-    s.reserve(std::distance(begin, end));
     auto it = begin;
     for (int pos = 0; it != end; ++it, ++pos) {
         if (it -> p_type == ELF::PT_LOAD) {

--- a/lib/bap_llvm/llvm_binary_38.hpp
+++ b/lib/bap_llvm/llvm_binary_38.hpp
@@ -103,7 +103,7 @@ error_or<symbol_sizes> getSymbolSizes(const ELFObjectFile<ELFT> &obj) {
                               [](const sec_hdr &hdr) { return (hdr.sh_type == ELF::SHT_DYNSYM); });
 
     if (!syms.size() && !is_dyn)
-        return success(symsbol_sizes());
+        return success(symbol_sizes());
 
     if (is_dyn)  // we aren't able to rely on iterators because of bug in llvm
         for (auto sym : obj.getDynamicSymbolIterators())

--- a/lib/bap_llvm/llvm_binary_38.hpp
+++ b/lib/bap_llvm/llvm_binary_38.hpp
@@ -101,12 +101,15 @@ error_or<symbol_sizes> getSymbolSizes(const ELFObjectFile<ELFT> &obj) {
     auto sections = obj.getELFFile()->sections();
     bool is_dyn = std::any_of(sections.begin(), sections.end(),
                               [](const sec_hdr &hdr) { return (hdr.sh_type == ELF::SHT_DYNSYM); });
-    if (!syms.size() && !is_dyn)
-        return success(symbol_sizes());
-    for (auto sym : obj.getDynamicSymbolIterators())
-        syms.push_back({sym, sym.getSize()});
 
-    return success(std::move(computeSymbolSizes(obj)));
+    if (!syms.size() && !is_dyn)
+        return success(symsbol_sizes());
+
+    if (is_dyn)  // we aren't able to rely on iterators because of bug in llvm
+        for (auto sym : obj.getDynamicSymbolIterators())
+            syms.push_back({sym, sym.getSize()});
+
+    return success(syms);
 }
 
 error_or<symbol_sizes> getSymbolSizes(const COFFObjectFile& obj) {


### PR DESCRIPTION
fix https://github.com/BinaryAnalysisPlatform/bap/issues/656

This PR fixes bugs that crashed bap with *.o elf files.
There are two bugs in two llvm-versions:
1) iteration over elf header in case of segments absence fails with segfault in 
`llvm 3 .4 `.
2) iteration over  dynamic symbols in `llvm-3.8` fails with segfault in some cases. So  we just added one more check.