### PR TITLE
fixed symbols names in objdump symbolizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ _oasis
 /plugins/ida/bap_ida_config.ml
 /plugins/objdump/objdump_config.ml
 /plugins/api/api_config.ml
+/plugins/primus_lisp/primus_lisp_config.ml

--- a/oasis/common
+++ b/oasis/common
@@ -11,7 +11,7 @@ Plugins:     META (0.4)
 AlphaFeatures: ocamlbuild_more_args, compiled_setup_ml
 BuildTools: ocamlbuild
 XOCamlbuildExtraArgs:
-     -j 32
+     -j 2
      -use-ocamlfind
      -classic-display
      -plugin-tags "'package(findlib),package(core_kernel),package(ppx_driver.ocamlbuild)'"


### PR DESCRIPTION
Fixed cases cases when section names could be treated as
symbol names, and consequently we had symbols like `.text`.