### PR TITLE
renamed plugins files

### DIFF
--- a/lib/bap_build/bap_build.ml
+++ b/lib/bap_build/bap_build.ml
@@ -131,10 +131,6 @@ module Plugin_rules = struct
 
   let is_cmx file = Filename.check_suffix file ".cmx"
 
-  let dashify = String.map ~f:(function
-      | '_' -> '-'
-      | c -> c)
-
   let bundle env =
     let requires =
       packages () |> List.concat_map ~f:(fun pkg ->
@@ -154,7 +150,7 @@ module Plugin_rules = struct
     Cmd (S [
         A "bapbundle"; A "pack";
         T (Tags.of_list ["bundle"; "library"; "plugin"]);
-        A "-name"; A (dashify (env "%"));
+        A "-name"; A (env "%");
         A "-main"; A (env "%.cmxs");
         A "-main"; A (env "%.cma");
         requires; provides;

--- a/tools/bapbundle.ml
+++ b/tools/bapbundle.ml
@@ -77,12 +77,18 @@ module Update = struct
   let set_list s f =
     String.split ~on:',' s |> List.map ~f:String.strip |> set f
 
+  let set_name s =
+    set name @@
+    String.map ~f:(function
+        | '_' -> '-'
+        | c -> c) s
+
   let set_tags s = set_list s tags
   let set_cons s = set_list s cons
 
   let common_args = Arg.[
       "-author",    String (set author), "<name> Set bundle's author name";
-      "-name",      String (set name),   "<name> Set bundle's name";
+      "-name",      String set_name,     "<name> Set bundle's name";
       "-desc",      String (set desc),   "<text> Set bundle's description";
       "-tags",      String set_tags,     "<list> Set bundle's tags";
       "-cons",      String set_cons,     "<list> Set bundle's constraints";

--- a/tools/build_plugins.sh
+++ b/tools/build_plugins.sh
@@ -4,16 +4,16 @@ set -ue
 
 
 build_plugin() {
-    plugin=$1
-    if ocamlfind query bap-plugin-$plugin 2>/dev/null
+    plugin=bap_plugin_$1
+    if ocamlfind query bap-plugin-$1 2>/dev/null
     then
         TMPDIR=`mktemp -d`
         cd $TMPDIR
         touch $plugin.ml
-        bapbuild -package bap-plugin-$plugin $plugin.plugin
-        DESC=`ocamlfind query -format "%D" bap-plugin-$plugin`
-        CONS=`ocamlfind query -format "%(constraints)" bap-plugin-$plugin`
-        TAGS=`ocamlfind query -format "%(tags)" bap-plugin-$plugin`
+        bapbuild -package bap-plugin-$1 $plugin.plugin
+        DESC=`ocamlfind query -format "%D" bap-plugin-$1`
+        CONS=`ocamlfind query -format "%(constraints)" bap-plugin-$1`
+        TAGS=`ocamlfind query -format "%(tags)" bap-plugin-$1`
         if [ ! -z "$CONS" ]; then
             bapbundle update -cons "$CONS" $plugin.plugin
         fi
@@ -21,8 +21,10 @@ build_plugin() {
             bapbundle update -tags "$TAGS" $plugin.plugin
         fi
         bapbundle update -desc "$DESC" $plugin.plugin
+        bapbundle update -name $1 $plugin.plugin
 
-        bapbundle install $plugin.plugin
+        mv $plugin.plugin $1.plugin
+        bapbundle install $1.plugin
         cd -
         rm -rf $TMPDIR
     fi


### PR DESCRIPTION
fix https://github.com/BinaryAnalysisPlatform/bap/issues/678

Now files in bap plugin bundles, that were previously named `foo.cmxs` will be named as `bap_plugin_foo.cmxs` 

Also `bapbundle` starts to dashify bundle's name:
```
bapbundle update -name new_name foo.plugin
bapbundle show -m foo.plugin 
((name new-name)
 (version 1.0.0)
....
```

