### PR TITLE
compiling with cmdliner.1.0.0

### DIFF
--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -239,7 +239,8 @@ module Create() = struct
       | `S of string
     ]
 
-    let manpage (man:manpage_block list) : unit =
+    let manpage man =
+      let man = (man :> Manpage.block list) in
       term_info := Term.info ~doc ~man plugin_name
 
     let determined (p:'a param) : 'a future = p

--- a/oasis/primus-lisp
+++ b/oasis/primus-lisp
@@ -6,7 +6,7 @@ Flag primus_lisp
 Library primus_lisp_library_plugin
   Build$:       flag(everything) || flag(primus_lisp)
   Path:         plugins/primus_lisp
-  BuildDepends: bap-primus, cmdliner
+  BuildDepends: bap-primus
   FindlibName:     bap-plugin-primus_lisp
   CompiledObject:  best
   InternalModules: Primus_lisp_main,

--- a/oasis/run
+++ b/oasis/run
@@ -7,6 +7,6 @@ Library run_plugin
   Path: plugins/run
   FindlibName: bap-plugin-run
   CompiledObject: best
-  BuildDepends: bap, bap-primus, cmdliner
+  BuildDepends: bap, bap-primus
   InternalModules: Run_main
   XMETADescription: a pass that will run a program


### PR DESCRIPTION
so now `bap` works with both cmdliner.0.9.8 and cmdliner.1.0.0

partial fix for https://github.com/BinaryAnalysisPlatform/bap/issues/636

