### PR TITLE
fixed problem with loaders, registered in Project

### DIFF
--- a/lib/bap_disasm/bap_disasm_brancher.ml
+++ b/lib/bap_disasm/bap_disasm_brancher.ml
@@ -18,6 +18,8 @@ type brancher = t
 let create f = Brancher f
 let resolve (Brancher f) = f
 
+let empty = Brancher (fun _ _ -> [])
+
 let kind_of_dests = function
   | xs when List.for_all xs ~f:(fun (_,x) -> x = `Fall) -> `Fall
   | xs -> if List.exists  xs ~f:(fun (_,x) -> x = `Jump)

--- a/lib/bap_disasm/bap_disasm_brancher.mli
+++ b/lib/bap_disasm/bap_disasm_brancher.mli
@@ -18,4 +18,6 @@ val of_image : image -> t
 
 val resolve : t -> mem -> full_insn -> dests
 
+val empty : t
+
 module Factory : Factory with type t = t


### PR DESCRIPTION
fix for https://github.com/BinaryAnalysisPlatform/bap/issues/633

The problem was in signal propagation. When we merge different
rooters: ida rooter, internal and byteweight rooter, we get an empty
list of roots because an internal one waits for image, but doesn't
have it, and result stream doesn't fullfill with results from any of
rooters