### PR TITLE
update cmdliner + minor

### DIFF
--- a/lib/bap_ida/bap_ida.ml
+++ b/lib/bap_ida/bap_ida.ml
@@ -34,12 +34,14 @@ end
 module Ida = struct
   type t = Service.t
 
+  open Service
+
   exception Failed of string
   exception Not_in_path
 
   let create = Service.create
-  let exec (service:t) = service.exec
-  let close (service:t) = service.close ()
+  let exec service = service.exec
+  let close service = service.close ()
 
   let with_file target command =
     let ida = create target in

--- a/oasis/elf
+++ b/oasis/elf
@@ -5,7 +5,7 @@ Flag elf
 
 Library elf
   Path:          lib/bap_elf
-  Build$:        flag(elf)
+  Build$:        flag(everything) || flag(elf)
   FindlibName:   bap-elf
   BuildDepends:  bap, bitstring, camlp4, bitstring.syntax
   Modules: Bap_elf

--- a/plugins/map_terms/map_terms_main.ml
+++ b/plugins/map_terms/map_terms_main.ml
@@ -137,7 +137,7 @@ module Cmdline = struct
         sprintf ("%s, where $(i,ATTR) must be one of %s.")
           desc (enum attrs))
 
-  let colors = bold [
+  let colors = [
       "black"; "red"; "green"; "yellow"; "blue"; "magenta"; "cyan";
       "white"; "gray"
     ]
@@ -227,12 +227,12 @@ module Cmdline = struct
 
   let man = [
     `S "SYNOPSIS";
-    `P "$(b,bap) [$(b,--$(mname)-with)=$(i,SCHEME)]
-                 [$(b,--$(mname)-using)=$(i,FILE)] $(b,--$(mname))";
+    `P "$(b,bap) [$(b,--)$(mname)$(b,-with)=$(i,SCHEME)]
+                 [$(b,--)$(mname)$(b,-using)=$(i,FILE)] $(b,--)$(mname)";
     `S "DESCRIPTION";
     `P "Transform terms using a domain specific pattern matching language.
     The pass accepts a list of patterns via a command line argument
-    $(b,--)$(b,$(mname)-pattern) (that can be specified several times), or
+    $(b,--)$(mname)$(b,-pattern) (that can be specified several times), or
     via file, that contains a list of patterns. Each pattern is
     represented by a pair $(b,(<condition> <action>)). The $(b,<action>) specifies
     a transformation over a term, that is applied if a $(b,<condition>)
@@ -245,7 +245,7 @@ module Cmdline = struct
     <arg>)). Where $(b,<id>) must be a valid predicate or mapper
     name. There is a predefined set of standard functions, but it can
     be extended by adding new mappers or predicates to the BML
-    language using $(bap-bml) library. ";
+    language using $(b, bap-bml) library. ";
   ] @
     Predicates.section @
     Mappers.section @

--- a/plugins/trace/trace_main.ml
+++ b/plugins/trace/trace_main.ml
@@ -48,12 +48,12 @@ module Cmdline = struct
   let () = Config.manpage [
     `S "SYNOPSIS";
     `Pre "
-        $(b,bap) --$(b,$mname-dump)=$(i,URI)
-        $(b,bap) $(i,BINARY) --$(b,$mname-load)=$(i,URI)...
+        $(b,bap) $(b,--)$(mname)$(b,-dump)=$(i,URI)
+        $(b,bap) $(i,BINARY) $(b,--)$(mname)$(b,-load)=$(i,URI)...
        ";
     `S "DESCRIPTION";
     `P "Loads and prints traces. The plugin can be used in two
-       modes. When called as $(b,--$mname-dump) it will just dump the
+       modes. When called as $(b,--)$(mname)$(b,-dump) it will just dump the
        specified trace and exit. In the second mode, it will load
        specified traces, so that they can be used by
        analysis. The loaded traces must be runs of the analyzed

--- a/plugins/warn_unused/warn_unused_main.ml
+++ b/plugins/warn_unused/warn_unused_main.ml
@@ -90,31 +90,31 @@ module Cmdline = struct
   let man = [
     `S "SYNOPSIS";
     `Pre "
-    $(b,--$mname)
-    $(b,--$mname-taint)
-    $(b,--$mname-print)
-    $(b,--$mname-mark)";
+    $(b,--)$(mname)
+    $(b,--)$(mname)$(b,-taint)
+    $(b,--)$(mname)$(b,-print)
+    $(b,--)$(mname)$(b,-mark)";
     `S "DESCRIPTION";
     `P "If a subroutine has GNU attribute $(b,warn_unused_result) and
   its result is not used, then print a warning message.";
     `S "PASSES";
     `I begin
-      "$(b,--$mname-taint)",
+      "$(b,--)$(mname)$(b,-taint)",
       "Taint all values defined by functions that are marked with
      $(b,warn_unused_result) attribute. Will run $(b,callsites) as a
      dependency."
     end;
     `I begin
-      "$(b,--$mname-print)",
+      "$(b,--)$(mname)$(b,-print)",
       "Print all calls that weren't checked."
     end;
     `I begin
-      "$(b,--$mname-mark)",
+      "$(b,--)$(mname)$(b,-mark)",
       "Mark all unchecked calls with $(b,Term.dead) attribute"
     end;
     `I begin
-      "$(b,--$mname)",
-      "Same as $(b,--$mname-taint --propagate-taint --$mname-print)"
+      "$(b,--)$(mname)",
+      "Same as $(b,--)$(mname)$(b,-taint) $(b,--propagate-taint --)$(mname)$(b,-print)"
     end;
     `S "SEE ALSO";
     `P "$(b,bap-api)(1), $(b,bap-plugin-propagate-taint)(1), $(b,bap-plugin-taint)(1)"
@@ -123,7 +123,7 @@ module Cmdline = struct
   let passes = [name; "--taint"; "--mark"; "--print"]
 
   let pass name =
-    let doc = sprintf "run $mname-%s pass" name in
+    let doc = sprintf "run $(mname)$(b,-%s) pass" name in
     Config.(flag name ~doc)
 
   let taint_p = pass "taint"

--- a/src/bap_main.ml
+++ b/src/bap_main.ml
@@ -123,10 +123,10 @@ let program_info =
   let man = [
     `S "SYNOPSIS";
     `Pre "
-      $(b,$mname) [PLUGIN OPTION]... --list-formats
-      $(b,$mname) [PLUGIN OPTION]... [--source-type=$(i,SOURCE)] --list-plugins
-      $(b,$mname) [PLUGIN OPTION]... --$(i,PLUGIN)-help
-      $(b,$mname) $(i,FILE) [PLUGIN OPTION]... [OPTION]...";
+      $(mname) [PLUGIN OPTION]... --list-formats
+      $(mname) [PLUGIN OPTION]... [--source-type=$(i,SOURCE)] --list-plugins
+      $(mname) [PLUGIN OPTION]... --$(i,PLUGIN)-help
+      $(mname) $(i,FILE) [PLUGIN OPTION]... [OPTION]...";
     `S "DESCRIPTION";
     `P "A frontend to the Binary Analysis Platfrom library.
       The tool allows you to inspect binary programs by printing them

--- a/src/bap_mc.ml
+++ b/src/bap_mc.ml
@@ -208,8 +208,8 @@ module Cmdline = struct
     let man = [
       `S "SYNOPSIS";
       `Pre "
- $(b,$mname) [PLUGIN OPTION]... --list-formats
- $(b,$mname) [OPTION]... DATA";
+ $(mname) [PLUGIN OPTION]... --list-formats
+ $(mname) [OPTION]... DATA";
       `S "DESCRIPTION";
       `P "Disassemble a string of bytes. This is the BAP machine \
           code playground. It is intended to mimic a subset of \
@@ -232,7 +232,7 @@ module Cmdline = struct
         `P "$(b,bap)(1), $(b,bap-llvm)(1), $(b,llvm-mc)(1)"] in
     Term.(const create $(disassembler ()) $src $addr $only_one $arch $show_insn_size
           $insn_formats $bil_formats $bir_formats $show_kinds),
-    Term.info "bap-mc" ~doc ~man ~version
+    Term.info "bap-mc" ~doc ~man ~version:Config.version
 
   let exitf n =
     kfprintf (fun ppf -> pp_print_newline ppf (); exit n) err_formatter


### PR DESCRIPTION
This PR adds compatibility for `cmdliner 1.0` . 
Previous `cmdliner 0.9.8` still could be used as `bap` dependency. 
Also this PR fixes some minor bugs and warnings.
