### PR TITLE
Update tags

### DIFF
--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -261,7 +261,6 @@ module Create() = struct
           | x -> x in
         let tags = [
           `P (Manifest.tags manifest |>
-              List.map ~f:(sprintf "$(b,%s)") |>
               String.concat ~sep:", " |>
               sprintf "$(b,tags:) %s") ] in
         man @ see_also @ tags

--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -254,7 +254,7 @@ module Create() = struct
       | [] -> man
       | tags ->
         let default_see_also =
-          let h = "https://github.com/BinaryAnalysisPlatform/bap" in
+          let h = "www:bap.ece.cmu.edu" in
           [`S "SEE ALSO"; `P (sprintf "$(b,home:) $(i,%s)" h)] in
         let see_also, man = match extract_section "SEE ALSO" man with
           | [], man -> default_see_also, man

--- a/oasis/abi
+++ b/oasis/abi
@@ -18,4 +18,4 @@ Library abi_plugin
   BuildDepends:     bap, bap-abi
   InternalModules:  Abi_main
   XMETADescription: apply abi information to a project
-  XMETAExtraLines:  tags="pass"
+  XMETAExtraLines:  tags="abi, pass"

--- a/oasis/api
+++ b/oasis/api
@@ -20,4 +20,4 @@ Library api_plugin
   InternalModules:  Api_main, Api_config
   XMETADescription: add parameters to subroutines based on known API
   DataFiles:        api/c/*.h ($datadir/bap-api/c)
-  XMETAExtraLines:  tags="pass"
+  XMETAExtraLines:  tags="api, pass"

--- a/oasis/arm
+++ b/oasis/arm
@@ -36,4 +36,4 @@ Library arm_plugin
   BuildDepends:     bap-abi, bap-arm, bap-c
   InternalModules:  Arm_main, Arm_gnueabi
   XMETADescription: provide ARM lifter
-  XMETAExtraLines:  tags="lifter"
+  XMETAExtraLines:  tags="arm, lifter"

--- a/oasis/beagle
+++ b/oasis/beagle
@@ -9,7 +9,7 @@ Library beagle_plugin
   BuildDepends: bap, bap-microx, bap-beagle-prey, bap-strings
   InternalModules: Beagle_main
   XMETADescription: microx powered obfuscated string solver
-  XMETAExtraLines:  tags="pass, strings, deobfuscator"
+  XMETAExtraLines:  tags="deobfuscator, microx, primus, pass, strings"
 
 Library beagle_prey
   Build$: flag(everything) || flag(beagle)

--- a/oasis/beagle
+++ b/oasis/beagle
@@ -9,7 +9,7 @@ Library beagle_plugin
   BuildDepends: bap, bap-microx, bap-beagle-prey, bap-strings
   InternalModules: Beagle_main
   XMETADescription: microx powered obfuscated string solver
-  XMETAExtraLines:  tags="pass"
+  XMETAExtraLines:  tags="pass, strings, deobfuscator"
 
 Library beagle_prey
   Build$: flag(everything) || flag(beagle)
@@ -17,7 +17,7 @@ Library beagle_prey
   FindlibName: bap-beagle-prey
   Modules: Beagle_prey
   BuildDepends: bap, bap-primus
-  Xmetadescription: beagle attributes
+  XMETADescription: beagle attributes
 
 Library strings_plugin
   Build$:       flag(everything) || flag(beagle)
@@ -25,3 +25,5 @@ Library strings_plugin
   FindlibName:  bap-plugin-strings
   BuildDepends: bap, bap-strings, bap-beagle-prey
   InternalModules: Strings_main
+  XMETAExtraLines:  tags="pass, strings"
+  XMETADescription: find strings of characters

--- a/oasis/byteweight
+++ b/oasis/byteweight
@@ -18,4 +18,4 @@ Library byteweight_plugin
   BuildDepends:     bap, bap-byteweight
   InternalModules:  Byteweight_main
   XMETADescription: find function starts using Byteweight algorithm
-  XMETAExtraLines:  tags="pass"
+  XMETAExtraLines:  tags="pass, rooter"

--- a/oasis/cache
+++ b/oasis/cache
@@ -9,3 +9,4 @@ Library cache_plugin
   BuildDepends:     bap
   InternalModules:  Cache_main
   XMETADescription: provide caching services
+  XMETAExtraLines:  tags="cache"

--- a/oasis/common
+++ b/oasis/common
@@ -11,7 +11,7 @@ Plugins:     META (0.4)
 AlphaFeatures: ocamlbuild_more_args, compiled_setup_ml
 BuildTools: ocamlbuild
 XOCamlbuildExtraArgs:
-     -j 16
+     -j 2
      -use-ocamlfind
      -classic-display
      -plugin-tags "'package(findlib),package(core_kernel),package(ppx_driver.ocamlbuild)'"

--- a/oasis/common
+++ b/oasis/common
@@ -11,7 +11,7 @@ Plugins:     META (0.4)
 AlphaFeatures: ocamlbuild_more_args, compiled_setup_ml
 BuildTools: ocamlbuild
 XOCamlbuildExtraArgs:
-     -j 2
+     -j 16
      -use-ocamlfind
      -classic-display
      -plugin-tags "'package(findlib),package(core_kernel),package(ppx_driver.ocamlbuild)'"

--- a/oasis/cxxfilt
+++ b/oasis/cxxfilt
@@ -10,4 +10,4 @@ Library "cxxfilt_plugin"
   BuildDepends: core_kernel, bap-demangle, bap
   InternalModules: Cxxfilt_main, Cxxfilt_config
   XMETADescription: provide c++filt based demangler
-  XMETAExtraLines: tags="c++filt, demangler"
+  XMETAExtraLines: tags="c++, c++filt, demangler"

--- a/oasis/cxxfilt
+++ b/oasis/cxxfilt
@@ -10,4 +10,4 @@ Library "cxxfilt_plugin"
   BuildDepends: core_kernel, bap-demangle, bap
   InternalModules: Cxxfilt_main, Cxxfilt_config
   XMETADescription: provide c++filt based demangler
-  XMETAExtraLines: tags="pass"
+  XMETAExtraLines: tags="c++filt, demangler"

--- a/oasis/demangle
+++ b/oasis/demangle
@@ -18,4 +18,4 @@ Library "demangle_plugin"
   BuildDepends: core_kernel, bap-demangle, bap
   InternalModules: Demangle_main
   XMETADescription: demangle subroutine names
-  XMETAExtraLines:  tags="pass"
+  XMETAExtraLines:  tags="demangler"

--- a/oasis/dump-symbols
+++ b/oasis/dump-symbols
@@ -10,4 +10,4 @@ Library dump_symbols_plugin
   BuildDepends:     bap
   InternalModules:  Dump_symbols_main
   XMETADescription: dump symbol information as a list of blocks
-  XMETAExtraLines:  tags="pass"
+  XMETAExtraLines:  tags="printer"

--- a/oasis/elf
+++ b/oasis/elf
@@ -25,4 +25,4 @@ Library elf_loader_plugin
   BuildDepends:     bap, bap-elf, bap-dwarf
   InternalModules:  Elf_loader_main
   XMETADescription: read ELF and DWARF formats in a pure OCaml
-  XMETAExtraLines:  tags="loader"
+  XMETAExtraLines:  tags="legacy, loader, elf, dwarf"

--- a/oasis/frontc-parser
+++ b/oasis/frontc-parser
@@ -10,4 +10,4 @@ Library frontc_parser_plugin
   CompiledObject: best
   BuildDepends: bap, bap-c, FrontC
   InternalModules: Frontc_parser_main
-  XMETAExtraLines: tags="c, parser"
+  XMETAExtraLines: tags="api, c, parser"

--- a/oasis/frontc-parser
+++ b/oasis/frontc-parser
@@ -10,4 +10,4 @@ Library frontc_parser_plugin
   CompiledObject: best
   BuildDepends: bap, bap-c, FrontC
   InternalModules: Frontc_parser_main
-  XMETAExtraLines: tags="pass"
+  XMETAExtraLines: tags="c, parser"

--- a/oasis/ida
+++ b/oasis/ida
@@ -22,3 +22,4 @@ Library bap_ida_plugin
   Modules:          Ida_main
   InternalModules:  Bap_ida_config, Bap_ida_service, Bap_ida_check
   XMETADescription: use ida to provide rooter, symbolizer and reconstructor
+  XMETAExtraLines:  tags="ida, rooter, symbolizer, reconstructor"

--- a/oasis/ida-plugin
+++ b/oasis/ida-plugin
@@ -9,3 +9,4 @@ Library emit_ida_script_plugin
   BuildDepends:     bap
   Modules:          Emit_ida_script_main
   XMETADescription: extract a IDA python script from bap
+  XMETAExtraLines:  tags="ida, python"

--- a/oasis/llvm
+++ b/oasis/llvm
@@ -67,7 +67,7 @@ Library llvm_plugin
   FindlibName:     bap-plugin-llvm
   InternalModules: Llvm_main
   BuildDepends:    bap, bap-llvm
-  XMETAExtraLines: tags="disassembler"
+  XMETAExtraLines: tags="disassembler, llvm, loader, elf, macho, coff"
 
 Library legacy_llvm_plugin
   XMETADescription: provide legacy loader using LLVM library
@@ -76,6 +76,7 @@ Library legacy_llvm_plugin
   BuildDepends:    bap, bap-llvm
   FindlibName:     bap-plugin-legacy_llvm
   InternalModules: Legacy_loader_main
+  XMETAExtraLines: tags="legacy, llvm, loader, elf, macho, coff"
 
 Library relocatable_plugin
   XMETADescription: provides facility to load relocatable files using LLVM library
@@ -84,3 +85,4 @@ Library relocatable_plugin
   FindlibName:     bap-plugin-relocatable
   InternalModules: Relocatable_main, Rel_brancher
   BuildDepends:    bap, bap-llvm, ogre
+  XMETAExtraLines: tags="brancher, llvm, relocation"

--- a/oasis/llvm
+++ b/oasis/llvm
@@ -85,4 +85,4 @@ Library relocatable_plugin
   FindlibName:     bap-plugin-relocatable
   InternalModules: Relocatable_main, Rel_brancher
   BuildDepends:    bap, bap-llvm, ogre
-  XMETAExtraLines: tags="brancher, llvm, relocation"
+  XMETAExtraLines: tags="brancher, llvm, loader, ogre"

--- a/oasis/objdump
+++ b/oasis/objdump
@@ -10,4 +10,4 @@ Library objdump_plugin
   BuildDepends:     bap, re.pcre
   InternalModules:  Objdump_main, Objdump_config
   XMETADescription: use objdump to provide a symbolizer
-  XMETAExtraLines:  tags="pass"
+  XMETAExtraLines:  tags="objdump, symbolizer"

--- a/oasis/phoenix
+++ b/oasis/phoenix
@@ -15,4 +15,4 @@ Library phoenix_plugin
                     Phoenix_printing,
                     Phoenix_root
   XMETADescription: output project information in a phoenix format
-  XMETAExtraLines:  tags="pass"
+  XMETAExtraLines:  tags="printer"

--- a/oasis/piqi
+++ b/oasis/piqi
@@ -26,7 +26,7 @@ Library piqi_printers_plugin
   BuildDepends: bap-piqi
   InternalModules: Piqi_printers_main
   XMETADescription: provides piqi serialization for main data types (BIL, IR)
-  XMETAExtraLines:  tags="pass"
+  XMETAExtraLines:  tags="printer, serialization"
 
 Executable run_piqi_tests
   Path:       lib/bap_piqi/test

--- a/oasis/primus-lisp
+++ b/oasis/primus-lisp
@@ -14,3 +14,4 @@ Library primus_lisp_library_plugin
                    Primus_lisp_primitives
   XMETADescription: install and load Primus lisp libraries
   DataFiles:        lisp/*.lisp ($primus_lisp_library_path)
+  XMETAExtraLines:  tags="primus, lisp"

--- a/oasis/primus-support
+++ b/oasis/primus-support
@@ -12,7 +12,7 @@ Library primus_loader_plugin
   XMETADescription: generic program loader for Primus
   Modules: Primus_loader_main
   InternalModules: Primus_loader_basic
-  XMETAExtraLines: tags="primus, loader"
+  XMETAExtraLines: tags="abi, loader, primus"
 
 Library primus_promiscuous_plugin
   Path: plugins/primus_promiscuous
@@ -22,7 +22,7 @@ Library primus_promiscuous_plugin
   BuildDepends: bap, bap-primus, core_kernel
   XMETADescription: enables the promiscuous mode of execution
   Modules: Primus_promiscuous_main
-  XMETAExtraLines: tags="primus"
+  XMETAExtraLines: tags="primus, fuzz"
 
 Library primus_greedy_scheduler_plugin
   Path: plugins/primus_greedy
@@ -82,4 +82,4 @@ Library primus_propagate_taint_plugin
   BuildDepends: bap-primus
   XMETADescription: a taint propagation engine
   Modules: Primus_propagate_taint_main
-  XMETAExtraLines: tags="primus, taint"
+  XMETAExtraLines: tags="primus, taint, dataflow"

--- a/oasis/primus-support
+++ b/oasis/primus-support
@@ -12,6 +12,7 @@ Library primus_loader_plugin
   XMETADescription: generic program loader for Primus
   Modules: Primus_loader_main
   InternalModules: Primus_loader_basic
+  XMETAExtraLines: tags="primus, loader"
 
 Library primus_promiscuous_plugin
   Path: plugins/primus_promiscuous
@@ -21,6 +22,7 @@ Library primus_promiscuous_plugin
   BuildDepends: bap, bap-primus, core_kernel
   XMETADescription: enables the promiscuous mode of execution
   Modules: Primus_promiscuous_main
+  XMETAExtraLines: tags="primus"
 
 Library primus_greedy_scheduler_plugin
   Path: plugins/primus_greedy
@@ -30,6 +32,7 @@ Library primus_greedy_scheduler_plugin
   BuildDepends: bap, bap-primus, core_kernel
   XMETADescription: implements the greedy scheduling strategy
   Modules: Primus_greedy_main
+  XMETAExtraLines: tags="primus, scheduler"
 
 Library primus_round_robin_scheduler_plugin
   Path: plugins/primus_round_robin
@@ -39,6 +42,7 @@ Library primus_round_robin_scheduler_plugin
   BuildDepends: bap, bap-primus, core_kernel
   XMETADescription: implements the round-robin scheduling strategy
   Modules: Primus_round_robin_main
+  XMETAExtraLines: tags="primus, scheduler"
 
 Library primus_exploring_scheduler_plugin
   Path: plugins/primus_exploring
@@ -48,6 +52,7 @@ Library primus_exploring_scheduler_plugin
   BuildDepends: bap, bap-primus, core_kernel
   XMETADescription: implements the exploring scheduling strategy
   Modules: Primus_exploring_main
+  XMETAExtraLines: tags="primus, scheduler"
 
 Library primus_wandering_scheduler_plugin
   Path: plugins/primus_wandering
@@ -57,6 +62,7 @@ Library primus_wandering_scheduler_plugin
   BuildDepends: bap, bap-primus, core_kernel
   XMETADescription: implements the wandering scheduling strategy
   Modules: Primus_wandering_main
+  XMETAExtraLines: tags="primus, scheduler"
 
 Library primus_print_plugin
   Path: plugins/primus_print
@@ -66,6 +72,7 @@ Library primus_print_plugin
   BuildDepends: bap-primus
   XMETADescription: prints Primus states and observations
   Modules: Primus_print_main
+  XMETAExtraLines: tags="primus, printer"
 
 Library primus_propagate_taint_plugin
   Path: plugins/primus_propagate_taint
@@ -75,3 +82,4 @@ Library primus_propagate_taint_plugin
   BuildDepends: bap-primus
   XMETADescription: a taint propagation engine
   Modules: Primus_propagate_taint_main
+  XMETAExtraLines: tags="primus, taint"

--- a/oasis/primus-x86
+++ b/oasis/primus-x86
@@ -11,4 +11,4 @@ Library primus_x86_plugin
   XMETADescription: x86 support package
   Modules: Primus_x86_main
   InternalModules: Primus_x86_loader
-  XMETAExtraLines:  tags="primus, x86"
+  XMETAExtraLines:  tags="loader, primus, x86"

--- a/oasis/primus-x86
+++ b/oasis/primus-x86
@@ -11,3 +11,4 @@ Library primus_x86_plugin
   XMETADescription: x86 support package
   Modules: Primus_x86_main
   InternalModules: Primus_x86_loader
+  XMETAExtraLines:  tags="primus, x86"

--- a/oasis/print
+++ b/oasis/print
@@ -11,3 +11,4 @@ Library print_plugin
   BuildDepends:     bap, text-tags, bap-demangle
   InternalModules:  Print_main
   XMETADescription: print project in various formats
+  XMETAExtraLines:  tags="printer"

--- a/oasis/propagate-taint
+++ b/oasis/propagate-taint
@@ -9,4 +9,4 @@ Library propagate_taint_plugin
   BuildDepends: bap, bap-microx
   InternalModules: Propagate_taint_main, Propagator
   XMETADescription: propagate taints through a program
-  XMETAExtraLines:  tags="pass, taint"
+  XMETAExtraLines:  tags="dataflow, pass, taint"

--- a/oasis/propagate-taint
+++ b/oasis/propagate-taint
@@ -9,4 +9,4 @@ Library propagate_taint_plugin
   BuildDepends: bap, bap-microx
   InternalModules: Propagate_taint_main, Propagator
   XMETADescription: propagate taints through a program
-  XMETAExtraLines:  tags="pass"
+  XMETAExtraLines:  tags="pass, taint"

--- a/oasis/run
+++ b/oasis/run
@@ -10,4 +10,4 @@ Library run_plugin
   BuildDepends: bap, bap-primus
   InternalModules: Run_main
   XMETADescription: a pass that will run a program
-  XMETAExtraLines:  tags="pass, primus"
+  XMETAExtraLines:  tags="emulator, pass, primus"

--- a/oasis/run
+++ b/oasis/run
@@ -10,3 +10,4 @@ Library run_plugin
   BuildDepends: bap, bap-primus
   InternalModules: Run_main
   XMETADescription: a pass that will run a program
+  XMETAExtraLines:  tags="pass, primus"

--- a/oasis/symbol-reader
+++ b/oasis/symbol-reader
@@ -9,4 +9,4 @@ Library read_symbols_plugin
   BuildDepends:     bap
   Modules:          Read_symbols_main
   XMETADescription: read symbol information from file
-  XMETAExtraLines:  tags="pass"
+  XMETAExtraLines:  tags="reconstructor, rooter, symbolizer"

--- a/oasis/taint
+++ b/oasis/taint
@@ -9,4 +9,4 @@ Library taint_plugin
   BuildDepends: bap
   InternalModules: Taint_main
   XMETADescription: taint specified terms
-  XMETAExtraLines:  tags="pass, taint"
+  XMETAExtraLines:  tags="dataflow, pass, taint"

--- a/oasis/taint
+++ b/oasis/taint
@@ -9,4 +9,4 @@ Library taint_plugin
   BuildDepends: bap
   InternalModules: Taint_main
   XMETADescription: taint specified terms
-  XMETAExtraLines:  tags="pass"
+  XMETAExtraLines:  tags="pass, taint"

--- a/oasis/trace
+++ b/oasis/trace
@@ -10,4 +10,4 @@ Library trace_plugin
   Modules: Trace_main
   BuildDepends:   bap, bap-traces
   XMETADescription: manage execution traces
-  XMETAExtraLines:  tags="pass"
+  XMETAExtraLines:  tags="pass, printer, trace"

--- a/oasis/trace
+++ b/oasis/trace
@@ -10,4 +10,4 @@ Library trace_plugin
   Modules: Trace_main
   BuildDepends:   bap, bap-traces
   XMETADescription: manage execution traces
-  XMETAExtraLines:  tags="pass, printer, trace"
+  XMETAExtraLines:  tags="dynamic, pass, printer, trace"

--- a/oasis/warn-unused
+++ b/oasis/warn-unused
@@ -9,4 +9,4 @@ Library warn_unused_plugin
   BuildDepends: bap
   InternalModules: Warn_unused_main
   XMETADescription: warn about unused results of certain functions
-  XMETAExtraLines:  tags="pass"
+  XMETAExtraLines:  tags="analysis, checker, pass, security"

--- a/oasis/x86
+++ b/oasis/x86
@@ -51,4 +51,4 @@ Library x86_plugin
                    X86_tools_types,
                    X86_tools_vector,
                    X86_utils
- XMETAExtraLines:  tags="lifter, disassembler"
+ XMETAExtraLines:  tags="disassembler, lifter, x86"

--- a/src/bap_cmdline_terms.ml
+++ b/src/bap_cmdline_terms.ml
@@ -174,7 +174,12 @@ let list_plugins, list_plugin_doc =
   let doc =
     "List all available plugins or list plugins that provide some
      features, e.g. --list-plugins=disassembler,lifter" in
-  Arg.(value & opt ~vopt:(Some []) (some (list string)) None & info ["list-plugins"] ~doc), doc
+  Arg.(value & opt ~vopt:(Some []) (some (list string)) None
+       & info ["list-plugins"] ~doc), doc
+
+let list_tags, list_tags_doc =
+  let doc = "List all available plugin tags" in
+  Arg.(value & flag & info ["list-tags"] ~doc), doc
 
 let disable_plugin, disable_plugin_doc =
   let doc = "Don't load $(i,PLUGIN) automatically" in
@@ -196,6 +201,7 @@ let common_loader_options = [
   `I ("$(b,-l) $(i,PATH)", load_doc);
   `I ("$(b,-L)$(i,PATH)", load_path_doc);
   `I ("$(b,--list-plugins)", list_plugin_doc);
+  `I ("$(b,--list-tags)", list_tags_doc);
   `I ("$(b,--disable-plugin)", disable_plugin_doc);
   `I ("$(b,--disable-autoload)", no_auto_load_doc);
   `I ("$(b,--no-)$(i,PLUGIN)", disable_plugin_doc);

--- a/src/bap_cmdline_terms.ml
+++ b/src/bap_cmdline_terms.ml
@@ -182,7 +182,7 @@ let list_tags, list_tags_doc =
   Arg.(value & flag & info ["list-tags"] ~doc), doc
 
 let list_plugins_tags, list_plugins_tags_doc =
-  let doc = "List all available plugin with theirs tags" in
+  let doc = "List all available plugins with theirs tags" in
   Arg.(value & flag & info ["list-plugins-tags"] ~doc), doc
 
 let disable_plugin, disable_plugin_doc =

--- a/src/bap_cmdline_terms.ml
+++ b/src/bap_cmdline_terms.ml
@@ -181,6 +181,10 @@ let list_tags, list_tags_doc =
   let doc = "List all available plugin tags" in
   Arg.(value & flag & info ["list-tags"] ~doc), doc
 
+let list_plugins_tags, list_plugins_tags_doc =
+  let doc = "List all available plugin with theirs tags" in
+  Arg.(value & flag & info ["list-plugins-tags"] ~doc), doc
+
 let disable_plugin, disable_plugin_doc =
   let doc = "Don't load $(i,PLUGIN) automatically" in
   Arg.(value & opt_all string [] &
@@ -202,6 +206,7 @@ let common_loader_options = [
   `I ("$(b,-L)$(i,PATH)", load_path_doc);
   `I ("$(b,--list-plugins)", list_plugin_doc);
   `I ("$(b,--list-tags)", list_tags_doc);
+  `I ("$(b,--list-plugins-tags)", list_plugins_tags_doc);
   `I ("$(b,--disable-plugin)", disable_plugin_doc);
   `I ("$(b,--disable-autoload)", no_auto_load_doc);
   `I ("$(b,--no-)$(i,PLUGIN)", disable_plugin_doc);

--- a/src/bap_cmdline_terms.ml
+++ b/src/bap_cmdline_terms.ml
@@ -181,10 +181,6 @@ let list_tags, list_tags_doc =
   let doc = "List all available plugin tags" in
   Arg.(value & flag & info ["list-tags"] ~doc), doc
 
-let list_plugins_tags, list_plugins_tags_doc =
-  let doc = "List all available plugins with theirs tags" in
-  Arg.(value & flag & info ["list-plugins-tags"] ~doc), doc
-
 let disable_plugin, disable_plugin_doc =
   let doc = "Don't load $(i,PLUGIN) automatically" in
   Arg.(value & opt_all string [] &
@@ -206,7 +202,6 @@ let common_loader_options = [
   `I ("$(b,-L)$(i,PATH)", load_path_doc);
   `I ("$(b,--list-plugins)", list_plugin_doc);
   `I ("$(b,--list-tags)", list_tags_doc);
-  `I ("$(b,--list-plugins-tags)", list_plugins_tags_doc);
   `I ("$(b,--disable-plugin)", disable_plugin_doc);
   `I ("$(b,--disable-autoload)", no_auto_load_doc);
   `I ("$(b,--no-)$(i,PLUGIN)", disable_plugin_doc);

--- a/src/bap_cmdline_terms.mli
+++ b/src/bap_cmdline_terms.mli
@@ -20,6 +20,7 @@ val load_path : string list Term.t
 val list_plugins : string list option Term.t
 val disable_plugin : string list Term.t
 val no_auto_load : bool Term.t
+val list_tags : bool Term.t
 
 val loader_options : string list
 val common_loader_options : Manpage.block list

--- a/src/bap_cmdline_terms.mli
+++ b/src/bap_cmdline_terms.mli
@@ -21,6 +21,7 @@ val list_plugins : string list option Term.t
 val disable_plugin : string list Term.t
 val no_auto_load : bool Term.t
 val list_tags : bool Term.t
+val list_plugins_tags : bool Term.t
 
 val loader_options : string list
 val common_loader_options : Manpage.block list

--- a/src/bap_cmdline_terms.mli
+++ b/src/bap_cmdline_terms.mli
@@ -21,7 +21,6 @@ val list_plugins : string list option Term.t
 val disable_plugin : string list Term.t
 val no_auto_load : bool Term.t
 val list_tags : bool Term.t
-val list_plugins_tags : bool Term.t
 
 val loader_options : string list
 val common_loader_options : Manpage.block list


### PR DESCRIPTION
A short list of changes:

1) tag names are revised
2) tags are automatically added to plugins man pages, e.g.
<pre>
<b>SEE ALSO</b>
       <b>bap-api</b>(3), <b>bap-plugin-frontc-parser</b>(1)

       <b>tags</b>: api, pass
</pre> 
or
<pre>
<b>SEE ALSO</b>
       <b>home</b>: www:bap.ece.cmu.edu

       <b>tags</b>: deobfuscator, microx, primus, pass, strings
</pre>
3)  `--list-plugins` prints plugins in the alphabetical order
4) a new `--list-tags` command line option, that prints all known tags and corresponded plugins, e.g
```
abi                 abi, primus-loader
analysis            warn-unused
api                 api, frontc-parser
arm                 arm
brancher            relocatable
c                   frontc-parser
c++                 cxxfilt
c++filt             cxxfilt
cache               cache
checker             warn-unused
coff                llvm
dataflow            primus-propagate-taint, propagate-taint, taint
demangler           cxxfilt, demangle
deobfuscator        beagle
disassembler        llvm, x86
dynamic             trace
elf                 llvm
emulator            run
fuzz                primus-promiscuous
ida                 emit-ida-script, ida
lifter              arm, x86
lisp                primus-lisp
llvm                llvm, relocatable
loader              llvm, primus-loader, primus-x86, relocatable
macho               llvm
microx              beagle
objdump             objdump
ogre                relocatable
parser              frontc-parser
pass                abi, api, beagle, byteweight, callsites, map-terms,
                    propagate-taint, run, strings, taint, trace, warn-unused
primus              beagle, primus-exploring, primus-greedy, primus-lisp,
                    primus-loader, primus-print, primus-promiscuous,
                    primus-propagate-taint, primus-round-robin,
                    primus-wandering, primus-x86, run
printer             dump-symbols, phoenix, piqi-printers, primus-print,
                    print, trace
python              emit-ida-script
reconstructor       ida, read-symbols
rooter              byteweight, ida, read-symbols
scheduler           primus-exploring, primus-greedy, primus-round-robin,
                    primus-wandering
security            warn-unused
serialization       piqi-printers
strings             beagle, strings
symbolizer          ida, objdump, read-symbols
taint               primus-propagate-taint, propagate-taint, taint
trace               trace
x86                 primus-x86, x86

```