### PR TITLE
fix few bugs in bap-llvm

### DIFF
--- a/lib/bap_llvm/llvm_coff_loader.hpp
+++ b/lib/bap_llvm/llvm_coff_loader.hpp
@@ -255,7 +255,7 @@ void exported_symbols(const coff_obj &obj, ogre_doc &s) {
 }
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8 \
-    || LLVM_VERSION_MAJOR == 4 && LLVM_VERSION_MINOR == 0
+    || LLVM_VERSION_MAJOR == 4
 
 error_or<uint64_t> symbol_relative_address(const coff_obj &obj, const SymbolRef &sym) {
     auto base = obj.getImageBase();

--- a/lib/bap_llvm/llvm_disasm.cpp
+++ b/lib/bap_llvm/llvm_disasm.cpp
@@ -1,6 +1,5 @@
 #include <llvm/MC/MCAsmInfo.h>
 #include <llvm/MC/MCContext.h>
-#include <llvm/MC/MCDisassembler.h>
 #include <llvm/MC/MCInstPrinter.h>
 #include <llvm/MC/MCInstrInfo.h>
 #include <llvm/MC/MCRegisterInfo.h>
@@ -20,8 +19,14 @@
 #include "disasm.hpp"
 #include "llvm_disasm.h"
 
+#if LLVM_VERSION_MAJOR == 4
+#include <llvm/MC/MCDisassembler/MCDisassembler.h>
+#else
+#include <llvm/MC/MCDisassembler.h>
+#endif
+
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR == 4 && LLVM_VERSION_MINOR == 0
+    || LLVM_VERSION_MAJOR == 4
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/Triple.h>
 #include <llvm/ADT/Twine.h>
@@ -35,7 +40,7 @@
 
 //template <typename T>
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR == 4 && LLVM_VERSION_MINOR == 0
+    || LLVM_VERSION_MAJOR == 4
 template <typename T>
 using smart_ptr = std::unique_ptr<T>;
 template <class T>
@@ -78,7 +83,7 @@ bool ends_with(const std::string& str, const std::string &suffix) {
 //! identically on both versions.
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR == 4 && LLVM_VERSION_MINOR == 0
+    || LLVM_VERSION_MAJOR == 4
 class MemoryObject {
     memory mem;
 public:
@@ -178,7 +183,7 @@ class llvm_disassembler : public disassembler_interface {
     insn current;
     std::vector<int> prefixes;
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR == 4 && LLVM_VERSION_MINOR == 0
+    || LLVM_VERSION_MAJOR == 4
     shared_ptr<MemoryObject>                mem;
 #else
     shared_ptr<const llvm::MemoryObject>    mem;
@@ -266,7 +271,7 @@ public:
         }
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR == 4 && LLVM_VERSION_MINOR == 0
+    || LLVM_VERSION_MAJOR == 4
         smart_ptr<llvm::MCSymbolizer>
             symbolizer(target->createMCSymbolizer(
                            triple,
@@ -291,7 +296,7 @@ public:
         }
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR == 4 && LLVM_VERSION_MINOR == 0
+    || LLVM_VERSION_MAJOR == 4
         shared_ptr<llvm::MCInstPrinter>
             printer (target->createMCInstPrinter
                      (t, asm_info->getAssemblerDialect(), *asm_info, *ins_info, *reg_info));
@@ -311,7 +316,7 @@ public:
         printer->setPrintImmHex(true);
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR == 4 && LLVM_VERSION_MINOR == 0
+    || LLVM_VERSION_MAJOR == 4
         shared_ptr<llvm::MCDisassembler>
             dis(target->createMCDisassembler(*sub_info, *ctx));
 #else
@@ -326,7 +331,7 @@ public:
         }
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR == 4 && LLVM_VERSION_MINOR == 0
+    || LLVM_VERSION_MAJOR == 4
         dis->setSymbolizer(move(symbolizer));
 #else
         dis->setSymbolizer(symbolizer);
@@ -372,7 +377,7 @@ public:
     }
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR == 4 && LLVM_VERSION_MINOR == 0
+    || LLVM_VERSION_MAJOR == 4
     llvm::ArrayRef<uint8_t> view(uint64_t pc) {
         return mem->view(pc);
     }
@@ -448,7 +453,7 @@ public:
             std::string data;
             llvm::raw_string_ostream stream(data);
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR == 4 && LLVM_VERSION_MINOR == 0
+    || LLVM_VERSION_MAJOR == 4
             printer->printInst(&mcinst, stream, "", *sub_info);
 #else
             printer->printInst(&mcinst, stream, "");

--- a/lib/bap_llvm/llvm_elf_loader.hpp
+++ b/lib/bap_llvm/llvm_elf_loader.hpp
@@ -205,7 +205,7 @@ void symbol_entry(const ELFObjectFile<T> &obj, const SymbolRef &sym, ogre_doc &s
 }
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR == 4 && LLVM_VERSION_MINOR == 0
+    || LLVM_VERSION_MAJOR == 4
 
 template <typename T>
 uint64_t base_address(const ELFObjectFile<T> &obj) {

--- a/lib/bap_llvm/llvm_macho_loader.hpp
+++ b/lib/bap_llvm/llvm_macho_loader.hpp
@@ -356,7 +356,7 @@ void dynamic_relocations(const macho &obj, command_info &info, ogre_doc &s) {
 }
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8 \
-    || LLVM_VERSION_MAJOR == 4 && LLVM_VERSION_MINOR == 0
+    || LLVM_VERSION_MAJOR == 4
 
 commands macho_commands(const macho &obj) {
     commands cmds;

--- a/lib/bap_llvm/llvm_primitives.cpp
+++ b/lib/bap_llvm/llvm_primitives.cpp
@@ -18,7 +18,7 @@ uint64_t relative_address(uint64_t base, uint64_t abs) {
 }
 
 // 4.0 only
-#if LLVM_VERSION_MAJOR == 4 && LLVM_VERSION_MINOR == 0
+#if LLVM_VERSION_MAJOR == 4
 
 template <typename T>
 std::string error_message(Expected<T> &e) {
@@ -46,7 +46,7 @@ error_or<SymbolRef::Type> symbol_type(const SymbolRef &s) {
 #endif
 
 // 4.0 or 3.8
-#if LLVM_VERSION_MAJOR == 4 && LLVM_VERSION_MINOR == 0        \
+#if LLVM_VERSION_MAJOR == 4                                     \
     || LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8
 
 const char* get_raw_data(const ObjectFile &obj) {

--- a/lib/bap_llvm/llvm_primitives.hpp
+++ b/lib/bap_llvm/llvm_primitives.hpp
@@ -64,7 +64,7 @@ error_or<std::string> elf_section_name(const ELFFile<T> &elf, const typename ELF
 // template functions
 
 // 4.0
-#if LLVM_VERSION_MAJOR == 4 && LLVM_VERSION_MINOR == 0
+#if LLVM_VERSION_MAJOR == 4
 
 template <typename T>
 std::vector<typename ELFFile<T>::Elf_Phdr> elf_program_headers(const ELFFile<T> &elf) {
@@ -93,7 +93,7 @@ error_or<std::string> elf_section_name(const ELFFile<T> &elf, const typename ELF
     return success(er_name.get().str());
 }
 
-//3.8
+// 3.8
 #elif LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8
 
 template <typename T>
@@ -115,8 +115,8 @@ std::vector<typename ELFFile<T>::Elf_Shdr> elf_sections(const ELFFile<T> &elf) {
 template <typename T>
 error_or<std::string> elf_section_name(const ELFFile<T> &elf, const typename ELFFile<T>::Elf_Shdr *sec) {
     auto er_name = elf.getSectionName(sec);
-    if (er_name) return failure(er_name.getError().message());
-    return success(er_name->str());
+    if (er_name) return success(er_name->str());
+    return failure(er_name.getError().message());
 }
 
 // 3.4


### PR DESCRIPTION
this PR fixes two bugs:
- fixes recently added bug with sectoins name for `llvm 3.8`
- adds lost `#include` file for l`lvm 4.0`