### PR TITLE
Fixing rotate instructions

### DIFF
--- a/plugins/x86/x86_utils.ml
+++ b/plugins/x86/x86_utils.ml
@@ -16,8 +16,11 @@ let concat_explist elist =
   List.reduce_exn
     ~f:Bil.(^) elist
 
-(*FIXME: This is conversion from typ to nat1. It's used in cast expressions*)
-let (!!) = function Type.Imm v -> v | _ -> failwith "internal error"
+let bitwidth_of_type = function
+  | Type.Imm v -> v
+  | _ -> failwith "internal error"
+
+let (!!) = bitwidth_of_type
 
 let bytes_of_width t =
   let b = !!t in


### PR DESCRIPTION
According to the manual, `ror/rol` instructions has
the following calculation of the number of bit positions:
```
tempCOUNT ← (COUNT & COUNTMASK) MOD SIZE
```
We didn't  take a `mod size` in x86 lifter, while we should.

Also, BIL contains weird assignments like `OF := OF`,
when the flag is unchanged, so we will get rid of them.
(fix for https://github.com/BinaryAnalysisPlatform/bap/issues/706)
Finally, rotate instructions look like the following:
```
bap-mc "c000ff" --show-bil  --show-asm --arch=X86
rolb $0xff, (%eax) 
{
  orig_count1 := 7
  mem := mem
             with [EAX] <- mem[EAX] << orig_count1 | mem[EAX] >> 8 - orig_count1
  if (orig_count1 = 0) {
    CF := low:1[mem[EAX]]
  }
  else {
    if (orig_count1 = 1) {
      OF := CF ^ high:1[mem[EAX]]
    }
    else {
      OF := unknown[OF undefined after rotate of more then 1 bit]:u1
    }
  }
}
```
