### PR TITLE
Making YMM registers available for IA32 and AMD64 users.

### DIFF
--- a/lib/x86_cpu/x86_cpu.ml
+++ b/lib/x86_cpu/x86_cpu.ml
@@ -10,7 +10,7 @@ module Make_CPU(Env : ModeVars) = struct
   let gpr = Var.Set.of_list @@ [
       rax; rcx; rdx; rsi; rdi;
       rbx; rbp; rsp;
-    ] @ Array.to_list nums
+    ] @ Array.to_list r
 
   let flags = Var.Set.of_list [
       cf; pf; af; zf; sf; oF; df

--- a/lib/x86_cpu/x86_cpu.mli
+++ b/lib/x86_cpu/x86_cpu.mli
@@ -42,6 +42,8 @@ module IA32 : sig
   (** data register  *)
   val rdx : var
 
+  (** YMM registers that are available *)
+  val ymms: var array
 
 end
 

--- a/lib/x86_cpu/x86_cpu.mli
+++ b/lib/x86_cpu/x86_cpu.mli
@@ -53,7 +53,7 @@ module AMD64 : sig
   include Bap.Std.CPU
   include module type of IA32
 
-(** r8-r15 registers.
+  (** r8-r15 registers.
       Due to a legacy issues r.(0) -> r8, r.(1) -> r8, ... *)
   val r : var array
 end

--- a/lib/x86_cpu/x86_env.ml
+++ b/lib/x86_cpu/x86_env.ml
@@ -120,8 +120,8 @@ module type ModeVars = sig
   val mem : var
 
   (* r8 -> r15 *)
-  val nums : var array
   val r : var array
+  val ymms : var array
 end
 
 module R32 = struct
@@ -151,9 +151,12 @@ module R32 = struct
 
   let mem = mem.v32
 
-  (* r8 -> r15 *)
-  let nums = Array.init 8 ~f:(fun i -> Var.create "ERROR" (Type.imm 0) )
-  let r = nums
+  (* No r registers in x86 32-bit mode *)
+  let r = [||]
+
+  (* Only 8 YMM/XMM registers in x86 32-bit mode *)
+  let ymms = Array.sub ymms 0 8
+
 end
 
 module R64 = struct
@@ -184,8 +187,11 @@ module R64 = struct
   let mem = mem.v64
 
   (* r8 -> r15 *)
-  let nums = Array.init 8 ~f:(fun i -> Var.create (Printf.sprintf "R%d" (i+8)) reg64_t)
-  let r = nums
+  let r = Array.init 8 ~f:(fun i -> Var.create (Printf.sprintf "R%d" (i+8)) reg64_t)
+
+  (* All YMM/XMM registers are available *)
+  let ymms = ymms
+
 end
 
 let vars_of_mode mode =

--- a/lib/x86_cpu/x86_env.ml
+++ b/lib/x86_cpu/x86_env.ml
@@ -121,6 +121,7 @@ module type ModeVars = sig
 
   (* r8 -> r15 *)
   val r : var array
+  val nums : var array
   val ymms : var array
 end
 
@@ -153,6 +154,8 @@ module R32 = struct
 
   (* No r registers in x86 32-bit mode *)
   let r = [||]
+
+  let nums = r
 
   (* Only 8 YMM/XMM registers in x86 32-bit mode *)
   let ymms = Array.sub ymms 0 8
@@ -188,6 +191,8 @@ module R64 = struct
 
   (* r8 -> r15 *)
   let r = Array.init 8 ~f:(fun i -> Var.create (Printf.sprintf "R%d" (i+8)) reg64_t)
+
+  let nums = r
 
   (* All YMM/XMM registers are available *)
   let ymms = ymms

--- a/lib/x86_cpu/x86_env.mli
+++ b/lib/x86_cpu/x86_env.mli
@@ -51,9 +51,6 @@ val fpu_ctrl : var
 val mxcsr    : var
 
 
-(** array of yms registers  *)
-val ymms: var array
-
 
 val o_rax : operand
 val o_rcx : operand
@@ -147,11 +144,13 @@ module type ModeVars = sig
   val mem : var
   (* r8 -> r15 *)
 
-  val nums : var array
-
   (** r8-r15 registers.
       Due to a legacy issues r.(0) -> r8, r.(1) -> r8, ... *)
   val r : var array
+
+  (** array of yms registers  *)
+  val ymms: var array
+
 end
 
 

--- a/lib/x86_cpu/x86_env.mli
+++ b/lib/x86_cpu/x86_env.mli
@@ -148,7 +148,7 @@ module type ModeVars = sig
       Due to a legacy issues r.(0) -> r8, r.(1) -> r8, ... *)
   val r : var array
 
-  (** array of yms registers  *)
+  (** array of YMM registers  *)
   val ymms: var array
 
 end

--- a/lib/x86_cpu/x86_env.mli
+++ b/lib/x86_cpu/x86_env.mli
@@ -148,6 +148,10 @@ module type ModeVars = sig
       Due to a legacy issues r.(0) -> r8, r.(1) -> r8, ... *)
   val r : var array
 
+  [@@deprecated "[since 2018-01] user `r` instead"]
+  (** Legacy version of the `r` array, use `r` instead. *)
+  val nums : var array
+
   (** array of YMM registers  *)
   val ymms: var array
 

--- a/lib_test/x86/test_pshufb.ml
+++ b/lib_test/x86/test_pshufb.ml
@@ -106,8 +106,8 @@ let pshufb_rm = "\x66\x0f\x38\x00\x00" (** pshufb %xmm0, (%eax) *)
 
 (** tests that permutations works as expected  *)
 let test_rr (mask, expected) ctxt =
-  let xmm0 = X86_env.ymms.(0) in
-  let xmm1 = X86_env.ymms.(1) in
+  let xmm0 = X86_cpu.IA32.ymms.(0) in
+  let xmm1 = X86_cpu.IA32.ymms.(1) in
   let bil = Bil.[
       move xmm0 (int origin);
       move xmm1 (int mask);
@@ -130,7 +130,7 @@ end
     raise in some cases raised *)
 let test_rm addr expected ctxt =
   let open X86_env.R32 in
-  let xmm0 = X86_env.ymms.(0) in
+  let xmm0 = X86_cpu.IA32.ymms.(0) in
   let bil = Bil.[
       move rax (int addr);
       move mem

--- a/plugins/x86/x86_lifter.ml
+++ b/plugins/x86/x86_lifter.ml
@@ -35,10 +35,10 @@ module ToIR = struct
 
   (* copypasted from op2e_s below, but keeps the opcode width *)
   let op2e_s_keep_width mode ss has_rex t = function
-    | Ovec r when t = reg256_t -> (bits2ymme r, t)
-    | Ovec r when t = reg128_t -> (bits2ymm128e r, t)
-    | Ovec r when t = reg64_t -> (bits2ymm64e r, t)
-    | Ovec r when t = reg32_t -> (bits2ymm32e r, t)
+    | Ovec r when t = reg256_t -> (bits2ymme mode r, t)
+    | Ovec r when t = reg128_t -> (bits2ymm128e mode r, t)
+    | Ovec r when t = reg64_t -> (bits2ymm64e mode r, t)
+    | Ovec r when t = reg32_t -> (bits2ymm32e mode r, t)
     | Ovec _ ->
       let i = match t with
         | Type.Imm n -> ": "^(string_of_int n)
@@ -57,10 +57,10 @@ module ToIR = struct
     | Oimm i -> Bil.(Int (resize_word i !!t), t)
 
   let op2e_s mode ss has_rex t = function
-    | Ovec r when t = reg256_t -> bits2ymme r
-    | Ovec r when t = reg128_t -> bits2ymm128e r
-    | Ovec r when t = reg64_t -> bits2ymm64e r
-    | Ovec r when t = reg32_t -> bits2ymm32e r
+    | Ovec r when t = reg256_t -> bits2ymme mode r
+    | Ovec r when t = reg128_t -> bits2ymm128e mode r
+    | Ovec r when t = reg64_t -> bits2ymm64e mode r
+    | Ovec r when t = reg32_t -> bits2ymm32e mode r
     | Ovec _ ->
       let i = match t with
         | Type.Imm n -> ": "^(string_of_int n)
@@ -104,10 +104,10 @@ module ToIR = struct
     match v, t with
     (* Zero-extend 128-bit assignments to 256-bit ymms. *)
     | Ovec r, Type.Imm (128|64|32) when has_vex ->
-      let v = bits2ymm r in
+      let v = bits2ymm mode r in
       sub_assn reg256_t v Bil.(Cast (UNSIGNED, !!reg256_t, e))
     | Ovec r, Type.Imm (256|128|64|32) ->
-      let v = bits2ymm r in
+      let v = bits2ymm mode r in
       sub_assn t v e
     | Ovec _, _ -> disfailwith mode "invalid SIMD register size for assignment"
     (* Zero-extend 32-bit assignments to 64-bit registers. *)

--- a/plugins/x86/x86_utils.ml
+++ b/plugins/x86/x86_utils.ml
@@ -315,7 +315,7 @@ let bits2genreg mode =
     | 5 -> rbp
     | 6 -> rsi
     | 7 -> rdi
-    | i when i >= 8 && i <= 15 -> nums.(i-8)
+    | i when i >= 8 && i <= 15 -> r.(i-8)
     | _ -> failwith "bits2genreg takes 4 bits"
 
 let reg2bits mode x =
@@ -335,18 +335,24 @@ let bits2segreg = function
 
 let bits2segrege b = bits2segreg b |> Bil.var
 
-let bits2ymm b = ymms.(b)
+(* select the right YMM var based on mode *)
+let bits2ymm mode b =
+  let ymms = match mode with
+    | X86 -> R32.ymms
+    | X8664 -> R64.ymms
+  in
+  ymms.(b)
 
-let bits2ymme b = bits2ymm b |> Bil.var
+let bits2ymme mode b = bits2ymm mode b |> Bil.var
 
-let bits2ymm128e b =
-  bits2ymme b |> Bil.(cast low (!!reg128_t))
+let bits2ymm128e mode b =
+  bits2ymme mode b |> Bil.(cast low (!!reg128_t))
 
-let bits2ymm64e b =
-  bits2ymme b |> Bil.(cast low (!!reg64_t))
+let bits2ymm64e mode b =
+  bits2ymme mode b |> Bil.(cast low (!!reg64_t))
 
-let bits2ymm32e b =
-  bits2ymme b |> Bil.(cast low (!!reg32_t))
+let bits2ymm32e mode b =
+  bits2ymme mode b |> Bil.(cast low (!!reg32_t))
 
 let bits2xmm = bits2ymm128e
 
@@ -370,7 +376,7 @@ let bits2reg8e mode ?(has_rex=false) b =
     b land 3 |> bits2reg32e mode |>
     Bil.(cast low (!!reg16_t)) |>  Bil.(cast high (!!reg8_t))
 
-let reg2xmm mode r = reg2bits mode r |> bits2xmm
+let reg2xmm mode r = reg2bits mode r |> bits2xmm mode
 
 (* effective addresses for 16-bit addressing *)
 let eaddr16 mode =


### PR DESCRIPTION
The PR makes YMM registers available for IA32 and AMD64 users. The PR also fixes a few 
inconsistencies in the interface exposed internally in plugin modules (e.g., the x86_lifter):
the number of YMM registers now varies based on the architecture and the `nums`
array was removed and replaced by references to the AMD64 `r` array. The `r` array definition was
changed to empty for IA32 internals (it can still throw runtime errors and needs to be removed in
the future, but this version is better than the previous approach).