### PR TITLE
fixed mov with offset insn

### DIFF
--- a/plugins/x86/x86_tools_types.ml
+++ b/plugins/x86/x86_tools_types.ml
@@ -26,7 +26,7 @@ end
 (** Memory model *)
 module type MM = sig
   type t
-  val of_mem : mem -> seg:reg -> base:reg -> scale:imm -> index:reg -> disp:imm -> t
+  val of_mem : ?seg:reg -> ?base:reg -> ?scale:imm -> ?index:reg -> disp:imm -> mem -> t
   val of_offset : imm -> t
   val addr : t -> exp
   val addr_size : addr_size


### PR DESCRIPTION
fix https://github.com/BinaryAnalysisPlatform/bap/issues/752 for builds with llvm 3.8+ . 
Segment prefixes are handled as they should be:
1) without prefix
```
$ echo '0xa1,0x14,0x00,0x00,0x00' | bap-mc --arch=x86 --show-bil --show-insn --show-insn=asm --x86-lifter=modern
MOV32ao32(0x14,Nil)
movl 0x14, %eax
{
  EAX := mem[0x14, el]:u32
}
```
2) with prefix
```
$ echo '0x65,0xa1,0x14,0x00,0x00,0x00' | bap-mc --arch=x86 --show-bil --show-insn --show-insn=asm --x86-lifter=modern
MOV32ao32(0x14,GS)
movl %gs:0x14, %eax
{
  EAX := mem[GS_BASE + 0x14, el]:u32
}
```
