### PR TITLE
 added goto resoliving for non local indirect jumps

### DIFF
--- a/lib/bap_sema/bap_sema_lift.ml
+++ b/lib/bap_sema/bap_sema_lift.ml
@@ -194,8 +194,11 @@ let resolve_jmp ~local addrs jmp =
       ~f:(fun id -> Ir_jmp.with_kind jmp (make_kind id)) in
   match Ir_jmp.kind jmp with
   | Ret _ | Int _ -> jmp
-  | Goto (Indirect (Bil.Int addr)) when local ->
-    update_kind jmp addr (fun id -> Goto (Direct id))
+  | Goto (Indirect (Bil.Int addr)) ->
+    update_kind jmp addr (fun id ->
+        if local then Goto (Direct id)
+        else
+          Call (Call.create ~target:(Direct id) ()))
   | Goto _ -> jmp
   | Call call ->
     let jmp,call = match Call.target call with


### PR DESCRIPTION
Previously, only local indirect jumps were considered,
so tail call performed by branch instruction wouldn't
be resolved. This PR solves this issue