### PR TITLE
Minor bug fixes

### DIFF
--- a/lib/bap_llvm/llvm_primitives.hpp
+++ b/lib/bap_llvm/llvm_primitives.hpp
@@ -139,7 +139,7 @@ std::vector<typename ELFFile<T>::Elf_Shdr> elf_sections(const ELFFile<T> &elf) {
 template <typename T>
 error_or<std::string> elf_section_name(const ELFFile<T> &elf, const typename ELFFile<T>::Elf_Shdr *sec) {
     auto er_name = elf.getSectionName(sec);
-    if (er_name) return failure(er_name.getError().message());
+    if (error_code er = er_name) return failure(er.message());
     return success(er_name->str());
 }
 

--- a/plugins/primus_lisp/lisp/pointers.lisp
+++ b/plugins/primus_lisp/lisp/pointers.lisp
@@ -32,13 +32,13 @@
 
 (defmacro read-word (t p)
   "reads a word of type T at address P"
-  (let ((p p)
+  (let ((r p)
         (x (memory-read p))
         (n (-1 (sizeof t))))
     (while n
-      (incr p)
+      (incr r)
       (decr n)
-      (endian cat x (memory-read p)))
+      (set x (endian cat x (memory-read r))))
     x))
 
 (defmacro write-word (t p x)

--- a/plugins/x86/x86_mov_offset.ml
+++ b/plugins/x86/x86_mov_offset.ml
@@ -199,7 +199,8 @@ module Self = Self ()
 
 let () =
   if llvm_version = "3.4" then T_34.register ()
-  else if llvm_version = "3.8" || llvm_version = "4.0" then T_38.register ()
+  else if llvm_version = "3.8" || llvm_version = "4.0" || llvm_version = "5.0"
+  then T_38.register ()
   else
     Self.error
       "x86 MOV with offset instructions will not lifted due to unknown \


### PR DESCRIPTION
minor bug fixed:
1) in primus lisp - read-word didn't read a requested count of words
2) in x86-lifter - forgotten llvm version constraint for `movoffset` instruction
   after added llvm 5.0 support
3) in bap_llvm library fixed a bug that crushes bap build with llvm 3.4
