### PR TITLE
Fix source-type cmdline option

### DIFF
--- a/lib/bap/bap_project.ml
+++ b/lib/bap/bap_project.ml
@@ -119,6 +119,7 @@ module Input = struct
     let mem = Memory.create (Arch.endian arch) base big |> ok_exn in
     let section = Value.create Image.section "bap.user" in
     let data = Memmap.add Memmap.empty mem section in
+    Signal.send Info.got_img None;
     {arch; data; code = data; file = filename; finish = ident;}
 
   let available_loaders () =

--- a/lib/bap/bap_project.ml
+++ b/lib/bap/bap_project.ml
@@ -117,7 +117,6 @@ module Input = struct
     let mem = Memory.create (Arch.endian arch) base big |> ok_exn in
     let section = Value.create Image.section "bap.user" in
     let data = Memmap.add Memmap.empty mem section in
-    Signal.send Info.got_img None;
     {arch; data; code = data; file = filename; finish = ident;}
 
   let available_loaders () =

--- a/src/bap_cmdline_terms.ml
+++ b/src/bap_cmdline_terms.ml
@@ -147,10 +147,7 @@ let source_type : source Term.t =
             needed, then a version number can be specifed, separated
             from the format by a dash, e.g., `myproj.marshal`,
             `myproj.sexp-1.0', etc. If the format is not specified,
-            then the default reader will be used. The name can be also
-            of the form `<name>-custom', where <name> should be a name
-            of factory method registered for a file source in project
-            factory." in
+            then the default reader will be used." in
   Arg.(value & opt Bap_source_type.t `Binary & info ["source-type"]
          ~doc ~docv:"NAME")
 

--- a/src/bap_fmt_spec.mli
+++ b/src/bap_fmt_spec.mli
@@ -3,3 +3,4 @@ type t = [`file of string | `stdout] * string * string option [@@deriving sexp]
 
 val t : t Arg.converter
 
+val parse : string -> [`Ok of t | `Error of string]

--- a/src/bap_main.ml
+++ b/src/bap_main.ml
@@ -118,8 +118,7 @@ let main o =
     | Ok project ->
       Project.Cache.save (digest o) project;
       project in
-  let proj_of_file file =
-    let fmt,ver = parse_filename file in
+  let proj_of_file ?ver ?fmt file =
     In_channel.with_file file
       ~f:(fun ch -> Project.Io.load ?fmt ?ver ch) in
   let project = match Project.Cache.load (digest o) with
@@ -127,7 +126,11 @@ let main o =
       Project.restore_state proj;
       proj
     | None -> match o.source with
-      | `File _ -> proj_of_file o.filename
+      | `File "builtin" ->
+        let fmt,ver = parse_filename o.filename in
+        proj_of_file ?fmt ?ver o.filename
+      | `File fmt ->
+        proj_of_file ~fmt o.filename
       | `Memory arch ->
         proj_of_input @@
         Project.Input.binary arch ~filename:o.filename

--- a/src/bap_main.ml
+++ b/src/bap_main.ml
@@ -98,8 +98,8 @@ let process options project =
       | `stdout,fmt,ver ->
         Project.Io.show ~fmt ?ver project)
 
-let parse_filename filename =
-  let fmt = match String.index filename '.' with
+let extract_format filename =
+  let fmt = match String.rindex filename '.' with
     | None -> filename
     | Some n -> String.subo ~pos:(n+1) filename in
   match Bap_fmt_spec.parse fmt with
@@ -126,11 +126,9 @@ let main o =
       Project.restore_state proj;
       proj
     | None -> match o.source with
-      | `File "builtin" ->
-        let fmt,ver = parse_filename o.filename in
+      | `Project ->
+        let fmt,ver = extract_format o.filename in
         proj_of_file ?fmt ?ver o.filename
-      | `File fmt ->
-        proj_of_file ~fmt o.filename
       | `Memory arch ->
         proj_of_input @@
         Project.Input.binary arch ~filename:o.filename

--- a/src/bap_main.ml
+++ b/src/bap_main.ml
@@ -98,33 +98,11 @@ let process options project =
       | `stdout,fmt,ver ->
         Project.Io.show ~fmt ?ver project)
 
-let filename_info filename =
-  let rindex ?from what = match from with
-    | None -> String.rindex filename what
-    | Some ind -> String.rindex_from filename ind what in
-  let substr_from ?len pos = String.subo ~pos ?len filename in
-  let get_dot_ind dash_ind = match dash_ind with
-    | None -> rindex '.'
-    | Some dash_ind -> match rindex ~from:dash_ind '.' with
-      | None -> rindex '.'
-      | Some ind -> Some ind in
-  let dash_ind = rindex '-' in
-  match get_dot_ind dash_ind, dash_ind with
-  | Some dot, Some dash when dot < dash ->
-    let ver = substr_from (dash + 1) in
-    let fmt = substr_from ~len:(dash - dot - 1) (dot + 1) in
-    Some fmt, Some ver
-  | Some dot, _ ->
-    Some (substr_from (dot + 1)), None
-  | _ -> None, None
-
-let fmt filename =
-  let parse = fst Bap_fmt_spec.t in
-  let fmt =
-    match List.rev @@  String.split ~on:'.' name with
-    | fmt :: _ -> fmt
-    | _ -> name in
-  match parse fmt with
+let parse_filename filename =
+  let fmt = match String.index filename '.' with
+    | None -> filename
+    | Some n -> String.subo ~pos:(n+1) filename in
+  match Bap_fmt_spec.parse fmt with
   | `Error _ -> None, None
   | `Ok (_,fmt,ver) -> Some fmt, ver
 
@@ -141,19 +119,18 @@ let main o =
       Project.Cache.save (digest o) project;
       project in
   let load_from_file () =
-    (* let fmt,ver = fmt o.filename in *)
-    let fmt,ver = filename_info o.filename in
-    printf "format is %s\n" (Option.value ~default:"none" fmt);
-
+    let fmt,ver = parse_filename o.filename in
     In_channel.with_file o.filename
-      ~f:(fun ch -> Project.Io.load ?fmt ?ver ch) in
+      ~f:(fun ch ->
+          Project.Io.load ?fmt ?ver ch) in
   let project = match Project.Cache.load (digest o) with
     | Some proj ->
       Project.restore_state proj;
       proj
     | None -> match o.source with
       | `File _ -> load_from_file ()
-      | `Memory arch -> make @@
+      | `Memory arch ->
+        make @@
         Project.Input.binary arch ~filename:o.filename
       | `Binary -> make @@
         Project.Input.file ~loader:o.loader ~filename: o.filename in
@@ -277,7 +254,6 @@ let () =
   Log.start ();
   at_exit (pp_print_flush err_formatter);
   let argv,passes = run_loader () in
-  (* main (parse passes argv); exit 0 *)
   try main (parse passes argv); exit 0 with
   | Unknown_arch arch ->
     error "Invalid arch `%s', should be one of %s." arch

--- a/src/bap_main.ml
+++ b/src/bap_main.ml
@@ -141,7 +141,10 @@ let main o =
       Project.Cache.save (digest o) project;
       project in
   let load_from_file () =
-    let fmt,ver = fmt o.filename in
+    (* let fmt,ver = fmt o.filename in *)
+    let fmt,ver = filename_info o.filename in
+    printf "format is %s\n" (Option.value ~default:"none" fmt);
+
     In_channel.with_file o.filename
       ~f:(fun ch -> Project.Io.load ?fmt ?ver ch) in
   let project = match Project.Cache.load (digest o) with

--- a/src/bap_source_type.ml
+++ b/src/bap_source_type.ml
@@ -8,7 +8,7 @@ exception Unrecognized_source
 
 type t = [
   | `Binary
-  | `File of string
+  | `Project
   | `Memory of arch
 ] [@@deriving sexp]
 
@@ -19,9 +19,8 @@ let arch_exn str = match Arch.of_string str with
 
 let parse_source_type str = match String.split ~on:'-' str with
   | [arch;"code"] -> `Memory (arch_exn arch)
-  | [fmt;"custom"]  -> `File fmt
   | ["binary"] -> `Binary
-  | ["project"] -> `File "builtin"
+  | ["project"] -> `Project
   | _ -> raise Unrecognized_source
 
 let parse s =
@@ -31,6 +30,6 @@ let parse s =
 let pp ppf = function
   | `Memory arch -> fprintf ppf "%a-code" Arch.pp arch
   | `Binary -> fprintf ppf "binary"
-  | `File fmt -> fprintf ppf "%s-data" fmt
+  | `Project -> fprintf ppf "project"
 
 let t : 'a Arg.converter = parse,pp

--- a/src/bap_source_type.mli
+++ b/src/bap_source_type.mli
@@ -2,7 +2,7 @@ open Bap.Std
 
 type t = [
   | `Binary
-  | `File of string
+  | `Project
   | `Memory of arch
 ] [@@deriving sexp]
 


### PR DESCRIPTION
Cmdline option source-type had no effect. This PR solves this issue.
So there are not any errors when loading a project from `.marshal` file
or when using a raw code with bap.
fix https://github.com/BinaryAnalysisPlatform/bap/issues/694