### PR TITLE
fixes the search of destinations in the reconstructor

### DIFF
--- a/lib/bap_disasm/bap_disasm_reconstructor.ml
+++ b/lib/bap_disasm/bap_disasm_reconstructor.ml
@@ -24,13 +24,13 @@ let find_calls name roots cfg =
   List.iter roots ~f:(fun addr ->
       Hashtbl.set starts ~key:addr ~data:(name addr));
   Cfg.nodes cfg |> Seq.iter ~f:(fun blk ->
-      match Cfg.Node.outputs blk cfg |> Seq.hd with
-      | None -> ()
-      | Some e ->
-        let term = Block.terminator blk in
-        if Insn.(is call) term && Cfg.Edge.label e = `Jump then
-          let w = Block.addr (Cfg.Edge.dst e) in
-          Hashtbl.set starts ~key:w ~data:(name w));
+      let term = Block.terminator blk in
+      if Insn.(is call) term then
+        Seq.iter (Cfg.Node.outputs blk cfg)
+          ~f:(fun e ->
+              if Cfg.Edge.label e <> `Fall then
+                let w = Block.addr (Cfg.Edge.dst e) in
+                Hashtbl.set starts ~key:w ~data:(name w)));
   starts
 
 let reconstruct name roots cfg =


### PR DESCRIPTION
In the reconstructor block destinations are computed directly from the BIL representation, that is not correct, as BIL doesn't take into account the relocations. And if the relocatable brancher is used, then the CFG contains correct edges, but this information is ignored when we build a set of call destinations in the reconstructor.  This PR addresses this problem by searching a destination directly in CFG.
