### PR TITLE
Fixes memory printer

### DIFF
--- a/lib/bap_image/bap_memory.ml
+++ b/lib/bap_image/bap_memory.ml
@@ -419,7 +419,8 @@ include Printable.Make(struct
         (Word.(to_int64 word) |> ok_exn)
 
     let pp_small fmt t =
-      Format.fprintf fmt "%a: " print_word (Addr.signed t.addr);
+      let pp_addr ppf = Addr.pp_generic ~prefix:`none ~case:`lower ppf in
+      Format.fprintf fmt "%a: " pp_addr t.addr;
       iter t ~f:(fun b -> fprintf fmt "%a " print_word b)
 
     let pp fmt t =


### PR DESCRIPTION
fixes https://github.com/BinaryAnalysisPlatform/bap/issues/711

Just print address with a pretty printer from `Addr` module.
How it looks like:
```
~/factory/bap/testsuite$ bap obj/arm-linux-gnueabi-obj -dasm | head

Disassembly of section .text

c0000080: <sub_c0000080>
c0000080:
c0000080: fe ff ff eb                             bl #-0x8
c0000084:
c0000084: 08 00 0b e5                             str r0, [r11, #-0x8]
c0000088: 14 10 1b e5                             ldr r1, [r11, #-0x14]
c000008c: 10 00 1b e5                             ldr r0, [r11, #-0x10]
```
```
~/factory/bap-testsuite$ bap bin/x86_64-linux-gnu-echo -dasm | head

Disassembly of section 02

00000000004005d0: <.__gmon_start__>
00000000004005d0:
4005d0: ff 25 72 0a 20 00                         jmpq *0x200a72(%rip)

0000000000400538: <.init_proc>
0000000000400538:
400538: 48 83 ec 08                               subq $0x8, %rsp

```
```
$ bap /bin/echo -dasm | head
Disassembly of section 02

0000000000401038: <.init_proc>
0000000000401038:
401038: 48 83 ec 08                               subq $0x8, %rsp
40103c: 48 8b 05 b5 5f 20 00                      movq 0x205fb5(%rip), %rax
401043: 48 85 c0                                  testq %rax, %rax
401046: 74 05                                     je 0x5

```