### PR TITLE
moves to travis stages

### DIFF
--- a/.run_travis_tests.sh
+++ b/.run_travis_tests.sh
@@ -1,0 +1,20 @@
+TASK=$1
+
+eval `opam config env`
+
+comp=`opam config var switch`
+
+cp -r $HOME/save_opam/bin/* $HOME/.opam/$comp/bin/
+cp -r $HOME/save_opam/share/* $HOME/.opam/$comp/share/
+cp -r $HOME/save_opam/lib/* $HOME/.opam/$comp/lib/
+
+bap --version
+bap-byteweight update
+
+if [ "$TASK" == "checks" ]; then
+    bash -exc 'make check'
+fi
+
+if [ "$TASK" == "unit_tests" ]; then
+    bap_run_tests
+fi

--- a/.run_travis_tests.sh
+++ b/.run_travis_tests.sh
@@ -4,9 +4,9 @@ eval `opam config env`
 
 comp=`opam config var switch`
 
-cp -alu $HOME/save_opam/bin/* $HOME/.opam/$comp/bin/
-cp -alu $HOME/save_opam/share/* $HOME/.opam/$comp/share/
-cp -alu $HOME/save_opam/lib/* $HOME/.opam/$comp/lib/
+cp -r $HOME/save_opam/bin/* $HOME/.opam/$comp/bin/
+cp -r $HOME/save_opam/share/* $HOME/.opam/$comp/share/
+cp -r $HOME/save_opam/lib/* $HOME/.opam/$comp/lib/
 
 bap --version
 bap-byteweight update

--- a/.run_travis_tests.sh
+++ b/.run_travis_tests.sh
@@ -4,9 +4,9 @@ eval `opam config env`
 
 comp=`opam config var switch`
 
-cp -r $HOME/save_opam/bin/* $HOME/.opam/$comp/bin/
-cp -r $HOME/save_opam/share/* $HOME/.opam/$comp/share/
-cp -r $HOME/save_opam/lib/* $HOME/.opam/$comp/lib/
+cp -alu $HOME/save_opam/bin/* $HOME/.opam/$comp/bin/
+cp -alu $HOME/save_opam/share/* $HOME/.opam/$comp/share/
+cp -alu $HOME/save_opam/lib/* $HOME/.opam/$comp/lib/
 
 bap --version
 bap-byteweight update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,7 @@
 language: c
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
-script: bash -ex .travis-opam.sh
+
 sudo: required
-cache:
-  directories:
-    - $HOME/.opam
-  before_cache:
-    - opam remove bap -y
-    - rm -rf $HOME/.opam/log
+
 addons:
   apt:
     sources:
@@ -22,7 +16,7 @@ addons:
     - libssl-dev
     - libzip-dev
     - llvm
-    - llvm-3.4-dev
+    - llvm-3.8-dev
     - m4
     - ocaml
     - ocaml-base
@@ -35,11 +29,29 @@ addons:
     - dejagnu
     - jq
     - opam
+
+cache:
+  directories:
+  - $HOME/.opam
+  - $HOME/save_opam
+  before_cache:
+  - rm -rf $HOME/.opam/log
+
 env:
-  global:
-  - OPAMYES=true PACKAGE=bap TESTS=false OPAM_SWITCH=$OCAML_VERSION
-  matrix:
-  - OCAML_VERSION=4.03 BAP_RUN_TEST=false BAP_RUN_CHECK=false
-  - OCAML_VERSION=4.04 BAP_RUN_TEST=false BAP_RUN_CHECK=false
-  - OCAML_VERSION=4.05 BAP_RUN_TEST=true  BAP_RUN_CHECK=false
-  - OCAML_VERSION=4.05 BAP_RUN_TEST=false BAP_RUN_CHECK=true
+  - OCAML_VERSION=4.03
+  - OCAML_VERSION=4.04
+  - OCAML_VERSION=4.05 WITH_BUILD_CACHE=true
+
+stage: Compile
+script: bash -ex .travis_install.sh
+
+jobs:
+  include:
+  - stage: Unit tests and checks
+    env:
+    - OCAML_VERSION=4.05 WITH_BUILD_CACHE=true
+    script: bash -ex .run_travis_tests.sh unit_tests
+  - stage: Unit tests and checks
+    env:
+    - OCAML_VERSION=4.05 WITH_BUILD_CACHE=true
+    script: bash -ex .run_travis_tests.sh checks

--- a/.travis_install.sh
+++ b/.travis_install.sh
@@ -1,0 +1,21 @@
+export OPAMYES=true
+export PACKAGE=bap
+export TESTS=false
+
+if [ "$WITH_BUILD_CACHE" == "true" ]; then
+    export POST_INSTALL_HOOK='
+x=`ocamlfind query bap`
+if [ $x != "" ]; then
+   echo START TO PACK BAP
+   OPAM_SWITCH=`opam config var switch`
+   mkdir -p $HOME/save_opam
+   mkdir -p $HOME/save_opam/lib
+   cp -r $HOME/.opam/$OPAM_SWITCH/lib/bap* $HOME/save_opam/lib/
+   cp -r $HOME/.opam/$OPAM_SWITCH/bin/ $HOME/save_opam/
+   cp -r $HOME/.opam/$OPAM_SWITCH/share $HOME/save_opam/
+fi
+'
+fi
+
+wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
+bash -ex .travis-opam.sh

--- a/.travis_install.sh
+++ b/.travis_install.sh
@@ -10,9 +10,9 @@ if [ $x != "" ]; then
    OPAM_SWITCH=`opam config var switch`
    mkdir -p $HOME/save_opam
    mkdir -p $HOME/save_opam/lib
-   cp -r $HOME/.opam/$OPAM_SWITCH/lib/bap* $HOME/save_opam/lib/
-   cp -r $HOME/.opam/$OPAM_SWITCH/bin/ $HOME/save_opam/
-   cp -r $HOME/.opam/$OPAM_SWITCH/share $HOME/save_opam/
+   cp -al $HOME/.opam/$OPAM_SWITCH/lib/bap* $HOME/save_opam/lib/
+   cp -al $HOME/.opam/$OPAM_SWITCH/bin/ $HOME/save_opam/
+   cp -al $HOME/.opam/$OPAM_SWITCH/share $HOME/save_opam/
 fi
 '
 fi

--- a/.travis_install.sh
+++ b/.travis_install.sh
@@ -10,9 +10,9 @@ if [ $x != "" ]; then
    OPAM_SWITCH=`opam config var switch`
    mkdir -p $HOME/save_opam
    mkdir -p $HOME/save_opam/lib
-   cp -alu $HOME/.opam/$OPAM_SWITCH/lib/bap* $HOME/save_opam/lib/
-   cp -alu $HOME/.opam/$OPAM_SWITCH/bin/ $HOME/save_opam/
-   cp -alu $HOME/.opam/$OPAM_SWITCH/share $HOME/save_opam/
+   cp -r $HOME/.opam/$OPAM_SWITCH/lib/bap* $HOME/save_opam/lib/
+   cp -r $HOME/.opam/$OPAM_SWITCH/bin/ $HOME/save_opam/
+   cp -r $HOME/.opam/$OPAM_SWITCH/share $HOME/save_opam/
 fi
 '
 fi

--- a/.travis_install.sh
+++ b/.travis_install.sh
@@ -10,9 +10,9 @@ if [ $x != "" ]; then
    OPAM_SWITCH=`opam config var switch`
    mkdir -p $HOME/save_opam
    mkdir -p $HOME/save_opam/lib
-   cp -al $HOME/.opam/$OPAM_SWITCH/lib/bap* $HOME/save_opam/lib/
-   cp -al $HOME/.opam/$OPAM_SWITCH/bin/ $HOME/save_opam/
-   cp -al $HOME/.opam/$OPAM_SWITCH/share $HOME/save_opam/
+   cp -alu $HOME/.opam/$OPAM_SWITCH/lib/bap* $HOME/save_opam/lib/
+   cp -alu $HOME/.opam/$OPAM_SWITCH/bin/ $HOME/save_opam/
+   cp -alu $HOME/.opam/$OPAM_SWITCH/share $HOME/save_opam/
 fi
 '
 fi

--- a/Makefile
+++ b/Makefile
@@ -39,12 +39,8 @@ distclean:
 .PHONY: check
 
 test: build
-ifneq ("$(BAP_NO_TESTS)","true")
 	$(SETUP) -test $(BAPTESTFLAGS)
-endif
 
 check:
-ifneq ("$(BAP_NO_CHECKS)","true")
 	if [ -d .git ]; then git submodule init; git submodule update; 	fi
 	make -C testsuite
-endif

--- a/Makefile
+++ b/Makefile
@@ -39,12 +39,12 @@ distclean:
 .PHONY: check
 
 test: build
-ifeq ("$(BAP_RUN_TEST)","true")
+ifneq ("$(BAP_NO_TESTS)","true")
 	$(SETUP) -test $(BAPTESTFLAGS)
 endif
 
 check:
-ifeq ("$(BAP_RUN_CHECK)","true")
+ifneq ("$(BAP_NO_CHECKS)","true")
 	if [ -d .git ]; then git submodule init; git submodule update; 	fi
 	make -C testsuite
 endif

--- a/opam/opam
+++ b/opam/opam
@@ -109,9 +109,8 @@ install: [
   ["ocamlfind" "remove" "ogre"]
   ["ocamlfind" "remove" "bare"]
   [make "reinstall"]
-  ["bap-byteweight" "update" "--url=https://github.com/BinaryAnalysisPlatform/bap/releases/download/v1.3.0/sigs_full.zip"]
-  [make "test"]
-  [make "check"]
+  ["bap-byteweight" "update" "--url=https://github.com/BinaryAnalysisPlatform/bap/releases/download/v1.4.0/sigs.zip"]
+  ["cp" "run_tests.native" "%{bin}%/bap_run_tests"]
 ]
 
 remove: [
@@ -206,6 +205,7 @@ remove: [
   ["rm" "-f" "%{bin}%/bap-byteweight"]
   ["rm" "-f" "%{bin}%/bapbuild"]
   ["rm" "-f" "%{bin}%/baptop"]
+  ["rm" "-f" "%{bin}%/bap_run_tests"]
 ]
 
 depends: [


### PR DESCRIPTION
Starting from this PR our CI will get profit from `travis` stages feature. 
So what do we have:
- three parallel builds, that just compile and install `bap` for each supported compiler. One of the builds also warms up a cache for next stages;
 - parallel stages for unit tests and `testsuite` checks.