### PR TITLE
prevents x86 lifter from botching bap

### DIFF
--- a/plugins/x86/x86_utils.ml
+++ b/plugins/x86/x86_utils.ml
@@ -405,6 +405,5 @@ let bh_e mode = bits2reg8e mode 7
 
 
 let pp_insn ppf (mem,insn) =
-  Format.fprintf ppf "%a: %s"
-    Addr.pp_hex (Memory.min_addr mem)
-    (Disasm_expert.Basic.Insn.asm insn)
+  Format.fprintf ppf "%a %s"
+    Memory.pp mem (Disasm_expert.Basic.Insn.asm insn)


### PR DESCRIPTION
There are quite a few `_exn` functions in the modern x86 that make
some assumptions about the structure of data, that shouldn't be done,
as we shall not make any hard assumptions about the output of the
disassembler or the binary input itself.

This commit fixes an issue that arises when bap is applied to binaries
that are compiled for the latest version of Mac OS X that leads to an
abnormal termination with an unhandled exception. The failure is
indeed provoked by the llvm backend that loses the segment prefix,
though under no circumstances shall we do any preconditioning on the
LLVM output. I've grepped the code to find other possible issues and
found quite a lot uses of the `_exn` that are not justified or at
least questionable.

So far, I've added a try/catch clause around the lifter, that will
prevent those exceptions from crashing the whole process. Though in
future we shall revisit this issue and carefully review all mournings
that x86 lifter is dumping into the log file. This commit also makes
those messages more actionable by adding binary representations of
failed instructions.