### PR TITLE
removes the bogus `open Re_perl` statement

### DIFF
--- a/plugins/objdump/.merlin
+++ b/plugins/objdump/.merlin
@@ -1,3 +1,4 @@
 PKG cmdliner
 PKG re.pcre
+B ../../_build/plugins/objdump
 REC

--- a/plugins/objdump/objdump_main.ml
+++ b/plugins/objdump/objdump_main.ml
@@ -2,7 +2,6 @@ open Core_kernel.Std
 open Bap_future.Std
 open Bap.Std
 open Regular.Std
-open Re_perl
 open Format
 open Option.Monad_infix
 open Objdump_config


### PR DESCRIPTION
it's not necessary and breaks buils in the newer jbuilder compiled
`re` library, as it no longer installs cmi files to the same folder.

also fixes the .merlin file by adding the build files location