### PR TITLE
bumps the bap version to 1.5.0-dev

### DIFF
--- a/.run_travis_tests.sh
+++ b/.run_travis_tests.sh
@@ -9,7 +9,6 @@ cp -r $HOME/save_opam/share/* $HOME/.opam/$comp/share/
 cp -r $HOME/save_opam/lib/* $HOME/.opam/$comp/lib/
 
 bap --version
-bap-byteweight update
 
 if [ "$TASK" == "checks" ]; then
     bash -exc 'make check'

--- a/oasis/common
+++ b/oasis/common
@@ -1,6 +1,6 @@
 OASISFormat: 0.4
 Name:        bap
-Version:     1.4.0
+Version:     1.5.0-dev
 OCamlVersion: >= 4.03
 Synopsis:    BAP Core Library
 Authors:     BAP Team


### PR DESCRIPTION
to prevent the confusion with the already released version