### PR TITLE
produces correct callgraphs if there are no calls in a program

### DIFF
--- a/lib/bap_types/bap_ir_callgraph.ml
+++ b/lib/bap_types/bap_ir_callgraph.ml
@@ -9,7 +9,8 @@ module G = Graphlib.Make(Tid)(struct type t = jmp term list end)
 let create program =
   Term.enum sub_t program |> Seq.fold ~init:G.empty ~f:(fun g sub ->
       let src = Term.tid sub in
-      Term.enum blk_t sub |> Seq.fold ~init:g ~f:(fun g blk ->
+      let init = G.Node.insert src g in
+      Term.enum blk_t sub |> Seq.fold ~init ~f:(fun g blk ->
           Term.enum jmp_t blk |>
           Seq.fold ~init:Tid.Map.empty ~f:(fun dsts jmp ->
               match Ir_jmp.kind jmp with


### PR DESCRIPTION
An empty call graph was produced in a degenerative case, when there
are no calls at all, i.e., when there are no edges in the callgraph.
Now it will produce a graph that will have only nodes, in that case.