### PR TITLE
restores the section view

### DIFF
--- a/plugins/print/print_main.ml
+++ b/plugins/print/print_main.ml
@@ -234,7 +234,6 @@ let setup_tabs ppf =
   pp_set_tab ppf () [@ocaml.warning "-3"]
 
 let print_disasm pp_insn subs secs ppf proj =
-
   let memory = Project.memory proj in
   let syms = Project.symbols proj in
   pp_open_tbox ppf () [@ocaml.warning "-3"];

--- a/plugins/print/print_main.ml
+++ b/plugins/print/print_main.ml
@@ -29,14 +29,14 @@ let should_print = function
 
 
 let find_section_for_addr memory addr =
-  Memmap.lookup memory addr |> Seq.find_map ~f:(fun (mem,v) ->
+  Memmap.lookup memory addr |> Seq.find_map ~f:(fun (_,v) ->
       Value.get Image.section v)
 
 let bir memory sub =
   Term.get_attr sub address >>=
   find_section_for_addr memory
 
-let sym memory (name,entry,cfg) =
+let sym memory (_,entry,_) =
   Block.addr entry |>
   find_section_for_addr memory
 
@@ -49,10 +49,10 @@ let print_symbols subs secs demangler fmts ppf proj =
   let demangle = create_demangler demangler in
   let symtab = Project.symbols proj in
   Symtab.to_sequence symtab |>
-  Seq.filter ~f:(fun ((name,entry,cfg) as fn) ->
+  Seq.filter ~f:(fun ((name,_,_) as fn) ->
       should_print subs name &&
       should_print secs (sec_name (Project.memory proj) sym fn)) |>
-  Seq.iter ~f:(fun ((name,entry,cfg) as fn) ->
+  Seq.iter ~f:(fun ((name,entry,_) as fn) ->
       List.iter fmts ~f:(function
           | `with_name ->
             fprintf ppf "%s " @@ demangle name
@@ -226,16 +226,15 @@ let print_bir_graph subs secs ppf proj =
   Term.enum sub_t prog |> Seq.iter ~f:(fun sub ->
       fprintf ppf "%a@." Graphs.Ir.pp (Sub.to_cfg sub))
 
-let pp_addr ppf addr =
-  let width = Addr.bitwidth addr / 4 in
-  fprintf ppf "%0*Lx" width
-    (Word.(to_int64 addr) |> ok_exn)
+let pp_addr ppf a =
+  Addr.pp_generic ~prefix:`none ~case:`lower ppf a
 
 let setup_tabs ppf =
   pp_print_as ppf 50 "";
   pp_set_tab ppf () [@ocaml.warning "-3"]
 
 let print_disasm pp_insn subs secs ppf proj =
+
   let memory = Project.memory proj in
   let syms = Project.symbols proj in
   pp_open_tbox ppf () [@ocaml.warning "-3"];
@@ -243,7 +242,7 @@ let print_disasm pp_insn subs secs ppf proj =
   Memmap.filter_map memory ~f:(Value.get Image.section) |>
   Memmap.to_sequence |> Seq.iter ~f:(fun (mem,sec) ->
       Symtab.intersecting syms mem |>
-      List.filter ~f:(fun (name,entry,cfg) ->
+      List.filter ~f:(fun (name,_,_) ->
           should_print subs name) |> function
       | [] -> ()
       | _ when not(should_print secs sec) -> ()


### PR DESCRIPTION
This PR restores a section view

When we switched to `ogre`, we started to tag segments memory regions both
as segments and sections. That's why we have an output like `Disassembly of section 02` when using `bap` with `-dasm` option.

fix https://github.com/BinaryAnalysisPlatform/bap/issues/780

Also, this PR makes printing a bit more pretty, and examples bellow show it.
How it was before:
```
0000000004006ed: <print_endline>
00000000004006ed:
4006ed: 55                                        pushq %rbp
4006ee: 48 89 e5                                  movq %rsp, %rbp
4006f1: 48 83 ec 20                               subq $0x20, %rsp
4006f5: 48 89 7d e8                               movq %rdi, -0x18(%rbp)
4006f9: 48 8b 45 e8                               movq -0x18(%rbp), %rax
4006fd: 48 89 45 f8                               movq %rax, -0x8(%rbp)
400701: eb 19                                     jmp 0x19
000000000040071c:
40071c: 48 8b 45 f8                               movq -0x8(%rbp), %rax
400720: 0f b6 00                                  movzbl (%rax), %eax
400723: 84 c0                                     testb %al, %al
```
How it looks like now:

```
4006ed: <print_endline>
4006ed:
4006ed: 55                                        pushq %rbp
4006ee: 48 89 e5                                  movq %rsp, %rbp
4006f1: 48 83 ec 20                               subq $0x20, %rsp
4006f5: 48 89 7d e8                               movq %rdi, -0x18(%rbp)
4006f9: 48 8b 45 e8                               movq -0x18(%rbp), %rax
4006fd: 48 89 45 f8                               movq %rax, -0x8(%rbp)
400701: eb 19                                     jmp 0x19
40071c:
40071c: 48 8b 45 f8                               movq -0x8(%rbp), %rax
400720: 0f b6 00                                  movzbl (%rax), %eax
400723: 84 c0                                     testb %al, %al

