### PR TITLE
Expose gcd, lcm, and gcdext functions on BAP bitvectors

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -564,6 +564,7 @@ module Std : sig
       (** [arshift x y] shift [x] by [y] bits to the right and fill with
           the sign bit.  *)
       val arshift : t -> t -> t
+
     end
 
     (** The integer signature.  *)
@@ -1507,6 +1508,41 @@ module Std : sig
 
     (** [a -- n] is [npred a n]  *)
     val (--) : t -> int -> t
+
+    (** [gcd x y] is the greatest common divisor of [x] and [y]
+        in the integers. Note that this is not always the greatest
+        common divisor in the bitvectors of fixed length. For example,
+        in the 32-bit unsigned integers, [2 = 2 + 2^32 = 2(1 + 2^31)].
+        Thus, [1 + 2^31] is a divisor of [2], even though [gcd 2 2 = 2].
+        Two properties that still hold are:
+        1. Both [x] and [y] are multiples of [gcd x y], and
+        2. [gcd x y <= min (abs x) (abs y)] *)
+    val gcd : t -> t -> t Or_error.t
+
+    (** [lcm x y] is the least common multiple of [x] and [y]
+        in the integers. Note that, like [gcd x y], this is not
+        always the least common multiple of [x] and [y] in the fixed-
+        length bitvectors. See the [gcd] documentation for an example.
+        The result of this function will always be some common multiple
+        of the inputs, even in the fixed-width bitvectors. *)
+    val lcm : t -> t -> t Or_error.t
+
+    (** [gcdext x y] returns [(g, s, t)] where [g = gcd x y] and
+        [g = s*x + t*y]. See the documentation for [gcd x y] for
+        why this function is tricky to use. *)
+    val gcdext : t -> t -> (t * t * t) Or_error.t
+
+    (** [gcd_exn x y] is the same as [gcd], but will raise
+        an exception on error.  *)
+    val gcd_exn : t -> t -> t
+
+    (** [lcm_exn x y] is the same as [lcm], but will raise
+        an exception on error.  *)
+    val lcm_exn : t -> t -> t
+
+    (** [gcdext_exn x y] is the same as [gcdext], but will raise
+        an exception on error.  *)
+    val gcdext_exn : t -> t -> t * t * t
 
     (** {2 Iteration over bitvector components }  *)
 

--- a/lib/bap_types/bap_bitvector.ml
+++ b/lib/bap_types/bap_bitvector.ml
@@ -124,6 +124,11 @@ module Make(Size : Compare) = struct
   let lift1 op t = create (unop op t) (bitwidth t)
   let lift2 op t1 t2 = create (binop op t1 t2) (bitwidth t1)
 
+  let lift2_triple op t1 t2 : t * t * t =
+    let (a, b, c) = binop op t1 t2 in
+    let w = bitwidth t1 in
+    create a w, create b w, create c w
+
   let pp_generic
       ?(case:[`lower|`upper]=`upper)
       ?(prefix:[`auto|`base|`none|`this of string]=`auto)
@@ -275,6 +280,17 @@ let (++) t n = nsucc t n
 let (--) t n = npred t n
 let succ n = n ++ 1
 let pred n = n -- 1
+
+let gcd_exn    = lift2 Bignum.gcd
+let lcm_exn    = lift2 Bignum.lcm
+let gcdext_exn = lift2_triple Bignum.gcdext
+
+let gcd a b = Or_error.try_with (fun () ->
+    gcd_exn a b)
+let lcm a b = Or_error.try_with (fun () ->
+    lcm_exn a b)
+let gcdext a b = Or_error.try_with (fun () ->
+    gcdext_exn a b)
 
 let concat x y =
   let w = bitwidth x + bitwidth y in

--- a/lib/bap_types/bap_bitvector.mli
+++ b/lib/bap_types/bap_bitvector.mli
@@ -44,6 +44,12 @@ val nsucc : t -> int -> t
 val npred : t -> int -> t
 val (++) : t -> int -> t
 val (--) : t -> int -> t
+val gcd    : t -> t -> t Or_error.t
+val lcm    : t -> t -> t Or_error.t
+val gcdext : t -> t -> (t * t * t) Or_error.t
+val gcd_exn    : t -> t -> t
+val lcm_exn    : t -> t -> t
+val gcdext_exn : t -> t -> t * t * t
 val enum_bytes : t -> endian ->    t Sequence.t
 val enum_chars : t -> endian -> char Sequence.t
 val enum_bits  : t -> endian -> bool Sequence.t

--- a/lib_test/bap_types/test_bitvector.ml
+++ b/lib_test/bap_types/test_bitvector.ml
@@ -252,8 +252,8 @@ let suite () =
     "arshift" >:: arshift ~width:8 ~expect:0xff 0xFF 0x2 ;
     "gcd" >:: gcd ~width:8 ~expect:0x4 0x10 0xC ;
     "gcd" >:: gcd ~width:8 ~expect:0x1 0x11 0xF ;
-    "lcm" >:: lcm ~width:8 ~expect:0x18 0x10 0xC ;
-    "lcm" >:: lcm ~width:8 ~expect:0x23 0x1C 0x23 ;
+    "lcm" >:: lcm ~width:8 ~expect:0x30 0x10 0xC ;
+    "lcm" >:: lcm ~width:8 ~expect:0x8C 0x1C 0x23 ;
     "gcdext" >:: gcdext ~width:8 ~expect:(0x4,0x1,-0x1) 0x10 0xC ;
 
     (* a small cheatsheet for a bit numbering *)

--- a/lib_test/bap_types/test_bitvector.ml
+++ b/lib_test/bap_types/test_bitvector.ml
@@ -52,10 +52,30 @@ let binary op ~width ~expect x y ctxt =
     ~cmp:Word.equal
     !$expect (op !$x !$y)
 
+let binary3 op ~width ~expect x y ctxt =
+  let (!$) = Word.of_int ~width in
+  let (!$$$) (a, b, c) = (!$a, !$b, !$c) in
+  let equal (a, b, c) (a', b', c') =
+    Word.equal a a' &&
+    Word.equal b b' &&
+    Word.equal c c' in
+  let to_string (a, b, c) =
+    Printf.sprintf "(%s,%s,%s)"
+      (Word.to_string a)
+      (Word.to_string b)
+      (Word.to_string c) in
+  assert_equal ~ctxt
+    ~printer:to_string
+    ~cmp:equal
+    !$$$expect (op !$x !$y)
+
 let sub = binary Word.Int_exn.sub
 let lshift = binary Word.Int_exn.lshift
 let rshift = binary Word.Int_exn.rshift
 let arshift = binary Word.Int_exn.arshift
+let gcd = binary Word.gcd_exn
+let lcm = binary Word.lcm_exn
+let gcdext = binary3 Word.gcdext_exn
 
 let is yes ctxt = assert_bool "doesn't hold" yes
 
@@ -230,6 +250,11 @@ let suite () =
     "lshift" >:: lshift ~width:8 ~expect:0x0 0x1 0xA ;
     "rshift" >:: rshift ~width:8 ~expect:0x3f 0xFF 0x2 ;
     "arshift" >:: arshift ~width:8 ~expect:0xff 0xFF 0x2 ;
+    "gcd" >:: gcd ~width:8 ~expect:0x4 0x10 0xC ;
+    "gcd" >:: gcd ~width:8 ~expect:0x1 0x11 0xF ;
+    "lcm" >:: lcm ~width:8 ~expect:0x18 0x10 0xC ;
+    "lcm" >:: lcm ~width:8 ~expect:0x23 0x1C 0x23 ;
+    "gcdext" >:: gcdext ~width:8 ~expect:(0x4,0x1,-0x1) 0x10 0xC ;
 
     (* a small cheatsheet for a bit numbering *)
     (** D    A    D    5    *)
@@ -242,6 +267,6 @@ let suite () =
     "mono_size"   >:: (fun ctxt ->
         try
           ignore Word.(Mono.(zero_32 < b0));
-          assert_string "Monoprhic comparison"
+          assert_string "Monomorphic comparison"
         with exn -> ());
   ]


### PR DESCRIPTION
Adds the functions `gcd`, `lcm`, and `gcdext` to the bitvector interface. `gcd` computes the greatest common denominator of the inputs, `lcm` computes the least common multiple, and `gcdext` also computes coefficients `s` and `t` such that if `gcdext x y = (d, s, t)` then `d = s*x + t*y`.

Also adds functions `gcd_exn`, `lcm_exn`, and `gcdext_exn` that raise exceptions on improper inputs rather than returning an error.