### PR TITLE
fixes relative addresses in llvm backend

### DIFF
--- a/lib/bap_llvm/llvm_coff_loader.hpp
+++ b/lib/bap_llvm/llvm_coff_loader.hpp
@@ -46,7 +46,7 @@ void section(const coff_section &sec, uint64_t image_base,  ogre_doc &s) {
         s.entry("code-entry") << sec.Name << sec.PointerToRawData << sec.SizeOfRawData;
 }
 
-void symbol(const std::string &name, uint64_t relative_addr, uint64_t size, uint64_t off, SymbolRef::Type typ, ogre_doc &s) {
+void symbol(const std::string &name, int64_t relative_addr, uint64_t size, uint64_t off, SymbolRef::Type typ, ogre_doc &s) {
     s.entry("symbol-entry") << name << relative_addr << size << off;
     if (typ == SymbolRef::ST_Function)
         s.entry("code-entry") << name << off << size;
@@ -60,7 +60,7 @@ error_or<uint64_t> symbol_file_offset(const coff_obj &obj, const SymbolRef &sym)
 const coff_section* get_coff_section(const coff_obj &obj, const SectionRef &sec);
 error_or<int> section_number(const coff_obj &obj, const SymbolRef &sym);
 error_or<uint64_t> symbol_value(const coff_obj &obj, const SymbolRef &sym);
-error_or<uint64_t> symbol_relative_address(const coff_obj &obj, const SymbolRef &sym);
+error_or<int64_t> symbol_relative_address(const coff_obj &obj, const SymbolRef &sym);
 
 const coff_section * get_coff_section(const coff_obj &obj, std::size_t index) {
     const coff_section *sec = nullptr;
@@ -257,7 +257,7 @@ void exported_symbols(const coff_obj &obj, ogre_doc &s) {
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8 \
     || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 5
 
-error_or<uint64_t> symbol_relative_address(const coff_obj &obj, const SymbolRef &sym) {
+error_or<int64_t> symbol_relative_address(const coff_obj &obj, const SymbolRef &sym) {
     auto base = obj.getImageBase();
     auto addr = symbol_address(obj, sym);
     if (!addr) return addr;
@@ -321,7 +321,7 @@ error_or<pe32plus_header> get_pe32plus_header(const coff_obj &obj) {
 #elif LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 4
 
 // symbol address for 3.4 is already relative, i.e. doesn't include image base
-error_or<uint64_t> symbol_relative_address(const coff_obj &obj, const SymbolRef &sym) {
+error_or<int64_t> symbol_relative_address(const coff_obj &obj, const SymbolRef &sym) {
     return symbol_address(obj, sym);
 }
 

--- a/lib/bap_llvm/llvm_elf_loader.hpp
+++ b/lib/bap_llvm/llvm_elf_loader.hpp
@@ -161,10 +161,10 @@ error_or<uint64_t> symbol_file_offset(const ELFObjectFile<T> &obj, const SymbolR
 }
 
 template <typename T>
-error_or<uint64_t> symbol_address(const ELFObjectFile<T> &obj, const SymbolRef &sym) {
+error_or<int64_t> symbol_address(const ELFObjectFile<T> &obj, const SymbolRef &sym) {
     auto sym_elf = obj.getSymbol(sym.getRawDataRefImpl());
     if (is_rel(obj) && !is_abs_symbol(*sym_elf)) { // abs symbols does not affected by relocations
-        return success(uint64_t(0));
+        return success(int64_t(0));
     } else {
         auto addr = prim::symbol_address(sym);
         if (!addr) return addr;

--- a/lib/bap_llvm/llvm_macho_loader.hpp
+++ b/lib/bap_llvm/llvm_macho_loader.hpp
@@ -156,7 +156,7 @@ uint32_t section_type(const macho &obj, SectionRef sec) {
     return section_flags(obj, sec) & MachO::SECTION_TYPE;
 }
 
-void section(const std::string &name, uint64_t rel_addr, uint64_t size, uint64_t off, ogre_doc &s) {
+void section(const std::string &name, int64_t rel_addr, uint64_t size, uint64_t off, ogre_doc &s) {
      s.entry("section-entry") << name << rel_addr << size << off;
 }
 
@@ -242,9 +242,9 @@ bool is_in_section(const macho &obj, const SymbolRef &sym) {
     return ((typ & MachO::N_TYPE) == MachO::N_SECT);
 }
 
-error_or<uint64_t> symbol_address(const macho &obj, const SymbolRef &sym) {
+error_or<int64_t> symbol_address(const macho &obj, const SymbolRef &sym) {
     if (is_relocatable(obj))
-        return success(uint64_t(0));
+        return success(int64_t(0));
     auto addr = prim::symbol_address(sym);
     if (!addr) return addr;
     auto base = image_base(obj);

--- a/lib/bap_llvm/llvm_primitives.cpp
+++ b/lib/bap_llvm/llvm_primitives.cpp
@@ -12,7 +12,7 @@ std::string arch_of_object(const llvm::object::ObjectFile &obj) {
     return Triple::getArchTypeName(static_cast<Triple::ArchType>(obj.getArch()));
 }
 
-uint64_t relative_address(uint64_t base, uint64_t abs) {
+int64_t relative_address(uint64_t base, uint64_t abs) {
     return (abs - base);
 }
 

--- a/lib/bap_llvm/llvm_primitives.cpp
+++ b/lib/bap_llvm/llvm_primitives.cpp
@@ -13,8 +13,7 @@ std::string arch_of_object(const llvm::object::ObjectFile &obj) {
 }
 
 uint64_t relative_address(uint64_t base, uint64_t abs) {
-    if (abs >= base) return (abs - base);
-    else return abs;
+    return (abs - base);
 }
 
 // 4.0 only

--- a/lib/bap_llvm/llvm_primitives.hpp
+++ b/lib/bap_llvm/llvm_primitives.hpp
@@ -43,8 +43,8 @@ error_or<uint64_t> symbol_size(const SymbolRef &s);
 uint64_t relocation_offset(const RelocationRef &rel);
 
 // misc
-// returns abs - base if abs >= base or just abs otherwise
-uint64_t relative_address(uint64_t base, uint64_t abs);
+// returns abs - base
+int64_t relative_address(uint64_t base, uint64_t abs);
 
 typedef std::vector<std::pair<SymbolRef, uint64_t>> symbols_sizes;
 


### PR DESCRIPTION
There was a kind of bug in llvm backend: relative address for any binary entry was defined as non-negative value. Probably, it wasn't a very bad choice, since we don't want to
deal with negative addresses. But from another point of view, we always convert relative address to absolute and negative address should not happen. And we actually inject wrong
information in ogre when storing non-negative numbers: converting them to absolute addresses assigns a real value to every entry, dependless if it had a meaningful address or not at all.