### PR TITLE
Primus Lisp enhancements

### DIFF
--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -2138,6 +2138,47 @@ ident ::= ?any atom that is not recognized as a <word>?
         val pp_program : Format.formatter -> program -> unit
       end
 
+      module Doc : sig
+
+        (** Abstract Element of a document.
+
+            A documentation element is something that can be printed.
+            We keep it abstract, as we plan to extend it in the future.
+        *)
+        module type Element = sig
+          type t
+          val pp : Format.formatter -> t -> unit
+        end
+
+        module Category : Element
+        module Name     : Element
+        module Descr    : Element
+
+
+
+        (** Documentation index.
+
+            Documentation index has the following ogranization:
+
+            {[
+              Category 1:
+               - Element1 Name, Element1 Description;
+               - Element2 Name, Element2 Description;
+               ...
+              Category2:
+               - ...
+            ]}
+
+            All entries are sorted in alphabetic order.
+
+        *)
+        type index = (Category.t * (Name.t * Descr.t) list) list
+
+        module Make(Machine : Machine.S) : sig
+          val generate_index : index Machine.t
+        end
+      end
+
 
       (** Lisp Type System.
 

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -770,7 +770,6 @@ module Std : sig
         [observation >>> fun (x,y,z)] -> ... *)
     module Interpreter : sig
 
-
       (** [pc_change x] happens every time a code at address [x] is executed.  *)
       val pc_change : addr observation
 
@@ -905,6 +904,9 @@ module Std : sig
 
         (** [halt] halts the machine by raise the [Halt] exception.  *)
         val halt : never_returns m
+
+
+        val interrupt : int m
 
 
         (** [pc] current value of a program counter.*)

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -139,7 +139,7 @@ module Std : sig
 
           This interface provides access to the data stream of all
           providers expresses as a stream of s-expressions.
-       *)
+      *)
       module Provider : sig
         type t = provider
 
@@ -244,7 +244,7 @@ module Std : sig
     module Machine : sig
 
       (** [init] event occurs just after all components have been
-         initialized, and before the execution starts*)
+          initialized, and before the execution starts*)
       val init : unit observation
 
       (** The [finished] event occurs when the machine terminates.   *)
@@ -720,7 +720,7 @@ module Std : sig
             Implementors of Primus components are encouraged to use the
             [Index] module and implement their own mapping with bijection
             enforced by the abstraction.
-         *)
+        *)
         module Symbol : sig
 
 
@@ -807,6 +807,13 @@ module Std : sig
       (** [written (v,x)] happens after [x] is assinged to [v]  *)
       val written : (var * value) observation
 
+
+      (** [jumping (cond,dest)] happens just before a jump to [dest]
+          is taken under the condition [cond].
+
+          @since 1.5.0 *)
+      val jumping : (value * value) observation
+
       (** [undefined x] happens when a computation produces an
           undefined value [x].  *)
       val undefined : value observation
@@ -891,7 +898,7 @@ module Std : sig
       val halting : unit observation
 
       (** [interrupt n] occurs on the machine interrupt [n] (aka CPU
-         exception) *)
+          exception) *)
       val interrupt : int observation
 
       type exn += Halt
@@ -906,7 +913,7 @@ module Std : sig
         val halt : never_returns m
 
 
-        val interrupt : int m
+        val interrupt : int -> unit m
 
 
         (** [pc] current value of a program counter.*)
@@ -1220,8 +1227,31 @@ module Std : sig
         val exec : name -> unit m
 
 
+        (** [resolve_addr name] returns the address associated with the
+            given [name].  *)
+        val resolve_addr : name -> addr option m
+
+
+        (** [resolve_symbol name] returns the symbolic name associated
+            with the given [name].
+
+            @since 1.5.0
+        *)
+        val resolve_symbol : name -> string option m
+
+
+        (** [resolve_tid name] returns the term identifier associated
+            with the given [name].
+
+            @since 1.5.0
+        *)
+        val resolve_tid : name -> tid option m
+
+
         (** [is_linked name] computes to [true] if the [name] is
-            associated with some code.  *)
+            associated with some code.
+
+            @since 1.5.0 *)
         val is_linked : name -> bool m
       end
     end
@@ -2067,7 +2097,7 @@ ident ::= ?any atom that is not recognized as a <word>?
 
 
       (** an abstract type that represents messages send with the
-         [msg] form. *)
+          [msg] form. *)
       type message
 
 
@@ -2181,7 +2211,7 @@ ident ::= ?any atom that is not recognized as a <word>?
 
 
           (** a machine integer - a word that has the same width as
-             [Arch.addr_size] *)
+              [Arch.addr_size] *)
           val int : t
 
 
@@ -2212,7 +2242,7 @@ ident ::= ?any atom that is not recognized as a <word>?
           val tuple : t list -> [`Tuple of t list]
 
           (** [all t] specifies that a function accepts a variable
-          number of arguments all having type [t].  *)
+              number of arguments all having type [t].  *)
           val all : t -> [`All of t]
 
           (** [one t] specifies that a function accepts one argument
@@ -2240,8 +2270,8 @@ ident ::= ?any atom that is not recognized as a <word>?
 
 
         (** [check env prog] type checks program in the environment
-           [env] and returns a list of errors. If the list is empty
-           the the program is well-typed.
+            [env] and returns a list of errors. If the list is empty
+            the the program is well-typed.
 
             Note: this function is currently experimental *)
         val check : Var.t seq -> program -> error list
@@ -2263,7 +2293,7 @@ ident ::= ?any atom that is not recognized as a <word>?
 
 
         (** [pp ppf msg] prints the message into the specified
-        formatter [ppf]. *)
+            formatter [ppf]. *)
         val pp : Format.formatter -> t -> unit
       end
 
@@ -2300,7 +2330,7 @@ ident ::= ?any atom that is not recognized as a <word>?
       type exn += Runtime_error of string
 
       (** [message] observation occurs every time a message is sent
-         from the Primus Machine.  *)
+          from the Primus Machine.  *)
       val message : message observation
 
       (** Make(Machine) creates a Lisp machine embedded into the

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -2012,6 +2012,7 @@ entity ::=
   | <declarations>
   | <constant-definition>
   | <substitution-definition>
+  | <parameter-definition>
   | <macro-definition>
   | <function-definition>
   | <method-definition>
@@ -2022,9 +2023,14 @@ declarations ::= (declare <attribute> ...)
 
 constant-definition ::=
   | (defconstant <ident> <atom>)
-  | (defconstant <ident> <docstring> <atom>)
-  | (defconstant <ident> <declarations> <atom>)
-  | (defconstant <ident> <docstring> <declarations> <atom>)
+  | (defconstant <ident> <atom> <docstring>)
+  | (defconstant <ident> <atom> <declarations>)
+  | (defconstant <ident> <atom> <declarations> <docstring>)
+
+parameter-definition ::=
+  | (defparameter <ident> <atom>)
+  | (defparameter <ident> <atom> <docstring>)
+  | (defparameter <ident> <atom> <declarations> <docstring>)
 
 substitution-definition ::=
   | (defsubst <ident> <atom> ...)

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -2414,6 +2414,19 @@ ident ::= ?any atom that is not recognized as a <word>?
             [Runtime_error].  *)
         val failf : ('a, unit, string, unit -> 'b Machine.t) format4 -> 'a
 
+        (** [eval_fun name args] calls a lisp function with the given
+            [name], that is the most specific to the current context
+            and is applicable to the specified list of arguments.
+
+            @since 1.5 *)
+        val eval_fun : string -> value list -> value Machine.t
+
+        (** [eval_method name args] invokes all methods with the given
+            [name] that are applicable in the current context to the
+            specified list of arguments.
+
+            @since 1.5 *)
+        val eval_method : string -> value list -> unit Machine.t
 
         (** [link_primitives prims] provides the primitives [prims]   *)
         val link_primitives : primitives -> unit Machine.t

--- a/lib/bap_primus/bap_primus_env.ml
+++ b/lib/bap_primus/bap_primus_env.ml
@@ -110,6 +110,10 @@ module Make(Machine : Machine) = struct
         | None -> Machine.raise (Undefined_var var)
         | Some gen -> gen_word gen width >>= Value.of_word
 
+  let has var =
+    Machine.Local.get state >>| fun t ->
+    Map.mem t.values var || Map.mem t.random var
+
   let keys dic = Map.to_sequence dic |> Seq.map ~f:fst
 
   let all =

--- a/lib/bap_primus/bap_primus_env.mli
+++ b/lib/bap_primus/bap_primus_env.mli
@@ -9,5 +9,6 @@ module Make(Machine : Machine) : sig
   val get : var -> value Machine.t
   val set : var -> value -> unit Machine.t
   val add : var -> Generator.t -> unit Machine.t
+  val has : var -> bool Machine.t
   val all : var seq Machine.t
 end

--- a/lib/bap_primus/bap_primus_interpreter.ml
+++ b/lib/bap_primus/bap_primus_interpreter.ml
@@ -390,14 +390,14 @@ module Make (Machine : Machine) = struct
 
   let goto c = label c
   let ret l = label l
-  let interrupt n _r = !!will_interrupt n
+  let interrupt n  = !!will_interrupt n
 
   let jump t = match Jmp.kind t with
     | Call c -> call c
     | Goto l -> goto l
     | Ret l -> ret l
     | Int (n,r) ->
-      interrupt n r >>= fun () ->
+      interrupt n >>= fun () ->
       Code.exec (`tid r)
 
   let jmp t = eval_exp (Jmp.cond t) >>| fun {value} -> Word.is_one value

--- a/lib/bap_primus/bap_primus_interpreter.ml
+++ b/lib/bap_primus/bap_primus_interpreter.ml
@@ -93,6 +93,9 @@ let written,on_written =
 let undefined,on_undefined =
   Observation.provide ~inspect:sexp_of_value "undefined"
 
+let jumping,will_jump =
+  Observation.provide ~inspect:sexp_of_values "jumping"
+
 
 let results r op = Sexp.List [op; sexp_of_value r]
 
@@ -376,42 +379,52 @@ module Make (Machine : Machine) = struct
   let def t = Def.lhs t := Def.rhs t
   let def = term normal def_t def
 
-  let label : label -> _ = function
-    | Direct t -> Code.exec (`tid t)
+  let will_jump_to_tid cond dst =
+    Code.resolve_addr (`tid dst) >>= function
+    | None -> Machine.return ()
+    | Some addr ->
+      Value.of_word addr >>= fun addr ->
+      !!will_jump (cond,addr)
+
+  let label cond : label -> _ = function
+    | Direct t ->
+      will_jump_to_tid cond t >>= fun () ->
+      Code.exec (`tid t)
     | Indirect x ->
-      eval_exp x >>= fun {value} ->
+      eval_exp x >>= fun ({value} as dst) ->
+      !!will_jump (cond,dst) >>= fun () ->
       Code.exec (`addr value)
 
-  let call c =
-    label (Call.target c) >>= fun () ->
+  let call cond c =
+    label cond (Call.target c) >>= fun () ->
     match Call.return c with
-    | Some t -> label t
+    | Some t -> label cond t
     | None -> failf "a non-return call returned" ()
 
-  let goto c = label c
-  let ret l = label l
+  let goto cond c = label cond c
+  let ret cond l = label cond l
   let interrupt n  = !!will_interrupt n
 
-  let jump t = match Jmp.kind t with
-    | Call c -> call c
-    | Goto l -> goto l
-    | Ret l -> ret l
+  let jump cond t = match Jmp.kind t with
+    | Call c -> call cond c
+    | Goto l -> goto cond l
+    | Ret l -> ret cond l
     | Int (n,r) ->
       interrupt n >>= fun () ->
       Code.exec (`tid r)
 
-  let jmp t = eval_exp (Jmp.cond t) >>| fun {value} -> Word.is_one value
+  let jmp t = eval_exp (Jmp.cond t) >>| fun ({value} as cond) ->
+    Option.some_if (Word.is_one value) (cond,t)
   let jmp = term normal jmp_t jmp
-
 
   let blk t =
     (* todo add the phi nodes, or think at least.. *)
     Machine.Seq.iter (Term.enum def_t t) ~f:def >>= fun () ->
-    Machine.Seq.find (Term.enum jmp_t t) ~f:jmp
+    Machine.Seq.find_map (Term.enum jmp_t t) ~f:jmp
 
   let finish = function
     | None -> Machine.return ()
-    | Some code -> jump code
+    | Some (cond,code) -> jump cond code
 
   let arg_def t = match Arg.intent t with
     | None | Some (In|Both) -> Arg.lhs t := Arg.rhs t

--- a/lib/bap_primus/bap_primus_interpreter.mli
+++ b/lib/bap_primus/bap_primus_interpreter.mli
@@ -56,6 +56,7 @@ type exn += Halt
 module Make (Machine : Machine) : sig
   type 'a m = 'a Machine.t
   val halt : never_returns m
+  val interrupt : int -> unit m
   val pc : addr m
   val pos : pos m
   val sub : sub term -> unit m

--- a/lib/bap_primus/bap_primus_interpreter.mli
+++ b/lib/bap_primus/bap_primus_interpreter.mli
@@ -14,6 +14,7 @@ val reading : var observation
 val read : (var * value) observation
 val writing : var observation
 val written : (var * value) observation
+val jumping : (value * value) observation
 val undefined : value observation
 val const : value observation
 

--- a/lib/bap_primus/bap_primus_linker.ml
+++ b/lib/bap_primus/bap_primus_linker.ml
@@ -20,8 +20,16 @@ end
 
 type code = (module Code)
 
+(* the same piece of code can be referred via multiple names *)
+type refs = {
+  term : tid option;
+  name : string option;
+  addr : addr option;
+}
+
 type t = {
   codes : code Int.Map.t;
+  alias : refs Int.Map.t;
   terms : int Tid.Map.t;
   names : int String.Map.t;
   addrs : int Addr.Map.t;
@@ -32,11 +40,12 @@ let empty = {
   terms = Tid.Map.empty;
   names = String.Map.empty;
   addrs = Addr.Map.empty;
+  alias = Int.Map.empty;
 }
 
 let unresolved_handler = `symbol "__primus_linker_unresolved_call"
 
-include struct 
+include struct
   open Sexp
 
   let string_of_name = function
@@ -46,7 +55,7 @@ include struct
   let sexp_of_name n = Sexp.Atom (string_of_name n)
   let sexp_of_value {value=x} = Atom (asprintf "%a" Word.pp_hex x)
   let sexp_of_args = List.map ~f:sexp_of_value
-  let sexp_of_call (dst,args) = 
+  let sexp_of_call (dst,args) =
     List (Atom dst :: sexp_of_args args)
 end
 
@@ -79,15 +88,13 @@ let add_code code codes =
   let key = Option.value ~default:1 max_key in
   key, Map.add codes ~key ~data:code
 
+let id_of_name name s = match name with
+  | `symbol name -> Map.find s.names name
+  | `addr addr -> Map.find s.addrs addr
+  | `tid tid -> Map.find s.terms tid
 
-let find k1 m1 m2 = match Map.find m1 k1 with
-  | None -> None
-  | Some k2 -> Map.find m2 k2
-
-let code_of_name name s = match name with
-  | `symbol name -> find name s.names s.codes
-  | `addr addr -> find addr s.addrs s.codes
-  | `tid tid -> find tid s.terms s.codes
+let code_of_name name s =
+  Option.bind (id_of_name name s) ~f:(Map.find s.codes)
 
 let lookup_name k t1 names : string option =
   match Map.find t1 k with
@@ -133,6 +140,9 @@ module Make(Machine : Machine) = struct
     | None -> do_fail name
     | Some code -> run name code
 
+  let make_refs term name addr =
+    {term; name; addr}
+
   let link ?addr ?name ?tid code =
     Machine.Local.update state ~f:(fun s ->
         let key,codes = add_code code s.codes in
@@ -142,12 +152,29 @@ module Make(Machine : Machine) = struct
         let terms = update s.terms tid in
         let names = update s.names name in
         let addrs = update s.addrs addr in
-        {codes; terms; names; addrs})
+        let alias = Map.add s.alias ~key ~data:{
+            term=tid;
+            name;
+            addr
+          } in
+        {codes; terms; names; addrs; alias})
 
   let exec name =
     Machine.Local.get state >>| code_of_name name >>= function
     | None -> fail name
     | Some code -> run name code
+
+  let resolve f name =
+    Machine.Local.get state >>| fun s ->
+    match id_of_name name s with
+    | None -> None
+    | Some id -> match Map.find s.alias id with
+      | None -> None
+      | Some refs -> f refs
+
+  let resolve_addr = resolve (fun x -> x.addr)
+  let resolve_symbol = resolve (fun x -> x.name)
+  let resolve_tid = resolve (fun x -> x.term)
 
 end
 

--- a/lib/bap_primus/bap_primus_linker.mli
+++ b/lib/bap_primus/bap_primus_linker.mli
@@ -40,4 +40,7 @@ module Make(Machine : Machine) : sig
 
   val is_linked : name -> bool m
 
+  val resolve_addr : name -> addr option m
+  val resolve_symbol : name -> string option m
+  val resolve_tid : name -> tid option m
 end

--- a/lib/bap_primus/bap_primus_lisp.ml
+++ b/lib/bap_primus/bap_primus_lisp.ml
@@ -582,6 +582,9 @@ module Make(Machine : Machine) = struct
         Lisp.Def.Closure.of_primitive def
           (module Packed : Lisp.Def.Closure) |>
         link_primitive)
+
+  let eval_method = Self.eval_signal
+  let eval_fun = Self.eval_lisp
 end
 
 let init ?log:_ ?paths:_ _features  =

--- a/lib/bap_primus/bap_primus_lisp.ml
+++ b/lib/bap_primus/bap_primus_lisp.ml
@@ -687,7 +687,8 @@ module Doc = struct
   let normalize xs =
     List.Assoc.map xs ~f:normalize_descr |>
     String.Map.of_alist_reduce ~f:(fun x y ->
-        if x = y then x
+        if x = "" then y else if y = "" then x
+        else if x = y then x
         else sprintf "%s\nOR\n%s" x y) |>
     Map.to_alist
 

--- a/lib/bap_primus/bap_primus_lisp.mli
+++ b/lib/bap_primus/bap_primus_lisp.mli
@@ -92,6 +92,10 @@ module Make (Machine : Machine) : sig
     'a observation ->
     ('a -> value list Machine.t) -> unit Machine.t
 
+  val eval_fun : string -> value list -> value Machine.t
+
+  val eval_method  : string -> value list -> unit Machine.t
+
   (* deprecated *)
   val link_primitives : primitives -> unit Machine.t
 end

--- a/lib/bap_primus/bap_primus_lisp.mli
+++ b/lib/bap_primus/bap_primus_lisp.mli
@@ -10,8 +10,24 @@ type message
 module Load : sig
   type error
   val program : ?paths:string list -> Project.t -> string list -> (program,error) result
-  val pp_program : Format.formatter -> program -> unit
-  val pp_error : Format.formatter -> error -> unit
+  val pp_program : formatter -> program -> unit
+  val pp_error : formatter -> error -> unit
+end
+
+module Doc : sig
+  module type Element = sig
+    type t
+    val pp : formatter -> t -> unit
+  end
+
+  module Category : Element
+  module Name     : Element
+  module Descr    : Element
+  type index = (Category.t * (Name.t * Descr.t) list) list
+
+  module Make(Machine : Machine) : sig
+    val generate_index : index Machine.t
+  end
 end
 
 module Message : sig

--- a/lib/bap_primus/bap_primus_lisp_def.ml
+++ b/lib/bap_primus/bap_primus_lisp_def.ml
@@ -42,6 +42,9 @@ type const = {
   value : string;
 }
 
+type para = {
+  default : ast;
+}
 
 type 'a primitive = (value list -> 'a)
 
@@ -91,6 +94,22 @@ end
 
 module Meth = Func
 
+module Para =  struct
+  let create : 'a def =
+    fun ?(docs="") ?(attrs=Attribute.Set.empty) name default ->
+      create {
+        meta = {name; docs; attrs};
+        code = {default};
+      }
+
+  let default p = p.data.code.default
+  let with_default t default = {
+    t with data = {
+      t.data with code = {default}
+    }
+  }
+end
+
 module Macro = struct
   type error += Bad_subst of tree * tree list
   let args = field param
@@ -104,12 +123,12 @@ module Macro = struct
   let take_rest xs ys =
     let rec take xs ys zs = match xs,ys with
       | [],[] -> Some zs
-      | [x], (_ :: _ :: ys as rest) -> Some ((x,rest)::zs)
+      | [x], (_ :: _ :: _ as rest) -> Some ((x,rest)::zs)
       | x :: xs, y :: ys -> take xs ys ((x,[y])::zs)
       | _ :: _, [] | [],_ -> None in
     match take xs ys []with
     | Some [] -> Some (0,[])
-    | Some ((z,rest) :: _ as bs) ->
+    | Some ((_,rest) :: _ as bs) ->
       Some (List.length rest, List.rev bs)
     | None -> None
 

--- a/lib/bap_primus/bap_primus_lisp_def.mli
+++ b/lib/bap_primus/bap_primus_lisp_def.mli
@@ -19,6 +19,7 @@ type const
 type prim
 type closure = (module Closure)
 type 'a primitive
+type para
 
 type attrs = Attribute.set
 
@@ -35,11 +36,17 @@ module Func : sig
   val with_body : func t -> ast -> func t
 end
 
-module Meth : sig 
+module Meth : sig
   val create : (var list -> ast -> tree -> meth t) def
   val args : meth t -> var list
   val body : meth t -> ast
   val with_body : meth t -> ast -> meth t
+end
+
+module Para : sig
+  val create : (ast -> tree -> para t) def
+  val default : para t -> ast
+  val with_default : para t -> ast -> para t
 end
 
 module Macro : sig

--- a/lib/bap_primus/bap_primus_lisp_parse.ml
+++ b/lib/bap_primus/bap_primus_lisp_parse.ml
@@ -459,23 +459,23 @@ module Parse = struct
     | {data=List [
         {data=Atom "defconstant"};
         {data=Atom name};
+        {data=Atom body};
         {data=Atom docs};
         {data=List ({data=Atom "declare"} :: attrs)};
-        {data=Atom body };
       ]} when is_quoted docs ->
       defconst ~docs ~attrs name body state gattrs s
     | {data=List [
         {data=Atom "defconstant"};
         {data=Atom name};
-        {data=Atom docs};
         {data=Atom body };
+        {data=Atom docs};
       ]} when is_quoted docs ->
       defconst ~docs name body state gattrs s
     | {data=List [
         {data=Atom "defconstant"};
         {data=Atom name};
-        {data=List ({data=Atom "declare"} :: attrs)};
         {data=Atom body};
+        {data=List ({data=Atom "declare"} :: attrs)};
       ]} ->
       defconst ~attrs name body state gattrs s
     | {data=List [

--- a/lib/bap_primus/bap_primus_lisp_program.ml
+++ b/lib/bap_primus/bap_primus_lisp_program.ml
@@ -202,9 +202,25 @@ let pp_def ppf d =
     (pp_print_list ~pp_sep:pp_print_space pp_var) (Def.Func.args d)
     Ast.pp_prog (Def.Func.body d)
 
-let pp ppf {defs} =
-  fprintf ppf "Printing %d definitions@\n" (List.length defs);
-  fprintf ppf "@[<v>%a@]" (pp_print_list pp_def) defs
+let pp_met ppf d =
+  fprintf ppf "@[<2>(defmethod %s @[<2>(%a)@]@ %a)@]@,"
+    (Def.name d)
+    (pp_print_list ~pp_sep:pp_print_space pp_var) (Def.Meth.args d)
+    Ast.pp_prog (Def.Meth.body d)
+
+let pp_par ppf d =
+  fprintf ppf "@[<2>(defparamerter %s@,%a@,%S)@]"
+    (Def.name d)
+    Ast.pp_prog (Def.Para.default d)
+    (Def.docs d)
+
+let pp ppf {pars; mets; defs;} =
+  let pp_items pp items =
+    fprintf ppf "@[<v>%a@]" (pp_print_list pp) items in
+  pp_items pp_par pars;
+  pp_items pp_met mets;
+  pp_items pp_def defs
+
 
 module Use = struct
   let empty = String.Map.empty

--- a/lib/bap_primus/bap_primus_lisp_program.mli
+++ b/lib/bap_primus/bap_primus_lisp_program.mli
@@ -23,6 +23,7 @@ module Items : sig
   val const : Def.const item
   val func  : Def.func  item
   val meth  : Def.meth  item
+  val para  : Def.para item
   val primitive  : Def.prim item
 end
 

--- a/plugins/primus_lisp/lisp/ascii.lisp
+++ b/plugins/primus_lisp/lisp/ascii.lisp
@@ -1,8 +1,16 @@
-(defun ascii-special (s) (< s 32))
+(defun ascii-special (s)
+  "(ascii-special S) is true if S is an ascii special character"
+  (< s 32))
 (defun ascii-whitespace (s:8)
+  "(ascii-whitespace S)is true if S is a whitespace"
   (or (= s 10)
       (= s 13)
       (= s 32)))
 
-(defun ascii-sign (s:8) (if (= s ?+) 1 -1))
-(defun ascii-digit (s:8) (< (- s ?0) 10))
+(defun ascii-sign (s:8)
+  "(ascii-sign S) is 1 if S is + and -1 otherwise"
+  (if (= s ?+) 1 -1))
+
+(defun ascii-digit (s:8)
+  "(ascii-digit s) is true if S is an ascii representation of decimal digit"
+  (< (- s ?0) 10))

--- a/plugins/primus_lisp/lisp/init.lisp
+++ b/plugins/primus_lisp/lisp/init.lisp
@@ -1,33 +1,51 @@
 
-(defconstant true 1:1)
-(defconstant false 0:1)
-(defconstant nil false)
+(defconstant true 1:1  "true is another name for 1:1")
+(defconstant false 0:1 "false is another name for 0:1")
+(defconstant nil false "nil is another name for false")
 
 (defmacro when (cnd body)
-  "if CND is true then evalute BODY
-   and return the value of last expression
-   in BODY, otherwise return false"
+  "(when CND BODY) if CND is true then evalutes BODY and returns the
+   value of last expression in BODY, otherwise returns false."
   (if cnd (prog body) ()))
 
 (defmacro until (c b)
+  "(unit COND BODY) if CND is not true then evaluates BODY and returns
+   the value of the last expression in BODY, otherwise returns false. "
   (while (not c) b))
 
+(defun non-zero (x)
+  "(non-zero X) is true if X is not zero"
+  (not (is-zero x)))
 
-(defun non-zero (x) (not (is-zero x)))
-(defmacro += (x y) (set x (+ x y)))
+(defmacro += (x y)
+  "(+= X Y) assigns a sum of X and Y to variable X"
+  (set x (+ x y)))
 
-(defun -1 (x) (- x 1))
-(defun +1 (x) (+ x 1))
+(defun -1 (x)
+  "(-1 X) returns the predecessor of X"
+  (- x 1))
 
-(defmacro incr (x) (set x (+1 x)))
+(defun +1 (x)
+  "(+1 x) returns the successor of X"
+  (+ x 1))
+
+(defmacro incr (x)
+  "(incr X Y ...) increments the value bound with the variables X, Y, ..."
+  (set x (+1 x)))
+
 (defmacro incr (x xs)
   (prog (incr x) (incr xs)))
 
-(defmacro decr (x) (set x (-1 x)))
+(defmacro decr (x)
+  "(decr X Y ...) decrements the value bound with the variables X, Y, ..."
+  (set x (-1 x)))
 (defmacro decr (x xs)
   (prog (decr x) (decr xs)))
 
-(defmacro and (x) x)
+(defmacro and (x)
+  "(and X Y ...) evaluates expressions X,Y,... until the first
+  expression that returns false. The value of the whole form is the
+  value of the last evaluated expression." x)
 (defmacro and (x xs)
   (let ((r x)) (if r (and xs) r)))
 
@@ -38,28 +56,36 @@
    expression returned the truth value, then the result of the whole
    form is 0:1"
   (let ((r x)) (if r r (or xs))))
-
 (defmacro or (x) x)
 
 (defun compare (x y)
+  "(compare X Y) returns 0 if X = Y, -1 if X<Y and +1 if X>Y"
   (if (< x y) (-1 0) (if (> x y) 1 0)))
 
-
 (defmacro assert (c)
+  "(assert COND) terminates program if COND is false"
   (when (not c)
     (msg "Assertion (assert $0) failed" c)
     (error "Assert_failure")))
 
-(defmacro is-in (x y) (= x y))
+(defmacro is-in (x y)
+  "(is-in X A B C ...) returns true if X is equal A or B or C or ..."
+  (= x y))
 (defmacro is-in (x y ys)
   (or (is-in x y) (is-in x ys)))
 
-
-(defmacro fold (f a x) (f a x))
+(defmacro fold (f a x)
+  "(fold F A X Y ...) expands to (F (F A X) Y) ..."
+  (f a x))
 (defmacro fold (f a x xs) (fold f (f a x) xs))
-(defmacro min (x)      x)
+
+(defmacro min (x)
+  "(min X Y ...) returns the lower bound of the (X,Y,...) set"
+      x)
 (defmacro min (p q)    (let ((x p) (y q)) (if (< x y) x y)))
 (defmacro min (x y ys) (min (min x y) ys))
-(defmacro max (x)      x)
+(defmacro max (x)
+  "(max X Y ...) returns the upper bound of the (X,Y,...) set"
+  x)
 (defmacro max (p q)    (let ((x p) (y q)) (if (> x y) x y)))
 (defmacro max (x y ys) (max (max x y) ys))

--- a/plugins/primus_lisp/lisp/memory.lisp
+++ b/plugins/primus_lisp/lisp/memory.lisp
@@ -1,24 +1,28 @@
 ;; functions to access memory
 
 (defun points-to-null (p)
-  "true if P points to a zero byte"
+  "(points-to-null P) true if P points to a zero byte"
   (is-zero (memory-read p)))
 
 (defun copy-byte (dst src)
-  "copies byte from address SRC to DST"
+  "(copy-byte DST SRC) copies byte from
+   address SRC to DST."
   (memory-write dst (memory-read src)))
 
 (defmacro copy-byte-shift (dst src)
-  "copies byte from DST to SRC and increments SRC and DST"
+  "(copy-byte-shift DST SRC) copies byte from
+   DST to SRC and increments SRC and DST."
   (prog (copy-byte dst src)
         (incr dst src)))
 
 (defmacro copy-byte-shift-left (dst src)
-  "copies byte from DST to SRC and decrements SRC and DST"
+  "(copy-byte-shift-left DST SRC) copies
+   byte from DST to SRC and decrements SRC and DST."
   (prog (copy-byte dst src)
         (decr dst src)))
 
 (defmacro make-copy (copy-byte dst src len)
+  "<internal>"
   (let ((ret dst))
     (while len
       (decr len)
@@ -26,9 +30,11 @@
     ret))
 
 (defmacro copy-right (dst src len)
-  "copies LEN bytes from SRC to DST (left to right)"
+  "(copy-right DST SRC LEN) copies LEN bytes
+    from SRC to DST (left to right)"
   (make-copy copy-byte-shift dst src len))
 
 (defmacro copy-left (dst src len)
-  "copies LEN bytes from SRC to DST (right to left)"
+  "(copy-left DST SRC LEN) copies LEN bytes
+    from SRC to DST (right to left)"
   (make-copy copy-byte-shift-left dst src len))

--- a/plugins/primus_lisp/lisp/pointers.lisp
+++ b/plugins/primus_lisp/lisp/pointers.lisp
@@ -2,27 +2,31 @@
 
 (require types)
 
-
 (defmacro ptr+ (t p n)
-  "increments a pointer N times"
+  "(ptr+ T P N) increments N times the
+    pointer P to a value of type T."
   (+ p (* (sizeof t) n)))
 
 (defmacro ptr+1 (type p)
-  "increments a pointer"
+  "(ptr+1 T P) increments the pointer P to
+   a value of to type T."
   (ptr+ type p 1))
 
 (defmacro endian (f x y)
-  "word endianness"
+  "(endian F X Y) expands to (F Y X) if applied
+   in the little endian context"
   (declare (context (endian little)))
   (f y x))
 
 (defmacro endian (f x y)
-  "word endianness"
+  "(endian F X Y) expands to (F X Y) if applied
+   in the big endian context"
   (declare (context (endian big)))
   (f x y))
 
 (defmacro nth-byte-of-word (t i x)
-  "extracts nth byte of a word, based on endianness."
+  "(nth-byte-of-word T N X) returns N-th byte
+   of the word X that has type T"
   (let ((n (sizeof t))
         (j (endian - n i))
         (k (if (< j n) (- j 1) (+ j n)))
@@ -31,7 +35,7 @@
     (extract hi lo x)))
 
 (defmacro read-word (t a)
-  "reads a word of type T at address A"
+  "(read-word T A) reads a word of type T at address A"
   (let ((p a)
         (x (memory-read p))
         (n (-1 (sizeof t))))
@@ -42,7 +46,7 @@
     x))
 
 (defmacro write-word (t a x)
-  "writes a word of type T to address A"
+  "(write-word T A X) writes the word X of type T to address A"
   (let ((p a)
         (n (sizeof t))
         (i 0))
@@ -52,13 +56,16 @@
     p))
 
 (defmacro points-to (t p v)
-  "reads a word from address P and compares it with V"
+  "(points-to T P V) return true if t P points
+  to a value of type T that is equal to V."
   (= (read-word t p) (cast t v)))
 
 (defmacro array-get (t p n)
-  "gets N-th element of an array P"
+  "(array-get T P N) gets the N-th element of the
+   array of elements of type T, pointed by P"
   (read-word t (ptr+ t p n)))
 
 (defmacro array-set (t p n w)
-  "sets N-th element of an array P"
+  "(array-set T P N W) sets to W the N-th element of the array of
+   elements of type T, pointed by P"
   (write-word t (ptr+ p n) w))

--- a/plugins/primus_lisp/lisp/primus.lisp
+++ b/plugins/primus_lisp/lisp/primus.lisp
@@ -1,3 +1,4 @@
 (defun handle-unresolved-names ()
+  "(handle-unresolved-names) emits a diagnostic message when called"
   (declare (external "__primus_linker_unresolved_call"))
   (msg "skipping a jump to an unknown destination at $0" (get-current-program-counter)))

--- a/plugins/primus_lisp/lisp/simple-memory-allocator.lisp
+++ b/plugins/primus_lisp/lisp/simple-memory-allocator.lisp
@@ -1,14 +1,36 @@
 (require string)
 
+(defparameter *malloc-max-chunk-size* nil
+  "the maximum size of a single memory chunk,
+   if nil then there is no limit. ")
+
+(defparameter *malloc-max-arena-size* nil
+  "the maximum number of bytes totally allocated by malloc,
+   if not set, then there is no limit")
+
+(defparameter *malloc-arena-start* brk
+  "the starting address of the malloc arena")
+
+(defparameter *malloc-guard-edges* 0
+  "if not nil, then add padding of the specified size
+   around allocated chunks")
+
+(defparameter *malloc-guard-pattern* 0xA5
+  "a byte that will be used to fill guard edges")
+
+
 (defun malloc (n)
   "allocates a memory region of size N"
   (declare (external "malloc"))
   (if (= n 0) brk
-    (let ((ptr brk)
-          (failed (memory-allocate ptr n)))
-      (if failed 0
-        (set brk (+ brk n))
-        ptr))))
+    (if (malloc-will-reach-limit n) 0
+      (let ((n (+ n (* 2 *malloc-guard-edges*)))
+            (ptr brk)
+            (failed (memory-allocate ptr n 0)))
+        (if failed 0
+          (set brk (+ brk n))
+          (malloc/fill-edges ptr n)
+          (+ ptr *malloc-guard-edges*))))))
 
 ;; in our simplistic malloc implementation, free is just a nop
 (defun free (p)
@@ -18,6 +40,24 @@
 (defun calloc (n s)
   "allocates memory and initializes it with zero"
   (declare (external "calloc"))
-  (let ((size (* n s))
-        (ptr (malloc size)))
-    (memset ptr 0 size)))
+  (malloc (* n s)))
+
+
+(defun malloc-heap-size ()
+  (- brk *malloc-arena-start*))
+
+
+(defun malloc-will-reach-limit (n)
+  (or (and *malloc-max-chunk-size*
+           (> n *malloc-max-chunk-size*))
+      (and *malloc-max-arena-size*
+           (> (malloc-heap-size) *malloc-max-arena-size*))))
+
+(defun malloc/fill-edges (ptr n)
+  (when *malloc-guard-edges*
+    (memset ptr
+            *malloc-guard-pattern*
+            *malloc-guard-edges*)
+    (memset (- (+ ptr n) *malloc-guard-edges*)
+            *malloc-guard-pattern*
+            *malloc-guard-edges*)))

--- a/plugins/primus_lisp/primus_lisp_main.ml
+++ b/plugins/primus_lisp/primus_lisp_main.ml
@@ -27,7 +27,7 @@ module Documentation = struct
     List.iter index ~f:(fun (cat,elts) ->
         fprintf ppf "* %a@\n" Primus.Lisp.Doc.Category.pp cat;
         List.iter elts ~f:(fun (name,desc) ->
-            fprintf ppf "** %a@\n%a@\n@\n"
+            fprintf ppf "** %a@\n%a@\n"
               Primus.Lisp.Doc.Name.pp name
               Primus.Lisp.Doc.Descr.pp desc))
 

--- a/plugins/primus_lisp/primus_lisp_primitives.ml
+++ b/plugins/primus_lisp/primus_lisp_primitives.ml
@@ -279,43 +279,100 @@ module Primitives(Machine : Primus.Machine.S) = struct
 
   let init () =
     let open Primus.Lisp.Type.Spec in
-    let def name types closure =
-      Lisp.define ~types name closure in
+    let def name types closure docs =
+      Lisp.define ~types ~docs name closure  in
     Machine.sequence [
-      def "is-zero" (all any @-> bool) (module IsZero);
-      def "is-positive" (all any @-> bool) (module IsPositive);
-      def "is-negative" (all any @-> bool) (module IsNegative);
-      def "word-width" (unit @-> int)  (module WordWidth);
-      def "exit-with" (one int @-> any) (module ExitWith);
-      def "memory-read" (one int @-> byte) (module MemoryRead);
-      def "memory-write" (tuple [int; byte] @-> int) (module MemoryWrite);
-      def "memory-allocate" (tuple [int; int] // all byte @-> byte) (module MemoryAllocate);
-      def "get-current-program-counter" (unit @-> int) (module GetPC);
-      def "+" (all a @-> a) (module Add);
-      def "-" (all a @-> a) (module Sub);
-      def "*" (all a @-> a) (module Mul);
-      def "/" (all a @-> a) (module Div);
-      def "s/" (all a @-> a) (module SDiv);
-      def "mod" (all a @-> a) (module Mod);
-      def "signed-mod" (all a @-> a) (module SignedMod);
-      def "lshift" (tuple [a; b] @-> a) (module Lshift);
-      def "rshift" (tuple [a; b] @-> a) (module Rshift);
-      def "arshift" (tuple [a; b] @-> a) (module Arshift);
-      def "=" (all a @-> bool) (module Equal);
-      def "/=" (all a @-> bool) (module NotEqual);
-      def "logand" (all a @-> a) (module Logand);
-      def "logor" (all a @-> a) (module Logor);
-      def "logxor" (all a @-> a) (module Logxor);
-      def "concat" (all any @-> any) (module Concat);
-      def "extract" (tuple [any; any; any] @-> any) (module Extract);
-      def "lnot" (one a @-> a) (module Lnot);
-      def "not" (one a @-> a) (module Not);
-      def "neg" (one a @-> a) (module Neg);
-      def "<" (all a @-> bool) (module Less);
-      def ">" (all a @-> bool) (module Greater);
-      def "<=" (all a @-> bool) (module LessEqual);
-      def ">=" (all a @-> bool) (module GreaterEqual);
-      def "symbol-concat" (all sym @-> sym) (module SymbolConcat);
+      def "is-zero" (all any @-> bool) (module IsZero)
+        "(is-zero X Y ...) returns true if all arguments are zeros";
+      def "is-positive" (all any @-> bool) (module IsPositive)
+        "(is-positive X Y ...) returns true if all arguments are positive";
+      def "is-negative" (all any @-> bool) (module IsNegative)
+        "(is-negative X Y ...) returns true if all arguments are negative";
+      def "word-width" (unit @-> int)  (module WordWidth)
+        "(word-width) returns machine word widht in bits";
+      def "exit-with" (one int @-> any) (module ExitWith)
+        "(exit-with N) terminates program with the exit codeN";
+      def "memory-read" (one int @-> byte) (module MemoryRead)
+        "(memory-read A) loads one byte from the address A";
+      def "memory-write" (tuple [int; byte] @-> int) (module MemoryWrite)
+        "(memory-write A X) stores by X to A";
+      def "memory-allocate" (tuple [int; int] // all byte @-> byte) (module MemoryAllocate)
+        "(memory-allocate P N V?) maps memory region [P,P+N), if V is
+         provided, then fills the newly mapped region with the value V";
+      def "get-current-program-counter" (unit @-> int) (module GetPC)
+        "(get-current-program-counter) returns current program cunnter";
+      def "+" (all a @-> a) (module Add)
+        "(+ X Y ...) returns the sum of arguments, or 0 if there are
+         no arguments,";
+      def "-" (all a @-> a) (module Sub)
+        "(- X Y Z ...) returns X - Y - Z - ..., or 0 if there are no
+         arguments.";
+      def "*" (all a @-> a) (module Mul)
+        "(* X Y Z ...) returns the product of arguments or 1 if the list
+        of arguments is empty";
+      def "/" (all a @-> a) (module Div)
+        "(/ X Y Z ...) returns X / Y / Z / ... or 0 if the list of
+         arguments is empty";
+      def "s/" (all a @-> a) (module SDiv)
+        "(s/ X Y Z ...) returns X s/ Y s/ Z s/ ... or 0 if the list of
+         arguments is empty, where s/ is the signed division operation";
+      def "mod" (all a @-> a) (module Mod)
+        "(mod X Y Z ...) returns X % Y % Z % ... or 0 if the list of
+         arguments is empty, where % is the modulo operation";
+      def "signed-mod" (all a @-> a) (module SignedMod)
+        "(signed-mod X Y Z ...) returns X % Y % Z % ... or 0 if the list of
+         arguments is empty, where % is the signed modulo operation";
+      def "lshift" (tuple [a; b] @-> a) (module Lshift)
+        "(lshift X N) logically shifts X left by N bits";
+      def "rshift" (tuple [a; b] @-> a) (module Rshift)
+        "(rshift X N) logically shifts X right by N bits";
+      def "arshift" (tuple [a; b] @-> a) (module Arshift)
+        "(arshift X N) arithmetically shifts X right by N bits";
+      def "=" (all a @-> bool) (module Equal)
+        "(= X Y Z ...) returns true if all arguments are equal. True
+        if the list of arguments is empty";
+      def "/=" (all a @-> bool) (module NotEqual)
+        "(/= X Y Z ...) returns true if at least one argument is not
+         equal to another argument. Returns false if the list of
+         arguments is empty";
+      def "logand" (all a @-> a) (module Logand)
+        "(logand X Y Z ...) returns X & Y & Z & ... or 0 if the list of
+         arguments is empty, where & is the bitwise AND
+         operation. Returns ~0 if the list of arguments is empty";
+      def "logor" (all a @-> a) (module Logor)
+        "(logor X Y Z ...) returns X | Y | Z | ... or 0 if the list of
+         arguments is empty, where | is the bitwise OR operation";
+      def "logxor" (all a @-> a) (module Logxor)
+        "(logxor X Y Z ...) returns X ^ Y ^ Z ^ ... or 0 if the list of
+         arguments is empty, where ^ is the bitwise XOR operation";
+      def "concat" (all any @-> any) (module Concat)
+        "(concat X Y Z ...) concatenates words X, Y, Z, ... into one
+         big word";
+      def "extract" (tuple [any; any; any] @-> any) (module Extract)
+        "(extract HI LO X) extracts bits from HI to LO (including
+           both) from the word X ";
+      def "lnot" (one a @-> a) (module Lnot)
+        "(lnot X) returns the one complement of X";
+      def "not" (one a @-> a) (module Not)
+        "(not X) returns true if X is zero";
+      def "neg" (one a @-> a) (module Neg)
+        "(neg X) returns the two complement of X";
+      def "<" (all a @-> bool) (module Less)
+        "(< X Y Z ...) is true if the list of arguments is an
+         strict ascending chain or if it is empty";
+      def ">" (all a @-> bool) (module Greater)
+        "(< X Y Z ...) is true if the list of arguments is a
+         strict descending chain or if it is empty";
+      def "<=" (all a @-> bool) (module LessEqual)
+        "(< X Y Z ...) is true if the list of arguments is an
+         ascending chain or if it is empty";
+      def ">=" (all a @-> bool) (module GreaterEqual)
+        "(< X Y Z ...) is true if the list of arguments is a
+         descending chain or if it is empty";
+      def "symbol-concat" (all sym @-> sym) (module SymbolConcat)
+        "(symbol-concat X Y Z ...) returns a new symbol that is a
+        concatenation of symbols X,Y,Z,... "
+      ;
     ]
 end
 

--- a/plugins/primus_lisp/primus_lisp_primitives.ml
+++ b/plugins/primus_lisp/primus_lisp_primitives.ml
@@ -309,4 +309,4 @@ module Primitives(Machine : Primus.Machine.S) = struct
     ]
 end
 
-let () = Primus.Machine.add_component (module Primitives)
+let init () = Primus.Machine.add_component (module Primitives)

--- a/plugins/primus_lisp/primus_lisp_primitives.mli
+++ b/plugins/primus_lisp/primus_lisp_primitives.mli
@@ -1,0 +1,1 @@
+val init : unit -> unit

--- a/plugins/primus_loader/primus_loader_basic.ml
+++ b/plugins/primus_loader/primus_loader_basic.ml
@@ -180,17 +180,17 @@ module Make(Param : Param)(Machine : Primus.Machine.S)  = struct
 
 
   let names prog = (object
-    inherit [string Addr.Map.t] Term.visitor
+    inherit [addr String.Map.t] Term.visitor
     method! enter_term _ t env =
       match Term.get_attr t address with
       | None -> env
-      | Some addr -> Map.add env ~key:addr ~data:(Term.name t)
-  end)#run prog Addr.Map.empty
+      | Some addr -> Map.add env ~key:(Term.name t) ~data:addr
+  end)#run prog String.Map.empty
 
   let init_names () =
     Machine.get () >>= fun proj ->
     Map.to_sequence (names (Project.program proj)) |>
-    Machine.Seq.iter ~f:(fun (addr,name) -> set_word name addr)
+    Machine.Seq.iter ~f:(fun (name,addr) -> set_word name addr)
 
   let init () =
     setup_stack () >>= fun () ->

--- a/plugins/primus_test/lisp/check-value.lisp
+++ b/plugins/primus_test/lisp/check-value.lisp
@@ -21,11 +21,13 @@
 (require taint)
 
 (defun check-value (v)
+  "(check-value V) marks V as a value that must be checked"
   (let ((pc (incident-location))
         (tid (taint-introduce-directly 'check-value v)))
     (dict-add 'check-value/required tid pc)))
 
 (defun check-value-clear (v)
+  "(check-value-clear V) marks V as a value that was checked."
   (let ((taint (taint-get-direct 'check-value v))
         (pc (dict-get 'check-value/required taint)))
     (when taint

--- a/plugins/run/run_main.ml
+++ b/plugins/run/run_main.ml
@@ -131,7 +131,7 @@ let run = function
     else Machine.return ()
 
 
-let pp_var ppf v = 
+let pp_var ppf v =
   fprintf ppf "%a" Sexp.pp (Var.sexp_of_t v)
 
 let typecheck =
@@ -139,7 +139,7 @@ let typecheck =
   Env.all >>| fun vars ->
   match Primus.Lisp.Type.check vars prog with
   | [] -> info "The Lisp Machine program is well-typed"
-  | xs -> 
+  | xs ->
     warning "The Lisp Machine program is ill-typed";
     info "The typechecker is broken for now, ignore the message above";
     List.iter xs ~f:(eprintf "%a@\n" Primus.Lisp.Type.pp_error)
@@ -162,7 +162,6 @@ let main {Config.get=(!)} proj =
     proj
 
 let deps = [
-  "primus-lisp"; 
   "trivial-condition-form"
 ]
 


### PR DESCRIPTION
This PR provides various enhancements to the Primus Lisp subsystem that aim to make it faster and easier to use. 

## Documentation generator

This PR provides a very crude and fast coded autodoc generator, that dumps docstrings in the dot format (that I manually translate to html using emacs), example could be [found here][1]. This is very preliminary, and only the API index is generated (no module/aka features documentation). Anyway, I believe it is much better than nothing. 

## Makes the Primus Lisp interface public

Basically, the whole interface is just two functions: `eval_fun` and `eval_method`. Now it is possible to run Lisp programs without actually having the IR.

## Adds runtime parameters

This is a new feature in Primus Lisp. Now a module can specify parameters using the `defparameter` form. Parameters are like any other global variables, except that they could be [documented][2], and have the default form. The default form is not evaluated until the parameter is used. It is also is not evaluated if a parameter is set by a user. Probably, the best place is to initialize the parameters is in the `init` method. 

## Enhanced `malloc` Model

Using the new parameters mechanim we enhanced the malloc model with several new features:
- the [maximum size of each allocated chunk][3]
- the [maximum size of the malloc heap][4]
- [guarding edges, optionally filled with patterns to detect buffer overflows][5]

The new implementation is also using a more efficient calloc model with the O(1) memory and time complexity (unlike previous O(N)). 

## More precise control flow observations 

A new `jumping` observation is much more precise and easier to use than the existing `enter/leave-jmp` as it operates on the lower level and doesn't loose the information about the value origins. This event also made it possible to remove the TCF precondition from the Primus Lisp or Run modules/passes. (We still leave the TCF pass as a dependency though, as although it is not necessary it still makes analysis easier)

## Bug fixes
- A bug fix in the method dispatching procedure, that basically made all except one method useless
- A potential race condition between primitives initialization and program linking 
- A potential bug due to the lack of reindexing of method and parameters bodies.

## Makes Primus Lisp easier to bootstrap

Previously some passes should be run to initialize the Primus Lisp subsystem. That was quite unclear how all machinery interacts and what is the task of each pass. Now this is rectified, as all Primus Lisp plugins perform their effects during the load time, so it is only necessary to do `Plugins.run ~provides:["primus"] ()` to get the Primus subsystem up and running... err not running fortunately, but ready to be run.  


## Implementation optimization

This PR proposes a more optimal implementation of  the Primus local variables stack and made it O(logN) instead of O(N) as well as removed unnecessary stuff from it, to keep it lighter. 
 
For further details please consider reading the commit messages, and thanks for reading and reviewing. 


[1]: http://binaryanalysisplatform.github.io/bap/api/master/primus/lisp/
[2]: http://binaryanalysisplatform.github.io/bap/api/master/primus/lisp/#sec-6-1
[3]: http://binaryanalysisplatform.github.io/bap/api/master/primus/lisp/#sec-6-5
[4]: http://binaryanalysisplatform.github.io/bap/api/master/primus/lisp/#sec-6-4
[5]: http://binaryanalysisplatform.github.io/bap/api/master/primus/lisp/#sec-6-2