### PR TITLE
improves macho loader

### DIFF
--- a/lib/bap_llvm/llvm_macho_loader.hpp
+++ b/lib/bap_llvm/llvm_macho_loader.hpp
@@ -149,16 +149,15 @@ void entry_point(const macho &obj, ogre_doc &s) {
             return;
         }
     }
-    std::vector<uint64_t> addrs;
+    uint64_t entry = INT_MAX;
     for (auto sec : prim::sections(obj)) {
         auto addr = prim::section_address(sec);
         if (!addr) continue;
         if (section_flags(obj, sec) & MachO::S_ATTR_PURE_INSTRUCTIONS)
-            addrs.push_back(*addr);
+            entry = std::min(*addr, entry);
     }
-    std::sort(addrs.begin(), addrs.end());
-    if (addrs.size() > 0)
-        s.entry("entry") << addrs.front();
+    if (entry != INT_MAX)
+        s.entry("entry") << entry;
 }
 
 void image_info(const macho &obj, ogre_doc &s) {

--- a/lib/bap_llvm/llvm_macho_loader.hpp
+++ b/lib/bap_llvm/llvm_macho_loader.hpp
@@ -387,8 +387,8 @@ void indirect_symbols(const macho &obj, const MachO::dysymtab_command &dlc, ogre
 }
 
 // we are going to take a look only to indirect symbols and external relocations.
-// this part mainly for bundles, since a it's not enough just to iterate over
-// sections in order to get relocations, e.g. like we do for MH_OBJECT files.
+// this part is mainly for bundles, since it's not enough just to iterate over
+// sections in order to get relocations, e.g. like we do it for MH_OBJECT files.
 void dynamic_relocations(const macho &obj, command_info &info, ogre_doc &s) {
     if (info.C.cmd == MachO::LoadCommandType::LC_DYSYMTAB) {
         MachO::dysymtab_command cmd = obj.getDysymtabLoadCommand();

--- a/lib/bap_llvm/llvm_macho_loader.hpp
+++ b/lib/bap_llvm/llvm_macho_loader.hpp
@@ -314,26 +314,30 @@ void iterate_macho_commands(const macho &obj, ogre_doc &s) {
         macho_command(obj, cmd, s);
 }
 
-
-void swap_rel(MachO::relocation_info &rel) {
-    MachO::any_relocation_info *any =
-        reinterpret_cast<MachO::any_relocation_info *>(&rel);
-    sys::swapStruct(*any);
+MachO::relocation_info get_rel(const macho &obj, uint32_t off) {
+    const char *ptr = prim::get_raw_data(obj) + off;
+    MachO::relocation_info rel;
+    if (obj.isLittleEndian() != sys::IsLittleEndianHost) {
+        MachO::any_relocation_info any;
+        memcpy(&any, ptr, sizeof(MachO::any_relocation_info));
+        MachO::swapStruct(any);
+        memcpy(&rel, &any, sizeof(MachO::relocation_info));
+    } else {
+        memcpy(&rel, ptr, sizeof(MachO::relocation_info));
+    }
+    return rel;
 }
 
-void iterate_dyn_relocations(const macho &obj, std::size_t off, std::size_t num, ogre_doc &s) {
-    const char *ptr = prim::get_raw_data(obj);
-    std::size_t next = off;
+void iterate_dyn_relocations(const macho &obj, uint32_t off, uint32_t num, ogre_doc &s) {
+    uint32_t next = off;
     for (std::size_t i = 0; i < num; ++i) {
-        const MachO::relocation_info *rel = reinterpret_cast<const MachO::relocation_info *>(ptr + next);
-        if (obj.isLittleEndian() != sys::IsLittleEndianHost)
-            swap_rel(*rel);
-        if (rel->r_address & MachO::R_SCATTERED) {
+        MachO::relocation_info rel = get_rel(obj, next);
+        if (rel.r_address & MachO::R_SCATTERED) {
             // not supported
             next = next + sizeof(MachO::scattered_relocation_info);
         } else {
-            if (rel->r_extern)
-                symbol_reference(obj, rel->r_symbolnum, rel->r_address, s);
+            if (rel.r_extern)
+                symbol_reference(obj, rel.r_symbolnum, rel.r_address, s);
             next = next + sizeof(MachO::relocation_info);
         }
     }

--- a/lib/bap_llvm/llvm_macho_loader.hpp
+++ b/lib/bap_llvm/llvm_macho_loader.hpp
@@ -161,7 +161,6 @@ void entry_point(const macho &obj, ogre_doc &s) {
         s.entry("entry") << addrs.front();
 }
 
-// LC_MAIN command is absent in some file types, so we provide an entry here
 void image_info(const macho &obj, ogre_doc &s) {
     if (!is_exec(obj))
         s.raw_entry("(entry 0)");
@@ -363,7 +362,7 @@ void indirect_symbols(const macho &obj, const MachO::dysymtab_command &dlc, ogre
                 auto i_addr = addr + j * stride;
                 auto i_offs = offs + j * stride;
 
-                uint index = n + j;
+                uint64_t index = n + j;
                 uint64_t offset = dlc.indirectsymoff + index * sizeof(uint32_t);
                 if (offset > obj_size)
                     continue;

--- a/lib/bap_llvm/llvm_macho_loader.hpp
+++ b/lib/bap_llvm/llvm_macho_loader.hpp
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include <iostream>
 #include <iomanip>
-
+#include <limits>
 
 #if LLVM_VERSION_MAJOR >= 5 && LLVM_VERSION_MAJOR < 7
 #include <llvm/BinaryFormat/MachO.h>
@@ -151,14 +151,15 @@ void entry_point(const macho &obj, ogre_doc &s) {
             return;
         }
     }
-    uint64_t entry = INT_MAX;
+    uint64_t max = std::numeric_limits<uint64_t>::max();
+    uint64_t entry = max;
     for (auto sec : prim::sections(obj)) {
         auto addr = prim::section_address(sec);
         if (!addr) continue;
         if (section_flags(obj, sec) & MachO::S_ATTR_PURE_INSTRUCTIONS)
             entry = std::min(*addr, entry);
     }
-    if (entry != INT_MAX)
+    if (entry != max)
         s.entry("entry") << entry;
 }
 

--- a/lib/bap_llvm/llvm_macho_loader.hpp
+++ b/lib/bap_llvm/llvm_macho_loader.hpp
@@ -68,7 +68,9 @@ uint32_t filetype(const macho &obj) {
 bool is_relocatable(const macho &obj) {
     return (filetype(obj) == MachO::MH_OBJECT ||
             filetype(obj) == MachO::MH_KEXT_BUNDLE ||
-            filetype(obj) == MachO::MH_BUNDLE);
+            filetype(obj) == MachO::MH_BUNDLE ||
+            filetype(obj) == MachO::MH_DYLIB ||
+            filetype(obj) == MachO::MH_DYLIB_STUB);
 }
 
 bool is_exec(const macho &obj) { return filetype(obj) == MachO::MH_EXECUTE;  }


### PR DESCRIPTION
Previously, only little endian binaries were expected in our macho loader, so this caused unexpected behavior with big endian binaries. This PR fix it, as well adds some more guards for reliability.

Also, this PR fixes problem with an entry point for old macho binaries: they just don't contain so-called `LC_MAIN` command, and entry point as part of the binary structure is absent.
But we can workaround this problem by emitting entry point as an address of a first executable section.