### PR TITLE
rectifies project construction

### DIFF
--- a/lib/bap_future/bap_future.ml
+++ b/lib/bap_future/bap_future.ml
@@ -550,6 +550,20 @@ module Std = struct
       link s s' f;
       s'
 
+    let concat ss =
+      let stream, signal = create () in
+      List.iter ss ~f:(fun s -> observe s (fun x -> Signal.send signal x));
+      stream
+
+    let concat_merge ss ~f =
+      let pair x = Some x, Some x in
+      parse (concat ss) ~init:None
+        ~f:(fun state x -> match state with
+            | None -> pair x
+            | Some y ->
+              let z = f x y in
+              pair z)
+
     type 'a stream = 'a t
 
     module Variadic = Variadic.Make(struct

--- a/lib/bap_future/bap_future.mli
+++ b/lib/bap_future/bap_future.mli
@@ -525,13 +525,28 @@ module Std : sig
         values xs, producing a stream of results.*)
     val apply : ('a -> 'b) t -> 'a t -> 'b t
 
+    (** [concat ss] - concats a list of streams [ss] to a single
+        stream, that contains all values of [ss] *)
+    val concat : 'a t list -> 'a t
 
+    (** [concat_merge xs ~f] - concats a list of streams [ss]
+        to a single stream, where all values are merge with [f]*)
+    val concat_merge : 'a t list -> f:('a -> 'a -> 'a) -> 'a t
+
+    (** [split xs ~f] - transforms a stream [xs] to a pair of streams,
+        according to applying [f] to elements of [xs]. *)
     val split : 'a t -> f:('a -> 'b * 'c) -> 'b t * 'c t
 
+    (** [zip xs ys] - transforms a pair of streams [xs] and [ys]
+        to a single stream of pairs *)
     val zip : 'a t -> 'b t -> ('a * 'b) t
 
+    (** [unzip xs] - transforms a stream of pairs [xs] to a pair
+        of streams *)
     val unzip : ('a * 'b) t -> 'a t * 'b t
 
+    (** [once xs] - transforms a stream [xs] to a stream with
+        an only first value occured in [xs] *)
     val once : 'a t -> 'a t
 
     (** [parse ss ~init ~f] parses stream [ss] and builds new stream

--- a/lib/bap_future/bap_future.mli
+++ b/lib/bap_future/bap_future.mli
@@ -531,7 +531,7 @@ module Std : sig
         that elements of the same stream will preserve their ordering.*)
     val concat : 'a t list -> 'a t
 
-    (** [concat_merge xs ~f] builds a stream that of elements, that will 
+    (** [concat_merge xs ~f] builds a stream, that will 
         produce elements from the input list and applies [f] to all 
         consecutive elements. The ordering of the input list does not 
         mandate the ordering of elemenets in the output stream, and is

--- a/lib/bap_future/bap_future.mli
+++ b/lib/bap_future/bap_future.mli
@@ -525,28 +525,28 @@ module Std : sig
         values xs, producing a stream of results.*)
     val apply : ('a -> 'b) t -> 'a t -> 'b t
 
-    (** [concat ss] - concats a list of streams [ss] to a single
-        stream, that contains all values of [ss] *)
+    (** [concat ss] - concatenates a list of streams [ss] to a single
+        stream, that contains all values of [ss]. *)
     val concat : 'a t list -> 'a t
 
-    (** [concat_merge xs ~f] - concats a list of streams [ss]
-        to a single stream, where all values are merge with [f]*)
+    (** [concat_merge xs ~f] - concatenates a list of streams [ss]
+        to a single stream, where all values are merged with [f]*)
     val concat_merge : 'a t list -> f:('a -> 'a -> 'a) -> 'a t
 
     (** [split xs ~f] - transforms a stream [xs] to a pair of streams,
         according to applying [f] to elements of [xs]. *)
     val split : 'a t -> f:('a -> 'b * 'c) -> 'b t * 'c t
 
-    (** [zip xs ys] - transforms a pair of streams [xs] and [ys]
-        to a single stream of pairs *)
+    (** [zip xs ys] - transforms a pair of streams to a stream of
+        pairs. *)
     val zip : 'a t -> 'b t -> ('a * 'b) t
 
-    (** [unzip xs] - transforms a stream of pairs [xs] to a pair
-        of streams *)
+    (** [unzip xs] - transforms a stream of pairs to a pair of
+        streams. *)
     val unzip : ('a * 'b) t -> 'a t * 'b t
 
     (** [once xs] - transforms a stream [xs] to a stream with
-        an only first value occured in [xs] *)
+        the only first value occured in [xs]. *)
     val once : 'a t -> 'a t
 
     (** [parse ss ~init ~f] parses stream [ss] and builds new stream

--- a/lib/bap_future/bap_future.mli
+++ b/lib/bap_future/bap_future.mli
@@ -525,28 +525,35 @@ module Std : sig
         values xs, producing a stream of results.*)
     val apply : ('a -> 'b) t -> 'a t -> 'b t
 
-    (** [concat ss] - concatenates a list of streams [ss] to a single
-        stream, that contains all values of [ss]. *)
+    (** [concat ss] returns a stream that will produce elements from 
+        the input list of streams [ss]. The ordering of the elements
+        of different streams is unspecified, though it is guaranteed
+        that elements of the same stream will preserve their ordering.*)
     val concat : 'a t list -> 'a t
 
-    (** [concat_merge xs ~f] - concatenates a list of streams [ss]
-        to a single stream, where all values are merged with [f]*)
+    (** [concat_merge xs ~f] builds a stream that of elements, that will 
+        produce elements from the input list and applies [f] to all 
+        consecutive elements. The ordering of the input list does not 
+        mandate the ordering of elemenets in the output stream, and is
+        undefined. See [concat] for more information.*)
     val concat_merge : 'a t list -> f:('a -> 'a -> 'a) -> 'a t
 
-    (** [split xs ~f] - transforms a stream [xs] to a pair of streams,
-        according to applying [f] to elements of [xs]. *)
+    (** [split xs ~f] returns a pair of streams, where the first stream 
+        contains [fst (f x)] for each [x] in [xs] and the second stream
+        contains [snd (f x)] for each [x] in [xs]. *)
     val split : 'a t -> f:('a -> 'b * 'c) -> 'b t * 'c t
 
-    (** [zip xs ys] - transforms a pair of streams to a stream of
-        pairs. *)
+    (** [zip xs ys] creates a steam that will produce an element [(x,y)] 
+        every time both [xs] and [ys] produce elements [x] and [y] respectively *)
     val zip : 'a t -> 'b t -> ('a * 'b) t
 
-    (** [unzip xs] - transforms a stream of pairs to a pair of
-        streams. *)
+    (** [unzip xs] creates a pair of streams, where the first stream contains
+        [fst x] for each [x] in [xs] and the second stream contains [snd x] for
+        each [x] in [xs]. Essentially, the same as [split ~f:ident] *)
     val unzip : ('a * 'b) t -> 'a t * 'b t
 
-    (** [once xs] - transforms a stream [xs] to a stream with
-        the only first value occured in [xs]. *)
+    (** [once xs] creates a stream that will at most contain the next value 
+        produced by [xs] and nothing more. *)
     val once : 'a t -> 'a t
 
     (** [parse ss ~init ~f] parses stream [ss] and builds new stream

--- a/src/bap_main.ml
+++ b/src/bap_main.ml
@@ -23,18 +23,13 @@ let reconstructor =
   find_source (module Reconstructor.Factory) reconstructor
 
 let merge_streams ss ~f : 'a Source.t =
-  let stream, signal = Stream.create () in
-  List.iter ss ~f:(fun s -> Stream.observe s (fun x -> Signal.send signal x));
-  let pair x = Some x, Some x in
-  Stream.parse stream ~init:None
-    ~f:(fun prev curr -> match curr, prev with
-        | Ok curr, None -> pair (Ok curr)
-        | Ok curr, Some (Ok prev) -> pair (Ok (f prev curr))
-        | Ok _, Some (Error e)
-        | Error e, Some (Ok _) -> pair (Error e)
-        | Error e, None -> Some (Error e), None
-        | Error curr, Some (Error prev) ->
-          pair (Error (Error.of_list [prev; curr])))
+  Stream.concat_merge ss
+    ~f:(fun s s' -> match s, s' with
+        | Ok s, Ok s' -> Ok (f s s')
+        | Ok _, Error er
+        | Error er, Ok _ -> Error er
+        | Error er, Error er' ->
+          Error (Error.of_list [er; er']))
 
 let merge_sources create field (o : Bap_options.t) ~f =  match field o with
   | [] -> None


### PR DESCRIPTION
This PR moves some preliminary parts of project creation to the module `Project` itself.
Also, PR adds `concat` and `concat_merge` to `Bap_future` library.

Previously, we were creating project somehow like following:
```
let input = Project.Input.file "exe";;
let Ok proj = Project.create ?rooter:(Rooter.Factory.find "internal") input;;
```
With this PR a process of project creation looks much more simple:
```
let input = Project.Input.file "/bin/ls" ;;
let pr = Project.create input ;;
```