### PR TITLE
removes duplicated sections in disassemble output

### DIFF
--- a/lib/bap/bap_project.ml
+++ b/lib/bap/bap_project.ml
@@ -116,8 +116,9 @@ module Input = struct
     let base = Option.value base ~default:(null arch) in
     let mem = Memory.create (Arch.endian arch) base big |> ok_exn in
     let section = Value.create Image.section "bap.user" in
-    let data = Memmap.add Memmap.empty mem section in
-    {arch; data; code = data; file = filename; finish = ident;}
+    let code = Memmap.add Memmap.empty mem section in
+    let data = Memmap.empty  in
+    {arch; data; code; file = filename; finish = ident;}
 
   let available_loaders () =
     Hashtbl.keys loaders @ Image.available_backends ()


### PR DESCRIPTION
Sections were printed twice in disassembly output when using bap with pure binary code. This PR
removes this behavior:
```
$ bap some_exe -dasm --source-type x86-code --read-symbols-from start

Disassembly of section bap.user

0: <_start>
0:
0: 66 31 c0                                       xorw %ax, %ax
3: 66 40                                          incw %ax
5: 66 89 c1                                       movw %ax, %cx
```