### PR TITLE
changes the Primus memory representation to preserve value identity

### DIFF
--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -1308,11 +1308,24 @@ module Std : sig
           [Machine] monad.  *)
       module Make(Machine : Machine.S) : sig
 
-        (** [load addr] loads a byte from the given address *)
+
+        (** [set a] loads a byte from the address [a]  *)
+        val get : addr -> value Machine.t
+
+
+        (** [set a x] stores the byte [x] at the address [a]. *)
+        val set : addr -> value -> unit Machine.t
+
+        (** [load a] loads a byte from the given address [a].
+
+            Same as [get a >>= Value.to_word]
+        *)
         val load : addr -> word Machine.t
 
+        (** [store a x] stores the byte [x] at the address [a].
 
-        (** [store addr x] stores a byte [x] at the given address [addr]  *)
+            Same as [Value.of_word x >>= set a].
+        *)
         val store : addr -> word -> unit Machine.t
 
         (** [add_text mem] maps a memory chunk [mem] as executable and

--- a/lib/bap_primus/bap_primus_interpreter.ml
+++ b/lib/bap_primus/bap_primus_interpreter.ml
@@ -250,6 +250,16 @@ module Make (Machine : Machine) = struct
     value c >>= fun r ->
     !!on_const r >>| fun () -> r
 
+  let load_byte a =
+    !!on_loading a >>= fun () ->
+    Memory.get a.value >>= fun r ->
+    !!on_loaded (a,r) >>| fun () -> r
+
+  let store_byte a x =
+    !!on_storing a >>= fun () ->
+    Memory.set a.value x >>= fun () ->
+    !!on_stored (a,x)
+
   let rec eval_exp x =
     let eval = function
       | Bil.Load (Bil.Var _, a,_,`r8) -> eval_load a
@@ -268,18 +278,12 @@ module Make (Machine : Machine) = struct
     !!exp_entered x >>= fun () ->
     eval x >>= fun r ->
     !!exp_left x >>| fun () -> r
-  and eval_load a =
-    eval_exp a >>= fun a ->
-    !!on_loading a >>= fun () ->
-    Memory.load a.value >>= value >>= fun r ->
-    !!on_loaded (a,r) >>| fun () -> r
+  and eval_load a = eval_exp a >>= load_byte
   and eval_store m a x =
     eval_exp m >>= fun _ ->
     eval_exp a >>= fun a ->
     eval_exp x >>= fun x ->
-    !!on_storing a >>= fun () ->
-    Memory.store a.value x.value >>= fun () ->
-    !!on_stored (a,x) >>| fun () -> a
+    store_byte a x >>| fun () -> a
   and eval_binop op x y =
     eval_exp x >>= fun x ->
     eval_exp y >>= fun y ->
@@ -310,15 +314,36 @@ module Make (Machine : Machine) = struct
     let (module Target) = target_of_arch (Project.arch proj) in
     Target.CPU.mem
 
-  let load a e s =
-    mem >>= fun m ->
-    eval_exp Bil.(Load (var m, int a.value,e,s))
+  let succ x =
+    Value.one (Value.bitwidth x) >>= fun one ->
+    binop PLUS x one
+
+  let rec do_load a e s =
+    load_byte a >>= fun v ->
+    if s = 8 then Machine.return v
+    else succ a >>= fun a ->
+      do_load a e (s - 8) >>= fun u -> match e with
+      | LittleEndian -> concat u v
+      | BigEndian -> concat v u
+
+  let load a e s = do_load a e (Size.in_bits s)
+
+  let rec do_store a x s hd tl =
+    cast hd 8 x >>= fun b ->
+    store_byte a b >>= fun () ->
+    if s = 8 then Machine.return ()
+    else succ a >>= fun a ->
+      cast tl (s - 8) x >>= fun x ->
+      do_store a x (s - 8) hd tl
 
   let store a x e s =
-    mem >>= fun m ->
-    Machine.ignore_m @@
-    eval_exp Bil.(Store (var m,int a.value,int x.value,e,s))
-
+    if s = `r8 then store_byte a x
+    else
+      let open Bil.Types in
+      let s = Size.in_bits s in
+      match e with
+      | LittleEndian -> do_store a x s LOW HIGH
+      | BigEndian    -> do_store a x s HIGH LOW
 
   let update_pc t =
     match Term.get_attr t address with

--- a/lib/bap_primus/bap_primus_memory.mli
+++ b/lib/bap_primus/bap_primus_memory.mli
@@ -10,6 +10,9 @@ module Make(Machine : Machine) : sig
   val load  : addr -> word Machine.t
   val store : addr -> word -> unit Machine.t
 
+  val get : addr -> value Machine.t
+  val set : addr -> value -> unit Machine.t
+
   val add_text : mem -> unit Machine.t
   val add_data : mem -> unit Machine.t
 


### PR DESCRIPTION
Historically, our implementation of the memory storage was a mapping from bitvectors to bitvectors, thus any store operation was forgetful as the identity of a value was discarded (where a value in Primus is a tuple of data and a unique identifier). For a long time we were considering this as a feature, articulating that `x` and `load a (store a x)` are two different values, even though, they are usually structuraly equal. However, it was also observed, that in many cases during the analysis we would like to preserve this identities, thus we were forced to maintain our own mappings between words and value identities in this or that way.

The proposed solution should satisfy both camps, those who believe that `x` and `load a (store a x)` are in general different, and those who say, that in practice they are equal as in Leibniz equality. The memory component will now store values instead of bitvectors, so it won't loose any information. At the same time components may define semantics of the load/store operations as they wish, e.g., to implement a mapping of control registers to memory, and other non-trivial memory representations and mechanisms.

By default, however, the interpreter will ensure that `load a (store a x)` and `x` has the same idenity if `x` is a byte. If `x` is a word of an arbitrary length then it will be projected into several bytes with the extract operation during the store operation, and assembled back with the concat operation durintg the load operation.