### PR TITLE
fixes calls search in the reconstructor

### DIFF
--- a/lib/bap_disasm/bap_disasm_reconstructor.ml
+++ b/lib/bap_disasm/bap_disasm_reconstructor.ml
@@ -24,6 +24,9 @@ let find_calls name roots cfg =
   List.iter roots ~f:(fun addr ->
       Hashtbl.set starts ~key:addr ~data:(name addr));
   Cfg.nodes cfg |> Seq.iter ~f:(fun blk ->
+      if Seq.is_empty (Cfg.Node.inputs blk cfg) then
+        let addr = Block.addr blk in
+        Hashtbl.set starts ~key:addr ~data:(name addr);
       let term = Block.terminator blk in
       if Insn.(is call) term then
         Seq.iter (Cfg.Node.outputs blk cfg)


### PR DESCRIPTION
fixes https://github.com/BinaryAnalysisPlatform/bap/issues/801

This PR fixes a problem with a disassembling of pure code: as there are not any functions in there, bap just doesn't output anything.

What we actually do here is not about only those files, but about reconstruction at all: we consider all blocks in the reconstructor that don't have input edges as functions starts. And it makes sense, e.g. in case of libraries: there is not any precondition that every function will be called by some other function from this library.