### PR TITLE
rectifies powerpc lifter

### DIFF
--- a/plugins/powerpc/powerpc.mli
+++ b/plugins/powerpc/powerpc.mli
@@ -526,6 +526,10 @@ module Std : sig
   (** [one] is a one bit length expression set to one *)
   val one  : exp
 
+  (** [ones bitwidth] - returns an expression of [bitwidth]
+      with all bits set to one *)
+  val ones : bitwidth -> exp
+
   (** [extract e lx rx] extracts portion of [e] starting
       at bit [lx] and ending at bit [rx], all bounds
       are inclusive. Bits indexes start from the most

--- a/plugins/powerpc/powerpc.mli
+++ b/plugins/powerpc/powerpc.mli
@@ -662,15 +662,16 @@ module Std : sig
     module E : Model_exp
     include Model with type t := var
 
-    val mem : var
-    val flags : Var.Set.t
     val gpr_bitwidth : int
     val fpr_bitwidth : int
-    val vr_bitwidth  : int
-    val cr_bitwidth  : int
     val lr_bitwidth  : int
     val ctr_bitwidth : int
     val tar_bitwidth : int
+    val cr_bitwidth  : int
+    val vr_bitwidth  : int
+
+    val mem : var
+    val flags : Var.Set.t
   end
 
   module PowerPC_32 : PowerPC

--- a/plugins/powerpc/powerpc_branch.ml
+++ b/plugins/powerpc/powerpc_branch.ml
@@ -171,10 +171,11 @@ let blr cpu _ops =
 
 let blrl cpu _ops =
   let sh = unsigned const byte 2 in
-  let tm = unsigned var doubleword in
+  let tm = unsigned var cpu.word_width in
+  let step = unsigned const byte 4 in
   RTL.[
     tm := cpu.lr land (ones cpu.word_width << sh);
-    cpu.lr := cpu.pc + unsigned const byte 4;
+    cpu.lr := cpu.pc + step;
     cpu.jmp tm;
   ]
 
@@ -198,14 +199,12 @@ let bcctr cpu ops =
   let bi = unsigned cpu.reg ops.(1) in
   let cond_ok = unsigned var bit in
   let x = unsigned var (bitwidth 5) in
-  let tm = unsigned var doubleword in
-  let sh = unsigned const doubleword 2 in
+  let sh = unsigned const byte 2 in
   RTL.[
     x := last bo 5;
     cond_ok := (nth bit x 0 = one) lor (bi lxor (lnot (nth bit x 1)));
     when_ (cond_ok) [
-      tm := first cpu.ctr 62;
-      cpu.jmp (tm << sh);
+      cpu.jmp (cpu.ctr land (ones cpu.word_width << sh));
     ];
   ]
 
@@ -217,11 +216,9 @@ let bcctrl = update_link_register ^ bcctr
     4e 80 04 20   bctr
     4e 80 04 21   bctrl *)
 let bctr cpu _ops =
-  let tm = unsigned var doubleword in
-  let sh = unsigned const doubleword 2 in
+  let sh = unsigned const byte 2 in
   RTL.[
-    tm := first cpu.ctr 62;
-    cpu.jmp (tm << sh);
+    cpu.jmp (cpu.ctr land (ones cpu.word_width << sh));
   ]
 
 let bctrl = update_link_register ^ bctr
@@ -246,7 +243,7 @@ let bctar cpu ops =
     ctr_ok := nth bit x 2 lor ((cpu.ctr <> zero) lxor (nth bit x 3));
     cond_ok := nth bit x 0 lor (bi lxor (lnot (nth bit x 1)));
     when_ (ctr_ok land cond_ok) [
-      cpu.jmp (cpu.tar << sh);
+      cpu.jmp (cpu.tar land (ones cpu.word_width << sh));
     ]
   ]
 

--- a/plugins/powerpc/powerpc_dsl.ml
+++ b/plugins/powerpc/powerpc_dsl.ml
@@ -68,6 +68,7 @@ let of_string signed s =
 
 let zero = Exp.of_word Word.b0
 let one  = Exp.of_word Word.b1
+let ones w = Exp.of_word (Word.ones w)
 
 let first e bits =
   let w = Exp.width e in

--- a/plugins/powerpc/powerpc_dsl.mli
+++ b/plugins/powerpc/powerpc_dsl.mli
@@ -26,6 +26,7 @@ val unsigned : 'a ec -> 'a
 
 val zero : exp
 val one  : exp
+val ones : bitwidth -> exp
 
 (** [extract e lx rx] extracts portion of [e] starting
     at bit [lx] and ending at bit [rx], all bounds

--- a/plugins/powerpc/powerpc_load.ml
+++ b/plugins/powerpc/powerpc_load.ml
@@ -197,7 +197,7 @@ let lwaux cpu ops =
     ra := ra + rb;
   ]
 
-(** Fixed-point Load Dobuleword
+(** Fixed-point Load Doubleword
     Pages 48-54 of IBM Power ISATM Version 3.0 B
     examples:
     e8 29 00 08    ld r1, 8(r9) *)
@@ -209,7 +209,7 @@ let ld cpu ops =
     rt := cpu.load (ra + im) doubleword;
   ]
 
-(** Fixed-point Load Dobuleword Indexed
+(** Fixed-point Load Doubleword Indexed
     Pages 48-54 of IBM Power ISATM Version 3.0 B
     examples:
     7c 28 48 2a    ldx r1, r8, r9 *)
@@ -221,7 +221,7 @@ let ldx cpu ops =
     rt := cpu.load (ra + rb) doubleword;
   ]
 
-(** Fixed-point Load Dobuleword with Update
+(** Fixed-point Load Doubleword with Update
     Pages 48-54 of IBM Power ISATM Version 3.0 B
     examples:
     e8 29 00 09    ldu r1, 8(r9) *)
@@ -234,7 +234,7 @@ let ldu cpu ops =
     ra := ra + im;
   ]
 
-(** Fixed-point Load Dobuleword with Update Indexed
+(** Fixed-point Load Doubleword with Update Indexed
     Pages 48-54 of IBM Power ISATM Version 3.0 B
     examples:
     7c 28 48 6a    ldux r1, r8, r9 *)

--- a/plugins/powerpc/powerpc_logical.ml
+++ b/plugins/powerpc/powerpc_logical.ml
@@ -301,24 +301,25 @@ let cmpb cpu ops =
   let ra = unsigned cpu.reg ops.(0) in
   let rs = unsigned cpu.reg ops.(1) in
   let rb = unsigned cpu.reg ops.(2) in
-  let xb = unsigned const doubleword 0xFF in
+  let xb = unsigned const byte 0xFF in
   let ind = unsigned var byte in
   let byte_i = unsigned var byte in
   let byte_j = unsigned var byte in
-  let max = unsigned const byte 7 in
+  let byte_k = unsigned var byte in
   let sh = unsigned const byte 8 in
-  let tmp = unsigned var doubleword in
+  let tmp = unsigned var cpu.word_width in
   RTL.[
     ind := zero;
     tmp := zero;
-    foreach byte_i rs [
+    foreach byte_k tmp [
+      byte_i := nth byte (rs << (ind * sh)) 0;
       byte_j := nth byte (rb << (ind * sh)) 0;
       when_ (byte_i = byte_j) [
-        tmp := tmp lor (xb << ((max - ind) * sh));
+        byte_k := xb;
       ];
       ind := ind + one;
     ];
-    ra := high cpu.word_width tmp;
+    ra := tmp;
   ]
 
 (** Fixed-point Population Count Bytes/Words/Doubleword
@@ -330,26 +331,28 @@ let cmpb cpu ops =
 let popcntw cpu ops =
   let ra = unsigned cpu.reg ops.(0) in
   let rs = unsigned cpu.reg ops.(1) in
-  let cnt = unsigned var doubleword in
-  let res = unsigned var doubleword in
+  let cnt = unsigned var word in
+  let res = unsigned var cpu.word_width in
   let word_i = unsigned var word in
+  let word_j = unsigned var word in
   let bit_i = unsigned var bit in
   let ind = unsigned var word in
   let x = unsigned const byte 32 in
   RTL.[
     res := zero;
-    ind := one;
-    foreach word_i rs [
+    ind := zero;
+    foreach word_j res [
       cnt := zero;
+      word_i := nth word (rs << ind * x) 0;
       foreach bit_i word_i [
         when_ (bit_i = one) [
           cnt := cnt + one;
         ];
       ];
-      res := res lor (cnt << (ind * x));
-      ind := ind - one;
+      word_j := cnt;
+      ind := ind + one;
     ];
-    ra := high cpu.word_width res;
+    ra := res;
   ]
 
 let popcntd cpu ops =

--- a/plugins/powerpc/powerpc_model.mli
+++ b/plugins/powerpc/powerpc_model.mli
@@ -53,16 +53,15 @@ end
 module type PowerPC = sig
   module E : Model_exp
   include Model with type t := var
-
-  val mem : var
-  val flags : Var.Set.t
   val gpr_bitwidth : int
   val fpr_bitwidth : int
-  val vr_bitwidth  : int
-  val cr_bitwidth  : int
   val lr_bitwidth  : int
   val ctr_bitwidth : int
   val tar_bitwidth : int
+  val cr_bitwidth  : int
+  val vr_bitwidth  : int
+  val mem : var
+  val flags : Var.Set.t
 end
 
 module PowerPC_32 : PowerPC

--- a/plugins/powerpc/powerpc_rotate.ml
+++ b/plugins/powerpc/powerpc_rotate.ml
@@ -67,7 +67,7 @@ let rlwnm cpu ops =
       mask := (mask << (width ra - stop)) lor (mask >> (start + one));
     ];
     tmp := nth word rs 1;
-    ra := (nth doubleword ((tmp ^ tmp ^ tmp) << (last rb 5)) 0) land mask;
+    ra := (nth cpu.word_width ((tmp ^ tmp ^ tmp) << (last rb 5)) 0) land mask;
   ]
 
 (** Fix-point Rotate Left Word Immediate then Mask Insert
@@ -103,7 +103,7 @@ let rlwimi cpu ops =
       mask := (mask << (width ra - stop)) lor (mask >> (start + one));
     ];
     tmp1 := nth word rs 1;
-    tmp2 := nth doubleword ((tmp1 ^ tmp1 ^ tmp1) << sh) 0;
+    tmp2 := nth cpu.word_width ((tmp1 ^ tmp1 ^ tmp1) << sh) 0;
     ra := (tmp2 land mask) lor (ra land (lnot mask));
   ]
 


### PR DESCRIPTION
There are some efforts on PowerPC lifter.
A brief list of changes:
1) fixed a bug in branch instructions with an alignment of addresses from `lr`, `ctr` and `tar` registers.  
2) added a `val ones : bitwidth -> exp `  funciton, that could come in handy for masks;
3) updated `PowerPC` model: we still had `lr` and `ctr` registers of 64 bits length even for 32 bits arch;
4) refactored a couple of instructions: `cmpb` and `popcntw`, just because it was easy to write much readable implementation;
5) reduced a using of `doubleword`. It's a kind of artifact that we have from a time when all registers in our model were 64 bits length, and therefore we didn't pay much attention to
variables length we created. And now, when we have different models with a respect to address size, a using of `doubleword` is not a mistake, but it makes a code less understandable. For example, usually, there is not any sense to create a temporary variable of  `doubleword` length to hold some intermediate value from one-word length register. So this PR eliminates most of such cases.
