### PR TITLE
adds ogre dump format

### DIFF
--- a/plugins/print/print_main.ml
+++ b/plugins/print/print_main.ml
@@ -45,6 +45,11 @@ let sec_name memory fn sub =
   | None -> "bap.virtual"
   | Some name -> name
 
+let print_spec ppf proj =
+  match Project.get proj Image.specification with
+  | None -> warning "The file specification is not found"
+  | Some spec ->  Format.fprintf ppf "%a" Ogre.Doc.pp spec
+
 let print_symbols subs secs demangler fmts ppf proj =
   let demangle = create_demangler demangler in
   let symtab = Project.symbols proj in
@@ -288,6 +293,7 @@ let main attrs ansi_colors demangle symbol_fmts subs secs =
   Project.add_writer ~ver "callgraph"
     ~desc:"print program callgraph in DOT format" pp_callgraph;
   let pp_cfg = Data.Write.create ~pp:(print_bir_graph subs secs) () in
+  let pp_spec = Data.Write.create ~pp:print_spec () in
   let pp_disasm_bil =
     Data.Write.create ~pp:(print_disasm (pp_bil "pretty") subs secs) () in
   let pp_disasm_bil_adt =
@@ -317,8 +323,9 @@ let main attrs ansi_colors demangle symbol_fmts subs secs =
   Project.add_writer ~ver "bil.adt"
     ~desc:"print BIL instructions in ADT format" pp_disasm_bil_adt;
   Project.add_writer ~ver "bil.sexp"
-    ~desc:"print BIL instructions in Sexp format" pp_disasm_bil_sexp
-
+    ~desc:"print BIL instructions in Sexp format" pp_disasm_bil_sexp;
+  Project.add_writer
+    ~desc:"print the file specification in the OGRE format" ~ver "ogre" pp_spec
 
 let () =
   let open Adt in


### PR DESCRIPTION
this PR adds ogre dump format:
```
$ bap /bin/echo --dump=ogre
(declare arch (name str))
(declare base-address (addr int))
...
(arch x86_64)
(base-address 4194304)
...
```