### PR TITLE
adds mangling of duplicated subroutines

### DIFF
--- a/lib/bap_types/bap_ir.ml
+++ b/lib/bap_types/bap_ir.ml
@@ -189,10 +189,8 @@ end = struct
             keep_name tids sub.self.name sub.tid
           else tids) in
     Array.map news ~f:(fun sub ->
-        if Map.existsi tids
-            ~f:(fun ~key:name ~data:tid ->
-                String.equal name sub.self.name &&
-                Tid.equal tid sub.tid) then sub
+        let tid' = Map.find_exn tids sub.self.name in
+        if Tid.equal tid' sub.tid then sub
         else mangle_sub sub)
 
   let empty () = {subs = [| |] ;  paths = Tid.Table.create () }

--- a/lib/bap_types/bap_ir.ml
+++ b/lib/bap_types/bap_ir.ml
@@ -188,10 +188,12 @@ end = struct
           if is_new sub.tid sub.self.name then
             keep_name tids sub.self.name sub.tid
           else tids) in
-    Array.map news ~f:(fun sub ->
-        let tid' = Map.find_exn tids sub.self.name in
-        if Tid.equal tid' sub.tid then sub
-        else mangle_sub sub)
+    if Array.length news = Map.length tids then news
+    else
+      Array.map news ~f:(fun sub ->
+          let tid' = Map.find_exn tids sub.self.name in
+          if Tid.equal tid' sub.tid then sub
+          else mangle_sub sub)
 
   let empty () = {subs = [| |] ;  paths = Tid.Table.create () }
 


### PR DESCRIPTION
fix https://github.com/BinaryAnalysisPlatform/bap/issues/808

We track every addition of a subroutine to a program by storing names and tids in a table. Every addition replaces previous entries with the same name. When someone requests a result, it's easy to tell if a subroutine name needs in demangling: if a `tid` in the table for this name is differ from a subroutine's one, then other subroutine started to use this name, and we need to demangle current name. The same is true for subroutine aliases.