### PR TITLE
fixes a few bugs in Primus

### DIFF
--- a/lib/bap_primus/bap_primus_interpreter.ml
+++ b/lib/bap_primus/bap_primus_interpreter.ml
@@ -274,7 +274,7 @@ module Make (Machine : Machine) = struct
     Memory.load a.value >>= value >>= fun r ->
     !!on_loaded (a,r) >>| fun () -> r
   and eval_store m a x =
-    eval_exp m >>= fun _ ->
+    eval_storage m >>= fun () ->
     eval_exp a >>= fun a ->
     eval_exp x >>= fun x ->
     !!on_storing a >>= fun () ->
@@ -300,6 +300,9 @@ module Make (Machine : Machine) = struct
     eval_exp x >>= fun x ->
     eval_exp y >>= fun y ->
     concat x y
+  and eval_storage = function
+    | Var _ -> Machine.return ()
+    | mem -> Machine.void (eval_exp mem)
 
   let eval_exp x = eval_exp (Exp.simpl (Exp.normalize x))
 

--- a/lib/bap_primus/bap_primus_interpreter.ml
+++ b/lib/bap_primus/bap_primus_interpreter.ml
@@ -367,8 +367,10 @@ module Make (Machine : Machine) = struct
       Machine.Local.update state (fun s -> {s with curr}) >>= fun () ->
       enter cls curr t >>= fun () ->
       Machine.catch (f t)
-        (fun exn -> leave cls curr t >>= fun () -> Machine.raise exn)
-      >>= fun r ->
+        (fun exn ->
+           leave cls curr t >>= fun () ->
+           cleanup >>= fun () ->
+           Machine.raise exn) >>= fun r ->
       leave cls curr t >>= fun () ->
       cleanup >>= fun () ->
       return r

--- a/lib/bap_primus/bap_primus_interpreter.ml
+++ b/lib/bap_primus/bap_primus_interpreter.ml
@@ -407,7 +407,7 @@ module Make (Machine : Machine) = struct
     | None -> failf "a non-return call returned" ()
 
   let goto cond c = label cond c
-  let ret cond l = label cond l
+  let ret _ _ = Machine.return ()
   let interrupt n  = !!will_interrupt n
 
   let jump cond t = match Jmp.kind t with

--- a/lib/bap_primus/bap_primus_lisp.ml
+++ b/lib/bap_primus/bap_primus_lisp.ml
@@ -516,7 +516,7 @@ module Make(Machine : Machine) = struct
 
         let exec =
           eval_args >>= fun bs ->
-          let args = List.map ~f:snd bs in
+          let args = List.rev_map ~f:snd bs in
           Eval.const Word.b0 >>= fun init ->
           Interp.eval_advices Advice.Before init name args >>= fun _ ->
           Machine.Local.update state ~f:(Vars.push_frame bs) >>= fun () ->

--- a/lib/bap_primus/bap_primus_lisp.ml
+++ b/lib/bap_primus/bap_primus_lisp.ml
@@ -168,7 +168,6 @@ module Interpreter(Machine : Machine) = struct
   module Linker = Bap_primus_linker.Make(Machine)
   module Eval = Bap_primus_interpreter.Make(Machine)
   module Env = Bap_primus_env.Make(Machine)
-  module Mem = Bap_primus_memory.Make(Machine)
   module Value = Bap_primus_value.Make(Machine)
   module Vars = Locals(Machine)
 

--- a/lib/bap_primus/bap_primus_machine.ml
+++ b/lib/bap_primus/bap_primus_machine.ml
@@ -10,16 +10,30 @@ module Observation = Bap_primus_observation
 module type Component = Component
 module type S = Machine
 type nonrec component = component
+module State = Bap_primus_state
+type id = Monad.State.Multi.id
 
 let exn_raised,raise_exn =
   Observation.provide
     ~inspect:(fun exn -> Sexp.Atom (Bap_primus_exn.to_string exn))
     "exception"
 
+let fork,forked =
+  Observation.provide
+    ~inspect:(fun (parent,child) -> Sexp.List [
+        Monad.State.Multi.Id.sexp_of_t parent;
+        Monad.State.Multi.Id.sexp_of_t child;
+      ])
+    "machine-fork"
 
 
-module State = Bap_primus_state
-type id = Monad.State.Multi.id
+let switch,switched =
+  Observation.provide
+    ~inspect:(fun (parent,child) -> Sexp.List [
+        Monad.State.Multi.Id.sexp_of_t parent;
+        Monad.State.Multi.Id.sexp_of_t child;
+      ])
+    "machine-switch"
 
 module Make(M : Monad.S) = struct
   module PE = struct
@@ -35,7 +49,7 @@ module Make(M : Monad.S) = struct
   and state = {
     args    : string array;
     envp    : string array;
-    curr    : unit -> id t;
+    curr    : unit -> unit t;
     proj    : project;
     local   : State.Bag.t;
     global  : State.Bag.t;
@@ -158,9 +172,9 @@ module Make(M : Monad.S) = struct
 
 
   let fork_state () = lifts (SM.fork ())
-  let switch_state id = lifts (SM.switch id)
-  let store_curr k id =
-    lifts (SM.update (fun s -> {s with curr = fun () -> k (Ok id)}))
+  let switch_state id : unit c = lifts (SM.switch id)
+  let store_curr k =
+    lifts (SM.update (fun s -> {s with curr = fun () -> k (Ok ())}))
 
   (* switch_task SM.fork *)
 
@@ -175,19 +189,25 @@ module Make(M : Monad.S) = struct
   let global = SM.global
   let current () = lifts (SM.current ())
 
+  let notify_fork pid =
+    current () >>= fun cid ->
+    Observation.make forked (pid,cid)
+
   let fork () : unit c =
-    current () >>= fun pid ->
-    C.call ~f:(fun ~cc:k -> store_curr k pid >>= fork_state >>= current) >>=
-    switch_state
+    C.call ~f:(fun ~cc:k ->
+        current () >>= fun pid ->
+        store_curr k >>=
+        fork_state >>= fun () ->
+        notify_fork pid)
 
   let switch id : unit c =
-    current () >>= fun cid ->
     C.call ~f:(fun ~cc:k ->
-        store_curr k cid >>= fun () ->
+        current () >>= fun pid ->
+        store_curr k >>= fun () ->
         switch_state id >>= fun () ->
         lifts (SM.get ()) >>= fun s ->
-        s.curr ()) >>=
-    switch_state
+        Observation.make switched (pid,id) >>= fun () ->
+        s.curr ())
 
   let raise exn =
     Observation.make raise_exn exn >>= fun () ->
@@ -204,7 +224,7 @@ module Make(M : Monad.S) = struct
   let init proj args envp = {
     args;
     envp;
-    curr = current;
+    curr = return;
     global = State.Bag.empty;
     local = State.Bag.empty;
     observations = Bap_primus_observation.empty;
@@ -221,7 +241,7 @@ module Make(M : Monad.S) = struct
         (SM.run
            (C.run m (function
                 | Ok _ -> extract @@ fun s -> Ok s.proj
-                | Error err -> extract @@ fun s -> Error err))
+                | Error err -> extract @@ fun _ -> Error err))
            (init proj args envp))
         (fun (r,{proj}) -> match r with
            | Ok _ -> M.return (Normal, proj)

--- a/plugins/primus_greedy/primus_greedy_main.ml
+++ b/plugins/primus_greedy/primus_greedy_main.ml
@@ -47,7 +47,9 @@ module Greedy(Machine : Primus.Machine.S) = struct
       Machine.switch Machine.global
     | Some cid ->
       info "switch to machine %a" Id.pp cid;
-      Machine.switch cid
+      Machine.switch cid >>= fun () ->
+      Eval.halt >>=
+      never_returns
 
 
   let halt () =

--- a/plugins/primus_lisp/lisp/init.lisp
+++ b/plugins/primus_lisp/lisp/init.lisp
@@ -59,8 +59,9 @@
 (defmacro or (x) x)
 
 (defun compare (x y)
-  "(compare X Y) returns 0 if X = Y, -1 if X<Y and +1 if X>Y"
-  (if (< x y) (-1 0) (if (> x y) 1 0)))
+  "(compare X Y) returns 0 if X = Y, a negative value if X<Y
+   and a positive value if X>Y"
+  (- x y))
 
 (defmacro assert (c)
   "(assert COND) terminates program if COND is false"

--- a/plugins/primus_lisp/lisp/memory.lisp
+++ b/plugins/primus_lisp/lisp/memory.lisp
@@ -6,12 +6,12 @@
 
 (defun copy-byte (dst src)
   "(copy-byte DST SRC) copies byte from
-   address SRC to DST."
+   the address SRC to DST."
   (memory-write dst (memory-read src)))
 
 (defmacro copy-byte-shift (dst src)
   "(copy-byte-shift DST SRC) copies byte from
-   DST to SRC and increments SRC and DST."
+   SRC to DST and increments SRC and DST."
   (prog (copy-byte dst src)
         (incr dst src)))
 

--- a/plugins/primus_lisp/lisp/pointers.lisp
+++ b/plugins/primus_lisp/lisp/pointers.lisp
@@ -46,7 +46,10 @@
     x))
 
 (defmacro write-word (t a x)
-  "(write-word T A X) writes the word X of type T to address A"
+  "(write-word T A X) writes the word X of type T to address A
+  returns an address that points to the first byte that follows
+  the just written word.
+  "
   (let ((p a)
         (n (sizeof t))
         (i 0))
@@ -67,5 +70,6 @@
 
 (defmacro array-set (t p n w)
   "(array-set T P N W) sets to W the N-th element of the array of
-   elements of type T, pointed by P"
+   elements of type T, pointed by P. Returns a pointer to the next
+   element"
   (write-word t (ptr+ p n) w))

--- a/plugins/primus_lisp/lisp/simple-memory-allocator.lisp
+++ b/plugins/primus_lisp/lisp/simple-memory-allocator.lisp
@@ -40,7 +40,7 @@
 (defun calloc (n s)
   "allocates memory and initializes it with zero"
   (declare (external "calloc"))
-  (malloc (* n s)))
+  (malloc (* n s))) ; in our implementation malloc zeros memory
 
 
 (defun malloc-heap-size ()

--- a/plugins/primus_lisp/lisp/simple-memory-allocator.lisp
+++ b/plugins/primus_lisp/lisp/simple-memory-allocator.lisp
@@ -19,10 +19,13 @@
   "a byte that will be used to fill guard edges")
 
 
+(defparameter *malloc-zero-sentinel* 0
+  "a pointer that is returned by (malloc 0)")
+
 (defun malloc (n)
   "allocates a memory region of size N"
   (declare (external "malloc"))
-  (if (= n 0) brk
+  (if (= n 0) *malloc-zero-sentinel*
     (if (malloc-will-reach-limit n) 0
       (let ((n (+ n (* 2 *malloc-guard-edges*)))
             (ptr brk)

--- a/plugins/primus_lisp/lisp/string.lisp
+++ b/plugins/primus_lisp/lisp/string.lisp
@@ -9,6 +9,7 @@
       (incr len p))
     len))
 
+
 (defun strcpy (dst src)
   (declare (external "strcpy"))
   (let ((dst dst))
@@ -20,7 +21,7 @@
 (defun strncpy (dst src len)
   (declare (external "strncpy"))
   (let ((dst dst))
-    (while (and len (not (points-to-null dst)))
+    (while (and len (not (points-to-null src)))
       (decr len)
       (copy-byte-shift dst src))
     (memory-write dst 0:8))
@@ -29,7 +30,7 @@
 (defun strdup (src)
   (declare (external "strdup"))
   (let ((dst (malloc (+1 (strlen src)))))
-    (when dst (strcpy dst src))))
+    (and dst (strcpy dst src))))
 
 
 (defun memmove (dst src len)
@@ -84,6 +85,18 @@
   (declare (external "strrchr"))
   (memrchr p c (+ (strlen p) 1)))
 
+
+(defun strpbrk (str set)
+  (declare (external "strpbrk"))
+  (let ((p set) (found 0))
+    (while (and
+            (not (points-to-null p))
+            (not found))
+      (set found (strchr s (memory-read p)))
+      (incr p))
+    found))
+
+
 (defun memset (p c n)
   (declare (external "memset"))
   (let ((p p))
@@ -101,10 +114,18 @@
       (incr p1 p2 i))
     res))
 
+(defun strlen/with-null (s)
+  "returns a length of the string S
+   (including the terminating null character)"
+  (+1 (strlen s)))
+
 (defun strncmp (s1 s2 n)
   (declare (external "strncmp"))
-  (memcmp s1 s2 (min (strlen s1) (strlen s2) n)))
+  (memcmp s1 s2 (min n
+                     (strlen/with-null s1)
+                     (strlen/with-null s2))))
 
 (defun strcmp (s1 s2)
   (declare (external "strcmp"))
-  (memcmp s1 s2 (min (strlen s1) (strlen s2))))
+  (memcmp s1 s2 (min (strlen/with-null s1)
+                     (strlen/with-null s2))))

--- a/plugins/primus_promiscuous/primus_promiscuous_main.ml
+++ b/plugins/primus_promiscuous/primus_promiscuous_main.ml
@@ -127,7 +127,11 @@ module Main(Machine : Primus.Machine.S) = struct
       Machine.current () >>= fun pid ->
       do_fork blk ~child:Machine.return >>= fun id ->
       if id = pid then Machine.return ()
-      else Linker.exec (`tid dst)
+      else
+        Machine.Global.get state >>= fun {forkpoints} ->
+        if Set.mem forkpoints dst
+        then Eval.halt >>= never_returns
+        else Linker.exec (`tid dst)
     | _ -> Machine.return ()
 
   let fork_on_calls blk jmp = match Jmp.kind jmp with

--- a/plugins/primus_promiscuous/primus_promiscuous_main.ml
+++ b/plugins/primus_promiscuous/primus_promiscuous_main.ml
@@ -142,9 +142,12 @@ module Main(Machine : Primus.Machine.S) = struct
     | None -> true
     | Some last -> Term.same def last
 
+  let has_no_def blk = Term.length def_t blk = 0
+
   let step level =
     let open Primus.Pos in
     match level with
+    | Blk {me=blk} when has_no_def blk -> fork blk
     | Def {up={me=blk}; me=def} when is_last blk def ->
       fork blk
     | Jmp {up={me=blk}; me=jmp} -> fork_on_calls blk jmp

--- a/plugins/primus_test/lisp/memcheck-malloc.lisp
+++ b/plugins/primus_test/lisp/memcheck-malloc.lisp
@@ -7,6 +7,9 @@
 (defmethod loaded (ptr)
   (memcheck-access 'malloc ptr))
 
+(defmethod stored (ptr)
+  (memcheck-access 'malloc ptr))
+
 (defmethod call-return (name len ptr)
-  (when (= name 'malloc)
+  (when (and len ptr (= name 'malloc))
     (memcheck-acquire 'malloc ptr len)))

--- a/plugins/primus_test/lisp/memcheck-malloc.lisp
+++ b/plugins/primus_test/lisp/memcheck-malloc.lisp
@@ -1,7 +1,8 @@
 (require memcheck)
 
 (defmethod call (name ptr)
-  (when (and ptr (= name 'free))
+  (when (and ptr (= name 'free)
+             (not (= ptr *malloc-zero-sentinel*)))
     (memcheck-release 'malloc ptr)))
 
 (defmethod loaded (ptr)
@@ -13,3 +14,27 @@
 (defmethod call-return (name len ptr)
   (when (and len ptr (= name 'malloc))
     (memcheck-acquire 'malloc ptr len)))
+
+
+(defmethod call (name dst src len)
+  (when (is-in name 'strncpy 'memmove 'memcpy 'memcmp 'strncmp)
+    (check/both dst src len)))
+
+(defmethod call (name dst src c len)
+  (when (= name 'memccpy)
+    (check/both dst src len)))
+
+(defmethod call-return (name dst len)
+  (when (= name 'strlen)
+    (memcheck-bounds 'malloc dst len)))
+
+(defmethod call (name ptr c len)
+  (when (is-in name 'memchr 'memrchr)
+    (memcheck-bounds 'malloc ptr len)))
+
+
+
+
+(defun check/both (dst src len)
+  (memcheck-bounds 'malloc src len)
+  (memcheck-bounds 'malloc dst len))


### PR DESCRIPTION
I'm sorry for pushing this as a single branch, but it is better to push this to upstream, otherwise I will begin to stockpile this fixes. I will try to prettify my bad behavior with a pretty table of contents below

Bug fixes
=======
- [do not evaluate atomic memory variable](df26135) to prevent type errors;
- [fixes term tear down procedure](114245b) it is still broken, but less than it was;
- [disable call bypassing](a763457) when a call is taken, otherwise we are returning to the same place twice;
- [ignore return statments](0a224d7) the interpreter should just stop at the end of the function and let the caller to continue. Otherwise, we will resume at the caller twice - first when the caller returns and the second time when machine stops. I will later provide some checks for control flow integrity that will verify that we are resuming to the correct destination and some heuristic that will detect return statements, that are not detected as such by our disassembler;
 - [fixed forking on blocks with an empty set of definitions, again](1aa3b07) the previous attempt to fix didn't anticipate that a block without definitions doesn't have definitions ;)
- [fixed parameter order in call and call-return observations for functions linked with Primus](fada6ed) - it was broken by the recent optimization of the frame allocation;

- [fixed some lisp stubs, added some more](0d06846);

Features
=======

- [added the zero-sentinel parameter to malloc](0d06846);
- [Buffer Overflow Checker](a20ea4e);
