### PR TITLE
Add an interface for binnable interval trees

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -953,9 +953,8 @@ module Std : sig
 
     (**  Binable Abstract Interval.
 
-         An extension of the Interval signature that supports the
-         necessary extensions to be serializable as a
-         {{!Value}universal value}.
+         An extension of the Interval signature with the
+         Binable interface.
     *)
     module type Interval_binable = sig
       type t [@@deriving bin_io, compare, sexp]
@@ -965,9 +964,8 @@ module Std : sig
 
     (** Binable Interval Tree.
 
-        An extension of the Interval tree signature that supports
-        the necessary extensions to be serializable as a
-        {{!Value}universal value}.
+        An extension of the Interval tree signature with the
+        Binable interface.
     *)
     module type S_binable = sig
       type 'a t [@@deriving bin_io, compare, sexp]

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -950,6 +950,38 @@ module Std : sig
     module Make(Interval : Interval) : S
       with type key := Interval.t
        and type point := Interval.point
+
+    (**  Binable Abstract Interval.
+
+         An extension of the Interval signature that supports the
+         necessary extensions to be serializable as a
+         {{!Value}universal value}.
+    *)
+    module type Interval_binable = sig
+      type t [@@deriving bin_io, compare, sexp]
+      type point [@@deriving bin_io, compare, sexp]
+      include Interval with type t := t and type point := point
+    end
+
+    (** Binable Interval Tree.
+
+        An extension of the Interval tree signature that supports
+        the necessary extensions to be serializable as a
+        {{!Value}universal value}.
+    *)
+    module type S_binable = sig
+      type 'a t [@@deriving bin_io, compare, sexp]
+      include S with type 'a t := 'a t
+    end
+
+    (** [Make_binable(Interval)] create an abstract interval tree data type
+        that uses abstract [Interval] and can be serialized as a
+        {{!Value}universal value}.
+    *)
+    module Make_binable(Interval : Interval_binable) : S_binable
+      with type key := Interval.t
+       and type point := Interval.point
+
   end
 
   type value               [@@deriving bin_io, compare, sexp]

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -973,8 +973,8 @@ module Std : sig
     end
 
     (** [Make_binable(Interval)] create an abstract interval tree data type
-        that uses abstract [Interval] and can be serialized as a
-        {{!Value}universal value}.
+        that uses abstract [Interval] and can be serialized via the Binable
+        interface.
     *)
     module Make_binable(Interval : Interval_binable) : S_binable
       with type key := Interval.t

--- a/lib/bap_types/bap_interval_tree.ml
+++ b/lib/bap_types/bap_interval_tree.ml
@@ -315,3 +315,92 @@ module Make(Interval : Interval) = struct
   let fold_result = C.fold_result
 end
 
+module type Interval_binable = sig
+  type t [@@deriving bin_io, compare, sexp]
+  type point [@@deriving bin_io, compare, sexp]
+  include Interval with type t := t and type point := point
+end
+
+module type S_binable = sig
+  type 'a t [@@deriving bin_io, compare, sexp]
+  include S with type 'a t := 'a t
+end
+
+module Make_binable(Interval : Interval_binable) = struct
+  module Base = Make(Interval)
+
+  type key = Interval.t [@@deriving sexp, compare, bin_io]
+
+  module Point = Comparable.Make_plain(struct
+      type t = Interval.point [@@deriving compare, sexp, bin_io]
+    end)
+
+  type point = Interval.point [@@deriving compare, sexp, bin_io]
+
+ type +'a node = 'a Base.node = {
+    lhs : 'a node option;
+    rhs : 'a node option;
+    key : key;
+    data : 'a;
+    height : int;
+    greatest : point;
+    least : point;
+  } [@@deriving fields, sexp, compare, bin_io]
+
+  type +'a t = 'a node option [@@deriving sexp, compare, bin_io]
+
+  let height = Base.height
+  let least = Base.least
+  let greatest = Base.greatest
+  let empty = Base.empty
+  let bound = Base.bound
+  let create = Base.create
+  let singleton = Base.singleton
+  let min_binding = Base.min_binding
+  let max_binding = Base.max_binding
+  let bal = Base.bal
+  let add = Base.add
+  let is_inside = Base.is_inside
+  let lookup = Base.lookup
+  let is_dominated = Base.is_dominated
+  let has_intersections = Base.has_intersections
+  let can't_be_in_tree = Base.can't_be_in_tree
+  let can't_be_dominated = Base.can't_be_dominated
+  let query = Base.query
+  let dominators = Base.dominators
+  let intersections = Base.intersections
+  let dominates = Base.dominates
+  let intersects = Base.intersects
+  let contains = Base.contains
+  let map = Base.map
+  let mapi = Base.mapi
+  let remove_min_binding = Base.remove_min_binding
+  let splice = Base.splice
+  let mem_equal = Base.mem_equal
+  let remove = Base.remove
+  let remove_if = Base.remove_if
+  let remove_intersections = Base.remove_intersections
+  let remove_dominators = Base.remove_dominators
+  let filter_mapi = Base.filter_mapi
+  let filter_map = Base.filter_map
+  let filter = Base.filter
+  let to_sequence = Base.to_sequence
+  let fold = Base.fold
+  let count = Base.count
+  let sum = Base.sum
+  let iter = Base.iter
+  let length = Base.length
+  let is_empty = Base.is_empty
+  let exists = Base.exists
+  let mem = Base.mem
+  let for_all = Base.for_all
+  let find_map = Base.find_map
+  let find = Base.find
+  let to_list = Base.to_list
+  let to_array = Base.to_array
+  let min_elt = Base.min_elt
+  let max_elt = Base.max_elt
+  let fold_until = Base.fold_until
+  let fold_result = Base.fold_result
+
+end

--- a/lib/bap_types/bap_interval_tree.ml
+++ b/lib/bap_types/bap_interval_tree.ml
@@ -331,10 +331,6 @@ module Make_binable(Interval : Interval_binable) = struct
 
   type key = Interval.t [@@deriving sexp, compare, bin_io]
 
-  module Point = Comparable.Make_plain(struct
-      type t = Interval.point [@@deriving compare, sexp, bin_io]
-    end)
-
   type point = Interval.point [@@deriving compare, sexp, bin_io]
 
  type +'a node = 'a Base.node = {
@@ -349,58 +345,8 @@ module Make_binable(Interval : Interval_binable) = struct
 
   type +'a t = 'a node option [@@deriving sexp, compare, bin_io]
 
-  let height = Base.height
-  let least = Base.least
-  let greatest = Base.greatest
-  let empty = Base.empty
-  let bound = Base.bound
-  let create = Base.create
-  let singleton = Base.singleton
-  let min_binding = Base.min_binding
-  let max_binding = Base.max_binding
-  let bal = Base.bal
-  let add = Base.add
-  let is_inside = Base.is_inside
-  let lookup = Base.lookup
-  let is_dominated = Base.is_dominated
-  let has_intersections = Base.has_intersections
-  let can't_be_in_tree = Base.can't_be_in_tree
-  let can't_be_dominated = Base.can't_be_dominated
-  let query = Base.query
-  let dominators = Base.dominators
-  let intersections = Base.intersections
-  let dominates = Base.dominates
-  let intersects = Base.intersects
-  let contains = Base.contains
-  let map = Base.map
-  let mapi = Base.mapi
-  let remove_min_binding = Base.remove_min_binding
-  let splice = Base.splice
-  let mem_equal = Base.mem_equal
-  let remove = Base.remove
-  let remove_if = Base.remove_if
-  let remove_intersections = Base.remove_intersections
-  let remove_dominators = Base.remove_dominators
-  let filter_mapi = Base.filter_mapi
-  let filter_map = Base.filter_map
-  let filter = Base.filter
-  let to_sequence = Base.to_sequence
-  let fold = Base.fold
-  let count = Base.count
-  let sum = Base.sum
-  let iter = Base.iter
-  let length = Base.length
-  let is_empty = Base.is_empty
-  let exists = Base.exists
-  let mem = Base.mem
-  let for_all = Base.for_all
-  let find_map = Base.find_map
-  let find = Base.find
-  let to_list = Base.to_list
-  let to_array = Base.to_array
-  let min_elt = Base.min_elt
-  let max_elt = Base.max_elt
-  let fold_until = Base.fold_until
-  let fold_result = Base.fold_result
+  include (Base : S with type key := key
+                     and type point := point
+                     and type 'a t := 'a t)
 
 end

--- a/lib/bap_types/bap_interval_tree.mli
+++ b/lib/bap_types/bap_interval_tree.mli
@@ -41,3 +41,18 @@ end
 module Make(Interval : Interval) : S 
   with type key := Interval.t 
    and type point := Interval.point
+
+module type Interval_binable = sig
+  type t [@@deriving bin_io, compare, sexp]
+  type point [@@deriving bin_io, compare, sexp]
+  include Interval with type t := t and type point := point
+end
+
+module type S_binable = sig
+  type 'a t [@@deriving bin_io, compare, sexp]
+  include S with type 'a t := 'a t
+end
+
+module Make_binable(Interval : Interval_binable) : S_binable
+  with type key := Interval.t
+   and type point := Interval.point


### PR DESCRIPTION
Add an interface and `Make_binable` functor for binable interval trees. This allows interval trees to be serialized and used as universal values (e.g. in term attributes).