### PR TITLE
intoduces a dependency between callsites and abi passes

### DIFF
--- a/plugins/callsites/callsites_main.ml
+++ b/plugins/callsites/callsites_main.ml
@@ -102,4 +102,4 @@ let () =
     `S "SEE ALSO";
     `P "$(b,bap-plugin-api)(1)"
   ];
-  Config.when_ready (fun _ -> Project.register_pass main)
+  Config.when_ready (fun _ -> Project.register_pass ~deps:["abi"] main)


### PR DESCRIPTION
Disclaimer
----------

I was really reluctant since the very beginning to introduce this
dependency, since we shouldn't depend on implementations but on
abstractions, but so far it looks like the easy solution, that, I
hope, won't last too long.

The Problem
-----------

`bap ./exe --taint-reg=malloc_result` may or may not work, depending
on the order of pass invocations. The root of the problem is that the
taint plugin depends on the callsites plugin, that requires the
argument information to be present in the subroutine
definitions. Since, the `abi` pass is an autorun pass it is aplied
before all other passes, including the `callsites` pass. However,
since for the better user experience, (haha) we decided to mark
the `taint` pass as an autorun pass, it is also run in the autorun
phase along all of its dependencies. So, it is quite possible that it
will be run before the abi pass.

The Solution
------------

I've added the dependency from the `abi` pass and altough I'm
insisting that we shouldn't depend on implementations, but on
abstractions, we don't have a better solution. Also `abi` pass
became an abstraction de-facto in bap, as it is actually a pass
that has its own pipeline of passes. We may devise a better solution
later, as currently @gitoleg is working on a generic solution with
services and service providers that will allow us to build right
dependencies between our analyses.