### PR TITLE
Add an `eval_cond` observation to allow observing non-taken conditionals

### DIFF
--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -812,10 +812,17 @@ module Std : sig
 
 
       (** [jumping (cond,dest)] happens just before a jump to [dest]
-          is taken under the condition [cond].
+          is taken under the specified condition [cond].
+          Note: [cond] is always [true]
 
           @since 1.5.0 *)
       val jumping : (value * value) observation
+
+      (** [eval_cond v] occurs every time the [cond] part of a jump is
+          evaluated.
+
+          @since 1.5.0 *)
+      val eval_cond : value observation
 
       (** [undefined x] happens when a computation produces an
           undefined value [x].  *)

--- a/lib/bap_primus/bap_primus_interpreter.ml
+++ b/lib/bap_primus/bap_primus_interpreter.ml
@@ -96,6 +96,9 @@ let undefined,on_undefined =
 let jumping,will_jump =
   Observation.provide ~inspect:sexp_of_values "jumping"
 
+let eval_cond,on_cond =
+  Observation.provide ~inspect:sexp_of_value "eval_cond"
+
 
 let results r op = Sexp.List [op; sexp_of_value r]
 
@@ -441,7 +444,8 @@ module Make (Machine : Machine) = struct
       interrupt n >>= fun () ->
       Code.exec (`tid r)
 
-  let jmp t = eval_exp (Jmp.cond t) >>| fun ({value} as cond) ->
+  let jmp t = eval_exp (Jmp.cond t) >>= fun ({value} as cond) ->
+    !!on_cond cond >>| fun () ->
     Option.some_if (Word.is_one value) (cond,t)
   let jmp = term normal jmp_t jmp
 

--- a/lib/bap_primus/bap_primus_interpreter.mli
+++ b/lib/bap_primus/bap_primus_interpreter.mli
@@ -15,6 +15,7 @@ val read : (var * value) observation
 val writing : var observation
 val written : (var * value) observation
 val jumping : (value * value) observation
+val eval_cond : value observation
 val undefined : value observation
 val const : value observation
 

--- a/plugins/primus_lisp/primus_lisp_main.ml
+++ b/plugins/primus_lisp/primus_lisp_main.ml
@@ -90,6 +90,8 @@ module Signals(Machine : Primus.Machine.S) = struct
         {|(written V X) is emited when X is written to V|};
       signal pc_change word one
         {|(pc-change PC) is emited when PC is updated|};
+      signal eval_cond value one
+        {|(eval_cond V) is emitted after evaluating a conditional to V|};
       signal jumping (value,value) pair
         {|(jumping C D) is emited before jump to D occurs under the
           condition C|};


### PR DESCRIPTION
The `jumping` observation allows for observing the taken conditionals
as well as the jump destination. This extra observation allows
observing all conditions that were evaluated up until the taken branch
(including the false ones). Conditions in branches _after_ the taken
branch will not be observed.