### PR TITLE
Rename Solution init value to default. Add Solution.derive

### DIFF
--- a/lib/graphlib/graphlib.mli
+++ b/lib/graphlib/graphlib.mli
@@ -612,9 +612,9 @@ module Std : sig
     type ('n,'d) t
 
 
-    (** [create constraints init] creates an initial approximation of a
-        solution. The [init] parameters defines the initial value of
-        all variables unspecified in the initial constraint.
+    (** [create constraints default] creates an initial approximation of a
+        solution. The [default] parameter defines the default value of
+        all variables unspecified in the initial constraints.
 
         @param constraints a finite mapping from variables to their
         value approximations.
@@ -623,7 +623,7 @@ module Std : sig
 
         - [not(is_fixpoint s)]
         - [iterations s = 0]
-        - [get s x = constraints[x] if x in constraints else init]
+        - [get s x = constraints[x] if x in constraints else default]
     *)
     val create : ('n,'d,_) Map.t -> 'd -> ('n,'d) t
 
@@ -632,6 +632,12 @@ module Std : sig
         made to obtain the current solution.  *)
     val iterations : ('n,'d) t -> int
 
+    (** [default s] return the default value assigned to all variables
+        not in the internal finite mapping. This is usually a bottom
+        or top value, depending on whether iteration increases or
+        decreases.
+    *)
+    val default : ('n,'d) t -> 'd
 
     (** [is_fixpoint s] is [true] if the solution is a fixed point
         solution, i.e., is a solution that stabilizes the system of
@@ -640,6 +646,13 @@ module Std : sig
 
     (** [get s x] returns a value of [x].  *)
     val get : ('n,'d) t -> 'n -> 'd
+
+    (** [derive s ~f default] creates a new solution from an old one
+        with a new [default] and where for each node [n] in [s]'s finite
+        map, if [f n (get s n) = Some v] then [n] maps to [v].
+    *)
+    val derive : ('n,'d) t -> f:('n -> 'd -> 'a option) -> 'a -> ('n,'a) t
+
   end
 
 

--- a/lib/graphlib/graphlib_graph.ml
+++ b/lib/graphlib/graphlib_graph.ml
@@ -1120,12 +1120,7 @@ module Fixpoint = struct
 
   let derive (Solution s) ~f default =
     let f ~key ~data = f key data in
-    Solution {
-      steps = s.steps;
-      iters = s.iters;
-      default;
-      approx = Map.filter_mapi ~f s.approx;
-    }
+    create (Map.filter_mapi ~f s.approx) default
 
   type ('a,'b) step =
     | Step of 'a

--- a/lib/graphlib/graphlib_intf.ml
+++ b/lib/graphlib/graphlib_intf.ml
@@ -118,6 +118,8 @@ module type Solution = sig
   type ('n,'d) t
   val create : ('n,'d,_) Map.t -> 'd -> ('n,'d) t
   val iterations : ('n,'d) t -> int
+  val default : ('n,'d) t -> 'd
   val is_fixpoint : ('n,'d) t -> bool
   val get : ('n,'d) t -> 'n -> 'd
+  val derive : ('n,'d) t -> f:('n -> 'd -> 'a option)  -> 'a -> ('n,'a) t
 end


### PR DESCRIPTION
Change the naming convention from `init` to `default` for default values in `Solution.t`s and expose this via a `Solution.default` getter function. Implement a `Solution.derive` function that allows for creating new `Solution.t`s from old ones.