### PR TITLE
Fix function names in docstrings

### DIFF
--- a/plugins/primus_taint/primus_taint_main.ml
+++ b/plugins/primus_taint/primus_taint_main.ml
@@ -145,12 +145,12 @@ module Setup(Machine : Primus.Machine.S) = struct
         (module GetIndirect);
 
       def "taint-sanitize-direct" (tuple [a; b] @-> c)
-        "(taint-get-indirect K X) removes any direct taint of the kind
+        "(taint-sanitize-direct K X) removes any direct taint of the kind
         K that is directly associated with the value X"
         (module SanitizeDirect);
 
       def "taint-sanitize-indirect" (tuple [a; b] @-> c)
-        "(taint-get-indirect K X) removes any direct taint of the kind
+        "(taint-sanitize-indirect K X) removes any direct taint of the kind
         K that is indirectly associated with the value X"
         (module SanitizeIndirect);
 


### PR DESCRIPTION
Fixes the function names in two documentation strings that incorrectly refer to another function.