### PR TITLE
adds traps for memory and division operations

### DIFF
--- a/lib/bap_primus/bap_primus_interpreter.ml
+++ b/lib/bap_primus/bap_primus_interpreter.ml
@@ -203,7 +203,7 @@ let () =
 
 
 let division_by_zero_handler = "__primus_division_by_zero_handler"
-let pagefault_handler =  "__primus_pagefault_hanlder"
+let pagefault_handler =  "__primus_pagefault_handler"
 
 
 module Make (Machine : Machine) = struct

--- a/lib/bap_primus/bap_primus_interpreter.mli
+++ b/lib/bap_primus/bap_primus_interpreter.mli
@@ -5,6 +5,9 @@ open Bap_primus_types
 val pc_change : addr observation
 val halting : unit observation
 val interrupt : int observation
+val division_by_zero : unit observation
+val segfault : addr observation
+val pagefault : addr observation
 
 val loading : value observation
 val loaded : (value * value) observation
@@ -54,6 +57,12 @@ val leave_jmp : jmp term observation
 
 
 type exn += Halt
+type exn += Division_by_zero
+type exn += Segmentation_fault of addr
+
+val division_by_zero_handler : string
+val pagefault_handler : string
+
 
 module Make (Machine : Machine) : sig
   type 'a m = 'a Machine.t

--- a/lib/bap_primus/bap_primus_linker.mli
+++ b/lib/bap_primus/bap_primus_linker.mli
@@ -13,6 +13,10 @@ type exn += Unbound_name of name
 
 val exec : name observation
 val will_exec : name statement
+val unresolved : name observation
+
+val unresolved_handler : string
+
 module Trace : sig
   val call : (string * value list) observation
   val call_entered : (string * value list) statement
@@ -25,6 +29,7 @@ end
 
 type code = (module Code)
 
+
 module Name : Regular.S with type t = name
 
 module Make(Machine : Machine) : sig
@@ -35,6 +40,9 @@ module Make(Machine : Machine) : sig
     ?name:string ->
     ?tid:tid ->
     code -> unit m
+
+  val lookup : name -> code option m
+  val unlink : name -> unit m
 
   val exec : name -> unit m
 

--- a/lib/bap_primus/bap_primus_memory.mli
+++ b/lib/bap_primus/bap_primus_memory.mli
@@ -3,7 +3,7 @@ open Bap_primus_types
 
 module Generator = Bap_primus_generator
 
-type exn += Segmentation_fault of addr
+type exn += Pagefault of addr
 
 module Make(Machine : Machine) : sig
 

--- a/plugins/primus_promiscuous/primus_promiscuous_main.ml
+++ b/plugins/primus_promiscuous/primus_promiscuous_main.ml
@@ -76,6 +76,18 @@ let assumptions blk =
         | Bil.Int _ -> assns, (neg assns) :: assms
         | _ -> failwith "Not in TCF") |> snd
 
+
+module TrapPageFault(Machine : Primus.Machine.S) = struct
+  module Code = Primus.Linker.Make(Machine)
+  let exec =
+    Code.unlink (`symbol Primus.Interpreter.pagefault_handler)
+end
+
+module DoNothing(Machine : Primus.Machine.S) = struct
+  let exec = Machine.return ()
+end
+
+
 module Main(Machine : Primus.Machine.S) = struct
   open Machine.Syntax
   module Eval = Primus.Interpreter.Make(Machine)
@@ -157,20 +169,30 @@ module Main(Machine : Primus.Machine.S) = struct
     | _ -> Machine.return ()
 
 
-  let map addr =
-    Mem.allocate ~generator:Primus.Generator.Random.Seeded.byte addr 1
+  let default_page_size = 4096
+  let default_generator = Primus.Generator.Random.Seeded.byte
 
-  let make_loadable value =
-    let addr = Primus.Value.to_word value in
-    Mem.is_mapped addr >>= function
-    | false -> map addr
-    | true -> Machine.return ()
+  let map_page already_mapped addr =
+    let rec map len =
+      let last = Addr.nsucc addr (len - 1) in
+      already_mapped last >>= function
+      | true -> map (len / 2)
+      | false ->
+        Mem.allocate ~generator:default_generator addr len in
+    map default_page_size
 
-  let make_writable value =
-    let addr = Primus.Value.to_word value in
-    Mem.is_writable addr >>= function
-    | false -> map addr
-    | true -> Machine.return ()
+  let trap () =
+    Linker.link ~name:Primus.Interpreter.pagefault_handler
+      (module TrapPageFault)
+
+  let pagefault x =
+    Mem.is_mapped x >>= function
+    | false -> map_page Mem.is_mapped x >>= trap
+    | true ->
+      Mem.is_writable x >>= function
+      | false -> map_page Mem.is_writable x >>= trap
+      | true -> Machine.return ()
+
 
   let mark_visited blk =
     Machine.Global.update state ~f:(fun t -> {
@@ -190,10 +212,19 @@ module Main(Machine : Primus.Machine.S) = struct
     Machine.Seq.iter ~f:(fun var ->
         Env.add var (Primus.Generator.static 0))
 
+  let ignore_division_by_zero =
+    Linker.link ~name:Primus.Interpreter.division_by_zero_handler
+      (module DoNothing)
+
+  let ignore_unresolved_names =
+    Linker.link ~name:Primus.Linker.unresolved_handler
+      (module DoNothing)
+
   let init () = Machine.sequence [
       setup_vars;
-      Primus.Interpreter.loading >>> make_loadable;
-      Primus.Interpreter.storing >>> make_writable;
+      ignore_division_by_zero;
+      ignore_unresolved_names;
+      Primus.Interpreter.pagefault >>> pagefault;
       Primus.Interpreter.leave_pos >>> step;
       Primus.Interpreter.leave_blk >>> mark_visited;
     ]


### PR DESCRIPTION
Division by zero as well as faulty memory operations may terminate the
Primus Machine. Previously we were just terminating it with a specific
exception. However, this exceptions should actually be represented by
an CPU/ABI-specific interrupt or trap. The proposed implementation
provides a mechanism that allows:

- trap the exception and translate it to a machine specific
  interrupt;

- ignore or fix it;

- catch it on a low-level.

The mechanism is based on the same idea as in the Linker that used the
primus_unresolved_handler to trap unresolved names. For each trap we
provide a corresponding observation, that could be used to install the
trap. The trap itself, is a special name, that could be linked (either
on a permanent basis, or from the observation). If the trap hanlder is
assigned, then it is invoked. Concrete behavior depends on a
particular trap, e.g.,

- for linker trap - the hanlder is invoked instead of the missing code;
- for the division by zero - if the handler returns
  then the result is undefined;
- for memory fault - the trap should fix the problem or terminate.

We also introduce the Pagefault exception, to represent memory
traps. We keep segfault as a non-maskable (non-preventable)
exception.

In addition, we have provided several new operations in the Linker
interface:
- unlink: for code unlinking, useful for removing traps
- lookup: useful for restoring other's traps

As a showcase, we also reimplemented some parts of the promiscuous
mode. Now we use the pagefault trap to prevent segmentation
faults. Also the fixing is more efficient as instead of mapping one
byte pages, we are mapping pages with size of up to 4k.

Besides others, this commit will also provide a fix for #839.