### PR TITLE
Remove special handling of jumps/cpuexns during linearization.

### DIFF
--- a/lib/bap_sema/bap_sema_lift.ml
+++ b/lib/bap_sema/bap_sema_lift.ml
@@ -92,8 +92,6 @@ let linear_of_stmt ?addr return insn stmt : linear list =
       [Instr (`Def ~@(Ir_def.create lhs rhs))]
     | Bil.If (cond, [],[]) -> []
     | Bil.If (cond,[],no) -> linearize Bil.(If (lnot cond, no,[]))
-    | Bil.If (cond,[Bil.CpuExn n],[]) -> cpuexn ~cond n
-    | Bil.If (cond,[Bil.Jmp exp],[]) -> [jump ~cond exp]
     | Bil.If (cond,yes,[]) ->
       let yes_label = Tid.create () in
       let tail = Tid.create () in


### PR DESCRIPTION
This is necessary for correctly handling control flow in BIL
containing the above patterns. One example explaining why this
is necessary is the following:

```
if false {
  CPUExn 10
}
x := 5
```

The above would be translated to:

```
    goto %takeoff
landing:
    goto %next
takeoff:
    when false cpuexn N return %landing
next:
     x := 5
```

Note that the `takeoff` basic block is missing the
possible control flow transition to the `next` block.

By removing these special cases jmps and cpuexn are handled as
normal statements within an `if` block.