### PR TITLE
Fix mem types

### DIFF
--- a/lib/bap_types/bap_helpers.ml
+++ b/lib/bap_types/bap_helpers.ml
@@ -228,7 +228,7 @@ module Type = struct
     | Type.Imm _,_,_ -> Type_error.expect_mem ()
     | Type.Mem (s,_) as t, Type.Imm s', Type.Imm u ->
       let s = Size.in_bits s in
-      if s < s'
+      if s <> s'
       then Type_error.expect (Type.Imm s) ~got:(Type.Imm s')
       else if is_error (Size.of_int u)
       then Type_error.wrong_cast ()

--- a/lib/bap_types/bap_helpers.ml
+++ b/lib/bap_types/bap_helpers.ml
@@ -680,6 +680,7 @@ module Normalize = struct
       | Var v -> Var.typ v
       | Store (m,_,_,_,_) -> infer m
       | Ite (_,x,y) -> both x y
+      | Unknown (_,t) -> t
       | _ -> invalid_arg "type error"
     and both x y =
       match infer x, infer y with


### PR DESCRIPTION
Fixes issues [#846](https://github.com/BinaryAnalysisPlatform/bap/issues/846) and [#843](https://github.com/BinaryAnalysisPlatform/bap/issues/843) by using the right comparison and adding a necessary case to a simplified type inference function.