### PR TITLE
ite-handling in Primus and allowing the user to disable ite-hoisting.

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -3653,8 +3653,8 @@ module Std : sig
     *)
     val is_referenced : var -> t -> bool
 
-    (** [normalize ?normalize_exp xs] produces a normalized BIL program
-        with the same[^1] semantics but in the BIL normalized
+    (** [normalize ?keep_ites ?normalize_exp xs] produces a normalized BIL
+        program with the same[^1] semantics but in the BIL normalized
         form (BNF). There are two normalized forms, both described
         below. The first form (BNF1) is more readable, the second form
         (BNF2) is more strict, but sometimes yields a code, that is hard
@@ -3721,8 +3721,12 @@ module Std : sig
         @param normalize_exp (defaults to [false]) if set to [true] then
         the returned program will be in BNF2.
 
+        @param keep_ites (defaults to [false]) if set to [true] then
+        the returned program will preserve ite expressions.
+
         @since 1.3 *)
-    val normalize : ?normalize_exp:bool -> stmt list -> stmt list
+    val normalize : ?keep_ites:bool -> ?normalize_exp:bool
+       -> stmt list -> stmt list
 
     (** [simpl ?ignore xs] recursively applies [Exp.simpl] and also
         simplifies [if] and [while] expressions with statically known

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -851,6 +851,11 @@ module Std : sig
           and produces [z] as a result.*)
       val concat : ((value * value) * value) observation
 
+      (** [ite ((cond, yes, no), res)] happens after the ite expression
+          that corresponds to ite([cond], [yes], [no]) is evaluated
+          to [res]. *)
+      val ite : ((value * value * value) * value) observation
+
       (** an identifier of a term that will be executed next.   *)
       val enter_term : tid observation
 

--- a/lib/bap_primus/bap_primus_interpreter.mli
+++ b/lib/bap_primus/bap_primus_interpreter.mli
@@ -27,6 +27,7 @@ val unop : ((unop * value) * value) observation
 val cast : ((cast * int * value) * value) observation
 val extract : ((int * int * value) * value) observation
 val concat : ((value * value) * value) observation
+val ite : ((value * value * value) * value) observation
 
 
 val enter_exp : exp observation

--- a/lib/bap_types/bap_helpers.ml
+++ b/lib/bap_types/bap_helpers.ml
@@ -1092,8 +1092,9 @@ module Normalize = struct
           hoist_stores (Move (v,store) :: substitute store (Var v) [stmt])
     end) bil
 
-  let bil ?normalize_exp:(ne=false) xs =
+  let bil ?(keep_ites=false) ?normalize_exp:(ne=false) xs =
     let normalize_exp = if ne then normalize_exp else ident in
+    let split_ite = if keep_ites then ident else split_ite in
     let rec run xs =
       List.concat_map ~f:hoist_non_generative_expressions xs |>
       normalize_conditionals |>

--- a/lib/bap_types/bap_helpers.mli
+++ b/lib/bap_types/bap_helpers.mli
@@ -21,7 +21,7 @@ val prune_unreferenced :
   ?virtuals:bool ->
   bil -> bil
 
-val normalize : ?normalize_exp:bool -> bil -> bil
+val normalize : ?keep_ites:bool -> ?normalize_exp:bool -> bil -> bil
 val normalize_negatives : bil -> bil
 val substitute : exp -> exp -> bil -> bil
 val substitute_var : var -> exp -> bil -> bil
@@ -106,7 +106,8 @@ module Stmt : sig
   val is_referenced : var -> stmt -> bool
   val fixpoint : (stmt -> stmt) -> (stmt -> stmt)
   val free_vars : stmt -> Bap_var.Set.t
-  val normalize : ?normalize_exp:bool -> stmt list -> stmt list
+  val normalize : ?keep_ites:bool -> ?normalize_exp:bool
+    -> stmt list -> stmt list
 end
 
 


### PR DESCRIPTION
The semantics of ite evaluation in Primus follow the latest updates
in the BIL specification:

   https://github.com/BinaryAnalysisPlatform/bil/pull/9

The extra option in the BIL normalization function enables the
user to preserve ite if that is desirable.