### PR TITLE
optimizes reconstructor, symtab, and brancher performance

### DIFF
--- a/lib/bap_disasm/bap_disasm_brancher.ml
+++ b/lib/bap_disasm/bap_disasm_brancher.ml
@@ -32,9 +32,17 @@ let kind_of_branches t f =
   | `Fall,`Fall -> `Fall
   | _           -> `Cond
 
+let has_jumps =
+  Bil.exists
+    (object
+      inherit [unit] Stmt.finder
+      method! enter_jmp _ r = r.return (Some ())
+    end)
 
 let rec dests_of_bil bil : dests =
-  Bil.fold_consts bil |> List.concat_map ~f:dests_of_stmt
+  if has_jumps bil then
+    Bil.fold_consts bil |> List.concat_map ~f:dests_of_stmt
+  else []
 and dests_of_stmt = function
   | Bil.Jmp (Bil.Int addr) -> [Some addr,`Jump]
   | Bil.Jmp (_) -> [None, `Jump]

--- a/lib/bap_disasm/bap_disasm_symtab.ml
+++ b/lib/bap_disasm/bap_disasm_symtab.ml
@@ -56,20 +56,18 @@ let filter_mem mem name entry =
   Memmap.filter mem ~f:(fun (n,e,_) ->
       not(String.(name = n) || Block.(entry = e)))
 
-let remove t (name,entry,_) : t = {
-  names = Map.remove t.names name;
-  addrs = Map.remove t.addrs (Block.addr entry);
-  memory = filter_mem t.memory name entry;
-}
-
-let filter t ((name,entry,_ ) as fn) =
-  if Map.mem t.names name || Map.mem t.addrs (Block.addr entry) then
-    remove t fn
+let remove t (name,entry,_) : t =
+  if Map.mem t.addrs (Block.addr entry) then
+    {
+      names = Map.remove t.names name;
+      addrs = Map.remove t.addrs (Block.addr entry);
+      memory = filter_mem t.memory name entry;
+    }
   else t
 
 let add_symbol t (name,entry,cfg) : t =
   let data = name,entry,cfg in
-  let t = filter t data in
+  let t = remove t data in
   {
     addrs = Map.add t.addrs ~key:(Block.addr entry) ~data;
     names = Map.add t.names ~key:name ~data;


### PR DESCRIPTION
This PR rectifies reconstructor, symtab and brancher with a respect to performance, without addition of a new behavior or breaking of an existing one.

Changes:
### reconstructor
Rewrote it and reduced the number of iterations over nodes/edges of cfg.
The main point is how we build the `filtered` cfg. Previously, we did like the following: take all nodes, add them ony-by-one to an empty cfg. So it was an iteration over all nodes of cfg. Then iterate over all edges, and add each of them if their's destination block is not root. 
Also, we did one more iteration over all nodes in `find_calls` function.

So what I'm proposing here is just to iterate once over the whole cfg to find all roots. and then build the `filtered` cfg by iterating over the roots and removing their input edges.

### symtab
There was a bit inefficient implementation of `add_symbol` function, so every addition of a symbol called filter on the whole table, although there were enough info to reduce such calls.
Concerning details. Every time we add symbol to the symtab we also remember it's name and address of an entry block. Also we filter `memmap` from previously added entries,
that have same name and entry block. But, as we remembered the address of the
entry block and the name of the symbol, we can check, if `memmap` needed to be
filtered without event touching it! 

### bracnher
Just a small fix that checks if an instruction has jumps at all before the subsequent call of `fold_consts` that could be heavy for some of the instructions