### PR TITLE
fixes the bug that was producing unreachable blocks

### DIFF
--- a/lib/bap_disasm/bap_disasm_reconstructor.ml
+++ b/lib/bap_disasm/bap_disasm_reconstructor.ml
@@ -50,8 +50,8 @@ let reconstruct name roots prog =
           else add cfg' (Cfg.Edge.dst edge)) in
   Set.fold entries ~init:Symtab.empty ~f:(fun tab entry ->
       let name = name (Block.addr entry) in
-      let fng = add Cfg.empty entry in
-      Symtab.add_symbol tab (name,entry,fng))
+      let cfg = add Cfg.empty entry in
+      Symtab.add_symbol tab (name,entry,cfg))
 
 let of_blocks syms =
   let reconstruct (cfg : cfg) =


### PR DESCRIPTION
The root of the problem was the rooter, which was producing roots that were pointing in the middle of an instruction. Since the disassembler was cutting a block on the start of each root this led to an incorrect CFG with non-connected components. 

It's fine for a rooter to produce such garbage, however, the disassembler shall not take rooter's output as granted. The new implementation keeps track of the set of addresses that start valid instructions and once this set is fully discovered removes those roots that do not belong to this set. 