### PR TITLE
deprecates X86_env.nums in correct place

### DIFF
--- a/lib/x86_cpu/x86_env.mli
+++ b/lib/x86_cpu/x86_env.mli
@@ -148,9 +148,9 @@ module type ModeVars = sig
       Due to a legacy issues r.(0) -> r8, r.(1) -> r8, ... *)
   val r : var array
 
-  [@@deprecated "[since 2018-01] user `r` instead"]
-  (** Legacy version of the `r` array, use `r` instead. *)
+  (** Legacy version of the `r` array. *)
   val nums : var array
+  [@@deprecated "[since 2018-01] use `r` instead"]
 
   (** array of YMM registers  *)
   val ymms: var array


### PR DESCRIPTION
just moved `[@@deprecated]` after `X86_env.nums`.
Previously we had in compile time the next warning
```
Warning 3: deprecated: CPU.r
[since 2018-01] user `r` instead
```
i.e. a new definition was deprecated, not a previous one.