### PR TITLE
saves cache index in bin_prot

### DIFF
--- a/plugins/ida/bap_ida_service.ml
+++ b/plugins/ida/bap_ida_service.ml
@@ -95,7 +95,9 @@ let cleanup_minidump () =
       Unix.lockf lock Unix.F_LOCK 0;
       protect ~f:(fun () ->
           List.iter files ~f:Sys.remove)
-        ~finally:(fun () -> Unix.lockf lock Unix.F_ULOCK 0)
+        ~finally:(fun () ->
+            Unix.lockf lock Unix.F_ULOCK 0;
+            Unix.close lock)
 
 (* ida works fine only if everything is in the same folder  *)
 let run (t:ida) cmd =


### PR DESCRIPTION
Previously we used `sexp` for storing index, but it turned out that it is very slow. And in this PR we save index with `bin_io`, that solves the problem.
Also, this PR fixes the issue with closing of lock files.