### PR TITLE
enables bap-elf

### DIFF
--- a/lib/bap_elf/bap_elf.mli
+++ b/lib/bap_elf/bap_elf.mli
@@ -1,6 +1,5 @@
 open Core_kernel.Std
 open Regular.Std
-open Bap.Std
 
 
 

--- a/lib/bap_elf/elf_types.ml
+++ b/lib/bap_elf/elf_types.ml
@@ -1,6 +1,5 @@
 open Core_kernel.Std
 open Regular.Std
-open Bap.Std
 
 type e_class =
   | ELFCLASS32

--- a/oasis/common.tags.in
+++ b/oasis/common.tags.in
@@ -3,6 +3,6 @@
 true: short_paths
 true: bin_annot
 true: debug
-<**/*>: predicate(ppx_driver)
-<**/*>: pp(ppx-jane -dump-ast -inline-test-drop)
+not <**/bap_elf/*>: predicate(ppx_driver)
+not <**/bap_elf/*>: pp(ppx-jane -dump-ast -inline-test-drop)
 true: warn(+a-4-6-7-9-27-29-32..42-44-45-48-50-60)

--- a/oasis/elf
+++ b/oasis/elf
@@ -5,9 +5,9 @@ Flag elf
 
 Library elf
   Path:          lib/bap_elf
-  Build$:        flag(elf)
+  Build$:        flag(everything) || flag(elf)
   FindlibName:   bap-elf
-  BuildDepends:  bap, bitstring, bitstring.ppx, ppx_deriving
+  BuildDepends:  bitstring, bitstring.ppx
   Modules: Bap_elf
   InternalModules:
                  Elf_parse,

--- a/oasis/elf
+++ b/oasis/elf
@@ -7,7 +7,7 @@ Library elf
   Path:          lib/bap_elf
   Build$:        flag(everything) || flag(elf)
   FindlibName:   bap-elf
-  BuildDepends:  bitstring, bitstring.ppx
+  BuildDepends:  bitstring, bitstring.ppx, regular
   Modules: Bap_elf
   InternalModules:
                  Elf_parse,

--- a/oasis/elf
+++ b/oasis/elf
@@ -5,7 +5,7 @@ Flag elf
 
 Library elf
   Path:          lib/bap_elf
-  Build$:        flag(everything) || flag(elf)
+  Build$:        flag(elf)
   FindlibName:   bap-elf
   BuildDepends:  bitstring, bitstring.ppx, regular
   Modules: Bap_elf


### PR DESCRIPTION
in order to use `bitstring.ppx`, we should not use `ppx_driver` and `ppx_custom` predicates according to bitstring META file. And ppx_jane can't be used too. That's why we just omit `bap_elf` directory in our tags file.

It turned out that we can't build `bap-elf` on every compilator we support. The constraint is `>= 4.04.1`. And we need to add it to `opam` file of `bap-elf` library

