### PR TITLE
added bap-signatures to dependencies

### DIFF
--- a/opam/opam
+++ b/opam/opam
@@ -109,7 +109,6 @@ install: [
   ["ocamlfind" "remove" "ogre"]
   ["ocamlfind" "remove" "bare"]
   [make "reinstall"]
-  ["bap-byteweight" "update" "--url=https://github.com/BinaryAnalysisPlatform/bap/releases/download/v1.4.0/sigs.zip"]
   ["cp" "run_tests.native" "%{bin}%/bap_run_tests"]
 ]
 
@@ -233,6 +232,7 @@ depends: [
     "piqi" {>= "0.7.4"}
     "conf-bap-llvm" {>= "1.1"}
     "parsexp"
+    "bap-signatures"
 ]
 
 


### PR DESCRIPTION
prevent CI from downloading signatures in build time
fix https://github.com/BinaryAnalysisPlatform/bap/issues/835
