### PR TITLE
few fixes in llvm backend 

### DIFF
--- a/lib/bap_llvm/llvm_coff_loader.hpp
+++ b/lib/bap_llvm/llvm_coff_loader.hpp
@@ -322,7 +322,9 @@ error_or<pe32plus_header> get_pe32plus_header(const coff_obj &obj) {
 
 // symbol address for 3.4 is already relative, i.e. doesn't include image base
 error_or<int64_t> symbol_relative_address(const coff_obj &obj, const SymbolRef &sym) {
-    return symbol_address(obj, sym);
+    auto addr = symbol_address(obj, sym);
+    if (!addr) return addr;
+    else return success(int64_t(*addr));
 }
 
 bool is_relocatable(const coff_obj &obj) {

--- a/lib/bap_llvm/llvm_macho_loader.hpp
+++ b/lib/bap_llvm/llvm_macho_loader.hpp
@@ -22,6 +22,19 @@
 #include <llvm/Object/SymbolSize.h>
 #endif
 
+#if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 4
+#include <llvm/Support/SwapByteOrder.h>
+namespace llvm { namespace sys {
+void swapByteOrder(uint64_t &x) { SwapByteOrder(x); };
+}
+
+namespace MachO {
+void swapStruct(MachO::any_relocation_info &reloc) {
+    sys::SwapByteOrder(reloc.r_word0);
+    sys::SwapByteOrder(reloc.r_word1);
+}}}
+#endif
+
 namespace loader {
 namespace macho_loader {
 
@@ -475,8 +488,8 @@ symbol_iterator get_symbol(const macho &obj, std::size_t index) {
 #elif LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 4
 
 std::size_t command_count(const macho &obj) {
-    if (obj.is64Bit())  return obj.getHeader64().ncmds;
-    else obj.getHeader().ncmds;
+    if (obj.is64Bit()) return obj.getHeader64().ncmds;
+    else return obj.getHeader().ncmds;
 }
 
 commands macho_commands(const macho &obj) {


### PR DESCRIPTION
Looks like that we didn't build bap with `llvm-3.4` for a while, so there were a couple of minor bugs there. This PR fixes them.