### PR TITLE
removed an unexhaustive pattern matching warning

### DIFF
--- a/plugins/x86/x86_tools_mem.ml
+++ b/plugins/x86/x86_tools_mem.ml
@@ -62,7 +62,8 @@ module Make (CPU : X86CPU) (RR : RR) (IM : IM) : MM = struct
       | #Reg.r32, `x86
       | #Reg.r64, _
       | #Reg.segment_base, _ -> RR.get reg
-      | #Reg.segment, _ -> Error.failwiths "invalid address register" reg RR.sexp_of_t
+      | (#Reg.segment | #Reg.r128 | #Reg.r256), _ ->
+        Error.failwiths "invalid address register" reg RR.sexp_of_t
 
     let make_scale scale =
       let shift = match scale with


### PR DESCRIPTION
We have the next nasty compilation warning:
```
File "plugins/x86/x86_tools_mem.ml", line 58, characters 6-322:
Warning 8: this pattern-matching is not exhaustive.
Here is an example of a case that is not matched:
((`YMM0|`YMM3|`XMM10|`XMM1|`YMM4|`XMM15|`XMM6|`YMM1|`YMM11|`XMM12|`YMM15|
 `XMM13|`YMM10|`YMM9|`YMM13|`XMM3|`XMM9|`XMM11|`YMM5|`XMM2|`YMM7|`YMM14|
 `YMM8|`YMM2|`XMM0|`XMM5|`XMM7|`XMM4|`XMM8|`XMM14|`YMM12|`YMM6),
_)
```
So what we need is just to update an error clause of pattern matching with SSE registers, as they 
don't participate in effective address computation, according to 
`Intel® 64 and IA-32 architectures software developer’s manual, volume 1,
Section 3.7.5 (Specifying an Offset)`

> 
> The offset part of a memory address can be specified directly as a static value (called a displacement) or through an address computation made up of one or more of the following components:
> 
> Displacement — An 8-, 16-, or 32-bit value.
> Base — The value in a general-purpose register.
> Index — The value in a general-purpose register.
> Scale factor — A value of 2, 4, or 8 that is multiplied by the index value.
> 
