### PR TITLE
silenced warnings from ours deprecations

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -7,6 +7,8 @@ open Graphlib.Std
 open Bap_future.Std
 
 module Std : sig
+  [@@@warning "-D"]
+
   (** {2 Overview}
 
       {3 Layered Architecture}
@@ -618,10 +620,7 @@ module Std : sig
 
   (**/**)
   module Legacy : sig
-    [@@@deprecated "[since 2018-03] Definitions in this module are deprecated"]
     module Monad : sig
-      [@@@deprecated
-        "[since 2018-03] The module is deprecated in favor of new monads library"]
       open Core_kernel.Std
       module type Basic = Monad.Basic
       module type Basic2 = Monad.Basic2
@@ -665,7 +664,10 @@ module Std : sig
         end
       end
     end
+    [@@deprecated
+      "[since 2018-03] The module is deprecated in favor of new monads library"]
   end
+  [@@deprecated "[since 2018-03] Definitions in this module are deprecated"]
 
   (**/**)
 
@@ -2270,8 +2272,6 @@ module Std : sig
 
     (** Predefined storage classes  *)
     module Storage : sig
-      [@@@deprecated "[since 2018-03] in favor of the Primus Framework"]
-      [@@@warning "-D"]
 
       (** linear storage literally implements operational
           semantics, but has O(N) lookup and uses space
@@ -2285,6 +2285,8 @@ module Std : sig
           update method. *)
       class sparse : storage
     end
+    [@@deprecated "[since 2018-03] in favor of the Primus Framework"]
+
 
     (** Value of a result.
         We slightly diverge from an operational semantics by allowing
@@ -2342,8 +2344,6 @@ module Std : sig
         @deprecated  Use the Primus Framework
     *)
     module Result : sig
-      [@@@deprecated "[since 2018-03] in favor of the Primus Framework"]
-      [@@@warning "-D"]
 
       (** result identifier  *)
       type id
@@ -2389,6 +2389,7 @@ module Std : sig
       module Value : Printable.S with type t = value
       include Printable.S with type t := t
     end
+    [@@deprecated "[since 2018-03] in favor of the Primus Framework"]
 
     (** Tries on BIL.
 
@@ -2694,8 +2695,6 @@ module Std : sig
       @deprecated  Use the Primus Framework
   *)
   module Context : sig
-    [@@@deprecated "[since 2018-03] in favor of the Primus Framework"]
-    [@@@warning "-D"]
 
     class t : object('s)
 
@@ -2711,7 +2710,7 @@ module Std : sig
           for debugging and introspection.  *)
       method bindings : (var * Bil.result) seq
     end
-  end
+  end [@@deprecated "[since 2018-03] in favor of the Primus Framework"]
 
   module Type_error : module type of Type.Error with type t = Type.Error.t
 
@@ -2862,8 +2861,6 @@ module Std : sig
       @deprecated  Use the Primus Framework
   *)
   module Expi : sig
-    [@@@deprecated "[since 2018-03] in favor of the Primus Framework"]
-    [@@@warning "-D"]
 
     open Bil.Result
     (**
@@ -3064,7 +3061,7 @@ module Std : sig
       with type ('a,'e) state = ('a,'e) M.t
 
     include S with type ('a,'e) state = ('a,'e) Monad.State.t
-  end
+  end [@@deprecated "[since 2018-03] in favor of the Primus Framework"]
 
   (** Expression {{!Expi}interpreter}  *)
   class ['a] expi : ['a] Expi.t
@@ -3091,8 +3088,6 @@ module Std : sig
     v}
   *)
   module Bili : sig
-    [@@@deprecated "[since 2018-03] in favor of the Primus Framework"]
-    [@@@warning "-D"]
 
     open Bil.Result
 
@@ -3128,7 +3123,8 @@ module Std : sig
 
     module Make(M : Monad.State.S2) : S with type ('a,'e) state = ('a,'e) M.t
     include S with type ('a,'e) state = ('a,'e) Monad.State.t
-  end
+  end [@@deprecated "[since 2018-03] in favor of the Primus Framework"]
+
 
   (** BIL {{!Bili}interpreter} *)
   class ['a] bili : ['a] Bili.t
@@ -3507,7 +3503,6 @@ module Std : sig
 
     (** [eval x] evaluate expression [x] to a value.  *)
     val eval : t -> Bil.value
-    [@@warning "-D"]
 
     include Regular.S with type t := t
     val pp_adt : t printer
@@ -4377,9 +4372,6 @@ module Std : sig
       @deprecated  Use the Primus Framework.
   *)
   module Biri : sig
-    [@@@deprecated "[since 2018-03] in favor of the Primus Framework"]
-    [@@@warning "-D"]
-
     open Bil.Result
 
     (** Biri evaluates terms in the context of a whole program (since
@@ -4507,7 +4499,8 @@ module Std : sig
       S with type ('a,'e) state = ('a,'e) M.t
 
     include S with type ('a,'e) state = ('a,'e) Monad.State.t
-  end
+  end [@@deprecated "[since 2018-03] in favor of the Primus Framework"]
+
 
   (** BIR {{!Biri}interpreter}  *)
   class ['a] biri : ['a] Biri.t
@@ -5107,7 +5100,6 @@ module Std : sig
       accessible for loading images.*)
 
   module Backend : sig
-    [@@@deprecated "[since 2017-08] Use new loader Ogre-powered loader interface"]
 
     (** memory access permissions  *)
     type perm = R | W | X | Or of perm * perm
@@ -5156,7 +5148,7 @@ module Std : sig
 
     (** the actual interface to be implemented  *)
     type t = Bigstring.t -> Img.t option
-  end
+  end [@@deprecated "[since 2017-08] Use new loader Ogre-powered loader interface"]
 
   (** Binary Image.  *)
   module Image : sig
@@ -7715,8 +7707,6 @@ module Std : sig
       usually associated with each variable of a given term. This set
       defines a set of taints with which a variable is tainted.*)
   module Taint : sig
-    [@@@deprecated "[since 2018-03] use the Bap Taint Framework instead"]
-    [@@@warning "-D"]
     type t = tid
 
     type set = Tid.Set.t [@@deriving bin_io, compare, sexp]
@@ -7843,7 +7833,7 @@ module Std : sig
     val pp_map : map printer
 
     module Map : Regular.S with type t = map
-  end
+  end [@@deprecated "[since 2018-03] use the Bap Taint Framework instead"]
 
   type 'a source = 'a Source.t
 

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -618,7 +618,9 @@ module Std : sig
     module Make(T : Base) : S with type t = T.t
   end
 
-  (**/**)
+  (** Legacy
+      @deprecated Definitions in this module are deprecated
+   **)
   module Legacy : sig
     module Monad : sig
       open Core_kernel.Std
@@ -2242,7 +2244,7 @@ module Std : sig
     end
 
     (** Result of a computation.
-        @deprecated  Use the Primus Framework.
+        @deprecated Use the Primus Framework.
     *)
     type result
     [@@deprecated "[since 2018-03] in favor of the Primus Framework"]
@@ -2258,7 +2260,6 @@ module Std : sig
         Bili.
 
         @deprecated  Use the Primus Framework.
-
     *)
     class type storage = object('s)
 
@@ -2270,7 +2271,9 @@ module Std : sig
     end
     [@@deprecated "[since 2018-03] in favor of the Primus Framework"]
 
-    (** Predefined storage classes  *)
+    (** Predefined storage classes
+        @deprecated Use the Primus Framework
+    *)
     module Storage : sig
 
       (** linear storage literally implements operational
@@ -3063,7 +3066,9 @@ module Std : sig
     include S with type ('a,'e) state = ('a,'e) Monad.State.t
   end [@@deprecated "[since 2018-03] in favor of the Primus Framework"]
 
-  (** Expression {{!Expi}interpreter}  *)
+  (** Expression {{!Expi}interpreter}
+      @deprecated Use the Primus Framework
+  *)
   class ['a] expi : ['a] Expi.t
   [@@deprecated "[since 2018-03] in favor of the Primus Framework"]
 
@@ -3086,6 +3091,8 @@ module Std : sig
       ctxt#bindings |> Seq.to_list;;
       - : (var * Bil.result) list = [(x, [0x1] false)]
     v}
+
+      @deprecated Use the Primus Framework
   *)
   module Bili : sig
 
@@ -3126,7 +3133,9 @@ module Std : sig
   end [@@deprecated "[since 2018-03] in favor of the Primus Framework"]
 
 
-  (** BIL {{!Bili}interpreter} *)
+  (** BIL {{!Bili}interpreter}
+      @deprecated Use the Primus Framework
+   *)
   class ['a] bili : ['a] Bili.t
   [@@deprecated "[since 2018-03] in favor of the Primus Framework"]
 
@@ -4502,8 +4511,11 @@ module Std : sig
   end [@@deprecated "[since 2018-03] in favor of the Primus Framework"]
 
 
-  (** BIR {{!Biri}interpreter}  *)
+  (** BIR {{!Biri}interpreter}
+      @deprecated Use the Primus Framework
+   *)
   class ['a] biri : ['a] Biri.t
+  [@@deprecated "[since 2018-03] in favor of the Primus Framework"]
 
   (** {3 Some predefined tags} *)
 
@@ -5097,8 +5109,10 @@ module Std : sig
 
       This interface must be implemented by a backend plugin, and
       registered with [Image.register] function in order to be
-      accessible for loading images.*)
+      accessible for loading images.
 
+      @deprecated Use new Ogre-powered loader interface
+   *)
   module Backend : sig
 
     (** memory access permissions  *)
@@ -5148,7 +5162,7 @@ module Std : sig
 
     (** the actual interface to be implemented  *)
     type t = Bigstring.t -> Img.t option
-  end [@@deprecated "[since 2017-08] Use new loader Ogre-powered loader interface"]
+  end [@@deprecated "[since 2017-08] Use new Ogre-powered loader interface"]
 
   (** Binary Image.  *)
   module Image : sig
@@ -5323,7 +5337,9 @@ module Std : sig
     val available_backends : unit -> string list
 
     (** [register_backend ~name backend] tries to register [backend] under
-        the specified [name]. *)
+        the specified [name].
+        @deprecated use register_loader instead
+    *)
     val register_backend : name:string -> Backend.t -> [ `Ok | `Duplicate ]
     [@@deprecated "[since 2017-07] use register_loader instead"]
 
@@ -7705,8 +7721,12 @@ module Std : sig
       We represent a taint with a term identifier, to designate that a
       taint was produced by a term with the given id. A taint set is
       usually associated with each variable of a given term. This set
-      defines a set of taints with which a variable is tainted.*)
+      defines a set of taints with which a variable is tainted.
+
+      @deprecated use the Bap Taint Framework
+  *)
   module Taint : sig
+
     type t = tid
 
     type set = Tid.Set.t [@@deriving bin_io, compare, sexp]

--- a/lib/bap_bml/bap_bml.ml
+++ b/lib/bap_bml/bap_bml.ml
@@ -1,6 +1,7 @@
 open Core_kernel.Std
 open Bap.Std
 
+[@@@warning "-D"]
 
 exception Parse_error of string
 

--- a/lib/bap_llvm/bap_llvm_loader.ml
+++ b/lib/bap_llvm/bap_llvm_loader.ml
@@ -1,8 +1,9 @@
 open Core_kernel.Std
 open Bap.Std
 open Monads.Std
-
 open Bap_llvm_binary
+
+[@@@warning "-D"]
 
 let make_addr arch addr =
   match Arch.addr_size arch with

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -6,7 +6,6 @@ open Bap_future.Std
 open Bap_strings.Std
 
 module Std : sig
-
   (** Primus - The Microexecution Framework.
 
 
@@ -57,6 +56,8 @@ module Std : sig
       it can modify other components (depending on their interface).
 
   *)
+  [@@@warning "-D"]
+
   module Primus : sig
     (** Machine Exception.
 

--- a/lib/microx/microx_concretizer.ml
+++ b/lib/microx/microx_concretizer.ml
@@ -5,6 +5,8 @@ open Monads.Std
 module SM = Monad.State
 open SM.Monad_infix
 
+[@@@warning "-D"]
+
 type policy = [`Random | `Fixed of int64 | `Interval of int64 * int64 ]
   [@@deriving sexp_of]
 
@@ -22,8 +24,10 @@ class ['a] main
     ?random_seed
     ?(reg_policy=`Random)
     ?(mem_policy=`Random) () =
+
   object(self)
     inherit ['a] expi as super
+
     initializer Option.iter random_seed ~f:Random.init
 
     method! eval_unknown _ t = self#emit reg_policy t

--- a/lib/microx/microx_concretizer.mli
+++ b/lib/microx/microx_concretizer.mli
@@ -1,5 +1,7 @@
 open Bap.Std
 
+[@@@warning "-D"]
+
 type policy = [
   | `Random
   | `Fixed of int64 | `Interval of int64 * int64 ]

--- a/lib/microx/microx_conqueror.ml
+++ b/lib/microx/microx_conqueror.ml
@@ -32,6 +32,8 @@ let merge_visited = Map.merge ~f:(fun ~key -> function
 class context
     ?(max_steps=Int.max_value)
     ?(max_loop= min 10 (max_steps / 10)) p  = object(self : 's)
+    [@@@warning "-D"]
+
   inherit Biri.context p
 
   val blk : blk term option = None
@@ -117,6 +119,7 @@ end
 class ['a] main ?(deterministic=false) p =
   object(self)
     constraint 'a = #context
+    [@@@warning "-D"]
     inherit ['a] Biri.t as super
 
     method! enter_term cls t =

--- a/lib/microx/microx_conqueror.mli
+++ b/lib/microx/microx_conqueror.mli
@@ -17,6 +17,7 @@ class context :
   ?max_steps:int ->
   ?max_loop:int ->
   program term -> object('s)
+    [@@@warning "-D"]
     inherit Biri.context
 
     method visited : int Tid.Map.t

--- a/lib_test/bap_image/test_image.ml
+++ b/lib_test/bap_image/test_image.ml
@@ -2,8 +2,9 @@ open Core_kernel.Std
 open OUnit2
 open Or_error
 open Word_size
-
 open Bap.Std
+
+[@@@warning "-D"]
 open Backend
 
 let ident = Int64.of_int
@@ -90,6 +91,7 @@ let () = List.iter ~f:(fun (name,backend) ->
     | `Ok -> ()
     | `Duplicate -> failwith name)
     backends
+[@@warning "-D"]
 
 let print_list r =
   let sexp_of_addr_list = sexp_of_list sexp_of_addr in

--- a/lib_test/bap_types/test_bili.ml
+++ b/lib_test/bap_types/test_bili.ml
@@ -34,12 +34,13 @@ let printer = function
 let assert_exp value exp ctxt =
   assert_equal ~ctxt ~printer value (Exp.eval exp)
 
-let assert_prg value prg ctxt =
+let assert_prg  value prg ctxt =
   let open Monad.State.Monad_infix in
   let bili = new bili in
   assert_equal ~ctxt ~printer value @@
   let res = bili#eval prg >>= fun () -> bili#lookup r >>| Bil.Result.value in
   Monad.State.eval res (new Bili.context)
+[@@warning "-D"]
 
 let suite () =
   "Bili" >::: [

--- a/lib_test/bap_types/test_optimizations.ml
+++ b/lib_test/bap_types/test_optimizations.ml
@@ -2,6 +2,8 @@ open Core_kernel
 open OUnit2
 open Bap.Std
 
+[@@@warning "-D"]
+
 let width = 8
 let typ = Type.imm width
 let int x = Bil.int (Word.of_int ~width x)

--- a/lib_test/powerpc/powerpc_tests_helpers.ml
+++ b/lib_test/powerpc/powerpc_tests_helpers.ml
@@ -2,6 +2,8 @@ open Core_kernel.Std
 open Bap.Std
 open OUnit2
 
+[@@@warning "-D"]
+
 module Dis = Disasm_expert.Basic
 
 module type Bitwidth = sig

--- a/lib_test/powerpc/powerpc_tests_helpers.mli
+++ b/lib_test/powerpc/powerpc_tests_helpers.mli
@@ -41,6 +41,7 @@ val check_gpr : ?addr:addr -> bil -> string -> var -> addr -> arch -> test_ctxt 
     of [init_bil] and code, obtained from lifting [bytes].
     [addr] is an instruction address, 0 by default. *)
 val eval : ?addr:addr -> bil -> string -> arch -> Bili.context
+[@@warning "-D"]
 
 (** [check_mem init bytes mem ~addr size expected ?endian arch ctxt] -
     tests if a word of [size] at [addr] in memory [mem] is equal to [expected].
@@ -50,6 +51,7 @@ val check_mem : bil -> string -> var -> addr:addr -> size:size -> addr -> ?endia
 
 (** [lookup_var context var] - returns a word, bound to [var] in [context] *)
 val lookup_var : Bili.context -> var -> word option
+[@@warning "-D"]
 
 (** [make_bytes ws] - return a string of bytes, that obtained from
     concatenaion of [ws] *)

--- a/lib_test/x86/test_pcmp.ml
+++ b/lib_test/x86/test_pcmp.ml
@@ -102,6 +102,7 @@ let test insn_name bytes x y ~expected _ctxt =
           insn_name (Word.to_string word) (Word.to_string expected);
       Word.equal word expected
     | _ -> false
+[@@warning "-D"]
 
 let test_eqb =
   let pcmpeqb = "\x66\x0f\x74\xc8" in (** pcmpeqb %xmm1, %xmm0 *)

--- a/lib_test/x86/test_pshufb.ml
+++ b/lib_test/x86/test_pshufb.ml
@@ -120,6 +120,7 @@ let test_rr (mask, expected) ctxt =
     match Bil.Result.value r with
     | Bil.Imm word -> Word.equal word expected
     | _ -> false
+[@@warning "-D"]
 
 class exn_visitor = object
   inherit [bool] Stmt.visitor

--- a/plugins/beagle/beagle_main.ml
+++ b/plugins/beagle/beagle_main.ml
@@ -7,6 +7,8 @@ open Bap_strings.Std
 open Bap_future.Std
 open Format
 
+[@@@warning "-D"]
+
 module type Alphabet = Strings.Unscrambler.Alphabet
 
 include Self()

--- a/plugins/primus_loader/primus_loader_basic.ml
+++ b/plugins/primus_loader/primus_loader_basic.ml
@@ -56,6 +56,7 @@ module Make(Param : Param)(Machine : Primus.Machine.S)  = struct
   let rec is set = function
     | Backend.Or (p1,p2) -> is set p1 || is set p2
     | bit -> bit = set
+  [@@warning "-D"]
 
   let segmentations =
     let open Image.Scheme in

--- a/plugins/primus_propagate_taint/primus_propagate_taint_main.ml
+++ b/plugins/primus_propagate_taint/primus_propagate_taint_main.ml
@@ -2,7 +2,7 @@ open Core_kernel.Std
 open Bap.Std
 open Monads.Std
 open Bap_primus.Std
-module Legacy_taint = Taint
+module Legacy_taint = Taint [@@warning "-D"]
 open Bap_taint.Std
 
 include Self()

--- a/plugins/propagate_taint/propagate_taint_main.ml
+++ b/plugins/propagate_taint/propagate_taint_main.ml
@@ -2,6 +2,8 @@ open Core_kernel.Std
 open Regular.Std
 open Graphlib.Std
 open Bap.Std
+
+[@@@warning "-D"]
 open Microx.Std
 open Format
 include Self()

--- a/plugins/propagate_taint/propagator.ml
+++ b/plugins/propagate_taint/propagator.ml
@@ -1,6 +1,8 @@
 open Core_kernel.Std
 open Regular.Std
 open Bap.Std
+
+[@@@warning "-D"]
 open Microx.Std
 open Monads.Std
 

--- a/plugins/propagate_taint/propagator.mli
+++ b/plugins/propagate_taint/propagator.mli
@@ -1,6 +1,8 @@
 open Core_kernel.Std
 open Regular.Std
 open Bap.Std
+
+[@@@warning "-D"]
 open Microx.Std
 
 exception Entry_point_not_found

--- a/plugins/taint/taint_main.ml
+++ b/plugins/taint/taint_main.ml
@@ -3,6 +3,8 @@ open Bap.Std
 include Self()
 open Format
 
+[@@@warning "-D"]
+
 type strain =
   | Addr of int64
   | Tid of string

--- a/plugins/warn_unused/warn_unused_main.ml
+++ b/plugins/warn_unused/warn_unused_main.ml
@@ -3,6 +3,8 @@ open Bap.Std
 include Self()
 open Format
 
+[@@@warning "-D"]
+
 let taint prog = (object(self)
   inherit Term.mapper as super
   method! map_def def =


### PR DESCRIPTION
This PR silences warnings from bap code during compilation of bap itself. Also, it turned out that few modules in `bap.mli` were deprecated in a way that doesn't emit warnings at all.

Just for the record, the next sample doesn't deprecate `module A`, because according to the documentation for attributes of level 3:
> They are not attached to any specific node in the syntax tree

```
module A = struct
  [@@@deprecated "[since ...]"]
  ...
end
```
And the next works as expected, although in this case, we have to do the depreciation at the end of the module, which makes it less readable for a user. But anyway, looks like we don't have any other choice.

```
module A = struct
  ...
end [@@deprecated "[since ...]"]
```