### PR TITLE
ensures static linking with llvm >= 4.0

### DIFF
--- a/oasis/llvm.setup.ml.in
+++ b/oasis/llvm.setup.ml.in
@@ -12,8 +12,13 @@ let llvm var () : unit =
     (fun () ->
        let llvm_config = BaseEnv.var_get "llvm_config" in
        let llvm_version = BaseEnv.var_get "llvm_version" in
+       let link_mode =
+         let llvm_static = BaseEnv.var_get "llvm_static" in
+         if strip_patch llvm_version > "3.8" && llvm_static = "true"
+         then "--link-static"
+         else "" in
        let extract v =
-	 OASISExec.run_read_one_line ~ctxt llvm_config ["--"^v] in
+	 OASISExec.run_read_one_line ~ctxt llvm_config [link_mode; "--"^v] in
        if strip_patch llvm_version > "3.4" && var = "ldflags"
        then extract var ^ " " ^ extract "system-libs"
        else extract var) |>


### PR DESCRIPTION
it turned out that after `llvm-4.0` a default linking mode is `shared`, and it's not what we want. e.g. debian package will be broken, as `bap` will be depend from `LLVM.so`.

our previous request for libraries now returns an extremly short list:
```
ubuntu@ubuntu-xenial:~$ llvm-config-4.0 --libs
-lLLVM-4.0
```
which is just shared library. So what we can do is to use a new flag for llvm-config:
```
ubuntu@ubuntu-xenial:~$ llvm-config-4.0 --link-static --libs
-lLLVMLTO -lLLVMPasses -lLLVMObjCARCOpts -lLLVMMIRParser ...

```
Here it is!