### PR TITLE
escapes strings before generating OGRE document

### DIFF
--- a/lib/bap_llvm/llvm_loader_utils.hpp
+++ b/lib/bap_llvm/llvm_loader_utils.hpp
@@ -12,19 +12,20 @@ namespace loader {
 
 using namespace llvm;
 
-bool str_mem(const std::string &s, char x) {
-    return (s.find(x) != std::string::npos);
+std::string escape(const std::string &src) {
+    std::stringstream dst;
+    for (auto it = src.begin(); it != src.end (); ++it) {
+        if (isalpha(*it) || isdigit(*it)) dst << *it;
+        else
+            dst << "\\x" << std::hex << int(*it) ;
+    }
+    return dst.str();
 }
 
-bool str_mem_any(const std::string &s, const std::string &p) {
-    return std::any_of(s.begin(), s.end(), [=](const char &x)
-                       {return str_mem(p,x);});
-}
-
-std::string smart_quoted(const std::string &s) {
-    std::string p = "() /\\";
-    if (str_mem_any(s, p) || s == "") return "\"" + s + "\"";
-    else return s;
+std::string quote(const std::string &s) {
+    std::stringstream x;
+    x << "\"" << escape(s) << "\"";
+    return x.str();
 }
 
 
@@ -66,7 +67,7 @@ struct ogre_doc {
     }
 
     friend ogre_doc & operator<<(ogre_doc &d, const std::string &t) {
-        if (d.s_) *d.s_ << " " << smart_quoted(t);
+        if (d.s_) *d.s_ << " " << quote(t);
         return d;
     }
 

--- a/lib/bap_llvm/llvm_loader_utils.hpp
+++ b/lib/bap_llvm/llvm_loader_utils.hpp
@@ -15,19 +15,13 @@ using namespace llvm;
 std::string escape(const std::string &src) {
     std::stringstream dst;
     for (auto it = src.begin(); it != src.end (); ++it) {
-        if (isalpha(*it) || isdigit(*it)) dst << *it;
+        if (isalpha(*it) || isdigit(*it))
+            dst << *it;
         else
             dst << "\\x" << std::hex << int(*it) ;
     }
     return dst.str();
 }
-
-std::string quote(const std::string &s) {
-    std::stringstream x;
-    x << "\"" << escape(s) << "\"";
-    return x.str();
-}
-
 
 // ogre doc
 // makes it easy to brew an ogre document.
@@ -36,8 +30,9 @@ std::string quote(const std::string &s) {
 // doc.entry("entry-name") << 42 << false;
 // ...
 // This return a doc with (entry-name 42 false) content.
-// All strings that contain slashes, parentheses or spaces
-// will be quoted. Entry name itself doesn't quoted
+// All strings are quoted. Also, all characters except
+// digits and letters are replaced by their's ascii codes.
+// Entry name itself doesn't quoted.
 // Also possible to add a raw entry, i.e data will be
 // added as it is:
 // ...
@@ -67,7 +62,7 @@ struct ogre_doc {
     }
 
     friend ogre_doc & operator<<(ogre_doc &d, const std::string &t) {
-        if (d.s_) *d.s_ << " " << quote(t);
+        if (d.s_) *d.s_ << " " << "\"" << escape(t) << "\"";
         return d;
     }
 


### PR DESCRIPTION
fixes https://github.com/BinaryAnalysisPlatform/bap/issues/890

Bap fails with a very nasty exception if the llvm backend produces an ogre document that can't be parsed due to an unexpected symbol sequence, e.g.  parsing of the
```
(symbol-entry "?<Constant "Disconnecting; %d\r\n">" 0x9258 0x14 0x4a2d8) 
```
failed just because of `;` symbol, which introduces a comment. 

Previously, we tended to quote strings only if there are some suspicious characters inside.
Starting from this PR we will quote any string in ogre document and replace any suspicious character with its code. And suspicious is everything but letters and digits:
```
(symbol-entry "\x3f\x3cConstant\x20\x22Disconnecting\x3b\x20\x25d\x5cr\x5cn\x22\x3e" 0x9258 0x14 0x4a2d8)
```

Note, these changes will not affect an ogre dump readability: 
```
(symbol-entry .text_45 46438 0 312806)
(symbol-entry .text_46 46484 0 312852)
(symbol-entry "?<Constant \"Disconnecting; %d\\r\\n\">" 37464 20 303832)
(symbol-entry "?<Constant \"mac.c\">" 37440 8 303808)
(symbol-entry "?<Constant \"macCtrl\">" 37448 8 303816)
(symbol-entry "?<Constant \"macMon\">" 37456 8 303824)
....
```


