### PR TITLE
changes an error message in case of empty file

### DIFF
--- a/lib/bap_llvm/bap_llvm_ogre_loader.ml
+++ b/lib/bap_llvm/bap_llvm_ogre_loader.ml
@@ -108,6 +108,7 @@ module Loader = struct
     with Llvm_loader_fail n -> match n with
       | 1 -> Or_error.error_string "File corrupted"
       | 2 -> Or_error.error_string "File format is not supported"
+      | 3 -> Or_error.error_string "File is empty"
       | n -> Or_error.errorf "fail with unexpected error code %d" n
 
   let map_file path =

--- a/lib/bap_llvm/bap_llvm_ogre_loader.ml
+++ b/lib/bap_llvm/bap_llvm_ogre_loader.ml
@@ -108,7 +108,6 @@ module Loader = struct
     with Llvm_loader_fail n -> match n with
       | 1 -> Or_error.error_string "File corrupted"
       | 2 -> Or_error.error_string "File format is not supported"
-      | 3 -> Or_error.error_string "File is empty"
       | n -> Or_error.errorf "fail with unexpected error code %d" n
 
   let map_file path =

--- a/lib/bap_llvm/bap_llvm_ogre_loader.ml
+++ b/lib/bap_llvm/bap_llvm_ogre_loader.ml
@@ -107,7 +107,10 @@ module Loader = struct
       to_image_doc doc
     with Llvm_loader_fail n -> match n with
       | 1 -> Or_error.error_string "File corrupted"
-      | 2 -> Or_error.error_string "File format is not supported"
+      | 2 ->
+         Or_error.error_string
+"File format is not supported: expected executable, library or \
+kernel module"
       | n -> Or_error.errorf "fail with unexpected error code %d" n
 
   let map_file path =

--- a/lib/bap_llvm/bap_llvm_ogre_loader.ml
+++ b/lib/bap_llvm/bap_llvm_ogre_loader.ml
@@ -107,10 +107,7 @@ module Loader = struct
       to_image_doc doc
     with Llvm_loader_fail n -> match n with
       | 1 -> Or_error.error_string "File corrupted"
-      | 2 ->
-         Or_error.error_string
-"File format is not supported: expected executable, library or \
-kernel module"
+      | 2 -> Or_error.error_string "File format is not supported"
       | n -> Or_error.errorf "fail with unexpected error code %d" n
 
   let map_file path =

--- a/lib/bap_llvm/llvm_loader_stubs.c
+++ b/lib/bap_llvm/llvm_loader_stubs.c
@@ -23,7 +23,7 @@ value bap_llvm_load_stub(value arg) {
     CAMLlocal1(result);
     const struct caml_ba_array* array = Caml_ba_array_val(arg);
     if ((!array->dim[0]) || (array->num_dims != 1))
-        failn(3);
+        failn(1);
     const struct bap_llvm_loader *loader =
         bap_llvm_loader_create((const char*)(array->data), array->dim[0]);
     if (bap_llvm_file_not_supported(loader))

--- a/lib/bap_llvm/llvm_loader_stubs.c
+++ b/lib/bap_llvm/llvm_loader_stubs.c
@@ -23,7 +23,7 @@ value bap_llvm_load_stub(value arg) {
     CAMLlocal1(result);
     const struct caml_ba_array* array = Caml_ba_array_val(arg);
     if ((!array->dim[0]) || (array->num_dims != 1))
-        failn(2);
+        failn(3);
     const struct bap_llvm_loader *loader =
         bap_llvm_loader_create((const char*)(array->data), array->dim[0]);
     if (bap_llvm_file_not_supported(loader))

--- a/lib/bap_llvm/llvm_loader_stubs.c
+++ b/lib/bap_llvm/llvm_loader_stubs.c
@@ -23,7 +23,7 @@ value bap_llvm_load_stub(value arg) {
     CAMLlocal1(result);
     const struct caml_ba_array* array = Caml_ba_array_val(arg);
     if ((!array->dim[0]) || (array->num_dims != 1))
-        failn(1);
+        failn(2);
     const struct bap_llvm_loader *loader =
         bap_llvm_loader_create((const char*)(array->data), array->dim[0]);
     if (bap_llvm_file_not_supported(loader))

--- a/src/bap_cmdline_terms.ml
+++ b/src/bap_cmdline_terms.ml
@@ -18,8 +18,8 @@ let check file =
   let exists =
     "file not found", Exists in
   let is_file =
-    "must be a regular file or symlink",
-    Or (Is_file, Is_link) in
+    "must be a regular file",
+    Is_file in
   let not_empty =
     "file is empty",
     Size_not_null in

--- a/src/bap_cmdline_terms.ml
+++ b/src/bap_cmdline_terms.ml
@@ -13,9 +13,26 @@ end
 let enum_processors (module T : With_factory) =
   T.Factory.list () |> List.map ~f:(fun x -> x,x)
 
+let check file =
+  let open FileUtil in
+  let exists =
+    "file not found", Exists in
+  let is_file =
+    "must be a regular file or symlink",
+    Or (Is_file, Is_link) in
+  let not_empty =
+    "file is empty",
+    Size_not_null in
+  let test_fail (_,t) = not (FileUtil.test t file) in
+  match List.find ~f:test_fail [exists; is_file; not_empty] with
+  | None -> `Ok file
+  | Some (m,_) -> `Error (sprintf "%s: %s" file m)
+
+let suitable_file = check, Format.pp_print_string
+
 let filename : string Term.t =
   let doc = "Input filename." in
-  Arg.(required & pos 0 (some non_dir_file) None &
+  Arg.(required & pos 0 (some suitable_file) None &
        info [] ~doc ~docv:"FILE")
 
 let logdir : string option Term.t =

--- a/src/bap_main.ml
+++ b/src/bap_main.ml
@@ -350,7 +350,7 @@ let nice_pp_error fmt er =
     match r with
     | With_backtrace (r, backtrace) ->
        Format.fprintf fmt "%a\n" pp r;
-       Format.fprintf fmt "Backtrace:\n%s" backtrace
+       Format.fprintf fmt "Backtrace:\n%s" @@ String.strip backtrace
     | String s -> Format.fprintf fmt "%s" s
     | r -> pp_sexp fmt (R.sexp_of_t r) in
   Format.fprintf fmt "%a" pp (R.of_info (Error.to_info er))

--- a/src/bap_main.ml
+++ b/src/bap_main.ml
@@ -343,7 +343,7 @@ let load_recipe () =
 let nice_pp_error fmt er =
   let module R = Info.Internal_repr in
   let rec pp_sexp fmt = function
-    | Sexp.Atom x -> Format.pp_print_string fmt x
+    | Sexp.Atom x -> Format.fprintf fmt "%s\n" x
     | Sexp.List xs -> List.iter ~f:(pp_sexp fmt) xs in
   let rec pp fmt r =
     let open R in

--- a/src/bap_main.ml
+++ b/src/bap_main.ml
@@ -340,6 +340,20 @@ let load_recipe () =
   | _,`Ok (Some r) -> eval_recipe r
   | _ -> Sys.argv
 
+let nice_pp_error fmt er =
+  let module R = Info.Internal_repr in
+  let rec pp_sexp fmt = function
+    | Sexp.Atom x -> Format.pp_print_string fmt x
+    | Sexp.List xs -> List.iter ~f:(pp_sexp fmt) xs in
+  let rec pp fmt r =
+    let open R in
+    match r with
+    | With_backtrace (r, backtrace) ->
+       Format.fprintf fmt "%a\n" pp r;
+       Format.fprintf fmt "Backtrace:\n%s" backtrace
+    | String s -> Format.fprintf fmt "%s" s
+    | r -> pp_sexp fmt (R.sexp_of_t r) in
+  Format.fprintf fmt "%a" pp (R.of_info (Error.to_info er))
 
 let () =
   let () =
@@ -360,7 +374,7 @@ let () =
   | Bap_plugin_loader.Plugin_not_found name ->
     error "Can't find a plugin bundle `%s'" name
   | Failed_to_create_project err ->
-    error "Failed to create a project: %a" Error.pp err
+    error "Failed to create a project: %a" nice_pp_error err
   | Project.Pass.Failed (Project.Pass.Unsat_dep (p,n)) ->
     error "Dependency `%s' of pass `%s' is not loaded"
       n (Project.Pass.name p)


### PR DESCRIPTION
This PR changes an error message if bap is using with an empty file:
```
$ touch /tmp/foo.txt
$ bap /tmp/foo.txt
Failed to create a project: ("File format is not supported: expected executable, library or kernel module"
  "Raised at file \"src/import0.ml\" (inlined), line 234, characters 22-32\
 \nCalled from file \"src/error.ml\" (inlined), line 9, characters 14-30\
 \nCalled from file \"src/or_error.ml\", line 70, characters 17-32\
 \nCalled from file \"lib/bap/bap_project.ml\", line 264, characters 47-54\
 \nCalled from file \"src/or_error.ml\", line 62, characters 9-15\
 \n")
```
fix https://github.com/BinaryAnalysisPlatform/bap/issues/895