### PR TITLE
prevents bap from fail if signatures are missed

### DIFF
--- a/plugins/byteweight/byteweight_main.ml
+++ b/plugins/byteweight/byteweight_main.ml
@@ -32,6 +32,9 @@ let create_finder path length threshold arch  =
     let bw = Binable.of_string (module BW) data in
     Ok (BW.find bw ~length ~threshold)
 
+let sigs_exists path =
+  Sys.file_exists (Option.value ~default:Sigs.default_path path)
+
 let main path length threshold =
   let finder arch = create_finder path length threshold arch in
   let find finder mem =
@@ -51,7 +54,12 @@ let main path length threshold =
   let rooter =
     let open Project.Info in
     Stream.Variadic.(apply (args arch $ code) ~f:find_roots) in
-  Rooter.Factory.register name rooter
+  if sigs_exists path then
+    Rooter.Factory.register name rooter
+  else
+    let () = warning "signature database is not available" in
+    info "advice - use `bap-byteweight` to install signatures"
+
 
 let () =
   let () = Config.manpage [


### PR DESCRIPTION
We have lot's of issues from users (espessialy new one) who can't launch bap because
signatures are not installed. So let's just check if signatures exist before registering the byteweight rooter. It will be more friendly then 
```
bap exe 
Failed to create a project: no signatures
Backtrace:
Raised at file "src/import0.ml" (inlined), line 234, characters 22-32
Called from file "src/error.ml" (inlined), line 9, characters 14-30
Called from file "src/or_error.ml", line 70, characters 17-32
Called from file "lib/bap/bap_project.ml" (inlined), line 192, characters 15-29
Called from file "lib/bap/bap_project.ml" (inlined), line 193, characters 35-41
Called from file "lib/bap/bap_project.ml", line 272, characters 19-36
Called from file "src/or_error.ml", line 62, characters 9-15

```