### PR TITLE
makes dead code elimination less conservative

### DIFF
--- a/plugins/optimization/optimization_main.ml
+++ b/plugins/optimization/optimization_main.ml
@@ -130,7 +130,6 @@ let process_sub free can_touch sub =
     let dead = Set.union dead dead' in
     if Set.is_empty dead' then s, dead
     else loop dead (clean can_touch dead' s) in
-  info "turning %s into the SSA form%!" (Sub.name sub);
   let ssa = Sub.ssa sub in
   let sub', dead = loop Tid.Set.empty ssa in
   O.create dead sub'

--- a/plugins/optimization/optimization_main.ml
+++ b/plugins/optimization/optimization_main.ml
@@ -130,8 +130,7 @@ let process_sub free can_touch sub =
     let dead = Set.union dead dead' in
     if Set.is_empty dead' then s, dead
     else loop dead (clean can_touch dead' s) in
-  let ssa = Sub.ssa sub in
-  let sub', dead = loop Tid.Set.empty ssa in
+  let sub', dead = loop Tid.Set.empty (Sub.ssa sub) in
   O.create dead sub'
 
 let digest_of_sub sub level =

--- a/plugins/optimization/optimization_main.ml
+++ b/plugins/optimization/optimization_main.ml
@@ -38,15 +38,6 @@ end
 let computed_def_use sub =
   def_use_collector#visit_sub sub (Var.Set.empty,Var.Set.empty)
 
-let protect dead protected =
-  Set.to_sequence dead ~order:`Decreasing |>
-  Seq.fold ~init:(Var.Set.empty,protected)
-    ~f:(fun (dead,protectors) var ->
-        if Set.mem protectors (Var.base var)
-        then (dead,Set.remove protectors (Var.base var))
-        else (Set.add dead var,protectors)) |>
-  fst
-
 let compute_dead can_touch protected sub =
   let defs,uses = computed_def_use sub in
   let dead = Set.diff defs uses in


### PR DESCRIPTION
As was noted in #905 the optimization passes sometimes misses an
opportunity to remove obvious assignments. The underlying reason
is that we compute a very conservative set of variables which are
used for interprocedural communication. And if a variable is a
member of this set then we do not delete it (under assumption, that
it could be used in other subroutines).

What was overconservative is that all versions of the same variable
were protected, while only the last definition one could be used for
interprocedural communication. The propsed change relaxes the
protected set, and removes only the last version of a variable from
the set of the dead variables.

Fixes #905