### PR TITLE
fixes the free-vars-by-dominators computation algorithm

### DIFF
--- a/lib/bap_sema/bap_sema_free_vars.ml
+++ b/lib/bap_sema/bap_sema_free_vars.ml
@@ -23,9 +23,9 @@ let defined_by_blk b =
 let free_vars_of_dom_tree dom root =
   let rec bfs (vars,kill) root =
     let cs = Tree.children dom root in
-    let kill = kill ++ defined_by_blk (blk root) in
     let vars = vars ++ Seq.fold cs ~init:Var.Set.empty ~f:(fun vars c ->
         Ir_blk.free_vars (blk c) -- kill ++ vars) in
+    let kill = kill ++ defined_by_blk (blk root) in
     Seq.fold cs ~init:(vars,kill) ~f:bfs in
   fst @@ bfs (Var.Set.empty,Var.Set.empty) root
 


### PR DESCRIPTION
This algorithm kicks in in the optimization-level=3 and ... breaks
everything. The bug was trivial, the kill set was computed before
the live set, hence a block was defining its own variables before it
was used.

This bug affects only 1.5 version with optimization-level=3.

Note, there is still a subtle problem with this algorithm that comes
from the "Everything Dominates Unreachable Block" lemma in the
dominators algorithm. And altough this theorem is valid wrt to the
graph theoretic definition of unreachable, which indeed implies that a
block is not reachable under no circumstances, in the binary analysis
an unreachable block is just a block that might be reachable we just
don't know by which paths. In other words, we have an
under-approximation of a control flow graph, and the unsoundness of
the graph is propagated to the unsoundness of the dominator tree
computation. That lies more or less in the vein with the idea of the
optimization-level=3 which is as as unsound as the underlying graph.