### PR TITLE
Fix ir graph's missing edges.

### DIFF
--- a/lib/bap_types/bap_attributes.ml
+++ b/lib/bap_types/bap_attributes.ml
@@ -49,6 +49,11 @@ module Background = struct
   let pp ppf c = Format.fprintf ppf "%s" @@ to_ascii c
 end
 
+module Succs = struct
+  type t = Bap_bitvector.t list [@@deriving bin_io, compare, sexp]
+  let pp ppf dsts = Format.fprintf ppf "%a" Sexp.pp (sexp_of_t dsts)
+end
+
 type color = Color.t [@@deriving bin_io, compare, sexp_poly]
 
 let comment = register (module String)
@@ -90,3 +95,7 @@ let foreground = register (module Foreground)
 let background = register (module Background)
     ~name:"background"
     ~uuid:"9a80a9cc-4106-48fc-abf3-55d7b333e734"
+
+let succs = register (module Succs)
+    ~name:"block successors"
+    ~uuid:"d2680f6c-19ef-11e9-ab14-d663bd873d93"

--- a/lib/bap_types/bap_ir_graph.ml
+++ b/lib/bap_types/bap_ir_graph.ml
@@ -138,16 +138,15 @@ let number_of_nodes t = Term.length blk_t t.sub
 let succ_tid_of_addr sub addr =
   Term.enum blk_t sub |>
   Seq.find ~f:(fun blk ->
-      match Term.get_attr blk address with
-      | Some x -> addr = x
-      | None -> false) >>|
-  fun blk -> Term.tid blk
+      (Term.get_attr blk address) = Some addr) >>|
+  Term.tid
 
 let preds_of_sub ?(rev=false) sub : Tid.Set.t Tid.Map.t =
   let update_pred map src dst =
     let (src, dst) = if rev then (dst, src) else (src, dst) in
-    let map = Pred.insert src map in
-    Pred.update src dst map in
+    Map.change map dst (function
+        | None -> Some (Tid.Set.singleton src)
+        | Some xs -> Some (Set.add xs src)) in
   Term.enum blk_t sub |>
   Seq.fold ~init:Tid.Map.empty ~f:(fun ins src ->
       let src_id = Term.tid src in


### PR DESCRIPTION
Earlier the IR graph was created from just the IR. Now we store the block successors with each block term as an attribute "succs". These successors are determined from the cfg. The attribute "succs" is used when creating the IR graph. This may not be the best way to fix the graph but it seems like simplest approach to me. The IR graph is fixed for the two test cases I tried.

This is not really a pull request, more like a review request (although you can accept this if it looks good to you).