### PR TITLE
preserves brancher information in the BIL code of an instruction

### DIFF
--- a/lib/bap_disasm/bap_disasm_rec.ml
+++ b/lib/bap_disasm/bap_disasm_rec.ml
@@ -400,8 +400,7 @@ let stage2 dis stage1 =
                 List.filter_map ~f:(function
                     | a, (`Cond | `Jump) -> a
                     | _ -> None) in
-              let bil = ensure_destinations bil dests in
-              mem,(insn,Some bil)
+              mem,(insn,Some (ensure_destinations bil dests))
             | _ -> mem, (insn, None)) in
     return {stage1; addrs; succs; preds; disasm}
 

--- a/lib/bap_disasm/bap_disasm_rec.ml
+++ b/lib/bap_disasm/bap_disasm_rec.ml
@@ -328,16 +328,16 @@ let add_destinations bil = function
   | dests ->
     let d = dests_of_bil bil in
     let d' = Addr.Set.of_list dests in
-    let new_ = Set.diff d' d in
-    if Set.is_empty new_ then bil
+    let n = Set.diff d' d in
+    if Set.is_empty n then bil
     else
     if has_jump bil then
       (object inherit Stmt.mapper
         method! map_jmp = function
-          | Int addr -> join_destinations (Set.add new_ addr)
-          | indirect -> make_switch indirect new_
+          | Int addr -> join_destinations (Set.add n addr)
+          | indirect -> make_switch indirect n
       end)#run bil
-    else bil @ join_destinations new_
+    else bil @ join_destinations n
 
 let stage2 dis stage1 =
   let stage1 = filter_valid stage1 in

--- a/lib/bap_disasm/bap_disasm_rec.ml
+++ b/lib/bap_disasm/bap_disasm_rec.ml
@@ -334,7 +334,7 @@ let add_destinations bil = function
        if has_jump bil then
          (object inherit Stmt.mapper
             method! map_jmp = function
-              | Int addr    -> join_destinations (Set.add new_ addr)
+              | Int addr -> join_destinations (Set.add new_ addr)
               | indirect -> make_switch indirect new_
           end)#run bil
        else bil @ join_destinations new_

--- a/lib/bap_disasm/bap_disasm_rec.ml
+++ b/lib/bap_disasm/bap_disasm_rec.ml
@@ -299,7 +299,7 @@ let create_indexes (dests : dests Addr.Table.t) =
 
 let filter_valid s = {s with inits = Set.inter s.inits s.valid}
 
-let itefy_destinations origin dests =
+let join_destinations origin dests =
   let dests = List.filter ~f:(fun a -> Addr.(a <> origin)) dests in
   let jmp x = [ Bil.(jmp (int x)) ] in
   let undecided x y =
@@ -334,8 +334,8 @@ let ensure_destinations bil dests =
   if is_diverged then
     (object inherit Stmt.mapper
       method! map_jmp = function
-        | Int a -> itefy_destinations a dests
-        | x -> make_switch x dests
+        | Int addr -> join_destinations addr dests
+        | indirect -> make_switch indirect dests
     end)#run bil
   else bil
 

--- a/lib/bap_disasm/bap_disasm_rec.ml
+++ b/lib/bap_disasm/bap_disasm_rec.ml
@@ -318,26 +318,26 @@ let make_switch x dests =
 
 let dests_of_bil bil =
   (object inherit [Addr.Set.t] Stmt.visitor
-     method! visit_jmp e dests = match e with
-       | Int w -> Set.add dests w
-       | _ -> dests
-   end)#run bil Addr.Set.empty
+    method! visit_jmp e dests = match e with
+      | Int w -> Set.add dests w
+      | _ -> dests
+  end)#run bil Addr.Set.empty
 
 let add_destinations bil = function
   | [] -> bil
   | dests ->
-     let d = dests_of_bil bil in
-     let d' = Addr.Set.of_list dests in
-     let new_ = Set.diff d' d in
-     if Set.is_empty new_ then bil
-     else
-       if has_jump bil then
-         (object inherit Stmt.mapper
-            method! map_jmp = function
-              | Int addr -> join_destinations (Set.add new_ addr)
-              | indirect -> make_switch indirect new_
-          end)#run bil
-       else bil @ join_destinations new_
+    let d = dests_of_bil bil in
+    let d' = Addr.Set.of_list dests in
+    let new_ = Set.diff d' d in
+    if Set.is_empty new_ then bil
+    else
+    if has_jump bil then
+      (object inherit Stmt.mapper
+        method! map_jmp = function
+          | Int addr -> join_destinations (Set.add new_ addr)
+          | indirect -> make_switch indirect new_
+      end)#run bil
+    else bil @ join_destinations new_
 
 let stage2 dis stage1 =
   let stage1 = filter_valid stage1 in
@@ -390,20 +390,19 @@ let stage2 dis stage1 =
     let disasm mem =
       Dis.run dis mem
         ~init:[] ~return:ident ~stopped:(fun s _ ->
-          Dis.stop s (Dis.insns s)) |>
+            Dis.stop s (Dis.insns s)) |>
       List.map ~f:(function
           | mem, None -> mem,(None,None)
           | mem, (Some ins as insn) ->
-             let dests =
-               Addrs.find stage1.dests (Memory.max_addr mem) |>
-                 Option.value ~default:[] |>
-                 List.filter_map ~f:(function
-                     | a, (`Cond | `Jump) -> a
-                     | _ -> None) in
-             match stage1.lift mem ins with
-             | Ok bil ->
-              mem,(insn,Some (add_destinations bil dests))
-            | _ -> mem, (insn, Some (add_destinations bil dests))) in
+            let dests =
+              Addrs.find stage1.dests (Memory.max_addr mem) |>
+              Option.value ~default:[] |>
+              List.filter_map ~f:(function
+                  | a, (`Cond | `Jump) -> a
+                  | _ -> None) in
+            match stage1.lift mem ins with
+            | Ok bil -> mem,(insn,Some (add_destinations bil dests))
+            | _      -> mem, (insn, Some (add_destinations [] dests))) in
     return {stage1; addrs; succs; preds; disasm}
 
 let stage3 s2 =


### PR DESCRIPTION
# Introduction
During the program reconstruction we rely on several sources of information, such as lifter and brancher. However, the information that we obtained from the brancher is not stored that leads to a mismatch later. This PR preserves the information provided by the brancher in the BIL code of an instruction. Ideally, the brancher should operate on the BIL level and fix the BIL itself, but we have what we have. 

# Design

We have two sources of information, `D` the set of destinations from the lifter and `D'` the set of destinations form the brancher, which are equally credible for us, but may provide conflicting information. Our task is to generate the BIL code that will have a set of destinations `R` which preserves the existing destinations (completeness) and do not introduce any false destinations (soundness), or formally `R = D + D'`. This requirement is not very strong, as it doesn't quantify over branch predicates, so this transformation might introduce extra (and sometimes unnecessary) non-determinism. However, we're trying to limit it as much as possible without making the code to complicate, in particular, we're ensuring that if `D'` is a subset of `D` (i.e., there is no new information from the brancher) then we don't touch the code. 

# Implementation

If we have conflicting information between the brancher and the lifter, we resolve it using a conditional branch predicated with the `unknown` expression,

```
if (unknown) jmp d1;
if (unknown) jmp d2;
...
if (unknown) jmp dm;
jmp d;
```

If there is no conflict, for example, when lifter tells us to jump to an indirect destination, while brancher gives some concrete destinations `[d1,d2,...,dm]`, we spill the following code:
```  
  if (RAX = d1) jmp d1;
  if (RAX = d2) jmp d2;
  ...
  if (RAX = dm) jmp dm;
  jmp RAX
```
# References

Resolves: #899
Previous attempt: #911 