### PR TITLE
fixes our travis-ci

### DIFF
--- a/.run_travis_tests.sh
+++ b/.run_travis_tests.sh
@@ -1,12 +1,11 @@
 TASK=$1
 
-eval `opam config env`
+mkdir -p $HOME/.opam/
 
-comp=`opam config var switch`
+comp=`ls $HOME/save_opam`
 
-cp -r $HOME/save_opam/bin/* $HOME/.opam/$comp/bin/
-cp -r $HOME/save_opam/share/* $HOME/.opam/$comp/share/
-cp -r $HOME/save_opam/lib/* $HOME/.opam/$comp/lib/
+cp -r $HOME/save_opam/$comp $HOME/.opam/
+export PATH=$HOME/.opam/$comp/bin:$PATH
 
 bap --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ addons:
 
 cache:
   directories:
-  - $HOME/.opam
   - $HOME/save_opam
-  before_cache:
+
+before_cache:
   - rm -rf $HOME/.opam/log
 
 env:

--- a/.travis_install.sh
+++ b/.travis_install.sh
@@ -8,13 +8,14 @@ rm -rf bap-veri
 git clone https://github.com/BinaryAnalysisPlatform/bap-veri.git
 opam pin add bap-veri bap-veri/ -y
 OPAM_SWITCH=`opam config var switch`
-mkdir -p $HOME/save_opam
-mkdir -p $HOME/save_opam/lib
-cp -r $HOME/.opam/$OPAM_SWITCH/bin/ $HOME/save_opam/
-cp -r $HOME/.opam/$OPAM_SWITCH/share $HOME/save_opam/
+mkdir -p $HOME/save_opam/$OPAM_SWITCH/lib/bap
+cp -r $HOME/.opam/$OPAM_SWITCH/bin/ $HOME/save_opam/$OPAM_SWITCH/
+cp -r $HOME/.opam/$OPAM_SWITCH/share $HOME/save_opam/$OPAM_SWITCH/
+cp -r $HOME/.opam/$OPAM_SWITCH/lib/bap/*.plugin $HOME/save_opam/$OPAM_SWITCH/lib/bap
+
 opam remove bap-veri -y
-cp -r $HOME/.opam/$OPAM_SWITCH/lib/bap* $HOME/save_opam/lib/
 '
+
 fi
 
 bash -ex .travis-opam.sh

--- a/oasis/llvm.setup.ml.in
+++ b/oasis/llvm.setup.ml.in
@@ -1,6 +1,4 @@
-let strip_patch ver =
-  if String.length ver <> 5 then ver
-  else String.sub ver 0 3
+let strip_patch ver = String.sub ver 0 3
 
 
 let llvm var () : unit =

--- a/opam/opam
+++ b/opam/opam
@@ -1,32 +1,60 @@
-opam-version: "1.2"
+opam-version: "2.0"
 name: "bap"
 version: "master"
 maintainer: "Ivan Gotovchits <ivg@ieee.org>"
 authors: "BAP Team"
+license: "MIT"
 homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
-dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
-license: "MIT"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "base-unix"
+  "bitstring"
+  "camlzip"
+  "cmdliner" {>= "1.0" & < "2.0"}
+  "ppx_jane" {>= "v0.9" & < "v0.10"}
+  "core_kernel" {>= "v0.9" & < "v0.10"}
+  "ezjsonm"
+  "fileutils"
+  "FrontC"
+  "oasis" {build & = "0.4.10"}
+  "ounit" {build}
+  "ocamlgraph" {>= "1.8.6"}
+  "ocamlfind" {>= "1.5.6" & < "2.0"}
+  "ocurl" {= "0.7.7"}
+  "re"
+  "uri" {>= "1.9.0"}
+  "utop"
+  "zarith"
+  "uuidm"
+  "piqi" {>= "0.7.4"}
+  "conf-bap-llvm" {>= "1.1"}
+  "parsexp"
+  "bap-signatures"
+]
+depopts: ["conf-ida" "conf-binutils"]
+flags: light-uninstall
 build: [
-  ["./configure"
-  "--prefix=%{prefix}%"
-  "--with-cxx=`which clang++`"
-  "--with-llvm-version=%{conf-bap-llvm:package-version}%" {conf-bap-llvm:installed}
-  "--with-llvm-config=%{conf-bap-llvm:config}%" {conf-bap-llvm:installed}
-  "--mandir=%{man}%"
-  "--enable-everything"
-  "--enable-tests"
-  "--%{conf-ida:enable}%-ida"
-  "--ida-path=%{conf-ida:path}%" {conf-ida:installed}
-  "--ida-headless=%{conf-ida:headless}%" {conf-ida:installed}
-  "--%{conf-ida:enable}%-fsi-benchmark"
-  "--%{conf-binutils:enable}%-objdump"
-  "--objdump-path=%{conf-binutils:objdump}%" {conf-binutils:installed}
-  "--objdump-targets=%{conf-binutils:targets}%" {conf-binutils:installed}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--with-cxx=`which clang++`"
+    "--with-llvm-version=%{conf-bap-llvm:package-version}%"
+      {conf-bap-llvm:installed}
+    "--with-llvm-config=%{conf-bap-llvm:config}%" {conf-bap-llvm:installed}
+    "--mandir=%{man}%"
+    "--enable-everything"
+    "--enable-tests"
+    "--%{conf-ida:enable}%-ida"
+    "--ida-path=%{conf-ida:path}%" {conf-ida:installed}
+    "--ida-headless=%{conf-ida:headless}%" {conf-ida:installed}
+    "--%{conf-ida:enable}%-fsi-benchmark"
+    "--%{conf-binutils:enable}%-objdump"
+    "--objdump-path=%{conf-binutils:objdump}%" {conf-binutils:installed}
+    "--objdump-targets=%{conf-binutils:targets}%" {conf-binutils:installed}
   ]
   [make]
 ]
-
 install: [
   ["ocamlfind" "remove" "bap"]
   ["ocamlfind" "remove" "bap-arm"]
@@ -113,7 +141,6 @@ install: [
   [make "reinstall"]
   ["cp" "run_tests.native" "%{bin}%/bap_run_tests"]
 ]
-
 remove: [
   ["ocamlfind" "remove" "bap"]
   ["ocamlfind" "remove" "bap-arm"]
@@ -210,68 +237,24 @@ remove: [
   ["rm" "-f" "%{bin}%/baptop"]
   ["rm" "-f" "%{bin}%/bap_run_tests"]
 ]
-
-depends: [
-    "base-unix"
-    "bitstring"
-    "camlzip"
-    "cmdliner" {>= "1.0" & < "2.0"}
-    "ppx_jane"    {>= "v0.9" & < "v0.10"}
-    "core_kernel" {>= "v0.9" & < "v0.10"}
-    "ezjsonm"
-    "faillib"
-    "fileutils"
-    "FrontC"
-    "oasis" {build & = "0.4.10"}
-    "ounit" {build}
-    "ocamlgraph" {>= "1.8.6"}
-    "ocamlfind" {>= "1.5.6" & < "2.0"}
-    "ocurl" {= "0.7.7"}
-    "optcomp"
-    "re"
-    "uri" {>= "1.9.0"}
-    "utop"
-    "zarith"
-    "uuidm"
-    "piqi" {>= "0.7.4"}
-    "conf-bap-llvm" {>= "1.1"}
-    "parsexp"
-    "bap-signatures"
-]
-
-
 depexts: [
-    [["ubuntu"] [
-        "libgmp-dev"
-        "libzip-dev"
-        "libcurl4-gnutls-dev"
-        "llvm-3.8-dev"
-        "time"
-        "clang"
-        "llvm"
-        "m4"
-        "dejagnu"
-     ]]
-     [["osx" "macports"] [
-        "gmp"
-        "llvm-3.8"
-        "graphviz"
-        "curl"
-        "libzip"
-     ]]
-     [["osx" "homebrew"] [
-        "gmp"
-        "homebrew/versions/llvm38"
-        "graphviz"
-        "curl"
-        "libzip"
-        "dejagnu"
-    ]]
+  [
+    "libgmp-dev"
+    "libzip-dev"
+    "libcurl4-gnutls-dev"
+    "llvm-3.8-dev"
+    "time"
+    "clang"
+    "llvm"
+    "m4"
+    "dejagnu"
+  ] {os-distribution = "ubuntu"}
+  ["gmp" "llvm-3.8" "graphviz" "curl" "libzip"]
+    {os = "macos" & os-distribution = "macports"}
+  ["gmp" "homebrew/versions/llvm38" "graphviz" "curl" "libzip" "dejagnu"]
+    {os = "macos" & os-distribution = "homebrew"}
 ]
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
 
-depopts: [
-   "conf-ida"
-   "conf-binutils"
-]
-
-available: [ocaml-version >= "4.02.3"]
+synopsis: "Binary Analysis Platform"
+description: "Binary Analysis Platform"

--- a/plugins/x86/x86_mov_offset.ml
+++ b/plugins/x86/x86_mov_offset.ml
@@ -194,6 +194,7 @@ module T = Make(Ver_common)
 module Self = Self ()
 
 let () =
+  let llvm_version = String.sub llvm_version 0 3 in
   if llvm_version = "3.4" then T_34.register ()
   else
   if List.mem ["3.8";"4.0";"5.0";"6.0";"7.0"] llvm_version ~equal:String.equal


### PR DESCRIPTION
We weren't able to run our tests on `travis-ci` so far, so this PR fixes this problem. 
Also, this PR contains changes:
 - `opam/opam` file converted to opam 2.0 format
 - few improvements in travis scripts in order to reduce size of caching data
 - minor fixes in the usage of `llvm-version` configure variable in order to operate on short versions like `3.8`, `7.0` etc., because the length of the version can be arbitary, like version `5.0.0git-929163d` on `travis`.  Note, that the variable itself didn't changed