### PR TITLE
bap-elf compatibility with safe-strings compilers

### DIFF
--- a/lib/bap_elf/elf_parse.ml
+++ b/lib/bap_elf/elf_parse.ml
@@ -438,6 +438,8 @@ let split bits size : bitstring * bitstring =
   | {|hd : size * 8 : bitstring;
       tl : -1       : bitstring|} -> hd,tl
 
+let bitstring_of_bytes b = b, 0, Bytes.length b
+
 (** returns a sequence of table entries  *)
 let split_table ti ~pos ~len data : bitstring Sequence.t Or_error.t =
   let open Or_error in
@@ -445,10 +447,10 @@ let split_table ti ~pos ~len data : bitstring Sequence.t Or_error.t =
   int_of_int64 ti.table_offset >>= fun offset ->
   validate_offsets "table" ~pos ~len ~offset ~size:table_size
   >>= fun () ->
-  let bits = String.create table_size in
-  Bigstring.To_string.blit
+  let bits = Bytes.create table_size in
+  Bigstring.To_bytes.blit
     ~src:data ~src_pos:(pos + offset) ~dst:bits ~dst_pos:0 ~len:table_size;
-  let t = Sequence.unfold ~init:(bitstring_of_string bits)
+  let t = Sequence.unfold ~init:(bitstring_of_bytes bits)
       ~f:(fun bits -> Some (split bits ti.entry_size)) in
   return (Sequence.take t ti.entry_num)
 
@@ -467,12 +469,12 @@ let from_bigstring_exn ?(pos=0) ?len data =
   let data_len = Bigstring.length data in
   let len = Option.value len ~default:data_len in
   validate_bounds ~pos ~len ~data_len >>= fun () ->
-  let header = String.create elf_max_header_size in
-  Bigstring.To_string.blit
+  let header = Bytes.create elf_max_header_size in
+  Bigstring.To_bytes.blit
     ~src:data ~src_pos:pos ~dst:header ~dst_pos:0
     ~len:elf_max_header_size;
   let (elf, seg_ti, sec_ti) =
-    parse_elf_hdr (bitstring_of_string header) in
+    parse_elf_hdr (bitstring_of_bytes header) in
   let endian = endian_of elf.e_data in
   split_table seg_ti ~pos ~len data >>= fun ph ->
   split_table sec_ti ~pos ~len data >>= fun sh ->

--- a/lib/bap_elf/elf_utils.ml
+++ b/lib/bap_elf/elf_utils.ml
@@ -8,10 +8,10 @@ let input_string0 ~pos data : string Or_error.t =
   | None -> errorf "string untermintated"
   | Some last ->
     let len = last - pos in
-    let dst = String.create len in
-    Bigstring.To_string.blit
+    let dst = Bytes.create len in
+    Bigstring.To_bytes.blit
       ~src:data ~src_pos:pos ~dst ~dst_pos:0 ~len;
-    return dst
+    return (Bytes.to_string dst)
 
 let section_name data elf section =
   match Sequence.nth elf.e_sections elf.e_shstrndx with
@@ -28,9 +28,9 @@ let string_of_section  data s : string Or_error.t =
   int_of_int64 s.sh_size >>= fun size ->
   int_of_int64 s.sh_offset >>= fun offset ->
   try
-    let dst = String.create size in
-    Bigstring.To_string.blit
+    let dst = Bytes.create size in
+    Bigstring.To_bytes.blit
       ~src:data ~src_pos:offset
       ~dst ~dst_pos:0 ~len:size;
-    return dst
+    return (Bytes.to_string dst)
   with exn -> of_exn exn

--- a/plugins/elf_loader/elf_loader_main.ml
+++ b/plugins/elf_loader/elf_loader_main.ml
@@ -44,11 +44,11 @@ let section_data  data s : string Or_error.t =
   int_of_int64 s.sh_size >>= fun size ->
   int_of_int64 s.sh_offset >>= fun offset ->
   try
-    let dst = String.create size in
-    Bigstring.To_string.blit
+    let dst = Bytes.create size in
+    Bigstring.To_bytes.blit
       ~src:data ~src_pos:offset
       ~dst ~dst_pos:0 ~len:size;
-    return dst
+    return (Bytes.to_string dst)
   with exn -> of_exn exn
 
 let create_symtab data endian elf  =


### PR DESCRIPTION
This PR  makes `bap-elf` compatible with safe-string compilers