### PR TITLE
few x86 enhancements

### DIFF
--- a/oasis/x86
+++ b/oasis/x86
@@ -28,6 +28,7 @@ Library x86_plugin
                    X86_cdq,
                    X86_cmpxchg,
                    X86_disasm,
+                   X86_endbr,
                    X86_lifter,
                    X86_main,
                    X86_mov,

--- a/plugins/x86/x86_endbr.ml
+++ b/plugins/x86/x86_endbr.ml
@@ -1,0 +1,15 @@
+open Core_kernel
+open Bap.Std
+open X86_asm.Reg
+
+module IA32  = X86_backend.IA32
+module AMD64 = X86_backend.AMD64
+
+type endbr = [ `ENDBR32 | `ENDBR64 ] [@@deriving bin_io, sexp, compare, enumerate]
+
+let lift _mem _insn = Ok [ ]
+
+let () =
+  let name op = sexp_of_endbr op |> Sexp.to_string in
+  List.iter all_of_endbr ~f:(fun op -> IA32.register (name op) lift);
+  List.iter all_of_endbr ~f:(fun op -> AMD64.register (name op) lift)

--- a/plugins/x86/x86_endbr.ml
+++ b/plugins/x86/x86_endbr.ml
@@ -7,7 +7,7 @@ module AMD64 = X86_backend.AMD64
 
 type endbr = [ `ENDBR32 | `ENDBR64 ] [@@deriving bin_io, sexp, compare, enumerate]
 
-let lift _mem _insn = Ok [ ]
+let lift _mem _insn = Ok [ Bil.special "end-of-branch" ]
 
 let () =
   let name op = sexp_of_endbr op |> Sexp.to_string in

--- a/plugins/x86/x86_lifter.ml
+++ b/plugins/x86/x86_lifter.ml
@@ -883,7 +883,7 @@ module ToIR = struct
            - if it was the other way round, you want to extend it anyway.
          * (I may be remembering things wrongly) *)
         [assn t r Bil.(Cast (LOW, !!t, a))]
-      | Call(o1, ra) when pref = [] ->
+      | Call(o1, ra)  ->
         (* If o1 is an immediate, we should syntactically have Jump(imm)
            so that the CFG algorithm knows where the jump goes.  Otherwise
            it will point to BB_Indirect.
@@ -1536,7 +1536,6 @@ module ToIR = struct
       | Sysenter | Syscall -> [Bil.Special "syscall"]
       (* Match everything exhaustively *)
       | Leave _ ->  unimplemented "to_ir: Leave"
-      | Call _ ->  unimplemented "to_ir: Call"
       | Lea _ ->  unimplemented "to_ir: Lea"
       | Movs _ ->  unimplemented "to_ir: Movs"
       | Cmps _ ->  unimplemented "to_ir: Cmps"


### PR DESCRIPTION
this PR adds a couple of x86 instructions:

1) adds `endbr` instructions
   Despite that we implement these instructions as `noop`, they still are very important for cfg integrity, 
   since they usually appear in the beginning of functions.
 
2) adds call instructions with operand override prefix.  
    Previously, we were lifting `call` instructions only if no prefixes present. But `x86_disasm` does all the 
    job needed for prefix comprehension (at least in  part of operand overriding).  

Few examples:
```   
$ echo "f3 0f 1e fa" | bap-mc --show-bil --show-insn
ENDBR64()
{

}
$ echo "f3 0f 1e fb" | bap-mc --show-bil --show-insn
ENDBR32()
{

}
$ echo "67 e8 00 fe ff ff" | bap-mc --show-bil --show-insn --addr=0x400500
CALL64pcrel32(-0x200)
{
  RSP := RSP - 8
  mem := mem with [RSP, el]:u64 <- 0x400506
  jmp 0x400306
}
```
fix https://github.com/BinaryAnalysisPlatform/bap/issues/901
