### PR TITLE
SSE XMM0 ABI 

### DIFF
--- a/lib/bap_primus/bap_primus_lisp.ml
+++ b/lib/bap_primus/bap_primus_lisp.ml
@@ -498,21 +498,23 @@ module Make(Machine : Machine) = struct
             (fun msg -> fun () -> Machine.raise (Runtime_error msg)) ppf
 
         let eval_args = Machine.List.map bs ~f:(fun (var,arg) ->
-            let open Bil.Types in
-            match Arg.rhs arg with
-            | Var v -> Eval.get v >>| fun w -> (var,w)
-            | Load (_,BinOp(op, Var sp, Int off),e,s) ->
-              Eval.get sp >>= fun sp ->
-              Eval.const off >>= fun off ->
-              Eval.binop op sp off >>= fun addr ->
-              Eval.load addr e s >>| fun w -> (var,w)
-            | _ -> failf "unsupported argument passing semantics" ())
+            Eval.exp (Arg.rhs arg) >>| fun w -> (var ,w))
+
+        let size_of_reg r = match Var.typ r with
+          | Imm x -> x
+          | _ -> assert false
 
         let eval_ret r = match ret with
           | None -> Machine.return ()
           | Some v -> match Arg.rhs v with
             | Bil.Var reg -> Eval.set reg r
-            | e -> failf "unknown return semantics: %a" Exp.pps e ()
+            | Bil.(Cast (LOW, rsize, Var reg)) ->
+            let vsize = size_of_reg reg in
+            Eval.get reg >>= fun lhs ->
+            Eval.extract ~hi:(vsize-1) ~lo:rsize lhs >>= fun high ->
+            Eval.concat high r >>= fun r ->
+            Eval.set reg r
+          | e -> failf "unknown return semantics: %a" Exp.pps e ()
 
         let exec =
           eval_args >>= fun bs ->
@@ -690,7 +692,6 @@ module Doc = struct
         else if x = y then x
         else sprintf "%s\nOR\n%s" x y) |>
     Map.to_alist
-
 
   let describe prog item =
     Lisp.Program.get prog item |> List.map ~f:(fun x ->

--- a/plugins/x86/x86_abi.ml
+++ b/plugins/x86/x86_abi.ml
@@ -16,7 +16,7 @@ module type abi = sig
   val arch : Arch.x86
   val name : string
   val size : C.Size.base
-  val arg  : C.Type.t -> pos -> exp
+  val arg  : C.Type.t -> int -> pos -> exp
   val demangle : string -> string
   val autodetect : project -> bool
 end
@@ -31,14 +31,14 @@ module SysV = struct
   let stack n = Stack.create arch n
 
 
-  let xmm r =  Bil.(cast low 64 (var ymms.(r)))
+  let xmm r width =  Bil.(cast low width (var ymms.(r)))
 
-  let flt = function
-    | Ret_0 -> xmm 0
-    | Ret_1 -> xmm 1
-    | Arg n -> xmm n
+  let flt width = function
+    | Ret_0 -> xmm 0 width
+    | Ret_1 -> xmm 1 width
+    | Arg n -> if Int.(n < 8) then (xmm n width) else stack Int.(n-8)
 
-  let int = function
+  let int _ = function
     | Ret_0 -> var rax
     | Ret_1 -> var rdx
     | Arg 0 -> var rdi
@@ -66,7 +66,7 @@ module CDECL = struct
   let name = "cdecl"
   let arch = `x86
   let stack n = Stack.create arch n
-  let arg _ = function
+  let arg _ _ = function
     | Ret_0 -> var rax
     | Ret_1 -> var rdx
     | Arg n -> stack Int.(n+1)
@@ -103,7 +103,7 @@ end
 module MS_64 = struct
   include SysV
   let name = "ms"
-  let arg _ = function
+  let arg _ _ = function
     | Ret_0 -> var rax
     | Ret_1 -> var rdx
     | Arg 0 -> var rcx
@@ -124,10 +124,10 @@ end
 module FASTCALL = struct
   include CDECL
   let name = "fastcall"
-  let arg t = function
+  let arg w t = function
     | Arg 0 -> var rcx
     | Arg 1 -> var rdx
-    | other -> arg t other
+    | other -> arg w t other
 end
 
 module WATCOM_STACK = struct
@@ -142,13 +142,13 @@ end
 module WATCOM_REGS = struct
   include WATCOM_STACK
   let name = "watcom-regs"
-  let arg t = function
+  let arg w t = function
     | Arg 0 -> var rax
     | Arg 1 -> var rdx
     | Arg 2 -> var rbx
     | Arg 3 -> var rcx
     | Arg n -> stack Int.(n-4)
-    | ret -> arg t ret
+    | ret -> arg w t ret
 end
 
 exception Unsupported
@@ -164,9 +164,9 @@ let supported_api (module Abi : abi) {C.Type.Proto.return; args} =
       | Some _ ->
         let data = C.Abi.data Abi.size return in
         if width > word && width <= word * 2
-        then Some (data, Bil.(Abi.arg return Ret_0 ^ Abi.arg return  Ret_1))
+        then Some (data, Bil.(Abi.arg return width Ret_0 ^ Abi.arg return width Ret_1))
         else if width <= word
-        then Some (data, Abi.arg return  Ret_0)
+        then Some (data, Abi.arg return width Ret_0)
         else
           (warning "size of return object doesn't fit into double word\n";
            raise Unsupported) in
@@ -177,13 +177,11 @@ let supported_api (module Abi : abi) {C.Type.Proto.return; args} =
         raise Unsupported
       | Some size -> match Size.of_int_opt size with
         | Some _ when size <= word ->
-          C.Abi.data Abi.size t, Abi.arg t (Arg i)
+          C.Abi.data Abi.size t, Abi.arg t size (Arg i)
         | _ ->
           warning "argument %d doesn't fit into word" i;
           raise Unsupported) in
   C.Abi.{return; params; hidden=[]}
-
-
 
 let supported () : (module abi) list = [
   (module SysV);

--- a/plugins/x86/x86_abi.ml
+++ b/plugins/x86/x86_abi.ml
@@ -49,9 +49,10 @@ module SysV = struct
     | Arg 5 -> var r.(1)
     | Arg n -> stack Int.(n-6)
 
-  let arg = function
-    | `Basic {C.Type.Spec.t=`double} -> flt
-    | _ -> int
+  let arg t width =
+    match t with
+    | `Basic {C.Type.Spec.t=(`float|`double)} -> flt width
+    | _ -> int 64
 
   let size = object
     inherit C.Size.base `LP64


### PR DESCRIPTION
The following code allows ymm registers to be cast to smaller register. This new casting operation is used to extract xmm registers from ymm registers in order to support monomorphic functions in sse. The SysV ABI is extended to receive more arguments and can now recognize functions that read and write to xmm0.