### PR TITLE
updates vagrant/docker files

### DIFF
--- a/docker/debian/testing/Dockerfile
+++ b/docker/debian/testing/Dockerfile
@@ -1,16 +1,50 @@
-FROM ocaml/opam:debian
+FROM debian:stretch
 MAINTAINER Ivan Gotovchits <ivg@ieee.org>
-RUN sudo apt-get -y update && sudo apt-get -y install \
-    llvm-3.8-dev \
+
+RUN apt-get -y update
+RUN apt-get -y install \
+    build-essential \
+    curl \
     git \
-    libcurl4-gnutls-dev \
-    libgmp-dev \
-    zlib1g-dev \
-    binutils-multiarch \
-    clang
-RUN opam init --auto-setup --comp=4.05.0 --yes
+    libx11-dev \
+    m4 \
+    pkg-config \
+    python-pip \
+    software-properties-common \
+    sudo \
+    unzip \
+    wget \
+    libcap-dev \
+    gcc \
+    make
+
+
+RUN useradd -m bap && echo "bap:bap" | chpasswd && adduser bap sudo
+RUN sed -i.bkp -e \
+      's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' \
+      /etc/sudoers
+USER bap
+WORKDIR /home/bap
+
+RUN wget https://github.com/projectatomic/bubblewrap/releases/download/v0.3.1/bubblewrap-0.3.1.tar.xz
+RUN tar xvf bubblewrap-0.3.1.tar.xz
+WORKDIR /home/bap/bubblewrap-0.3.1/
+RUN ./configure
+RUN make && sudo make install
+RUN bwrap --version
+WORKDIR /home/bap
+RUN rm -r bubblewrap-0.3.1 bubblewrap-0.3.1.tar.xz
+
+RUN wget https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh
+RUN echo "" | sh ./install.sh
+RUN opam --version
+
+RUN opam init --yes --compiler=4.05.0 --disable-sandboxing
+RUN eval $(opam env)
 RUN opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
-RUN LLVM_CONFIG=llvm-config-3.8 opam install conf-bap-llvm --yes
-RUN OPAMJOBS=16 opam install bap --yes
-RUN sudo apt-get install python-pip --yes
+RUN opam update
+RUN opam install depext --yes
+RUN OPAMJOBS=1 opam depext --install bap --yes
 RUN sudo pip install bap
+
+ENTRYPOINT ["opam", "config", "exec", "--"]

--- a/docker/debian/testing/Dockerfile
+++ b/docker/debian/testing/Dockerfile
@@ -26,7 +26,6 @@ RUN opam update
 RUN opam install depext --yes
 RUN OPAMJOBS=1 opam depext --install bap --yes
 RUN sudo pip install bap
-RUN sudo apt-get remove libncurses5-dev --yes
 
 WORKDIR /home/opam
 

--- a/docker/debian/testing/Dockerfile
+++ b/docker/debian/testing/Dockerfile
@@ -1,8 +1,8 @@
-FROM debian:stretch
+FROM ocaml/opam2:debian-stable
+
 MAINTAINER Ivan Gotovchits <ivg@ieee.org>
 
-RUN apt-get -y update
-RUN apt-get -y install \
+RUN sudo apt-get -y update && sudo apt-get -y install \
     build-essential \
     curl \
     git \
@@ -16,35 +16,18 @@ RUN apt-get -y install \
     wget \
     libcap-dev \
     gcc \
-    make
+    make \
+    libncurses5-dev
 
-
-RUN useradd -m bap && echo "bap:bap" | chpasswd && adduser bap sudo
-RUN sed -i.bkp -e \
-      's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' \
-      /etc/sudoers
-USER bap
-WORKDIR /home/bap
-
-RUN wget https://github.com/projectatomic/bubblewrap/releases/download/v0.3.1/bubblewrap-0.3.1.tar.xz
-RUN tar xvf bubblewrap-0.3.1.tar.xz
-WORKDIR /home/bap/bubblewrap-0.3.1/
-RUN ./configure
-RUN make && sudo make install
-RUN bwrap --version
-WORKDIR /home/bap
-RUN rm -r bubblewrap-0.3.1 bubblewrap-0.3.1.tar.xz
-
-RUN wget https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh
-RUN echo "" | sh ./install.sh
-RUN opam --version
-
-RUN opam init --yes --compiler=4.05.0 --disable-sandboxing
+RUN opam switch 4.05
 RUN eval $(opam env)
 RUN opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
 RUN opam update
 RUN opam install depext --yes
 RUN OPAMJOBS=1 opam depext --install bap --yes
 RUN sudo pip install bap
+RUN sudo apt-get remove libncurses5-dev --yes
+
+WORKDIR /home/opam
 
 ENTRYPOINT ["opam", "config", "exec", "--"]

--- a/docker/debian/testing/Dockerfile
+++ b/docker/debian/testing/Dockerfile
@@ -20,7 +20,7 @@ RUN sudo apt-get -y update && sudo apt-get -y install \
     libncurses5-dev
 
 RUN opam switch 4.05
-RUN eval $(opam env)
+RUN eval "$(opam env)"
 RUN opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
 RUN opam update
 RUN opam install depext --yes

--- a/docker/trusty/testing/Dockerfile
+++ b/docker/trusty/testing/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:trusty
 MAINTAINER Ivan Gotovchits <ivg@ieee.org>
-RUN apt-get -y update && apt-get -y install \
+
+RUN apt-get -y update
+RUN apt-get -y install \
     build-essential \
     curl \
     git \
@@ -11,20 +13,40 @@ RUN apt-get -y update && apt-get -y install \
     software-properties-common \
     sudo \
     unzip \
-    wget
-RUN add-apt-repository --yes ppa:avsm/ppa && apt-get update && apt-get -y install \
-    ocaml \
-    ocaml-native-compilers \
-    opam
+    wget \
+    libcap-dev \
+    gcc \
+    make \
+    libncurses5-dev
+
 RUN useradd -m bap && echo "bap:bap" | chpasswd && adduser bap sudo
 RUN sed -i.bkp -e \
       's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' \
       /etc/sudoers
 USER bap
 WORKDIR /home/bap
-RUN opam init --auto-setup --comp=4.05.0 --yes
+
+RUN wget https://github.com/projectatomic/bubblewrap/releases/download/v0.3.1/bubblewrap-0.3.1.tar.xz
+RUN tar xvf bubblewrap-0.3.1.tar.xz
+WORKDIR /home/bap/bubblewrap-0.3.1/
+RUN ./configure
+RUN make && sudo make install
+RUN bwrap --version
+WORKDIR /home/bap
+RUN rm -r bubblewrap-0.3.1 bubblewrap-0.3.1.tar.xz
+
+RUN wget https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh
+RUN echo "" | sh ./install.sh
+RUN opam --version
+
+RUN opam init --yes --compiler=4.05.0 --disable-sandboxing
+RUN eval $(opam env)
 RUN opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
 RUN opam update
+RUN opam install depext --yes
 RUN OPAMJOBS=1 opam depext --install bap --yes
 RUN sudo pip install bap
+
+RUN sudo apt-get remove libncurses5-dev --yes
+
 ENTRYPOINT ["opam", "config", "exec", "--"]

--- a/docker/trusty/testing/Dockerfile
+++ b/docker/trusty/testing/Dockerfile
@@ -26,15 +26,6 @@ RUN sed -i.bkp -e \
 USER bap
 WORKDIR /home/bap
 
-RUN wget https://github.com/projectatomic/bubblewrap/releases/download/v0.3.1/bubblewrap-0.3.1.tar.xz
-RUN tar xvf bubblewrap-0.3.1.tar.xz
-WORKDIR /home/bap/bubblewrap-0.3.1/
-RUN ./configure
-RUN make && sudo make install
-RUN bwrap --version
-WORKDIR /home/bap
-RUN rm -r bubblewrap-0.3.1 bubblewrap-0.3.1.tar.xz
-
 RUN wget https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh
 RUN echo "" | sh ./install.sh
 RUN opam --version

--- a/docker/trusty/testing/Dockerfile
+++ b/docker/trusty/testing/Dockerfile
@@ -30,7 +30,7 @@ RUN echo "" | sh ./install.sh
 RUN opam --version
 
 RUN opam init --yes --compiler=4.05.0 --disable-sandboxing
-RUN eval $(opam env)
+RUN eval "$(opam env)"
 RUN opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
 RUN opam update
 RUN opam install depext --yes

--- a/docker/trusty/testing/Dockerfile
+++ b/docker/trusty/testing/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:trusty
 MAINTAINER Ivan Gotovchits <ivg@ieee.org>
 
-RUN apt-get -y update
-RUN apt-get -y install \
+RUN apt-get -y update && apt-get -y install \
     build-essential \
     curl \
     git \

--- a/docker/trusty/testing/Dockerfile
+++ b/docker/trusty/testing/Dockerfile
@@ -37,6 +37,4 @@ RUN opam install depext --yes
 RUN OPAMJOBS=1 opam depext --install bap --yes
 RUN sudo pip install bap
 
-RUN sudo apt-get remove libncurses5-dev --yes
-
 ENTRYPOINT ["opam", "config", "exec", "--"]

--- a/docker/xenial/testing/Dockerfile
+++ b/docker/xenial/testing/Dockerfile
@@ -26,15 +26,6 @@ RUN sed -i.bkp -e \
 USER bap
 WORKDIR /home/bap
 
-RUN wget https://github.com/projectatomic/bubblewrap/releases/download/v0.3.1/bubblewrap-0.3.1.tar.xz
-RUN tar xvf bubblewrap-0.3.1.tar.xz
-WORKDIR /home/bap/bubblewrap-0.3.1/
-RUN ./configure
-RUN make && sudo make install
-RUN bwrap --version
-WORKDIR /home/bap
-RUN rm -r bubblewrap-0.3.1 bubblewrap-0.3.1.tar.xz
-
 RUN wget https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh
 RUN echo "" | sh ./install.sh
 RUN opam --version

--- a/docker/xenial/testing/Dockerfile
+++ b/docker/xenial/testing/Dockerfile
@@ -37,6 +37,4 @@ RUN opam install depext --yes
 RUN OPAMJOBS=1 opam depext --install bap --yes
 RUN sudo pip install bap
 
-RUN sudo apt-get remove libncurses5 --yes
-
 ENTRYPOINT ["opam", "config", "exec", "--"]

--- a/docker/xenial/testing/Dockerfile
+++ b/docker/xenial/testing/Dockerfile
@@ -30,7 +30,7 @@ RUN echo "" | sh ./install.sh
 RUN opam --version
 
 RUN opam init --yes --compiler=4.05.0 --disable-sandboxing
-RUN eval $(opam env)
+RUN eval "$(opam env)"
 RUN opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
 RUN opam update
 RUN opam install depext --yes

--- a/docker/xenial/testing/Dockerfile
+++ b/docker/xenial/testing/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:xenial
 MAINTAINER Ivan Gotovchits <ivg@ieee.org>
-RUN apt-get -y update && apt-get -y install \
+
+RUN apt-get -y update
+RUN apt-get -y install \
     build-essential \
     curl \
     git \
@@ -11,17 +13,40 @@ RUN apt-get -y update && apt-get -y install \
     software-properties-common \
     sudo \
     unzip \
-    wget
-RUN apt-get -y install opam
+    wget \
+    libcap-dev \
+    gcc \
+    make \
+    libncurses5-dev
+
 RUN useradd -m bap && echo "bap:bap" | chpasswd && adduser bap sudo
 RUN sed -i.bkp -e \
       's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' \
       /etc/sudoers
 USER bap
 WORKDIR /home/bap
-RUN opam init --auto-setup --comp=4.05.0 --yes
+
+RUN wget https://github.com/projectatomic/bubblewrap/releases/download/v0.3.1/bubblewrap-0.3.1.tar.xz
+RUN tar xvf bubblewrap-0.3.1.tar.xz
+WORKDIR /home/bap/bubblewrap-0.3.1/
+RUN ./configure
+RUN make && sudo make install
+RUN bwrap --version
+WORKDIR /home/bap
+RUN rm -r bubblewrap-0.3.1 bubblewrap-0.3.1.tar.xz
+
+RUN wget https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh
+RUN echo "" | sh ./install.sh
+RUN opam --version
+
+RUN opam init --yes --compiler=4.05.0 --disable-sandboxing
+RUN eval $(opam env)
 RUN opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
 RUN opam update
+RUN opam install depext --yes
 RUN OPAMJOBS=1 opam depext --install bap --yes
 RUN sudo pip install bap
+
+RUN sudo apt-get remove libncurses5 --yes
+
 ENTRYPOINT ["opam", "config", "exec", "--"]

--- a/docker/xenial/testing/Dockerfile
+++ b/docker/xenial/testing/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:xenial
 MAINTAINER Ivan Gotovchits <ivg@ieee.org>
 
-RUN apt-get -y update
-RUN apt-get -y install \
+RUN apt-get -y update && apt-get -y install \
     build-essential \
     curl \
     git \

--- a/vagrant/jessie64/Vagrantfile
+++ b/vagrant/jessie64/Vagrantfile
@@ -7,19 +7,25 @@ Vagrant.configure(2) do |config|
       vb.memory = "4096"
   end
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
-sudo apt-get -y update && sudo apt-get -y install \
-    llvm-3.8-dev \
-    git \
-    libcurl4-gnutls-dev \
-    libgmp-dev \
-    zlib1g-dev \
-    binutils-multiarch \
-    clang \
-    time
-opam init --auto-setup --comp=4.05.0 --yes
-eval `opam config env`
-LLVM_CONFIG=llvm-config-3.8 opam install conf-bap-llvm --yes
-opam install bap --yes
+sudo apt-get update
+sudo apt-get install curl make git m4 libcap-dev gcc unzip --yes
+
+wget https://github.com/projectatomic/bubblewrap/releases/download/v0.3.1/bubblewrap-0.3.1.tar.xz
+tar xvf bubblewrap-0.3.1.tar.xz
+cd bubblewrap-0.3.1
+./configure && make && sudo make install
+cd ../
+
+echo "" | sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
+
+sudo sysctl kernel.unprivileged_userns_clone=1
+
+yes | opam init --compiler=4.05.0
+eval $(opam env)
+
+opam install depext --yes
+opam depext bap  -i --yes
+
 sudo apt-get install python-pip --yes
 sudo pip install bap
 SHELL

--- a/vagrant/jessie64/Vagrantfile
+++ b/vagrant/jessie64/Vagrantfile
@@ -10,17 +10,9 @@ Vagrant.configure(2) do |config|
 sudo apt-get update
 sudo apt-get install curl make git m4 libcap-dev gcc unzip --yes
 
-wget https://github.com/projectatomic/bubblewrap/releases/download/v0.3.1/bubblewrap-0.3.1.tar.xz
-tar xvf bubblewrap-0.3.1.tar.xz
-cd bubblewrap-0.3.1
-./configure && make && sudo make install
-cd ../
-
 echo "" | sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
 
-sudo sysctl kernel.unprivileged_userns_clone=1
-
-yes | opam init --compiler=4.05.0
+yes | opam init --compiler=4.05.0 --disable-sandboxing
 eval $(opam env)
 
 opam install depext --yes

--- a/vagrant/trusty64/Vagrantfile
+++ b/vagrant/trusty64/Vagrantfile
@@ -7,13 +7,22 @@ Vagrant.configure(2) do |config|
       vb.memory = "4096"
   end
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
-sudo add-apt-repository --yes ppa:avsm/ppa
 sudo apt-get update
-sudo apt-get --yes install opam
-opam init --auto-setup --comp=4.05.0 --yes
-opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#bap-1.4
-eval `opam config env`
-opam depext bap --install --yes
+sudo apt-get install make git m4 libcap-dev gcc unzip --yes
+
+wget https://github.com/projectatomic/bubblewrap/releases/download/v0.3.1/bubblewrap-0.3.1.tar.xz
+tar xvf bubblewrap-0.3.1.tar.xz
+cd bubblewrap-0.3.1
+./configure && make && sudo make install
+cd ../
+
+echo "" | sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
+yes | opam init --compiler=4.05.0
+eval $(opam env)
+
+opam install depext --yes
+opam depext bap  -i --yes
+
 sudo apt-get install python-pip --yes
 sudo pip install bap
 SHELL

--- a/vagrant/trusty64/Vagrantfile
+++ b/vagrant/trusty64/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure(2) do |config|
   end
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
 sudo apt-get update
-sudo apt-get install make git m4 libcap-dev gcc unzip --yes
+sudo apt-get install make git m4 libcap-dev gcc unzip libncurses5-dev --yes
 
 wget https://github.com/projectatomic/bubblewrap/releases/download/v0.3.1/bubblewrap-0.3.1.tar.xz
 tar xvf bubblewrap-0.3.1.tar.xz

--- a/vagrant/xenial64/Vagrantfile
+++ b/vagrant/xenial64/Vagrantfile
@@ -8,11 +8,21 @@ Vagrant.configure(2) do |config|
   end
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
 sudo apt-get update
-sudo apt-get --yes install opam
-opam init --auto-setup --comp=4.05.0 --yes
-opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#bap-1.4
-eval `opam config env`
-opam depext bap --install --yes
+sudo apt-get install make git m4 libcap-dev gcc unzip --yes
+
+wget https://github.com/projectatomic/bubblewrap/releases/download/v0.3.1/bubblewrap-0.3.1.tar.xz
+tar xvf bubblewrap-0.3.1.tar.xz
+cd bubblewrap-0.3.1
+./configure && make && sudo make install
+cd ../
+
+echo "" | sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
+yes | opam init --compiler=4.05.0
+eval $(opam env)
+
+opam install depext --yes
+opam depext bap  -i --yes
+
 sudo apt-get install python-pip --yes
 sudo pip install bap
 SHELL

--- a/vagrant/xenial64/Vagrantfile
+++ b/vagrant/xenial64/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure(2) do |config|
   end
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
 sudo apt-get update
-sudo apt-get install make git m4 libcap-dev gcc unzip --yes
+sudo apt-get install make git m4 libcap-dev gcc unzip libncurses5-dev --yes
 
 wget https://github.com/projectatomic/bubblewrap/releases/download/v0.3.1/bubblewrap-0.3.1.tar.xz
 tar xvf bubblewrap-0.3.1.tar.xz


### PR DESCRIPTION
This PR updates vagrant/docker files due to new `opam` version.
Note, that `sanboxing` is disabled in docker files.