### PR TITLE
enables memory sharing between instructions

### DIFF
--- a/lib/bap_disasm/bap_disasm_rec.ml
+++ b/lib/bap_disasm/bap_disasm_rec.ml
@@ -31,7 +31,6 @@ type dst = [
   | `Fall of addr
 ] [@@deriving sexp]
 
-
 type error = [
   | `Failed_to_disasm of mem
   | `Failed_to_lift of mem * full_insn * Error.t
@@ -41,7 +40,6 @@ type maybe_insn = full_insn option * bil option [@@deriving sexp_of]
 type decoded = mem * maybe_insn [@@deriving sexp_of]
 
 type dests = Brancher.dests
-
 
 module Node = struct
   type t = block
@@ -87,7 +85,6 @@ type blk_dest = [
   | `Block of block * edge
   | `Unresolved of jump
 ]
-
 
 type stage1 = {
   base : mem;
@@ -252,7 +249,6 @@ let stage1 ?(rooter=Rooter.empty) lift brancher disasm base =
     ~invalid:(fun d mem s -> next d (errored s (`Failed_to_disasm mem)))
     ~stopped:next >>= update_intersections disasm brancher mem
 
-
 (* performs the initial markup.
 
    Returns three tables: leads, terms, and kinds. Leads is a mapping
@@ -376,7 +372,7 @@ let stage2 dis stage1 =
         else loop  (Some max_addr) start (next max_addr)
       | None ->
         match next_visited curr with
-        | Some (addr,_)-> loop None addr addr
+        | Some (addr,_) -> loop None addr addr
         | None when is_visited start && is_visited curr ->
           Option.map last ~f:(fun last -> start, (curr,last))
         | None -> None in

--- a/lib/bap_disasm/bap_disasm_rec.ml
+++ b/lib/bap_disasm/bap_disasm_rec.ml
@@ -69,13 +69,14 @@ module Visited = struct
   type t = entry Addr.Map.t
 
   let empty = Addr.Map.empty
-  let add t mem =
+
+  let add_insn t mem =
     Map.set t (Memory.min_addr mem) (Insn {last = Memory.max_addr mem})
 
-  let visit t addr =
+  let touch t addr =
     Map.update t addr ~f:(function
         | None -> Unknown
-        | Some x -> x)
+        | Some known -> known)
 
   let find_insn t a = match Map.find t a with
     | Some (Insn {last}) -> Some last
@@ -165,7 +166,7 @@ let is_jump s mem insn =
   has_jump (ok_nil (s.lift mem insn))
 
 let update s mem insn dests : stage1 =
-  let s = { s with visited = Visited.add s.visited mem } in
+  let s = { s with visited = Visited.add_insn s.visited mem } in
   if is_jump s mem insn then
     let () = update_dests s mem dests in
     let roots = List.(filter_map ~f:fst dests |> rev_append s.roots) in
@@ -187,26 +188,25 @@ let next dis s =
       let mem = Result.map_error mem ~f:(fun err -> Error.tag err "next_root") in
       mem >>= fun mem ->
       Dis.jump dis mem {s with roots; addr} in
-  let s = {s with visited = Visited.visit s.visited s.addr } in
+  let s = {s with visited = Visited.touch s.visited s.addr } in
   loop s
 
 let stop_on = [`Valid]
 
-let has_common_destination dests addrs a =
-  let find_destinations a = match Addrs.find dests a with
-    | None -> Addr.Set.empty
-    | Some ds -> List.filter_map ~f:fst ds |> Addr.Set.of_list in
-  let ds = find_destinations a in
-  List.exists addrs ~f:(fun a' ->
-      Addr.(a <> a') && not Set.(is_empty @@ inter ds (find_destinations a')))
-
 let update_intersections disasm brancher s =
   let dests = Addr.Table.create () in
+  let find_destinations a =
+    Option.value (Addrs.find dests a) ~default:[] in
   let next dis = function
     | [] -> Dis.stop dis []
     | addr :: roots ->
       Memory.view ~from:addr s.base >>= fun mem ->
       Dis.jump dis mem roots in
+  let equal_dest x y = match x,y with
+    | (Some a, _), (Some a',_) -> Addr.(a = a')
+    | _ -> false in
+  let is_intersected ds ds' =
+    List.exists ds ~f:(fun d -> List.exists ds' ~f:(equal_dest d)) in
   let visit_intersections = function
     | [] | [_] -> Ok ()
     | (from :: roots) as intersections ->
@@ -218,17 +218,20 @@ let update_intersections disasm brancher s =
             Hashtbl.set dests (Memory.min_addr mem) ds;
             next d roots)
         ~stopped:next >>= fun _ ->
-      List.iter intersections ~f:(fun a -> match Addrs.find dests a with
-          | Some ds when has_common_destination dests intersections a ->
-            Addrs.set s.dests a ds
-          | _ -> ());
+      List.iter intersections ~f:(fun a ->
+          let ds = find_destinations a in
+          let has_common =
+            List.exists intersections ~f:(fun a' ->
+                Addr.(a <> a') && is_intersected ds (find_destinations a')) in
+          if has_common then
+            Addrs.set s.dests a ds);
       Ok () in
   let intersections =
     Map.fold s.visited ~init:Addr.Map.empty
       ~f:(fun ~key:addr ~data:tail inters ->
-        match tail with
-        | Visited.Unknown -> inters
-        | Visited.Insn {last} -> Map.add_multi inters last addr) in
+          match tail with
+          | Visited.Unknown -> inters
+          | Visited.Insn {last} -> Map.add_multi inters last addr) in
   Map.fold intersections ~init:(Ok ()) ~f:(fun ~key:_ ~data:addrs r ->
       r >>= fun () -> visit_intersections addrs) >>= fun () ->
   return s


### PR DESCRIPTION
Given that `byteweight` can emit roots that point somewhere to the middle of a real instruction, we can end up with two possible scenarios:
1) Bytes from the pointed address can't be disassembled. It leads to malformed blocks, and that's the issue we already fixed by filtering only disassembleable code.
2) Bytes can be disassembled, and it's a more interesting and tough case.
   
Example:
```
8dd820:       45 0f be 07             movsbl (%r15),%r8d
8dd824:       83 c3 01                add    $0x1,%ebx
```
Byteweight gives us a root at `0x8dd821`, and instruction `0f be 07` is perfectly disassembled too. And in general, we can't decide which one is correct.
Our solution is to process both of the instructions: `0x8dd820` and `0x8dd821`, and create 3 blocks here: the first one is a block that terminates at instruction with bounds `0x8dd820 - 0x8dd823`, the second one is a block that contains the only instruction `0x8dd821 - 0x8dd823`, and finally a block at `0x8dd824` with fall-through edges from the previous two. Note, that we preserve an invariant that there is only one block at some address.

### Details of implementation:

We allow instructions to share bytes, with the only exception that a first byte, i.e. the address of an instruction must be unique and unambiguously define an instruction. That's why the last byte can't be a key in all previously used mappings.  Also, we can't iterate over the memory by incrementing addresses, as we did it before to find block bounds. That's why we use instruction bounds and addresses of start and end of any block correspond to a first and to the last bytes of some instructions.

We got rid of `Span` module. And now we remember all memory chunks where a successfully disassembled instruction occurred. For the same reason we don't need to check our input roots anymore: any call of `Set.mem inits` will be done for an address which can be only the first byte of an instruction and nothing else.

We consider all instructions that share max address as a barrier, and we unconditionally update destinations for them to get a behavior we described in the example above.

