### PR TITLE
enables bap-elf

### DIFF
--- a/lib/bap_elf/elf_parse.ml
+++ b/lib/bap_elf/elf_parse.ml
@@ -439,8 +439,8 @@ let split bits size : bitstring * bitstring =
       tl : -1       : bitstring|} -> hd,tl
 
 
-(* Bitlength needed that's why lsl 3 *)
-let bitstring_of_bytes b = b, 0, Bytes.length b lsl 3
+(* Bitlength needed that's why we multiply by 8 *)
+let bitstring_of_bytes b = b, 0, Bytes.length b * 8
 
 (** returns a sequence of table entries  *)
 let split_table ti ~pos ~len data : bitstring Sequence.t Or_error.t =

--- a/lib/bap_elf/elf_parse.ml
+++ b/lib/bap_elf/elf_parse.ml
@@ -438,7 +438,9 @@ let split bits size : bitstring * bitstring =
   | {|hd : size * 8 : bitstring;
       tl : -1       : bitstring|} -> hd,tl
 
-let bitstring_of_bytes b = b, 0, Bytes.length b
+
+(* Bitlength needed that's why lsl 3 *)
+let bitstring_of_bytes b = b, 0, Bytes.length b lsl 3
 
 (** returns a sequence of table entries  *)
 let split_table ti ~pos ~len data : bitstring Sequence.t Or_error.t =

--- a/oasis/elf
+++ b/oasis/elf
@@ -5,7 +5,7 @@ Flag elf
 
 Library elf
   Path:          lib/bap_elf
-  Build$:        flag(elf)
+  Build$:        flag(everything) || flag(elf)
   FindlibName:   bap-elf
   BuildDepends:  bitstring, bitstring.ppx, regular
   Modules: Bap_elf

--- a/oasis/elf
+++ b/oasis/elf
@@ -19,7 +19,7 @@ Library elf
 
 Library elf_loader_plugin
   Path:             plugins/elf_loader
-  Build$:           flag(elf)
+  Build$:           flag(everything) || flag(elf)
   FindlibName:      bap-plugin-elf_loader
   CompiledObject:   best
   BuildDepends:     bap, bap-elf, bap-dwarf


### PR DESCRIPTION
PR fixes  https://github.com/BinaryAnalysisPlatform/bap/issues/756

Also, this PR fixes a minor bug: the length of `bitstring` was computed incorrectly previously

