### PR TITLE
includes plugin name into the configuration path

### DIFF
--- a/.run_travis_tests.sh
+++ b/.run_travis_tests.sh
@@ -5,6 +5,8 @@ mkdir -p $HOME/.opam/
 comp=`ls $HOME/save_opam`
 
 cp -r $HOME/save_opam/$comp $HOME/.opam/
+cp $HOME/save_opam/$comp/config $HOME/.opam/
+
 export PATH=$HOME/.opam/$comp/bin:$PATH
 
 bap --version

--- a/.travis_install.sh
+++ b/.travis_install.sh
@@ -12,6 +12,7 @@ mkdir -p $HOME/save_opam/$OPAM_SWITCH/lib/bap
 cp -r $HOME/.opam/$OPAM_SWITCH/bin/ $HOME/save_opam/$OPAM_SWITCH/
 cp -r $HOME/.opam/$OPAM_SWITCH/share $HOME/save_opam/$OPAM_SWITCH/
 cp -r $HOME/.opam/$OPAM_SWITCH/lib/bap/*.plugin $HOME/save_opam/$OPAM_SWITCH/lib/bap
+cp $HOME/.opam/config $HOME/save_opam/$OPAM_SWITCH/
 
 opam remove bap-veri -y
 '

--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -139,7 +139,7 @@ module Create() = struct
     let conf_file_options : (string, string) List.Assoc.t =
       let conf_filename =
         let (/) = Filename.concat in
-        Bap_config.confdir / "config" in
+        confdir / "config" in
       let string_splitter str =
         let str = String.strip str in
         match String.split str ~on:'=' with


### PR DESCRIPTION
fixes https://github.com/BinaryAnalysisPlatform/bap/issues/691

`confdir` was already prefixed above as needed, but not used