### PR TITLE
removes upper constraint for llvm version

### DIFF
--- a/lib/bap_llvm/llvm_binary_38_40.hpp
+++ b/lib/bap_llvm/llvm_binary_38_40.hpp
@@ -1,5 +1,5 @@
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+    || LLVM_VERSION_MAJOR >= 4
 
 #ifndef LLVM_BINARY_38_40_HPP
 #define LLVM_BINARY_38_40_HPP
@@ -13,7 +13,7 @@
 #include <sstream>
 #include <tuple>
 
-#if LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+#if LLVM_VERSION_MAJOR >= 4
 #include <llvm/Support/Error.h>
 #endif
 
@@ -59,7 +59,7 @@ error_or<T> of_llvm_error_or(const llvm::ErrorOr<T> &e) {
     return success(e.get());
 }
 
-#if LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+#if LLVM_VERSION_MAJOR >= 4
 template <typename T>
 error_or<T> of_llvm_error_or(llvm::Expected<T> &e) {
     if (!e) {
@@ -223,7 +223,7 @@ error_or<object::Binary> get_binary(const char* data, std::size_t size) {
     StringRef data_ref(data, size);
     MemoryBufferRef buf(data_ref, "binary");
     auto binary = createBinary(buf);
-#if LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+#if LLVM_VERSION_MAJOR >= 4
     if (!binary)
         return failure(toString(binary.takeError()));
 #elif LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8

--- a/lib/bap_llvm/llvm_coff_loader.hpp
+++ b/lib/bap_llvm/llvm_coff_loader.hpp
@@ -255,7 +255,7 @@ void exported_symbols(const coff_obj &obj, ogre_doc &s) {
 }
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8 \
-    || LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+    || LLVM_VERSION_MAJOR >= 4
 
 error_or<int64_t> symbol_relative_address(const coff_obj &obj, const SymbolRef &sym) {
     auto base = obj.getImageBase();

--- a/lib/bap_llvm/llvm_disasm.cpp
+++ b/lib/bap_llvm/llvm_disasm.cpp
@@ -22,14 +22,14 @@
 #include "disasm.hpp"
 #include "llvm_disasm.h"
 
-#if LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+#if LLVM_VERSION_MAJOR >= 4
 #include <llvm/MC/MCDisassembler/MCDisassembler.h>
 #else
 #include <llvm/MC/MCDisassembler.h>
 #endif
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+    || LLVM_VERSION_MAJOR >= 4
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/Triple.h>
 #include <llvm/ADT/Twine.h>
@@ -43,7 +43,7 @@
 
 //template <typename T>
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+    || LLVM_VERSION_MAJOR >= 4
 template <typename T>
 using smart_ptr = std::unique_ptr<T>;
 template <class T>
@@ -86,7 +86,7 @@ bool ends_with(const std::string& str, const std::string &suffix) {
 //! identically on both versions.
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+    || LLVM_VERSION_MAJOR >= 4
 class MemoryObject {
     memory mem;
 public:
@@ -186,7 +186,7 @@ class llvm_disassembler : public disassembler_interface {
     insn current;
     std::vector<int> prefixes;
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+    || LLVM_VERSION_MAJOR >= 4
     shared_ptr<MemoryObject>                mem;
 #else
     shared_ptr<const llvm::MemoryObject>    mem;
@@ -274,7 +274,7 @@ public:
         }
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+    || LLVM_VERSION_MAJOR >= 4
         smart_ptr<llvm::MCSymbolizer>
             symbolizer(target->createMCSymbolizer(
                            triple,
@@ -299,7 +299,7 @@ public:
         }
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+    || LLVM_VERSION_MAJOR >= 4
         shared_ptr<llvm::MCInstPrinter>
             printer (target->createMCInstPrinter
                      (t, asm_info->getAssemblerDialect(), *asm_info, *ins_info, *reg_info));
@@ -319,7 +319,7 @@ public:
         printer->setPrintImmHex(true);
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+    || LLVM_VERSION_MAJOR >= 4
         shared_ptr<llvm::MCDisassembler>
             dis(target->createMCDisassembler(*sub_info, *ctx));
 #else
@@ -334,7 +334,7 @@ public:
         }
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+    || LLVM_VERSION_MAJOR >= 4
         dis->setSymbolizer(move(symbolizer));
 #else
         dis->setSymbolizer(symbolizer);
@@ -380,7 +380,7 @@ public:
     }
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+    || LLVM_VERSION_MAJOR >= 4
     llvm::ArrayRef<uint8_t> view(uint64_t pc) {
         return mem->view(pc);
     }
@@ -456,7 +456,7 @@ public:
             std::string data;
             llvm::raw_string_ostream stream(data);
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+    || LLVM_VERSION_MAJOR >= 4
             printer->printInst(&mcinst, stream, "", *sub_info);
 #else
             printer->printInst(&mcinst, stream, "");

--- a/lib/bap_llvm/llvm_elf_loader.hpp
+++ b/lib/bap_llvm/llvm_elf_loader.hpp
@@ -208,7 +208,7 @@ void symbol_entry(const ELFObjectFile<T> &obj, const SymbolRef &sym, ogre_doc &s
 }
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8          \
-    || LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+    || LLVM_VERSION_MAJOR >= 4
 
 template <typename T>
 uint64_t base_address(const ELFObjectFile<T> &obj) {

--- a/lib/bap_llvm/llvm_loader.hpp
+++ b/lib/bap_llvm/llvm_loader.hpp
@@ -13,7 +13,7 @@ namespace loader {
 using namespace llvm;
 using namespace llvm::object;
 
-#if LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+#if LLVM_VERSION_MAJOR >= 4
 
 error_or<object::Binary> get_binary(const char* data, std::size_t size) {
     StringRef data_ref(data, size);

--- a/lib/bap_llvm/llvm_macho_loader.hpp
+++ b/lib/bap_llvm/llvm_macho_loader.hpp
@@ -6,7 +6,7 @@
 #include <iomanip>
 #include <limits>
 
-#if LLVM_VERSION_MAJOR >= 5 && LLVM_VERSION_MAJOR < 8
+#if LLVM_VERSION_MAJOR >= 5
 #include <llvm/BinaryFormat/MachO.h>
 #else
 #include <llvm/Support/MachO.h>
@@ -461,7 +461,7 @@ void dynamic_relocations(const macho &obj, command_info &info, ogre_doc &s) {
 }
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8 \
-    || LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+    || LLVM_VERSION_MAJOR >= 4
 
 commands macho_commands(const macho &obj) {
     commands cmds;

--- a/lib/bap_llvm/llvm_primitives.cpp
+++ b/lib/bap_llvm/llvm_primitives.cpp
@@ -16,7 +16,7 @@ int64_t relative_address(uint64_t base, uint64_t abs) {
     return (abs - base);
 }
 
-#if LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+#if LLVM_VERSION_MAJOR >= 4
 
 template <typename T>
 std::string error_message(Expected<T> &e) {
@@ -44,7 +44,7 @@ error_or<SymbolRef::Type> symbol_type(const SymbolRef &s) {
 #endif
 
 // 4.0 or 3.8
-#if LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8          \
+#if LLVM_VERSION_MAJOR >= 4 \
     || LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8
 
 const char* get_raw_data(const ObjectFile &obj) {

--- a/lib/bap_llvm/llvm_primitives.hpp
+++ b/lib/bap_llvm/llvm_primitives.hpp
@@ -63,7 +63,7 @@ error_or<std::string> elf_section_name(const ELFFile<T> &elf, const typename ELF
 
 // template functions
 
-#if LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+#if LLVM_VERSION_MAJOR >= 4
 
 template <typename T>
 std::vector<typename ELFFile<T>::Elf_Phdr> elf_program_headers(const ELFFile<T> &elf) {

--- a/plugins/x86/x86_mov_offset.ml
+++ b/plugins/x86/x86_mov_offset.ml
@@ -196,10 +196,4 @@ module Self = Self ()
 let () =
   let llvm_version = String.sub llvm_version 0 3 in
   if llvm_version = "3.4" then T_34.register ()
-  else
-  if List.mem ["3.8";"4.0";"5.0";"6.0";"7.0"] llvm_version ~equal:String.equal
-  then T.register ()
-  else
-    Self.error
-      "x86 MOV with offset instructions will not lifted due to unknown \
-       llvm version %s\n" llvm_version
+  else T.register ()


### PR DESCRIPTION
let's trust to `llvm` and don't constraint its version from the above. 