### PR TITLE
fixes the order of arguments in the callsites plugin

### DIFF
--- a/plugins/callsites/callsites_main.ml
+++ b/plugins/callsites/callsites_main.ml
@@ -54,8 +54,8 @@ let target intent sub blk call =
     | _ -> None
   else Some blk
 
-(* Note, that we intentionally invert compare for Both and Out
-   arguments, since they will be inserted in reverted order later. *)
+(* Note, that output arguments will be inserted in the reverse order, so
+   we sort all of them in a natural way to get the following order: In Both Out *)
 let enum_args t =
   let compare x y =
     Option.compare compare_intent (Arg.intent x) (Arg.intent y) in

--- a/plugins/callsites/callsites_main.ml
+++ b/plugins/callsites/callsites_main.ml
@@ -54,6 +54,8 @@ let target intent sub blk call =
     | _ -> None
   else Some blk
 
+(* Note, that we intentionally invert compare for Both and Out
+   arguments, since they will be inserted in reverted order later. *)
 let enum_args t =
   let compare x y = match Arg.intent x, Arg.intent y with
     | None, None -> 0

--- a/plugins/callsites/callsites_main.ml
+++ b/plugins/callsites/callsites_main.ml
@@ -60,11 +60,11 @@ let enum_args t =
     | None, Some _ -> -1
     | Some _, None -> 1
     | Some x, Some y -> match x,y with
-       | In, _ -> -1
-       | _, In -> 1
-       | Out, Both -> -1
-       | Both, Out -> 1
-       | _ -> 0 in
+      | In, _ -> -1
+      | _, In -> 1
+      | Out, Both -> -1
+      | Both, Out -> 1
+      | _ -> 0 in
   Term.enum arg_t t |> Seq.to_list |> List.stable_sort ~compare
 
 let insert_defs prog sub =

--- a/plugins/callsites/callsites_main.ml
+++ b/plugins/callsites/callsites_main.ml
@@ -57,16 +57,8 @@ let target intent sub blk call =
 (* Note, that we intentionally invert compare for Both and Out
    arguments, since they will be inserted in reverted order later. *)
 let enum_args t =
-  let compare x y = match Arg.intent x, Arg.intent y with
-    | None, None -> 0
-    | None, Some _ -> -1
-    | Some _, None -> 1
-    | Some x, Some y -> match x,y with
-      | In, _ -> -1
-      | _, In -> 1
-      | Out, Both -> -1
-      | Both, Out -> 1
-      | _ -> 0 in
+  let compare x y =
+    Option.compare compare_intent (Arg.intent x) (Arg.intent y) in
   Term.enum arg_t t |> Seq.to_list |> List.stable_sort ~compare
 
 let insert_defs prog sub =

--- a/plugins/print/print_main.ml
+++ b/plugins/print/print_main.ml
@@ -89,6 +89,8 @@ module Adt = struct
   let pp_var ppf = Var.Io.print ~fmt:"adt" ppf
   let pp_exp ppf = Exp.Io.print ~fmt:"adt" ppf
 
+  let pp_word ppf = Word.pp_generic ~prefix:`base ~format:`hex ppf
+
   module Tid = struct
     let pp ppf tid = pr ppf "Tid(0x%a, %S)" Tid.pp tid (Tid.name tid)
   end
@@ -194,8 +196,8 @@ module Adt = struct
                        | Some name -> Some (name,mem)
                        | None -> None) in
     let pp_section ppf (name,mem) =
-      fprintf ppf {|Section(%S, %s, "|}
-        name (Addr.string_of_value (Memory.min_addr mem));
+      fprintf ppf {|Section(%S, %a, "|}
+        name pp_word (Memory.min_addr mem);
       Memory.iter ~word_size:`r8 mem ~f:(fun byte ->
           fprintf ppf "%a" pp_byte byte);
       fprintf ppf {|")|} in
@@ -203,9 +205,9 @@ module Adt = struct
 
   let pp_memmap ppf memmap =
     let pp_region ppf mem =
-      pr ppf "Region(%s,%s)"
-        (Addr.string_of_value (Memory.min_addr mem))
-        (Addr.string_of_value (Memory.max_addr mem)) in
+      pr ppf "Region(%a,%a)"
+        pp_word (Memory.min_addr mem)
+        pp_word (Memory.max_addr mem) in
     let pp_binding ppf (mem,attr) =
       pr ppf "Annotation(%a,@ %a)"
         pp_region mem pp_attr attr in


### PR DESCRIPTION
Previously, the callsites plugin was inserting arguments in a such way that dual intent arguments were evaluated after the return arguments. This PR fixes the order, so that the in/our arguments are evaluated before the out arguments. It is also takes extra care and sorts the arguments before inserting, so that we do not rely too much on the order of arguments in the subroutine term.

This PR fixes the #740 in which a wrong order of evaluation led to the destruction of a def-use chain.
