### PR TITLE
adds observations for primus lisp stubs

### DIFF
--- a/lib/bap_primus/bap_primus_linker.ml
+++ b/lib/bap_primus/bap_primus_linker.ml
@@ -79,6 +79,13 @@ module Trace = struct
 
   let return,call_returned =
     Observation.provide ~inspect:sexp_of_call "call-return"
+
+  let lisp_call,lisp_call_entered =
+    Observation.provide ~inspect:sexp_of_call "list-call"
+
+  let lisp_call_return,lisp_call_returned =
+    Observation.provide ~inspect:sexp_of_call "lisp-call-return"
+
 end
 include Trace
 

--- a/lib/bap_primus/bap_primus_linker.mli
+++ b/lib/bap_primus/bap_primus_linker.mli
@@ -22,6 +22,10 @@ module Trace : sig
   val call_entered : (string * value list) statement
   val return : (string * value list) observation
   val call_returned : (string * value list) statement
+  val lisp_call : (string * value list) observation
+  val lisp_call_entered : (string * value list) statement
+  val lisp_call_return : (string * value list) observation
+  val lisp_call_returned : (string * value list) statement
 end
 module type Code = functor (Machine : Machine) -> sig
   val exec : unit Machine.t

--- a/lib/bap_primus/bap_primus_lisp.ml
+++ b/lib/bap_primus/bap_primus_lisp.ml
@@ -300,10 +300,12 @@ module Interpreter(Machine : Machine) = struct
       let bs,frame_size = Vars.make_frame s.width bs in
       Eval.const Word.b0 >>= fun init ->
       notify_when is_external Trace.call_entered name args >>= fun () ->
+      notify_when is_external Trace.lisp_call_entered name args >>= fun () ->
       eval_advices Advice.Before init name args >>= fun _ ->
       Machine.Local.put state (Vars.push_frame bs s) >>= fun () ->
       eval_exp (Lisp.Def.Func.body fn) >>= fun r ->
       Machine.Local.update state ~f:(Vars.pop frame_size) >>= fun () ->
+      notify_when is_external Trace.lisp_call_returned name args >>= fun () ->
       notify_when is_external Trace.call_returned name (args @ [r]) >>= fun () ->
       eval_advices Advice.After r name args
 


### PR DESCRIPTION
This PR adds a couple of observations that will be invoked every time an externally linked stub is called and returns.

Enables a workaround for #879.

