### PR TITLE
removes dependency from clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
     packages:
     - camlp4
     - camlp4-extra
-    - clang
     - curl
     - libcurl4-gnutls-dev
     - libgmp-dev

--- a/opam/opam
+++ b/opam/opam
@@ -38,7 +38,6 @@ build: [
   [
     "./configure"
     "--prefix=%{prefix}%"
-    "--with-cxx=`which clang++`"
     "--with-llvm-version=%{conf-bap-llvm:package-version}%"
       {conf-bap-llvm:installed}
     "--with-llvm-config=%{conf-bap-llvm:config}%" {conf-bap-llvm:installed}
@@ -244,13 +243,11 @@ depexts: [
     "libcurl4-gnutls-dev"
     "llvm-3.8-dev"
     "time"
-    "clang"
     "llvm"
     "m4"
     "dejagnu"
   ] {os-distribution = "ubuntu"}
   [
-    "clang"
     "curl"
     "dejagnu"
     "gmp"


### PR DESCRIPTION
fixes https://github.com/BinaryAnalysisPlatform/bap/pull/918

Like it was suggested, let's drop the dependency from clang. The same should be done in our opam repository. 