### PR TITLE
Fixing common typos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -124,7 +124,7 @@
   - MachO Kernel Bundles (LLVM 3.8+ only)
   - Plain object files
   - Shared libraries
-- PR#630 Enhancments in IDA plugin
+- PR#630 Enhancements in IDA plugin
 
 
 ### Bug fixes
@@ -167,7 +167,7 @@
 
 - A powerful plugin system
 - Split Bap.Std into several libraries.
-- The disassembler layer is severly rewritten
+- The disassembler layer is severely rewritten
 - Made project storable and loadable
 - Added new injection points
 - Added BIL interpreters
@@ -188,8 +188,8 @@
    `Graphlib` is a generic library that extends a well known
    OCamlGraph library. `Graphlib` uses its own, more reach and modern,
    `Graph` interface that is isomorphic to OCamlGraph's `Sigs.P`
-   signature for persistant graphs. This interface is developed
-   according to the Janestreet's style guidlines and depends on
+   signature for persistent graphs. This interface is developed
+   according to the Janestreet's style guidelines and depends on
    Core_kernel library.  Other than the new interface, `Graphlib`
    provides several graph implementations, and generic algorithms.  To
    make our algorithms polymorphic over chosen graph representation we
@@ -199,7 +199,7 @@
 2. Refined IR.
 
    phi and arg terms were refined. a phi term now is a discriminated
-   set of expressions, and arguments are made more like a defintions.
+   set of expressions, and arguments are made more like a definition.
 
 3. SSA form
 
@@ -306,7 +306,7 @@
 
    Complex hierarchy is now hidden under one umbrella `bap.mli`.
    `Bap_*` modules are marked as internal and is no more installable
-   and, thus, they do not polute the namespace. This will of course,
+   and, thus, they do not pollute the namespace. This will of course,
    break the code that used this internal modules. It is intended
    behavior.
 
@@ -496,7 +496,7 @@ traversing for you, allowing you to override default behavior. Some
 handy algorithms, that use visitors are provided in an internal
 Bap_helpers module, that is included into resulting Bil
 module. Several optimizations were added to bap-objdump utility, like
-constant propogation, inlining, pruning unused variables and resolving
+constant propagation, inlining, pruning unused variables and resolving
 addresses to symbols.
 
 5. Insn interface now provides predicates to query insn classes, this

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -67,7 +67,7 @@ module Std : sig
       The standard library tries to be as extensible as possible. We
       are aware, that there are not good solutions for some problems, so
       we don't want to force our way of doing things. In short, we're
-      trying to provide mechanisms, not policies. We achive this by
+      trying to provide mechanisms, not policies. We achieve this by
       employing the dependency injection principle. By inversing the
       dependency we allow the library to depend on a user code. For
       example, a user code can teach the library how to disassemble
@@ -1153,7 +1153,7 @@ module Std : sig
       Examples:
       [0x5D:32s, 0b0101:16u, 5:64, +5:8, +0x5D:16].
 
-      If [base] is omitted base-10 is assumed. If the kind is ommited,
+      If [base] is omitted base-10 is assumed. If the kind is omitted,
       then the usigned kind is assumed. The output format is always in
       a hex representation with a full prefix.  . *)
   module Bitvector : sig
@@ -1694,7 +1694,7 @@ module Std : sig
     *)
     module Int_exn : Integer.S with type t = t
 
-    (** Arithmentic operations that doesn't check the widths.*)
+    (** Arithmetic operations that doesn't check the widths.*)
     module Unsafe  : Integer.S with type t = t
 
     (** Stable marshaling interface.  *)
@@ -1855,7 +1855,7 @@ module Std : sig
         | Concat  of exp * exp          (** concatenate two words  *)
       and typ =
         | Imm of int                     (** [Imm n] - n-bit immediate   *)
-        | Mem of addr_size * size        (** [Mem (a,t)] memory with a specifed addr_size *)
+        | Mem of addr_size * size        (** [Mem (a,t)] memory with a specified addr_size *)
       [@@deriving bin_io, compare, sexp]
 
       type stmt =
@@ -2146,7 +2146,7 @@ module Std : sig
     val is_referenced : var -> stmt list -> bool
 
     (** [is_assigned x p] is [true] if there exists such [Move]
-        statement, that [x] occures on the left side of it. If
+        statement, that [x] occurs on the left side of it. If
         [strict] is true, then only unconditional assignments are
         accounted. By default, [strict] is [false] *)
     val is_assigned : ?strict:bool -> var -> stmt list -> bool
@@ -2188,7 +2188,7 @@ module Std : sig
         order is to recall the sed's [s/in/out] syntax. *)
     val substitute : exp -> exp -> stmt list -> stmt list
 
-    (** [substitute_var x y p] substitutes all free occurences of
+    (** [substitute_var x y p] substitutes all free occurrences of
         variable [x] in program [p] by expression [y]. A variable is
         free if it is not bounded in a preceding statement or not bound
         with let expression.  *)
@@ -2257,7 +2257,7 @@ module Std : sig
         consistency and efficiency bytes are still reprented with
         bitvectors.
 
-        Storages should not take care of aliasing or endiannes, as they
+        Storages should not take care of aliasing or endianness, as they
         are byte addressable. All memory operations are normalized by
         Bili.
 
@@ -2405,7 +2405,7 @@ module Std : sig
         names and immediate values. Depending on your context it may be
         find or not. For example, two [SP] variables may compare as different
         if one of them was obtained from different compilation (and met
-        the other one through some persistant storage, e.g., file on hard
+        the other one through some persistent storage, e.g., file on hard
         disk). Moreover, BIL obtained from different lifters will have
         different names for the same registers. All this issues are
         addressed in normalized [Trie]. *)
@@ -2413,7 +2413,7 @@ module Std : sig
       type normalized_bil
 
       (** [normalize ?subst bil] normalize BIL. If [subst] is provided,
-          then substitute each occurence of the fst expression to the
+          then substitute each occurrence of the fst expression to the
           snd expression before the normalization. The effect of
           normalization is the following:
 
@@ -2615,7 +2615,7 @@ module Std : sig
       BIL variables are regular values. Variables can have
       indices. Usually the index is used to represent the same
       variable but at different time or space (control flow path).
-      This is particulary useful for representing variables in SSA
+      This is particularly useful for representing variables in SSA
       form.
 
       By default, comparison function takes indices into account. In
@@ -2646,10 +2646,10 @@ module Std : sig
     *)
     val create : ?is_virtual:bool -> ?fresh:bool -> string -> typ -> t
 
-    (** [name var] returns a name assosiated with variable  *)
+    (** [name var] returns a name associated with variable  *)
     val name : t -> string
 
-    (** [typ var] returns a type assosiated with variable  *)
+    (** [typ var] returns a type associated with variable  *)
     val typ : t -> typ
 
     (** [is_physical v] is [true] if [v] represents a contents of a
@@ -2728,7 +2728,7 @@ module Std : sig
       types for Expi, Bili, and Biri.
 
       Note, this is a low-level interface that can be used if you want
-      to build your own evaluators (interpeters). If you want to use
+      to build your own evaluators (interpreters). If you want to use
       already existing interpreter without drastically changing the
       semantics of BIL consider using the Primus Framework.
 
@@ -3048,7 +3048,7 @@ module Std : sig
 
         (** {2 Error conditions}  *)
 
-        (** a given typing error has occured  *)
+        (** a given typing error has occurred  *)
         method type_error : type_error -> 'a r
 
         (** we can't do this!  *)
@@ -3217,7 +3217,7 @@ module Std : sig
         possible for the expression to have this effect.
 
         The analysis applies a simple abstract interpretation to
-        approximate arithmetics and prove an absence of the division
+        approximate arithmetic and prove an absence of the division
         by zero. The load/store/read analysis is more precise than
         the division by zero, as the only source of the imprecision
         is a presence of conditional expressions.
@@ -3239,7 +3239,7 @@ module Std : sig
         position of the visitor *)
     class state : object
 
-      (** a stack of expr, that are parents for the currenly visiting
+      (** a stack of expr, that are parents for the currently visiting
           expression *)
       val exps_stack  : exp  list
 
@@ -3415,7 +3415,7 @@ module Std : sig
         something. See also {!Bil.exists} and {Stmt.exists}  *)
     val exists : unit #finder -> t -> bool
 
-    (** [substitute pat rep x] subsitutes each occurence of an
+    (** [substitute pat rep x] subsitutes each occurrence of an
         expression [pat] in [x] with an expression [rep] *)
     val substitute : exp -> exp -> exp -> exp
 
@@ -3452,7 +3452,7 @@ module Std : sig
         computation, e.g., [1 + 2 -> 3]
 
         - neutral element elimination: binary operations with one of
-        the operands being known to be neutral, are subtituted with
+        the operands being known to be neutral, are substituted with
         the other operand, e.g., [x * 1 -> x]
 
         - zero element propagation: binary operations applied to a
@@ -3475,7 +3475,7 @@ module Std : sig
         to the unary negation, e.g., [0 - x -> -x]
 
         - exclusive disjunction reduction: reduces an exclusive
-        disjunction of syntactically equal expresions to zero, e.g,
+        disjunction of syntactically equal expressions to zero, e.g,
         [42 ^ 42 -> 0]. Note, by default a read from a register is
         considered as a (co)effect, thus [xor eax eax] is not
         reduced, consider passing [~ignore:[Eff.reads]] if you want
@@ -3721,11 +3721,11 @@ module Std : sig
 
         - Memory load expressions can be only applied to a memory. This
         effectively disallows creation of temporary memory regions,
-        and requires all store operations to be commited via the
-        assignemnt operation. Also, this provides a guarantee, that
-        store expressions will not occur in integer assigments, jmp
+        and requires all store operations to be committed via the
+        assignment operation. Also, this provides a guarantee, that
+        store expressions will not occur in integer assignments, jmp
         destinations, and conditional expressions, leaving them valid
-        only in an assignment statment where the rhs has type mem_t.
+        only in an assignment statement where the rhs has type mem_t.
         This is effectively the same as make the [Load] constructor to
         have type ([Load (var,exp,endian,size)]).
 
@@ -3742,7 +3742,7 @@ module Std : sig
         the Move instruction.
 
         - All memory operations have sizes equal to one byte. Thus the
-        size and endiannes can be ignored in analysis. During the
+        size and endianness can be ignored in analysis. During the
         normalization, the following rewrites are performed
         {v
        let x = <expr> in ... x ... => ... <expr> ...
@@ -4269,7 +4269,7 @@ module Std : sig
 
     (** [create ?capacity default] creates an empty vector with a a given
         [capacity]. It is guaranteed that the default value will never
-        be seen by the user unless he put it into the vector explicitely
+        be seen by the user unless he put it into the vector explicitly
         with [append] or [set].
     *)
     val create : ?capacity:int -> 'a -> 'a t
@@ -4293,7 +4293,7 @@ module Std : sig
         [Container.S1] interface *)
     val map_to_array : 'a t -> f:('a -> 'b) -> 'b array
 
-    (** [findi xs ~f] retuns an index [i] and a value [x] of the first
+    (** [findi xs ~f] returns an index [i] and a value [x] of the first
         element of [xs], for which [f i x] is [true].  *)
     val findi : 'a t -> f:(int -> 'a -> bool) -> (int * 'a) option
 
@@ -4752,7 +4752,7 @@ module Std : sig
       val int64  : word reader
     end
 
-    (** {2 Printing and outputing}  *)
+    (** {2 Printing and outputting}  *)
     include Printable.S with type t := t
 
     (** [hexdump t out] outputs hexdump (as per [hexdump -C]) of the
@@ -4816,7 +4816,7 @@ module Std : sig
   (** Table.
 
       Tables are used to partition memory region into a set of
-      non-intersecting areas. Each area is assosiated with arbitrary
+      non-intersecting areas. Each area is associated with arbitrary
       value of type ['a] bound to the type of the table.
 
       All operations over tables are purely applicative, i.e. there is
@@ -4959,7 +4959,7 @@ module Std : sig
     (** [rev_map arity t tab] creates a reverse mapping from values of
         typeclass [t] stored in table [tab] to memory regions.
 
-        Note. not every mapping is reversable, for example, trying to obtain
+        Note. not every mapping is reversible, for example, trying to obtain
         a reverse of surjective mapping as a one-to-one mapping will
         result in an error. But surjective mappings can be reversed
         using [~one_to:many] mapping. A particular example of surjective
@@ -5182,7 +5182,7 @@ module Std : sig
     (** {2 Constructing}  *)
 
     (** constructing an image can result in actual image and a set
-        (hopefully empty) of errors occured in a process of decoding an
+        (hopefully empty) of errors occurred in a process of decoding an
         image, that do not prevent us from actually creating an image. So,
         this information messages can be considered as warnings. *)
     type result = (t * Error.t list) Or_error.t
@@ -5191,7 +5191,7 @@ module Std : sig
         specified by the [filename]. If [backend] is equal to "auto", then
         all backends are tried in order. If only one backend can read this
         file (i.e., there is no ambiguity), then image is returned. If
-        [backend] is not specifed, then the LLVM backend is used. *)
+        [backend] is not specified, then the LLVM backend is used. *)
     val create : ?backend:string -> path -> result
 
     (** [of_string ?backend ~data] creates an image from the specified
@@ -5526,7 +5526,7 @@ module Std : sig
 
     (** [mapi m f] the same as [map], but [f] is called with two
         arguments: [mem] and [tag], where [mem] is a memory region,
-        and [tag] is a [tag] assosiated with that region. *)
+        and [tag] is a [tag] associated with that region. *)
     val mapi : 'a t -> f:(mem -> 'a -> 'b) -> 'b t
 
     (** [filter map f] returns a map that contains only those elements
@@ -5539,7 +5539,7 @@ module Std : sig
     val filter_map : 'a t -> f:('a -> 'b option) -> 'b t
 
     (** [filter_mapi] is like [filter_map] but use function also accepts
-        would assosiated memory region *)
+        would associated memory region *)
     val filter_mapi : 'a t -> f:(mem -> 'a -> 'b option) -> 'b t
 
     (** [remove map mem] removes all bindings to [mem]  *)
@@ -5796,7 +5796,7 @@ module Std : sig
           disassembler for the specified [target]. All parameters are
           backend specific, consult the concrete backend for more
           information. In general, the greater [debug_level] is, the
-          more debug information will be outputed by a backend. To
+          more debug information will be outputted by a backend. To
           silent backend set it [0]. This is a default value. Example:
 
           [create ~debug_level:3 ~backend:"llvm" "x86_64" ~f:process]
@@ -5860,7 +5860,7 @@ module Std : sig
           valid instruction), it defaults to [step], i.e., to skipping.
 
           [hit state mem insn data] is called when one of the predicates
-          specifed by a user was hit. [insn] is actually the instruction
+          specified by a user was hit. [insn] is actually the instruction
           that satisfies the predicate. [mem] is a memory region spanned by
           the instruction. [data] is a user data. [insn] can be queried for
           assembly string and kinds even if the corresponding modes are
@@ -5875,7 +5875,7 @@ module Std : sig
         return:('s -> 'r) ->
         init:'s -> mem -> 'r
 
-      (** [insn_of_mem dis mem] performes a disassembly of one instruction
+      (** [insn_of_mem dis mem] performs a disassembly of one instruction
           from the a given memory region [mem]. Returns a tuple
           [imem,insn,`left over] where [imem] stands for a piece of memory
           consumed in a process of disassembly, [insn] can be [Some ins] if
@@ -6136,7 +6136,7 @@ module Std : sig
     (** [is property insn] is [true] if [insn] has [property]  *)
     val is  : must property -> t -> bool
 
-    (** [may propery insn] is [true] if [insn] has [property]  *)
+    (** [may property insn] is [true] if [insn] has [property]  *)
     val may : may  property -> t -> bool
 
     (** [must property insn] postulate that [insn] must have the [property]  *)
@@ -6639,7 +6639,7 @@ module Std : sig
   val target_of_arch : arch -> (module Target)
 
   (** Register new target architecture. If target for the given arch
-      already exists, then it will be superseeded by the new
+      already exists, then it will be superseded by the new
       target.  *)
   val register_target : arch -> (module Target) -> unit
 
@@ -6805,7 +6805,7 @@ module Std : sig
         [id], if such exists.  *)
     val next : ('a,'b) cls -> 'a t -> tid -> 'b t option
 
-    (** [prev t p id] returns a term that preceeds a term with a given
+    (** [prev t p id] returns a term that precedes a term with a given
         [id], if such exists.  *)
     val prev : ('a,'b) cls -> 'a t -> tid -> 'b t option
 
@@ -6817,7 +6817,7 @@ module Std : sig
     val after : ('a,'b) cls -> ?rev:bool -> 'a t -> tid -> 'b t seq
 
     (** [before t ?rev p tid] returns all term that occurs before
-        defintion with a given [tid] in blk. If there is no such
+        definition with a given [tid] in blk. If there is no such
         definition, then the sequence will be empty.  @param rev has
         the same meaning as in {!after}.  *)
     val before : ('a,'b) cls -> ?rev:bool -> 'a t -> tid -> 'b t seq
@@ -6903,7 +6903,7 @@ module Std : sig
 
     (** {2 Higher order mapping}  *)
 
-    (** Mapper perfoms deep identity term mapping. If you override any
+    (** Mapper performs deep identity term mapping. If you override any
         method make sure that you didn't forget to invoke parent's
         method, as OCaml will not call it for you.  *)
     class mapper : object
@@ -7710,7 +7710,7 @@ module Std : sig
 
         (** [register name cons] registers a method that creates a given
             source of information. If a method with the given name already
-            exists, then it will be superceeded by a new one.  *)
+            exists, then it will be superseded by a new one.  *)
         val register : string -> t source -> unit
       end
 
@@ -7834,7 +7834,7 @@ module Std : sig
           dependency - the consistency with BIR and BIL. Consider, BIL's
           [if] statement or BIR's conditional jump. If we will start to
           propagate taint from condition in [ite] expression, then we should
-          also propagate it in BIL's and BIR's conditionals. Unfortunatelly
+          also propagate it in BIL's and BIR's conditionals. Unfortunately
           the latter is not possible.
 
       *)
@@ -8314,7 +8314,7 @@ module Std : sig
         during the project reconstruction. See {!Project.create}
         function for more information on the reconstruction process. *)
     module Info : sig
-      (** occurs everytime a new file is opened. The value is a filename  *)
+      (** occurs every time a new file is opened. The value is a filename  *)
       val file : string stream
 
       (** occurs once input architecture is known  *)
@@ -8326,10 +8326,10 @@ module Std : sig
       (** occurs once code segment is discovered  *)
       val code : value memmap stream
 
-      (** occurs everytime a whole program control flow graph is changed  *)
+      (** occurs every time a whole program control flow graph is changed  *)
       val cfg : cfg stream
 
-      (** occurs everytime a symbol table is changed  *)
+      (** occurs every time a symbol table is changed  *)
       val symtab : symtab stream
 
       (** occurs every time a program term is changed during the
@@ -8494,7 +8494,7 @@ module Std : sig
       scope.
 
       It is designed to be used inside a plugin, but can be used in
-      a standalone program as well (this is usefull, for debugging
+      a standalone program as well (this is useful, for debugging
       plugins, by running them as a standalone applications).
 
       If run in a standalone mode, then field [name] would be set to
@@ -8556,10 +8556,10 @@ module Std : sig
         the total number of stages [s']. The note [n] may provide an
         additional textual explanation of the current stage. The report
         doesn't mean that the stage is finished, but rather that it is
-        entered. Thus for [s'] stages we expect to recieve [s'-1]
+        entered. Thus for [s'] stages we expect to receive [s'-1]
         reports. (This approach works fine with functional programming
         and iterating - as in functional programming it is more
-        convinient to report before computation, and during the indexed
+        convenient to report before computation, and during the indexed
         iteration the index of the last element is one less than the
         total number of elements).
 
@@ -8883,7 +8883,7 @@ module Std : sig
 
         A file named [log] is created in the [logdir] folder. If such
         file already exists in this folder, then the log rotation is
-        initated - the existing [log] file is renamed to [log~1],
+        initiated - the existing [log] file is renamed to [log~1],
         [log~1] to [log~2] and so on until there are no more files to
         rename, or the [log~99] is reached which is discarded
         (unlinked).

--- a/lib/bap_api/bap_api_abi.mli
+++ b/lib/bap_api/bap_api_abi.mli
@@ -31,7 +31,7 @@ type 'a language
 
 (** [register arch name f] registers an abi function [f] for abi with
     the given [name] and [arch]. If an abi for the given pair is
-    already registered, then it will be overriden. *)
+    already registered, then it will be overridden. *)
 
 type 'a t = 'a language -> sub term -> sub term
 val register : 'a language -> arch -> string -> 'a t -> unit

--- a/lib/bap_bml/bap_bml.mli
+++ b/lib/bap_bml/bap_bml.mli
@@ -21,7 +21,7 @@ module type Registry = sig
 
   (** [register name value] register [value] with a given [name].
       If [name] was already associated with some other value, then
-      it will be superseeded with the new binding.   *)
+      it will be superseded with the new binding.   *)
   val register : string -> t -> unit
 
   (** [find name] find a value associated with the given [value]  *)

--- a/lib/bap_build/bap_build.mli
+++ b/lib/bap_build/bap_build.mli
@@ -1,4 +1,4 @@
-(** bapbuild implentation library *)
+(** bapbuild implementation library *)
 
 
 (** bapbuild support library.

--- a/lib/bap_bundle/bap_bundle.mli
+++ b/lib/bap_bundle/bap_bundle.mli
@@ -24,7 +24,7 @@ module Std : sig
 
 
 
-  (** Program meta infromation.  *)
+  (** Program meta information.  *)
   module Manifest : sig
     type t = {
       name : string;            (** program name *)

--- a/lib/bap_byteweight/bap_byteweight.mli
+++ b/lib/bap_byteweight/bap_byteweight.mli
@@ -78,7 +78,7 @@ module type S = sig
   (** [next decider ~length ~threshold data begin] returns an offset
       greater then [begin] of the next substring of the given
       [length], that is positively classified, with the given
-      [thresold].  *)
+      [threshold].  *)
   val next : t ->
     length:int ->
     threshold:float ->

--- a/lib/bap_byteweight/bap_byteweight_signatures.mli
+++ b/lib/bap_byteweight/bap_byteweight_signatures.mli
@@ -8,7 +8,7 @@ type error = [
   | `Corrupted of string        (** Signature file is corrupted  *)
   | `No_signatures              (** Signature file is not found    *)
   | `No_entry of string         (** Corresponding entry not found  *)
-  | `Sys_error of string        (** System error has occured     *)
+  | `Sys_error of string        (** System error has occurred     *)
 ]
 
 
@@ -23,7 +23,7 @@ val save : ?comp:string -> mode:string -> path:string -> arch -> bytes ->
 
 
 (** [load ?comp ?path ~mode arch] finds a signature for the specified
-    [arch-comp-path] tripple. The [path] defaults to [default_path].*)
+    [arch-comp-path] triple. The [path] defaults to [default_path].*)
 val load : ?comp:string -> ?path:string -> mode:string -> arch ->
   (bytes,error) Result.t
 

--- a/lib/bap_c/bap_c_size.mli
+++ b/lib/bap_c/bap_c_size.mli
@@ -24,19 +24,19 @@ class base :  model -> object
     method bits : t -> bits option
 
     (** [alignment t] calculates an alignment restriction for data
-        type [t]. The default aligment rules are the following:
+        type [t]. The default alignment rules are the following:
         - if type is scalar then the alignment is [sizeof(t)];
         - if type is [elt\[\]] then the alignment is [sizeof(elt)];
         - if type is structure or union, the the alignment of is
           the maximum alignment of a field;
-        - if type is function, then aligment is equal to sizeof
+        - if type is function, then alignment is equal to sizeof
         pointer
         - if type is void then alignment is 8 bits.*)
     method alignment : t -> size
 
     (** [padding t off] computes a required padding at given offset
         that should be inserted before value of type [t] to satisfy
-        the aligment restriction for [t], as determined by the
+        the alignment restriction for [t], as determined by the
         [alignment] method.  *)
     method padding : t -> bits -> size option
 

--- a/lib/bap_c/bap_c_type_mapper_intf.ml
+++ b/lib/bap_c/bap_c_type_mapper_intf.ml
@@ -21,7 +21,7 @@ open Bap_c_type
     Override [enter_T] if an element shouldn't be morphed. The
     combination of [enter_t], [leave_T] allows to perform different
     visiting strategies. If mapping is needed then a [map_T] method
-    should be overriden. A usual pattern would be:
+    should be overridden. A usual pattern would be:
 
     {[
       class my_mapper = object(self)

--- a/lib/bap_disasm/bap_disasm_rec.ml
+++ b/lib/bap_disasm/bap_disasm_rec.ml
@@ -257,7 +257,7 @@ let stage1 ?(rooter=Rooter.empty) lift brancher disasm base =
 
    Returns three tables: leads, terms, and kinds. Leads is a mapping
    from leader to all predcessing terminators. Terms is a mapping from
-   terminators to all successing leaders. Kinds is a mapping from a
+   terminators to all successive leaders. Kinds is a mapping from a
    terminator addresses, to all outputs with each output including the
    kind annotation, e.g, Cond, Jump, etc. This also includes
    unresolved outputs.

--- a/lib/bap_disasm/disasm.h
+++ b/lib/bap_disasm/disasm.h
@@ -44,7 +44,7 @@
  *  2. registers names table
  *  3. memory region
  *
- *  Instructions and Registers tables are never changed throught the
+ *  Instructions and Registers tables are never changed through the
  *  life of a disassembler (they are indeed a function of the constructor
  *  parameters). Memory region can be changed after the disassembler was
  *  created, but since it is not changed in the disassembler step it can
@@ -133,7 +133,7 @@ int bap_disasm_backends_size(void);
  */
 const char* bap_disasm_backend_name(int i);
 
-/** assosiates memory region with a given disassembler. Current offset
+/** associates memory region with a given disassembler. Current offset
  * is automatically reset to 0.
  *
  * @pre memory region between (data+off) and (data+off+len-1)
@@ -232,7 +232,7 @@ int bap_disasm_offset(bap_disasm_type disasm);
  */
 void bap_disasm_run(bap_disasm_type disasm);
 
-/* clears instruction queue and all assosiated data
+/* clears instruction queue and all associated data
  * @pre none
  * @post instruction queue is empty
  */
@@ -242,7 +242,7 @@ void bap_disasm_insns_clear(bap_disasm_type disasm);
 int bap_disasm_insns_size(bap_disasm_type disasm);
 
 
-/* Quering instructions
+/* Querying instructions
  *
  * All functions below (if not stated otherwise) share the following
  * precondition:
@@ -293,7 +293,7 @@ int bap_disasm_insn_satisfies(bap_disasm_type disasm,
                               bap_disasm_insn_p_type p);
 
 
-/* Quering operands
+/* Querying operands
  *
  * All functions below share precondition that op is less than
  * ops_size and greater than zero

--- a/lib/bap_disasm/disasm.hpp
+++ b/lib/bap_disasm/disasm.hpp
@@ -34,10 +34,10 @@ struct operand;
 // If current instruction is invalid, then results of all other calls
 // to disassembler, that involves the instruction are undefined.
 struct disassembler_interface {
-    // disassemble one instruction, starting from addres \a pc.
+    // disassemble one instruction, starting from address \a pc.
     virtual void step(uint64_t pc) = 0;
 
-    // directs disassembler to a specifed memory region
+    // directs disassembler to a specified memory region
     virtual void set_memory(memory) = 0;
 
     // table, containing all instruction names

--- a/lib/bap_dwarf/dwarf_fbi.ml
+++ b/lib/bap_dwarf/dwarf_fbi.ml
@@ -222,7 +222,7 @@ let create data : t Or_error.t =
         | Error err ->
           eprintf
             "Warning: Dwarf parser stopped prematurely: %s\n\
-             \t\tSome symbols maybe ommited\n"
+             \t\tSome symbols maybe omitted\n"
             (Error.to_string_hum err);
           Sequence.Step.Done) in
   read_unit ()

--- a/lib/bap_future/bap_future.mli
+++ b/lib/bap_future/bap_future.mli
@@ -228,7 +228,7 @@ module Std : sig
       (** [('f,'r) t] is a list of arguments, where ['f] defines the
           arrow type of the arguments, and ['r] is the return type.
           C.f., ['f] and ['r] with the first and last parameter of
-          the [format] type constuctor.
+          the [format] type constructor.
       *)
       type ('f,'r) t
 
@@ -372,7 +372,7 @@ module Std : sig
     module Variadic : Variadic.S with type 'a arg = 'a t
 
 
-    (** [create ()] retuns a stream and a signal handler that is used
+    (** [create ()] returns a stream and a signal handler that is used
         to feed the stream. Every time a value is signaled, it will
         occur in the stream. *)
     val create : unit -> 'a t * 'a signal
@@ -534,7 +534,7 @@ module Std : sig
     (** [concat_merge xs ~f] builds a stream, that will 
         produce elements from the input list and applies [f] to all 
         consecutive elements. The ordering of the input list does not 
-        mandate the ordering of elemenets in the output stream, and is
+        mandate the ordering of elements in the output stream, and is
         undefined. See [concat] for more information.*)
     val concat_merge : 'a t list -> f:('a -> 'a -> 'a) -> 'a t
 

--- a/lib/bap_image/bap_image.ml
+++ b/lib/bap_image/bap_image.ml
@@ -367,7 +367,7 @@ module Derive = struct
     Fact.collect Ogre.Query.(select (from arch)) >>= fun s ->
     Fact.Seq.reduce ~f:(fun a1 a2 ->
         if Arch.equal a1 a2 then Fact.return a1
-        else Fact.failf "arch is ambigous" ())
+        else Fact.failf "arch is ambiguous" ())
         (Seq.filter_map ~f:Arch.of_string s) >>= fun a ->
     match a with
     | Some a -> Fact.return a

--- a/lib/bap_image/bap_memmap.mli
+++ b/lib/bap_image/bap_memmap.mli
@@ -75,7 +75,7 @@ val map : 'a t -> f:('a -> 'b) -> 'b t
 
 (** [mapi m f] the same as [map], but [f] is called with two
     arguments: [mem] and [tag], where [mem] is a memory region,
-    and [tag] is a [tag] assosiated with that region. *)
+    and [tag] is a [tag] associated with that region. *)
 val mapi : 'a t -> f:(mem -> 'a -> 'b) -> 'b t
 
 val filter : 'a t -> f:('a -> bool) -> 'a t
@@ -86,7 +86,7 @@ val filter : 'a t -> f:('a -> bool) -> 'a t
 val filter_map : 'a t -> f:('a -> 'b option) -> 'b t
 
 (** [filter_mapi] is like [filter_map] but use function also accepts
-    would assosiated memory region *)
+    would associated memory region *)
 val filter_mapi : 'a t -> f:(mem -> 'a -> 'b option) -> 'b t
 
 (** [remove map mem] removes all bindings to [mem]  *)

--- a/lib/bap_llvm/llvm_disasm.cpp
+++ b/lib/bap_llvm/llvm_disasm.cpp
@@ -202,7 +202,7 @@ public:
         llvm::Triple t(llvm::Triple::normalize(name));
         std::string triple = t.getTriple();
 
-        // returned value is not allocted
+        // returned value is not allocated
         const llvm::Target *target =
             llvm::TargetRegistry::lookupTarget(name,t,error);;
 

--- a/lib/bap_llvm/llvm_elf_loader.hpp
+++ b/lib/bap_llvm/llvm_elf_loader.hpp
@@ -33,7 +33,7 @@
 // else (external symbol).
 // So, our task is to resolve this case, i.e. to find a mapping from this offset to something sensible.
 //
-// First of all we should use absoulute offset, i.e. file offsets to make every mapping unique.
+// First of all we should use absolute offset, i.e. file offsets to make every mapping unique.
 // So full offset in example above will be computed as section offset + 0x31. And it is a place
 // where relocation should be applied.
 //
@@ -174,7 +174,7 @@ error_or<int64_t> symbol_address(const ELFObjectFile<T> &obj, const SymbolRef &s
 }
 
 // [symbol_reference obj relocation section doc] - provide information for [relocation]
-// that refered to [section]
+// that referred to [section]
 template <typename T>
 void symbol_reference(const ELFObjectFile<T> &obj, const RelocationRef &rel, section_iterator sec, ogre_doc &s) {
     auto it = rel.getSymbol();

--- a/lib/bap_llvm/llvm_error_or.hpp
+++ b/lib/bap_llvm/llvm_error_or.hpp
@@ -46,7 +46,7 @@
 //     ...
 //     error_or<ints> x = make_positive(some_vector);
 //     if (!x)      // check if error exists
-//         std::cerr << "some error occured: "<< x.message() << std::endl;
+//         std::cerr << "some error occurred: "<< x.message() << std::endl;
 //     for (auto w : x.warnings())
 //         std::cout << "warning! " << w << std::endl;
 //     ...
@@ -64,7 +64,7 @@
 //     }
 //     ...
 //
-//  && operator works as usualy:
+//  && operator works as usually:
 //     ...
 //     error_or<int> x = foo();
 //     error_or<int> y = bar()

--- a/lib/bap_llvm/llvm_loader_utils.hpp
+++ b/lib/bap_llvm/llvm_loader_utils.hpp
@@ -25,7 +25,7 @@ std::string escape(const std::string &src) {
 
 // ogre doc
 // makes it easy to brew an ogre document.
-// It's recomended to use it in the folowing ways:
+// It's recommended to use it in the following ways:
 // ...
 // doc.entry("entry-name") << 42 << false;
 // ...

--- a/lib/bap_plugins/bap_plugins.ml
+++ b/lib/bap_plugins/bap_plugins.ml
@@ -110,7 +110,7 @@ module Plugin = struct
 
   (** [load_entry plugin name] loads a compilation unit with the
       specified [name] required by [plugin]. The compilation unit
-      should not be alread linked to the main program. The unit is
+      should not be already linked to the main program. The unit is
       looked in the plugin bundle first and, if not found, looked in the
       system using the [Findlib] library. If the [findlib]
       infrastructure is not available (and a unit wasn't found in
@@ -298,7 +298,7 @@ module Plugins = struct
             List.map !events_backtrace ~f:(fun ev ->
                 Format.asprintf "%a" Sexp.pp
                   (Plugin.sexp_of_system_event ev)) in
-          Format.eprintf "An error has occured while loading `%s': %a\n
+          Format.eprintf "An error has occurred while loading `%s': %a\n
                           Events backtrace:\n%s\n
                           Aborting program ...\n%!"
             name Error.pp err backtrace;

--- a/lib/bap_plugins/bap_plugins.mli
+++ b/lib/bap_plugins/bap_plugins.mli
@@ -48,7 +48,7 @@ module Std : sig
         other system error. *)
     val load : ?argv:string array -> t -> unit Or_error.t
 
-    (** loaded event happens when a pass is succesfully loaded  *)
+    (** loaded event happens when a pass is successfully loaded  *)
     val loaded : t -> unit future
 
     val argv : unit -> string array
@@ -75,7 +75,7 @@ module Std : sig
       function is called, events of type [Plugins.events] will start
       to fire. By default they are intercepted by a logger, and by the
       default handler (see {!Plugins.run} function description about
-      the default handler). The logger will write the infromation
+      the default handler). The logger will write the information
       about events, that is useful for debugging issues with plugins.
   *)
   module Plugins : sig

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -28,7 +28,7 @@ module Std : sig
       means that any computation may have more than one result. Every
       time there is a non-determinism in the computation the machine
       state is cloned. Different scheduling policies mixed with
-      different non-deterministic startegies provide an analyst a vast
+      different non-deterministic strategies provide an analyst a vast
       selection of avenues to investigate.
 
       Primus is build around an idea of a component base linearly
@@ -107,7 +107,7 @@ module Std : sig
       (** An observation provider.
           A provider facilitates introspection of the Primus Machine,
           for the sake of debugging and dumping the effects. The
-          provider shoud not (and can't be) used for affecting the
+          provider should not (and can't be) used for affecting the
           behavior of a machine, or for the analysis, as its main
           purpose is debugging, logging, and tracing the execution.*)
       type provider
@@ -150,7 +150,7 @@ module Std : sig
         (** a total number of observers that subscribed to this provider  *)
         val observers : t -> int
 
-        (** triggers a stream of occurences of this observation  *)
+        (** triggers a stream of occurrences of this observation  *)
         val triggers : t -> unit stream
 
         (** a data stream from this observation *)
@@ -534,9 +534,9 @@ module Std : sig
 
         (** [id x] is a unique identifier of a value. Every
             evaluation of non-trivial computation produces a value
-            with new identifier. Only seting and reading a variable
+            with new identifier. Only setting and reading a variable
             preserves value identifiers. Each new constaint or
-            arithmentic, or memory expression produces a value with a
+            arithmetic, or memory expression produces a value with a
             new identifier.   *)
         val id : t -> id
 
@@ -709,7 +709,7 @@ module Std : sig
 
         (** Symbol Value Isomorphism.
 
-            A value can have a symbolic representation that is usefull
+            A value can have a symbolic representation that is useful
             to embed analysis in the machine computation. We inject
             symbols, represented with the [string] data type, into the
             value, using interning, i.e., each symbol is mapped to its
@@ -761,13 +761,13 @@ module Std : sig
 
     (** The Interpreter.
 
-        The Interpreter is the core componet of the Primus Machine. It
+        The Interpreter is the core component of the Primus Machine. It
         provides lots of observations, giving other components an
         ability to track every event that happens during the program
         evaluation. The components can affect the results of
         evaluation in a limited way, by affecting the state of the
         components that are used by the Interpreter, name the
-        Environemnt and the Memory.
+        Environment and the Memory.
 
         Note: we the [observation (x,y,z)] notation in the
         documentation to denote an observation of a value represented
@@ -809,7 +809,7 @@ module Std : sig
       (** [writing v] happens before a value is written to the variable [v]  *)
       val writing : var observation
 
-      (** [written (v,x)] happens after [x] is assinged to [v]  *)
+      (** [written (v,x)] happens after [x] is assigned to [v]  *)
       val written : (var * value) observation
 
 
@@ -951,7 +951,7 @@ module Std : sig
       (** [pagefault_hanlder] is a trap handler that is invoked when the [Pagefault]
           exception is raised by the machine memory component. If the handler is
           provided via the Linker, then it is invoked, otherwise a segmentation
-          fault is raised. If the hanlder returns normally then the faulty operation is
+          fault is raised. If the handler returns normally then the faulty operation is
           repeated.
 
           Note, page faults are usually handled together with the [pagefault]
@@ -1083,7 +1083,7 @@ module Std : sig
           the code provider to make corresponding observations, when a
           subroutine is entered or left.
 
-          By default, the code is provided by the BIR Interpeter and
+          By default, the code is provided by the BIR Interpreter and
           Primus Interpreter. Both care to provide corresponding
           observations. However, the Primus Lisp Interpreter provides call
           observations only when an externally visible function is
@@ -1186,7 +1186,7 @@ module Std : sig
             fragment into the Machine. The code can be invoked by one
             of the provided identifier. If no idetifiers were
             provided, then apparently code will not be ever invoked. If
-            an identifier was alread bound to some other code
+            an identifier was already bound to some other code
             fragment, then the old binding will be substituted by the new
             one.  *)
         val link :
@@ -1278,7 +1278,7 @@ module Std : sig
       end
 
 
-      (** Inifinite iterators produces infinite sequences.  *)
+      (** Infinite iterators produces infinite sequences.  *)
       module type Infinite = sig
         include Base
 
@@ -1364,7 +1364,7 @@ module Std : sig
       end
     end
 
-    (** Evaluation environemnt.
+    (** Evaluation environment.
 
         The Environment binds variables to values.*)
     module Env : sig
@@ -1379,7 +1379,7 @@ module Std : sig
 
         (** [get var] returns a value associated with the variable.
             Todo: it looks like that the interface doesn't allow
-            anyone to save bottom or memory values in the environemnt,
+            anyone to save bottom or memory values in the environment,
             thus the [get] operation should not return the
             [Bil.result].*)
         val get : var -> value Machine.t
@@ -1464,7 +1464,7 @@ module Std : sig
             produce values generated by a generator (defaults to a
             [Generator.Random.Seeded.byte]).
 
-            An attempt to write to a readonly segment, or an attemp to
+            An attempt to write to a readonly segment, or an attempt to
             execute non-executable segment will generate a
             segmentation fault. (TODO: provide more fine-granular traps).*)
         val allocate :
@@ -1514,7 +1514,7 @@ module Std : sig
         language as possible. In that sense Primus Lisp can be seen as
         an assembler, except that it can't really assemble binaries,
         as it operates over already existing and assembled
-        program. Primus Lisp, however is still quite powerfull, as the
+        program. Primus Lisp, however is still quite powerful, as the
         absence of suitable abstractions is compensated with powerful
         and versatile meta-programming system.
 
@@ -2121,7 +2121,7 @@ module Std : sig
             (msg "malloc($0) was called" arg)))
         v}
 
-        The [defmethod] form follows the general definiton template,
+        The [defmethod] form follows the general definition template,
         i.e., it can contain a docstring and declaration section, and
         selection and resolution rules are applicable to
         methods. Methods of the same signal are invoked in an
@@ -2385,7 +2385,7 @@ ident ::= ?any atom that is not recognized as a <word>?
 
 
           (** [var x] type variable [x]. All variables with the same
-              name in the scope of a definiton are unified.  *)
+              name in the scope of a definition are unified.  *)
           val var : string -> t
 
           (** [sym] symbol type.  *)

--- a/lib/bap_primus/bap_primus_lisp_context.mli
+++ b/lib/bap_primus/bap_primus_lisp_context.mli
@@ -24,8 +24,8 @@
     means, that a definition (i.e., a meaning of a name) can have
     multiple implementation (represented with different
     formulae). This is made by specifying a context of applicapibility
-    of a definiton. During the compile time the most suitable
-    definition is used (i.e., a defintion that is applicable and is
+    of a definition. During the compile time the most suitable
+    definition is used (i.e., a definition that is applicable and is
     the most specific from the set of all applicable definitions).
 
     The property of being most suitable is defined by the partial
@@ -69,7 +69,7 @@
     The idea is that it defines a new class of observations, that are
     derived from three other classes: memcheck-acquire,
     memcheck-release, and memcheck-violate. An additional constraint
-    is that the `?ptr` field of these threee events should be equal.
+    is that the `?ptr` field of these three events should be equal.
 
     The class above is represented as the following BARE rule:
 
@@ -118,7 +118,7 @@
 
     v}
 
-    This is, however, requres each slot of an observation class to be
+    This is, however, requires each slot of an observation class to be
     a value, not a symbol. So, we need to think more about it, maybe
     slots that are values, should be defined differently.
 
@@ -126,7 +126,7 @@
     {2 Method combination or super notation}
 
     The idea of the subtyping polymorphism is to provide a mechanism
-    for extensible refinement of a defintion. I.e., we start with a
+    for extensible refinement of a definition. I.e., we start with a
     generic definition and then extend it (without modification) in
     some more specific context. However, currently, there is no
     mechanisms to access a more general definition from a context of

--- a/lib/bap_primus/bap_primus_lisp_def.mli
+++ b/lib/bap_primus/bap_primus_lisp_def.mli
@@ -55,7 +55,7 @@ module Macro : sig
   val body : macro t -> tree
   val bind : macro t -> tree list -> (int * (string * tree list) list) option
 
-  (** [apply m bs] returns the body of [m] where any occurence of a
+  (** [apply m bs] returns the body of [m] where any occurrence of a
       variable [x] is substituted with [y] if [x,[y]] is in the list
       of bindings [bs].
 

--- a/lib/bap_primus/bap_primus_lisp_parse.ml
+++ b/lib/bap_primus/bap_primus_lisp_parse.ml
@@ -656,7 +656,7 @@ let string_of_defkind = function
   | Meth -> "method"
   | Para -> "parameter"
   | Macro -> "macro"
-  | Const -> "contant"
+  | Const -> "constant"
   | Subst -> "substitution"
 
 

--- a/lib/bap_primus/bap_primus_lisp_source.mli
+++ b/lib/bap_primus/bap_primus_lisp_source.mli
@@ -64,7 +64,7 @@ val loc : t -> Id.t -> Loc.t
 val has_loc : t -> Id.t -> bool
 
 (** [filename source id] returns the name of a file from which an
-    identity with the given [id] is orginating.
+    identity with the given [id] is originating.
 
     If the identity is not known to the source code repository, then
     a bogus filename is returned. *)

--- a/lib/bap_sema/bap_sema_lift.ml
+++ b/lib/bap_sema/bap_sema_lift.ml
@@ -24,7 +24,7 @@ open Format
    But a short survey into existing instruction sets shows, that call
    instructions doesn't allow to store something other then next
    instruction, e.g., `call` in x86, `bl` in ARM, `jal` in MIPS,
-   `call` and `jumpl` in SPARC (althought the latter allows to choose
+   `call` and `jumpl` in SPARC (although the latter allows to choose
    arbitrary register to store return address). That's all is not to
    say, that it is impossible to encode a call with return address
    different from a next instruction, that's why it is called a

--- a/lib/bap_strings/bap_strings_detector.mli
+++ b/lib/bap_strings/bap_strings_detector.mli
@@ -4,7 +4,7 @@
     The detector uses maximum aposteriori likelihood estimator (MAP)
     to detect code that operates with textual data.
 
-    We define textual data as a contigious blocks of characters from
+    We define textual data as a contiguous blocks of characters from
     a specified alphabet.
 
     In our model a code is a sequence of instructions. Each
@@ -14,7 +14,7 @@
     produced by unknown values that are used during the
     computation. Some of these values are textual data. Any particular
     instruction either works with data produced by textual values or
-    not. Moreover, we're looking for contigious sequences of
+    not. Moreover, we're looking for contiguous sequences of
     instructions that work with textual value.
 
     The detector doesn't depend on a particular instruction
@@ -80,7 +80,7 @@ val create :
 
 
 (** [run detector trace] runs a [detector] on a sequence on a [trace]
-    represented as a sequence of bytes accessed during an exection.
+    represented as a sequence of bytes accessed during an execution.
     Returns a sequence of char sequences, where each subsequence is
     represented as a string and contains characters that were assumed
     to belong to the textual data.

--- a/lib/bap_taint/bap_taint.ml
+++ b/lib/bap_taint/bap_taint.ml
@@ -114,7 +114,7 @@ type relation_kind = Direct | Indirect [@@deriving sexp_of]
  *
  *  With the selector object it is possible to write a function that
  *  will be polymorphic across two fields of the tainter (sort of
- *  extremly boundned polymorphism).
+ *  extremely bounded polymorphism).
 *)
 type relation = Rel : {
     field : (tainter, ('k,objects,'c) Map.t) Field.t;
@@ -335,7 +335,7 @@ module Propagation = struct
   end
 end
 
-(* tracks live tainted objects, removes unecessary references.
+(* tracks live tainted objects, removes unnecessary references.
 
    A tainted object is live, if it is reachable either directly or
    indirectly in the tainted. The indirect references are dropped

--- a/lib/bap_taint/bap_taint.mli
+++ b/lib/bap_taint/bap_taint.mli
@@ -48,7 +48,7 @@
     values passed to that function doesn't have any taints of the
     specified kind.
 
-    Other than classical approaches to taint analysis, decribed above,
+    Other than classical approaches to taint analysis, described above,
     the framework could be used for checking liveness properties,
     lifetime analysis, and other analysis that requires tracking the
     flow of information.
@@ -206,7 +206,7 @@ module Std : sig
 
             The low-level interface defines three primitives in terms of
             which we can express a more convenient high-level
-            interface. It is recommened to get acquainted with these
+            interface. It is recommended to get acquainted with these
             three primitives, to understand how the tracker works,
             however it is better to use the high level interface,
             whenever it is possible.

--- a/lib/bap_traces/bap_trace_events.mli
+++ b/lib/bap_traces/bap_trace_events.mli
@@ -51,16 +51,16 @@ val code_exec : chunk tag
     thread (process) id. *)
 val context_switch : int tag
 
-(** a system call has occured  *)
+(** a system call has occurred  *)
 val syscall : syscall tag
 
-(** a software exception has occured.  *)
+(** a software exception has occurred.  *)
 val exn : exn tag
 
-(** a control flow transfer from one procedure to another has occured  *)
+(** a control flow transfer from one procedure to another has occurred  *)
 val call : call tag
 
-(** a return from a call has occured  *)
+(** a return from a call has occurred  *)
 val return : return tag
 
 (** represent an executable module being loaded *)

--- a/lib/bap_traces/bap_traces.mli
+++ b/lib/bap_traces/bap_traces.mli
@@ -224,7 +224,7 @@ module Std : sig
       (** [ignore_errors] filters good events and silently drops error events  *)
       val ignore_errors : t
       (** [warn_on_error on_error] same as [ignore_errors] but calls
-          [on_error] function when an error has occured *)
+          [on_error] function when an error has occurred *)
       val warn_on_error : (Error.t -> unit) -> t
 
       (** [fail_on_error] will fail with an [error] [Error.raise error] *)
@@ -233,7 +233,7 @@ module Std : sig
       (** [stop_on_error] will silently finish a stream in case of error.  *)
       val stop_on_error : t
 
-      (** [pack_errors pack] will transform any occured error into event
+      (** [pack_errors pack] will transform any occurred error into event
           using [pack] function.  *)
       val pack_errors : (Error.t -> event) -> t
 
@@ -352,7 +352,7 @@ module Std : sig
     type t = {
       name : string;            (** a name of linked module *)
       low : addr;               (** the lowest mapped address *)
-      high : addr;              (** the hightest mapped address *)
+      high : addr;              (** the highest mapped address *)
     } [@@deriving bin_io, compare, fields, sexp]
   end
 
@@ -394,16 +394,16 @@ module Std : sig
         thread (process) id. *)
     val context_switch : int tag
 
-    (** a system call has occured  *)
+    (** a system call has occurred  *)
     val syscall : syscall tag
 
-    (** a software exception has occured.  *)
+    (** a software exception has occurred.  *)
     val exn : exn tag
 
-    (** a control flow transfer from one procedure to another has occured  *)
+    (** a control flow transfer from one procedure to another has occurred  *)
     val call : call tag
 
-    (** a return from a call has occured  *)
+    (** a return from a call has occurred  *)
     val return : return tag
 
     (** a module (shared library) is dynamically linked into a host program. *)

--- a/lib/bap_types/bap_addr.mli
+++ b/lib/bap_types/bap_addr.mli
@@ -12,14 +12,14 @@ open Core_kernel
 open Bap_common
 val memref : ?disp:int -> ?index:int -> ?scale:size -> addr -> addr
 
-(** Address arithmetics  *)
+(** Address arithmetic  *)
 module type Arith = sig
   include Integer
   val create : addr -> t Or_error.t
 end
 
-(** Arithmetics on 32-bit addresses *)
+(** Arithmetic on 32-bit addresses *)
 module R32 : Arith with type t = int32
 
-(** Arithmetics on 64-bit addresses  *)
+(** Arithmetic on 64-bit addresses  *)
 module R64 : Arith with type t = int64

--- a/lib/bap_types/bap_bitvector.ml
+++ b/lib/bap_types/bap_bitvector.ml
@@ -5,7 +5,7 @@ open Format
 
 
 (* current representation has a very big overhead,
-   depending on a size of a payload it is minumum five words,
+   depending on a size of a payload it is minimum five words,
    For example, although Zarith stores a 32bit word on a 64 bit
    machine in one word and represent it as an unboxed int, we still
    take four more words on top of that, as bitvector is represented as

--- a/lib/bap_types/bap_common.ml
+++ b/lib/bap_types/bap_common.ml
@@ -58,7 +58,7 @@ module Type = struct
   type t =
     (** [Imm n] - n-bit immediate   *)
     | Imm of nat1
-    (** [Mem (a,t)]memory with a specifed addr_size *)
+    (** [Mem (a,t)]memory with a specified addr_size *)
     | Mem of addr_size * size
     [@@deriving bin_io, compare, sexp, variants]
 end

--- a/lib/bap_types/bap_helpers.ml
+++ b/lib/bap_types/bap_helpers.ml
@@ -922,7 +922,7 @@ module Normalize = struct
      while-cond-hoisting
      ===================
 
-     a non-trivial while condition is a condition that contans an
+     a non-trivial while condition is a condition that contains an
      if-then-else expression, for example
 
         while (c ? x : y) prog;
@@ -965,16 +965,16 @@ module Normalize = struct
 
      We want to ensure that all load expressions refer to memory as a
      variable, not as arbitrary store expressions. This will
-     essentialy disallow memory operations that will not have any
+     essentially disallow memory operations that will not have any
      observable side effects, e.g., the [(mem [a] <- x)[a]]
      expression creates an anonymous memory storage on fly, stores a
-     value in it, and then discards it without commiting the effect of
-     writting.
+     value in it, and then discards it without committing the effect of
+     writing.
 
      The transformation will force the memory-commit operation, so
      that if there is any memory load with a non-trivial (i.e., not a
      variable) memory argument, then this argument is hoisted as a
-     seprate move instruction. This is not always correct, e.g.,
+     separate move instruction. This is not always correct, e.g.,
 
 
          z := (m[a]<-x)[a] + (m[a]<-y)[a]

--- a/lib/bare/bare.ml
+++ b/lib/bare/bare.ml
@@ -269,7 +269,7 @@ module Rule = struct
     | Unbound (v,r) ->
       fprintf ppf "%a:@\nError: Unbound variable %s@\n" pp_range r v
     | Wildcard r ->
-      fprintf ppf "%a:@\nError: Wilcards are not allowed on the right hand side@\n"
+      fprintf ppf "%a:@\nError: Wildcards are not allowed on the right hand side@\n"
         pp_range r
     | Not_a_sexp perr ->
       Parsexp.Parse_error.report ppf ~filename perr

--- a/lib/bare/bare.mli
+++ b/lib/bare/bare.mli
@@ -59,7 +59,7 @@ open Core_kernel
 
      - [(acquire SITE PTR LEN)] represents an allocation event, where
        SITE is an allocation site (i.e., an address of a program
-       instruction that perfroms an allocation), [PTR] is a pointer to
+       instruction that performs an allocation), [PTR] is a pointer to
        the allocated data, and [LEN] is the data size;
 
      - [(release SITE PTR LEN)] represents a memory deallocation
@@ -109,7 +109,7 @@ open Core_kernel
     A tuple is represented by an arbitrary S-expression. A variable is
     an atom that starts with the question mark. A special variable [?]
     (one question mark symbol) may occur on the left hand side of a
-    rule, and represents a freshly created variable. Every occurence
+    rule, and represents a freshly created variable. Every occurrence
     of the [?] symbol represents a different variable. Both sides of a
     rule may be empty (represented by the 0-tuple [()]).
 

--- a/lib/graphlib/graphlib.mli
+++ b/lib/graphlib/graphlib.mli
@@ -7,7 +7,7 @@ open Regular.Std
       {!Graphlib} is a generic library that extends a well known
       OCamlGraph library. {!Graphlib} uses its own, more reach,
       {!Graph} interface that is isomorphic to OCamlGraph's [Sigs.P]
-      signature for persistant graphs. Two functors witness the
+      signature for persistent graphs. Two functors witness the
       isomorphism of the interfaces:
       {!Graphlib.To_ocamlgraph} and {!Graphlib.Of_ocamlgraph}. Thanks
       to these functors, any algorithm written for OCamlGraph can be
@@ -93,16 +93,16 @@ module Std : sig
         [node] in a a given [graph] *)
     val preds : t -> graph -> t seq
 
-    (** [inputs node graph] is incomming edges of a [node] in [graph]  *)
+    (** [inputs node graph] is incoming edges of a [node] in [graph]  *)
     val inputs : t -> graph -> edge seq
 
     (** [outputs node graph] is outcomming edges of a [node] in [graph]  *)
     val outputs : t -> graph -> edge seq
 
     (** [degree ?dir n] when [in_or_out] is [`In] then returns
-        the amount of incomming edges, otherwise returns the amount of
+        the amount of incoming edges, otherwise returns the amount of
         outcomming edges. If parameter [dir] is left absent, then
-        return the amount of adjacent nodes (i.e., a sum of incomming
+        return the amount of adjacent nodes (i.e., a sum of incoming
         and outcomming edges).  *)
     val degree : ?dir:[`In | `Out] -> t -> graph -> int
 
@@ -484,7 +484,7 @@ module Std : sig
       role of «representative element». Depending on the nature of
       partitioning, this role can have different semantics.
 
-      This data structure is used to represent results of partioning of
+      This data structure is used to represent results of partitioning of
       a graph into groups of nodes, for example, to strongly connected
       components.*)
   module Partition : sig
@@ -586,7 +586,7 @@ module Std : sig
   end
 
   (** [Isomorphism] is a bijection between type [s] and [t].
-      Usefull for creating graph views and mapping graphs.
+      Useful for creating graph views and mapping graphs.
       See {!Graphlib.view} and {!Graphlib.Mapper}.
   *)
   module type Isomorphism = sig
@@ -1152,7 +1152,7 @@ module Std : sig
              and type Edge.label = EL.t
 
     (** [fixpoint ~equal ~init ~merge ~f g] computes a solution for a
-        system of equations denoted by graph [g], using the inital
+        system of equations denoted by graph [g], using the initial
         approximation [init] (obtained either with [Solution.create] or
         from the previous calls to [fixpoint]).
 
@@ -1215,7 +1215,7 @@ module Std : sig
 
         {4 Introduction}
 
-        The data domain is a set of values equiped with a partial
+        The data domain is a set of values equipped with a partial
         ordering operation [(L,<=)], also know as a lattice or a
         poset. We assume, that the lattice is complete, i.e., there
         are two special elements of a set that are called [top] and
@@ -1231,7 +1231,7 @@ module Std : sig
         information, the partial ordering between two pieces of
         information [a] and [b], e.g., [a <= b], tells us that [a]
         contains no more information than [b]. Therefore the [top]
-        value contans all the information, representable in the
+        value contains all the information, representable in the
         lattice, correspondingly the [bot] value represents an absence
         of information. Thus, we will consider the bottom value as an
         over approximation (or a lower approximation in terms of the
@@ -1340,7 +1340,7 @@ module Std : sig
         allows a user to choose the direction of approximation
         (ascending vs. descending) and how to accelerate the
         convergence in case of tall lattices by applying narrowing and
-        widening. The implentation fixes the iteration strategy (by
+        widening. The implementation fixes the iteration strategy (by
         always using the topological ordering). In case if you need a
         fixed point solver, that allows you to use different iteration
         strategies, the [fixpoint][1] library provides a descent
@@ -1394,7 +1394,7 @@ module Std : sig
         fixpoint, that will lead to an over-approximation of the
         ground truth, that is safe, but still looses
         precision. Therefore, it is necessary to apply widening as
-        rarely as possible. Unfortunatelly, a question where and when
+        rarely as possible. Unfortunately, a question where and when
         to apply widening is undecidable by itself, that's why
         heuristics are used. The [fixpoint] function, provides a
         limited capabilities to control widening via the [step i n x

--- a/lib/graphlib/graphlib_graph.ml
+++ b/lib/graphlib/graphlib_graph.ml
@@ -307,7 +307,7 @@ module Partition = struct
             (* By cases: if n < i or i < n < j then it is in one one
                of the original classes, otherwise n = i, then one
                should return i (as the class still contains these
-               elements) or n = j, in wich case these elements are now
+               elements) or n = j, in which case these elements are now
                in class i, or n > j, in which case we must left-shift them *)
             fun n -> if n < j then n
             else if n = j then i
@@ -558,7 +558,7 @@ module Of_ocamlgraph(G : Graph.Sig.P) = struct
          we can't rely that the order of iteration on edges and nodes
          will the same for otherwise equal graphs.
 
-         It is usually the same for persistant graphs, built from
+         It is usually the same for persistent graphs, built from
          maps. But in general we may not rely on this fact. So, we
          can't just compare using fold over set of edges and nodes,
          as in that case the following will not hold:

--- a/lib/monads/monads.mli
+++ b/lib/monads/monads.mli
@@ -616,7 +616,7 @@ module Std : sig
       (** [bind m f] passes the result of computation [m] to function [f] *)
       val bind : 'a t -> ('a -> 'b t) -> 'b t
 
-      (** [return x] creates a trivial compuation that results in [x]  *)
+      (** [return x] creates a trivial computation that results in [x]  *)
       val return : 'a -> 'a t
 
       (** map function can be derived from bind or provided explicitly  *)
@@ -642,7 +642,7 @@ module Std : sig
                 | `Custom of (('a, 'e) t -> f:('a -> 'b) -> ('b, 'e) t)
                 ]
 
-      (** [return x] creates a trivial compuation that results in [x]  *)
+      (** [return x] creates a trivial computation that results in [x]  *)
       val return : 'a -> ('a, _) t
 
     end
@@ -653,7 +653,7 @@ module Std : sig
         (containters) where functions return monadic computations
         instead of values.
 
-        As usuall, two interfaces are provided:
+        As usual, two interfaces are provided:
         -  {{!Std.Monad.Collection.S}Monad.Collection.S} for unary monad
         -  {{!Std.Monad.Collection.S2}Monad.Collection.S2} for binary monad
 
@@ -721,7 +721,7 @@ module Std : sig
         (** type of the container  *)
         type 'a t
 
-        (** [all cs] perfoms all computations in [cs] and returns a
+        (** [all cs] performs all computations in [cs] and returns a
             list of results in the same order. The order of
             evaluation is unspecified.  *)
         val all : ('a,'e) m t -> ('a t, 'e) m
@@ -810,7 +810,7 @@ module Std : sig
         val map_reduce : (module Monoid.S with type t = 'a) -> 'b t -> f:('b -> ('a,'e) m) -> ('a,'e) m
 
         (** [find xs ~f] returns the first element [x] of [xs] for
-            wich [f x] evaluates to [true].  *)
+            which [f x] evaluates to [true].  *)
         val find : 'a t -> f:('a -> (bool,'e) m) -> ('a option,'e) m
 
         (** [find_map xs ~f] returns the first computation [f x] for
@@ -838,7 +838,7 @@ module Std : sig
         (** type of the container  *)
         type 'a t
 
-        (** [all cs] perfoms all computations in [cs] and returns a
+        (** [all cs] performs all computations in [cs] and returns a
             list of results in the same order. The order of
             evaluation is unspecified.  *)
         val all : 'a m t -> 'a t m
@@ -925,7 +925,7 @@ module Std : sig
         val map_reduce : (module Monoid.S with type t = 'a) -> 'b t -> f:('b -> 'a m) -> 'a m
 
         (** [find xs ~f] returns the first element [x] of [xs] for
-            wich [f x] evaluates to [true].  *)
+            which [f x] evaluates to [true].  *)
         val find : 'a t -> f:('a -> bool m) -> 'a option m
 
         (** [find_map xs ~f] returns the first computation [f x] for
@@ -1355,7 +1355,7 @@ module Std : sig
         This monad can be used to denote partial computations or
         a limited form of non-deterministic computations where an
         absence of result, i.e., the bottom value, can be considered
-        as a posible outcome. *)
+        as a possible outcome. *)
     module Option : sig
 
       (** The unary option monad.  *)
@@ -1475,7 +1475,7 @@ module Std : sig
           include S
 
           (** [failf "<fmt>" <args> ()] constructs an error message
-              using the specified format descripton and returns a
+              using the specified format description and returns a
               computation that will result in the constructed
               error. *)
           val failf : ('a, Format.formatter, unit, unit -> 'b t) format4 -> 'a
@@ -1629,7 +1629,7 @@ module Std : sig
     module Writer : sig
       module type S = sig
 
-        (** type representing the system state (enironment)  *)
+        (** type representing the system state (environment)  *)
         type state
         include Trans.S
 
@@ -1686,12 +1686,12 @@ module Std : sig
         include Trans.S
         type env
 
-        (** [read ()] reads the environemnt  *)
+        (** [read ()] reads the environment  *)
         val read : unit -> env t
         include Monad with type 'a t := 'a t
       end
 
-      (** The reader monad interface with the environemnt type left
+      (** The reader monad interface with the environment type left
           variable.
 
           Note, although the type of the environment is variable it
@@ -1760,7 +1760,7 @@ module Std : sig
 
       (** an abstract type of stateful computations. The type variable
           ['a] denotes types of values and the type variable ['e] denotes a
-          type of the state (aka envionment, aka world).  *)
+          type of the state (aka environment, aka world).  *)
       type ('a,'e) state
 
       (** The State Monad interface with a fixed environment.   *)

--- a/lib/ogre/ogre.mli
+++ b/lib/ogre/ogre.mli
@@ -72,7 +72,7 @@ type doc
 (** type information associated with an attribute  *)
 type ('a,'k) typeinfo constraint 'k = _ -> _
 
-(** a decriptor of an attribute.
+(** a descriptor of an attribute.
 
     Used to construct attribute values, and to query
     documents. Created with [declare] function.
@@ -137,7 +137,7 @@ val declare : name:string -> ('f -> 'a, 'k) scheme -> 'f -> ('a, 'k) typeinfo
 
 (** Ogre type system.
 
-    Ogre type system is extremly simple, it has only four types:
+    Ogre type system is extremely simple, it has only four types:
     1. boolean - a logical type that has only two values (true,false);
     2. int - an integral number that maps to OCaml's [int64];
     3. float - a real number that maps to OCaml's [float];
@@ -354,7 +354,7 @@ module Query : sig
       reason for this, is that the query used as a value that is
       passed to some command constructor, (e.g.,[foreach]), that can
       work with fields individually, e.g., the following is a complete
-      correspondance of the SQL's:
+      correspondence of the SQL's:
 
       {v SELECT name FROM students WHERE gpa > 3.5 v}
 
@@ -524,7 +524,7 @@ module Doc : sig
 
   (** [load chan] loads a document from a channel, returns an error if
       a document is not well-formed, raises an exception if a system error
-      has occured.  *)
+      has occurred.  *)
   val load : In_channel.t -> doc Or_error.t
 
 
@@ -535,7 +535,7 @@ module Doc : sig
 
   (** [from_file name] reads a document from a file with the given
       [name], returns an error, if a document is not well-formed, raises
-      an exception if a system error has occured. *)
+      an exception if a system error has occurred. *)
   val from_file : string -> doc Or_error.t
 
 
@@ -623,7 +623,7 @@ module type S = sig
   (** [foreach query ~f:action] applies an [action] for each value of
       an attributes specified in the query. The [query] value is built
       using a domain specific language embedded into OCaml. This
-      language is very similiar to SQL, and has join and where
+      language is very similar to SQL, and has join and where
       clauses, e.g.,
 
       {[
@@ -687,7 +687,7 @@ module type S = sig
 
   (** [eval property document] makes an inference of a [property] based
       on facts stored in a [document]. If all requirements are
-      satisfied and no errors occured the inferred result.
+      satisfied and no errors occurred the inferred result.
 
       For example, given the property [names_of_best_students],
       defined as,
@@ -710,7 +710,7 @@ module type S = sig
   *)
   val eval : 'a t -> doc -> 'a  Or_error.t m
 
-  (** [exec op doc] executes an operation [op] that, presumabely,
+  (** [exec op doc] executes an operation [op] that, presumably,
       updates the document [doc], returns an updated version.*)
   val exec : 'a t -> doc -> doc Or_error.t m
 

--- a/lib/regular/regular.mli
+++ b/lib/regular/regular.mli
@@ -29,7 +29,7 @@ open Core_kernel
     {!Regular} interface, that each regular data type is expected to
     implement. This includes a full set of [Io] functions, that allows
     one to read, write and serialize values of the type (see {!Data}
-    interface). It also provides an inteface for creating different
+    interface). It also provides an interface for creating different
     collections from the values of that type, including trees,
     hashtables, maps, sets, etc. Also, it describes the whole algebra
     of comparison functions. For the opaque data types an interface
@@ -106,7 +106,7 @@ module Std : sig
 
       (** [str () t] is formatted output function that matches "%a"
           conversion format specifier in functions, that prints to string,
-          e.g., [sprintf], [failwithf], [errorf] and, suprisingly all
+          e.g., [sprintf], [failwithf], [errorf] and, surprisingly all
           [Lwt] printing function, including [Lwt_io.printf] and logging
           (or any other function with type ('a,unit,string,...)
           formatN`. Example:
@@ -383,7 +383,7 @@ module Std : sig
       (** Data cache.
 
           Store and retrieve data from cache. The cache can seen as a
-          persistant weak key-value storage. Data stored here can
+          persistent weak key-value storage. Data stored here can
           disappear at any time, but can survive for a long time
           (outliving the program). The library by itself doesn't provide
           a caching service for any type, only the interface. The
@@ -452,7 +452,7 @@ module Std : sig
       val default_reader : unit -> info
 
       (** [set_default_reader ?ver name] sets new default reader. If
-          version is not specifed then the latest available version is
+          version is not specified then the latest available version is
           used. Raises an exception if a reader with a given name doesn't
           exist.  *)
       val set_default_reader : ?ver:string -> string -> unit
@@ -470,7 +470,7 @@ module Std : sig
       val default_writer : unit -> info
 
       (** [set_default_writer ?ver name] sets new default writer. If
-          version is not specifed then the latest available version is
+          version is not specified then the latest available version is
           used. Raises an exception if a writer with a given name doesn't
           exist.  *)
       val set_default_writer : ?ver:string -> string -> unit
@@ -486,7 +486,7 @@ module Std : sig
       val default_printer : unit -> info option
 
       (** [set_default_printer ?ver name] sets new default printer. If
-          version is not specifed then the latest available version is
+          version is not specified then the latest available version is
           used. Raises an exception if a printer with a given name doesn't
           exist.  *)
       val set_default_printer : ?ver:string -> string -> unit

--- a/lib/regular/regular_seq.ml
+++ b/lib/regular/regular_seq.ml
@@ -23,7 +23,7 @@ let is_empty : 'a Sequence.t -> bool = length_is_bounded_by ~max:0
 let filter s ~f = filteri s ~f:(fun _ x -> f x)
 
 (* honestly stolen from newer core_kernel, to
-   get compatiblity with older library versions *)
+   get compatibility with older library versions *)
 let compare compare_a t1 t2 =
   with_return (fun r ->
       iter (zip_full t1 t2) ~f:(function

--- a/lib/text_tags/text_tags.mli
+++ b/lib/text_tags/text_tags.mli
@@ -93,7 +93,7 @@ open Format
 
     {2 Blocks mode}
 
-    The blocks mode grammar is very similiar to html mode, as it also
+    The blocks mode grammar is very similar to html mode, as it also
     uses sexp syntax.
 
     {v tag := "(", "id", value, ")" | "(", "title", value, ")" v}
@@ -116,7 +116,7 @@ open Format
       v}
 
     If both [id] and [title] is specified, then only title will be
-    outputed. Otherwise, [id] and [title] has the same behavior.
+    outputted. Otherwise, [id] and [title] has the same behavior.
 *)
 
 (** A name of mode, by default the following modes ares supported

--- a/lib_test/bap_dwarf/test_leb128.ml
+++ b/lib_test/bap_dwarf/test_leb128.ml
@@ -86,11 +86,11 @@ let size ~expect value t ctxt =
 
 
 let suite = "Leb128" >::: [
-    "unsinged int"   >:: rounds uints   @@ int   ~signed:false;
+    "unsigned int"   >:: rounds uints   @@ int   ~signed:false;
     "signed   int"   >:: rounds ints    @@ int   ~signed:true;
-    "unsinged int32" >:: rounds uints32 @@ int32 ~signed:false;
+    "unsigned int32" >:: rounds uints32 @@ int32 ~signed:false;
     "signed   int32" >:: rounds ints32  @@ int32 ~signed:true;
-    "unsinged int64" >:: rounds uints64 @@ int64 ~signed:false;
+    "unsigned int64" >:: rounds uints64 @@ int64 ~signed:false;
     "signed   int64" >:: rounds ints64  @@ int64 ~signed:true ;
     "int"            >:: rounds uints   @@ int   ~signed:true;
     "int32"          >:: rounds uints32 @@ int32 ~signed:true;

--- a/lib_test/bap_future/test_stream.ml
+++ b/lib_test/bap_future/test_stream.ml
@@ -173,7 +173,7 @@ let has_subscribers ctxt =
   let assert_no_subscribers ss = 
     assert_false "no subscribers" (Stream.has_subscribers ss) in
   let assert_exists_subscribers ss =
-    assert_bool "exisits subsribers" (Stream.has_subscribers ss) in
+    assert_bool "exists subscribers" (Stream.has_subscribers ss) in
   let ss, _, _ = Stream.of_list values in  
   let f x = () in
   assert_no_subscribers ss; 

--- a/lib_test/bap_image/test_llvm_loader.ml
+++ b/lib_test/bap_image/test_llvm_loader.ml
@@ -20,9 +20,9 @@ open Or_error
 open Bap_types.Std
 open Image_backend
 
-(* Accoding to llvm (ObjectFile.h line 186)
+(* According to llvm (ObjectFile.h line 186)
    symbols type can be debug or function.
-   Thats why we don't compare is_debug field *)
+   That's why we don't compare is_debug field *)
 module SS = Set.Make(
   struct
     include Symbol

--- a/lib_test/bap_types/test_graph.ml
+++ b/lib_test/bap_types/test_graph.ml
@@ -95,7 +95,7 @@ module Test_algo(Gl : Graph_for_algo) = struct
 
     let parent t child = Map.find t.iparents child
 
-    (* computes a set of all descendands of a given parent
+    (* computes a set of all descendants of a given parent
        (transitive closure) *)
     let rec descendants t parent =
       (* according to [1] each node is descendant of itself. *)
@@ -518,7 +518,7 @@ module Test_IR = struct
     | [{node_label="one"}; {node_label="two"}] -> ()
     | [{node_label="one"}; {node_label=l}] -> assert_failure "bad out"
     | [{node_label=l}; {node_label="two"}] -> assert_failure "bad inc"
-    | [] | [_] -> assert_failure "egde(n1,n2) doesn't exist"
+    | [] | [_] -> assert_failure "edge(n1,n2) doesn't exist"
     | _ -> assert_failure "bad out and inc"
 
   let (++) g x = G.Node.(insert (create x) g)

--- a/lib_test/powerpc/powerpc_branch_tests.ml
+++ b/lib_test/powerpc/powerpc_branch_tests.ml
@@ -21,7 +21,7 @@ let check_pc name c expected =
     assert_bool (sprintf "%s fail: pc is not a word" name) false
 
 let check_jmp_absence name c =
-  assert_bool (sprintf "%s fail: jmp occured" name) (c#pc = Bil.Bot)
+  assert_bool (sprintf "%s fail: jmp occurred" name) (c#pc = Bil.Bot)
 
 let addr_of_arch = function
   | `ppc -> Word.of_int64 ~width:32 0xABCD42AAL
@@ -179,7 +179,7 @@ let bclrl = bcXrX "gBCLRL" 16 1 lr
 let bcctr = bcXrX "gBCCTR" 528 0 ctr
 let bcctrl = bcXrX "gBCCTRL" 528 1 ctr
 
-(* will add as soon bctar will apear in llvm  *)
+(* will add as soon bctar will appear in llvm  *)
 let bctar = bcXrX "bctar" 560 0 tar
 let bctarl = bcXrX "bctarl" 560 1 tar
 

--- a/oasis/ida
+++ b/oasis/ida
@@ -1,7 +1,7 @@
 ########### Bap_ida Library #############################
 
 Flag ida
-  Description: Build IDA intergration library
+  Description: Build IDA integration library
   Default: false
 
 Library bap_ida

--- a/plugins/callsites/callsites_main.ml
+++ b/plugins/callsites/callsites_main.ml
@@ -88,7 +88,7 @@ let main proj =
 let () =
   Config.manpage [
     `S "DESCRIPTION";
-    `P "This pass will inject artifical definitions of a subroutine
+    `P "This pass will inject artificial definitions of a subroutine
       arguments at call sites. Consider function $(b,malloc) that has
       the following declaration in BIR:";
     `Pre "

--- a/plugins/elf_loader/elf_loader_main.ml
+++ b/plugins/elf_loader/elf_loader_main.ml
@@ -90,7 +90,7 @@ let create_symtab data endian elf  =
 
 (** @return
     [None] - if segment should be skipped as non interesting,
-    [Some error] - if an error has occured when we have tried
+    [Some error] - if an error has occurred when we have tried
                    to load segment,
     [Some (Ok segment)] - if we have loaded segment at the end.
 *)

--- a/plugins/emit_ida_script/emit_ida_script_main.ml
+++ b/plugins/emit_ida_script/emit_ida_script_main.ml
@@ -21,7 +21,7 @@ let string_of_color c = Sexp.to_string (sexp_of_color c)
 (** Each function in this module should return a string that should be
     a valid piece of python code. Except for the prologue and epilogue
     all pieces should be independent of each other, so that they can
-    be emited to the script in an arbitrary order.
+    be emitted to the script in an arbitrary order.
 
     The emitted code can contain substitutions. Each substitution is a
     string starting with a percent sign followed immediately by an

--- a/plugins/map_terms/map_terms_main.ml
+++ b/plugins/map_terms/map_terms_main.ml
@@ -193,11 +193,11 @@ module Cmdline = struct
 
     let call =
       `I (sprintf "$(b,(call DST))",
-          sprintf "Is satisfied when call of $(b,DST) occures")
+          sprintf "Is satisfied when call of $(b,DST) occurs")
 
     let goto =
       `I (sprintf "$(b,(goto LABEL))",
-          sprintf "Is satisfied when goto $(b,LABEL) occures")
+          sprintf "Is satisfied when goto $(b,LABEL) occurs")
 
     let call_return =
       `I (sprintf "$(b,(return DST))",

--- a/plugins/mips/mips_cpu.ml
+++ b/plugins/mips/mips_cpu.ml
@@ -24,7 +24,7 @@ let find m reg =
   List.filter_map reg_searches ~f:(fun f -> f reg) |> function
   | [] -> Exp.of_word (Word.zero gpr_bitwidth)
   | hd::[] -> hd
-  | _ -> mips_fail "Register name %s is ambigous!!!" (Reg.name reg)
+  | _ -> mips_fail "Register name %s is ambiguous!!!" (Reg.name reg)
 
 let make_cpu addr_size endian memory =
   let (module M) = match addr_size with

--- a/plugins/mips/mips_rtl.ml
+++ b/plugins/mips/mips_rtl.ml
@@ -145,7 +145,7 @@ module Exp = struct
     { sign = Unsigned; width; body = Vars (var, []); }
 
   let of_vars vars = match vars with
-    | [] -> mips_fail "can't constuct an expression from empty var list"
+    | [] -> mips_fail "can't construct an expression from empty var list"
     | v :: vars ->
       let width = width_of_vars (v::vars) in
       { sign = Unsigned; width; body = Vars (v, vars); }

--- a/plugins/powerpc/powerpc.mli
+++ b/plugins/powerpc/powerpc.mli
@@ -283,7 +283,7 @@
       5   let rc = unsigned reg ops.(3) in
       6   let tm = signed var doubleword in
       7   let xv = unsigned const word 42 in
-      8   let sh = unsinged const byte 2 in
+      8   let sh = unsigned const byte 2 in
       9   RTL.[
      10        rt := ra + im;
      11        tm = cpu.load rt halfword + xv;
@@ -429,7 +429,7 @@ module Std : sig
     (** [x + y] - sum *)
     val ( + ) : exp -> exp -> exp
 
-    (** [x - y] - substraction *)
+    (** [x - y] - subtraction *)
     val ( - ) : exp -> exp -> exp
 
     (** [x * y] - multiplication *)

--- a/plugins/powerpc/powerpc_add.ml
+++ b/plugins/powerpc/powerpc_add.ml
@@ -16,7 +16,7 @@
     | 7d 62 5c 15 |addco. r11, r2, r11|rc=1,oe=1|  not recognized    |  ---          |
     --------------------------------------------------------------------------------
 
-    And so on. Basicly, instructions
+    And so on. Basically, instructions
     addo addco addeo addmeo addzeo addo. addco. addeo. addmeo. addzeo.
     doesn't recognized by llvm.
 

--- a/plugins/powerpc/powerpc_rtl.ml
+++ b/plugins/powerpc/powerpc_rtl.ml
@@ -168,7 +168,7 @@ module Exp = struct
     { sign = Unsigned; width; body = Vars (var, []); }
 
   let of_vars vars = match vars with
-    | [] -> ppc_fail "can't constuct an expression from empty var list"
+    | [] -> ppc_fail "can't construct an expression from empty var list"
     | v :: vars ->
       let width = width_of_vars (v::vars) in
       { sign = Unsigned; width; body = Vars (v, vars); }

--- a/plugins/primus_greedy/primus_greedy_main.ml
+++ b/plugins/primus_greedy/primus_greedy_main.ml
@@ -84,7 +84,7 @@ manpage [
      are explored";
 
   `P
-    "The greedy scheduler will attempt to reschedule everytime a basic
+    "The greedy scheduler will attempt to reschedule every time a basic
     block is evaluated."
 ];;
 

--- a/plugins/primus_lisp/lisp/init.lisp
+++ b/plugins/primus_lisp/lisp/init.lisp
@@ -4,7 +4,7 @@
 (defconstant nil false "nil is another name for false")
 
 (defmacro when (cnd body)
-  "(when CND BODY) if CND is true then evalutes BODY and returns the
+  "(when CND BODY) if CND is true then evaluates BODY and returns the
    value of last expression in BODY, otherwise returns false."
   (if cnd (prog body) ()))
 

--- a/plugins/primus_lisp/lisp/pointers.lisp
+++ b/plugins/primus_lisp/lisp/pointers.lisp
@@ -1,4 +1,4 @@
-;; pointer arithmetics
+;; pointer arithmetic
 
 (require types)
 

--- a/plugins/primus_lisp/lisp/stdlib.lisp
+++ b/plugins/primus_lisp/lisp/stdlib.lisp
@@ -4,7 +4,7 @@
 (require simple-memory-allocator)
 
 (defun getenv (name)
-  "finds a value of an environemnt variable with the given name"
+  "finds a value of an environment variable with the given name"
   (declare (external "getenv"))
   (let ((p environ))
     (while (and (not (points-to-null p))

--- a/plugins/primus_lisp/primus_lisp_io.ml
+++ b/plugins/primus_lisp/primus_lisp_io.ml
@@ -255,13 +255,13 @@ let init redirections =
         def "channel-close"  (one int @-> int) (module Close)
           {|(channel-close DESCR) closes a channel that has the
             specified descriptor DESCR. If no such channel exists,
-            then retuns -1. Otherwise returns 0. The descriptor of the
+            then returns -1. Otherwise returns 0. The descriptor of the
             closed channel will be reused by the consequent calls
             to `channel-open'. If the channel had any data associated
             with it and not yet flushed, then the data is discarded. |};
         def "channel-flush"  (one int @-> int) (module Flush)
           {|(channel-flush DESCR) forces data that were written to a
-            channel that has the descriptor DESCR to be outputed to the
+            channel that has the descriptor DESCR to be outputted to the
             associated destination. Returns -1 if no such channel exists or
             if in case of an IO error.|};
         def "channel-input"  (one int @-> int) (module Input)

--- a/plugins/primus_lisp/primus_lisp_main.ml
+++ b/plugins/primus_lisp/primus_lisp_main.ml
@@ -86,29 +86,29 @@ module Signals(Machine : Primus.Machine.S) = struct
 
   let init = Machine.sequence Primus.Interpreter.[
       signal loaded (value,value) pair
-        {|(loaded A X) is emited when X is loaded from A|};
+        {|(loaded A X) is emitted when X is loaded from A|};
       signal stored (value,value) pair
-        {|(stored A X) is emited when X is stored to A|};
+        {|(stored A X) is emitted when X is stored to A|};
       signal read  (var,value) pair
-        {|(read V X) is emited when X is read from V|};
+        {|(read V X) is emitted when X is read from V|};
       signal written (var,value) pair
-        {|(written V X) is emited when X is written to V|};
+        {|(written V X) is emitted when X is written to V|};
       signal pc_change word one
-        {|(pc-change PC) is emited when PC is updated|};
+        {|(pc-change PC) is emitted when PC is updated|};
       signal eval_cond value one
         {|(eval_cond V) is emitted after evaluating a conditional to V|};
       signal jumping (value,value) pair
-        {|(jumping C D) is emited before jump to D occurs under the
+        {|(jumping C D) is emitted before jump to D occurs under the
           condition C|};
       signal Primus.Linker.Trace.call parameters call
-        {|(call NAME X Y ...) is emited when a call to a function with the
+        {|(call NAME X Y ...) is emitted when a call to a function with the
           symbolic NAME occurs with the specified list of arguments X,Y,...|};
       signal Primus.Linker.Trace.return parameters call
-        {|(call-return NAME X Y ... R) is emited when a call to a function with the
+        {|(call-return NAME X Y ... R) is emitted when a call to a function with the
           symbolic NAME returns with the specified list of arguments
           X,Y,... and return value R.|};
       signal interrupt int one
-        {|(interrupt N) is emited when the hardware interrupt N occurs|};
+        {|(interrupt N) is emitted when the hardware interrupt N occurs|};
       Lisp.signal Primus.Machine.init (fun () -> Machine.return [])
         ~doc:{|(init) occurs when the Primus Machine is initialized|};
       Lisp.signal Primus.Machine.finished (fun () -> Machine.return [])

--- a/plugins/primus_lisp/primus_lisp_primitives.ml
+++ b/plugins/primus_lisp/primus_lisp_primitives.ml
@@ -82,7 +82,7 @@ module MemoryAllocate(Machine : Primus.Machine.S) = struct
       let gen = match gen with
         | []  -> Ok None
         | [x] -> make_static_generator (Value.to_word x)
-        | _ -> Or_error.errorf "memory-allocate requies two or three arguments" in
+        | _ -> Or_error.errorf "memory-allocate requires two or three arguments" in
       if Result.is_error n || Result.is_error gen
       then negone
       else
@@ -293,7 +293,7 @@ module Primitives(Machine : Primus.Machine.S) = struct
       def "is-negative" (all any @-> bool) (module IsNegative)
         "(is-negative X Y ...) returns true if all arguments are negative";
       def "word-width" (unit @-> int)  (module WordWidth)
-        "(word-width) returns machine word widht in bits";
+        "(word-width) returns machine word width in bits";
       def "exit-with" (one int @-> any) (module ExitWith)
         "(exit-with N) terminates program with the exit codeN";
       def "memory-read" (one int @-> byte) (module MemoryRead)

--- a/plugins/primus_loader/primus_loader_basic.ml
+++ b/plugins/primus_loader/primus_loader_basic.ml
@@ -34,7 +34,7 @@ module Make(Param : Param)(Machine : Primus.Machine.S)  = struct
      Note: bottom is usually depicted at the top of the stack
      structure, and it is the highest address.
      Note: memory beyond top is readable, as it is the place,
-     where kernel should put argc, argv, and other infor to a
+     where kernel should put argc, argv, and other info to a
      user process *)
   let setup_stack () =
     target >>= fun (module Target) ->

--- a/plugins/primus_loader/primus_loader_basic.mli
+++ b/plugins/primus_loader/primus_loader_basic.mli
@@ -29,7 +29,7 @@ open Bap_primus.Std
     if an address size is 4 bytes, then SP+4 will point to the first
     argument (program name), SP+8 to the first specified command line
     argument, and so on. A null will follow the last argument. After
-    that the same null terminated table of environemnt variables will
+    that the same null terminated table of environment variables will
     follow. (It can be easy accessed via the [environ] symbol
 
     Note: the layout of the main function stack frame is not

--- a/plugins/primus_promiscuous/primus_promiscuous_main.ml
+++ b/plugins/primus_promiscuous/primus_promiscuous_main.ml
@@ -30,7 +30,7 @@ include Self()
    denotes logical negation.
 
    However, we would require an SMT solver to find such contexts. So,
-   the intepreter requires a program to be in a trivial condition form
+   the interpreter requires a program to be in a trivial condition form
    (TCF). In TCF every jmp condition must be a single variable or a
    constant true.
 

--- a/plugins/primus_propagate_taint/primus_propagate_taint_main.ml
+++ b/plugins/primus_propagate_taint/primus_propagate_taint_main.ml
@@ -246,7 +246,7 @@ manpage [
     will track, if it was marked with the $(b,tainted-reg)
     attribute. If it was marked with the $(b,tainted-ptr) attribute
     then we dereference this pointer and taint the dereferenced
-    address. If the right hand side is an abritrary expression, then
+    address. If the right hand side is an arbitrary expression, then
     we assume that all variables that are used in this expression
     contain values that are referencing directly or indirectly the
     tainted object."

--- a/plugins/primus_region/primus_region_main.ml
+++ b/plugins/primus_region/primus_region_main.ml
@@ -135,7 +135,7 @@ module Interface = struct
     `S "DESCRIPTION";
     `P
       "Provides a set of operations to store and manipulate interval
-    trees. The module provides a persistant storage for intervals,
+    trees. The module provides a persistent storage for intervals,
     denoted in the module as regions, since these intervals
     often represent memory regions. Intervals are stored in interval
     sets, that are implemented as efficient interval tree data

--- a/plugins/primus_taint/primus_taint_main.ml
+++ b/plugins/primus_taint/primus_taint_main.ml
@@ -176,7 +176,7 @@ module Signals(Machine : Primus.Machine.S) = struct
   module Object = Taint.Object.Make(Machine)
   module Value = Primus.Value.Make(Machine)
 
-  let doc = "(taint-finalize T L) is emited when the taint T is finilized
+  let doc = "(taint-finalize T L) is emitted when the taint T is finilized
      while still live if L is true or dead if T is false."
 
   let init () = Machine.sequence [

--- a/plugins/primus_test/lisp/memcheck.lisp
+++ b/plugins/primus_test/lisp/memcheck.lisp
@@ -7,7 +7,7 @@
 ;;;   reported when the same memory region is released twice;
 ;;;   reported when a region that was never acquired is released;
 ;;; - (incident use-after-release acquire release use)
-;;;   reported when a memory access opeartion occurs on a memory
+;;;   reported when a memory access operation occurs on a memory
 ;;;   region that was released
 ;;;
 ;;; Attributes:

--- a/plugins/propagate_taint/propagate_taint_main.ml
+++ b/plugins/propagate_taint/propagate_taint_main.ml
@@ -203,7 +203,7 @@ module Cmdline = struct
     `S "DESCRIPTION";
 
     `P "A taint propagation framework, that uses microexecution to
-    propagate the taint through a program. The execution is perfomed
+    propagate the taint through a program. The execution is performed
     using the ConquEror Engine, that is short for Concrete Evaluation
     with Errors. This execution engine allows to run incomplete
     programs with an unspecified user input. Moreover, to increase the
@@ -268,7 +268,7 @@ module Cmdline = struct
                                       In this mode we will follow only \
                                       one execution path, without \
                                       backtracking, giving a more \
-                                      feasable result, but much less \
+                                      feasible result, but much less \
                                       coverage")
 
   let print_coverage = Config.(flag "print-coverage"

--- a/plugins/taint/taint_main.ml
+++ b/plugins/taint/taint_main.ml
@@ -137,7 +137,7 @@ specified address. If a variable is passed, the the definition is
 tainted if it defines a variable with the given name. Finally, if tid
 is specified, then a definition must have the specified tid to be
 tainted. If several strains are specified, then all conditions must be
-satisfied. Consider ther following examples, |};
+satisfied. Consider the following examples, |};
     `Pre {|
      --taint-reg=0xBAD
      --taint-ptr=strcpy_dst

--- a/plugins/trivial_condition_form/trivial_condition_form_main.ml
+++ b/plugins/trivial_condition_form/trivial_condition_form_main.ml
@@ -50,7 +50,7 @@ manpage [
   `P "Ensures that all branching conditions are either a variable
 or a constant. We call such representation a Trivial Condition Form
 (TCF). During the translation all complex condition expressions are
-hoisted into the assignemnt section of a block.";
+hoisted into the assignment section of a block.";
 ];;
 
 

--- a/plugins/x86/x86_disasm.ml
+++ b/plugins/x86/x86_disasm.ml
@@ -1021,7 +1021,7 @@ let parse_instr mode mem addr =
             | _, Ovec 2, _ -> Bil.binop RSHIFT, "psrl", lowbits2elemt b2, i
             | _, Ovec 6, _ -> Bil.binop LSHIFT, "psll", lowbits2elemt b2, i
             | _, Ovec 4, _ -> Bil.binop ARSHIFT, "psra", lowbits2elemt b2, i
-            (* The shift amount of next two elements are multipled by eight *)
+            (* The shift amount of next two elements are multiplied by eight *)
             | 0x73, Ovec 3, Oimm i when prefix.opsize_override -> Bil.binop RSHIFT, "psrldq", t, Oimm (Addr.(i * bi8))
             | 0x73, Ovec 7, Oimm i when prefix.opsize_override -> Bil.binop LSHIFT, "pslldq", t, Oimm (Addr.(i * bi8))
             | _, Oreg i, _ -> disfailwith (Printf.sprintf "invalid psrl/psll encoding b2=%#x r=%#x" b2 i)

--- a/src/bap_byteweight_main.ml
+++ b/src/bap_byteweight_main.ml
@@ -220,9 +220,9 @@ module Cmdline = struct
   let threshold : float Term.t =
     let doc = "Decide that sequence starts a function \
                if m / n > $(docv),  where n is the total \
-               number of occurences of a given sequence in \
+               number of occurrences of a given sequence in \
                the training set, and m is how many times \
-               it has occured at the function start position." in
+               it has occurred at the function start position." in
     Arg.(value & opt float 0.5 &
          info ["threshold"; "t"] ~doc ~docv:"THRESHOLD")
 

--- a/src/bap_cmdline_terms.ml
+++ b/src/bap_cmdline_terms.ml
@@ -172,7 +172,7 @@ let source_type : source Term.t =
             `project`, then the input file must be project data
             serialized with some format available for project data
             type. The format can be encoded in the extension. If
-            needed, then a version number can be specifed, separated
+            needed, then a version number can be specified, separated
             from the format by a dash, e.g., `myproj.marshal`,
             `myproj.sexp-1.0', etc. If the format is not specified,
             then the default reader will be used." in
@@ -257,10 +257,10 @@ let recipe_doc = [
     "The $(b,option) command requires one mandatory parameter, the
     option name, and an arbitrary number of arguments that will be
     passed to the corresponding command line option. If there are more
-    than one argument then they will be concatenated with the comman
+    than one argument then they will be concatenated with the comma
     symbol, e.g., $(b,(option opt a b c d)) will be translated to
     $(b,--opt=a,b,c,d). Option arguments may contain substitution
-    symbols. A subsitution symbol starts with the dollar sign, that is
+    symbols. A substitution symbol starts with the dollar sign, that is
     followed by a named (optionally delimited with curly braces, to
     disambiguate it from the rest of the argument). There is one built
     in parameter called $(b,prefix), that is substituted with the path

--- a/src/bap_main.ml
+++ b/src/bap_main.ml
@@ -154,7 +154,7 @@ let program_info =
       $(mname) [PLUGIN OPTION]... --$(i,PLUGIN)-help
       $(mname) $(i,FILE) [PLUGIN OPTION]... [OPTION]...";
     `S "DESCRIPTION";
-    `P "A frontend to the Binary Analysis Platfrom library.
+    `P "A frontend to the Binary Analysis Platform library.
       The tool allows you to inspect binary programs by printing them
       in different representations including assembly, BIL, BIR,
       XML, HTML, JSON, Graphviz dot graphs and so on.";


### PR DESCRIPTION
Typos found with https://github.com/codespell-project/codespell

with the command:
$ codespell -q 2 -L iff,tarbal,mape,te,fpr,substract,ba,mor,creat,shold,eqaul,upto,uint,ans,unqoute,clos,archtype,amin,ith,cmo,avaliable,defintions,precendence,succeded

Hopefully only basic misspellings have been corrected.
Tell me if there are any errors!

(avaliable,precendence,succeded). Not cool to name variables with "typos".  :)

**Note:**
At https://github.com/BinaryAnalysisPlatform/bap/blob/master/lib/bap_disasm/bap_disasm_rec.ml#L259
**predcessing** is a typo but I have no correction...