### PR TITLE
fixes constant-tracker

### DIFF
--- a/plugins/constant_tracker/lisp/check-null-pointers.lisp
+++ b/plugins/constant_tracker/lisp/check-null-pointers.lisp
@@ -1,5 +1,5 @@
 (defun check-null-pointer (ptr)
-  (when (and (not ptr) (all-static-constants ptr))
+  (when (and (not ptr) (all-static-constant ptr))
     (incident-report 'null-pointer-dereference (incident-location))))
 
 (defmethod loading (ptr)

--- a/plugins/primus_lisp/primus_lisp_main.ml
+++ b/plugins/primus_lisp/primus_lisp_main.ml
@@ -85,8 +85,12 @@ module Signals(Machine : Primus.Machine.S) = struct
     Machine.List.all (proj kind arg)
 
   let init = Machine.sequence Primus.Interpreter.[
+      signal loading value one
+        {|(loading A) is emitted before load from A occurs|};
       signal loaded (value,value) pair
         {|(loaded A X) is emitted when X is loaded from A|};
+      signal storing value one
+        {|(storing A) is emitted before store to A occurs|};
       signal stored (value,value) pair
         {|(stored A X) is emitted when X is stored to A|};
       signal read  (var,value) pair


### PR DESCRIPTION
This PR fixes a couple of bugs that prevent constant-tracker from working correctly:
1) a typo in the lisp code
2) forgotten signals `loading` and `storing`