### PR TITLE
switches off primus-taint-gc by default

### DIFF
--- a/plugins/primus_taint/primus_taint_main.ml
+++ b/plugins/primus_taint/primus_taint_main.ml
@@ -246,7 +246,7 @@ let collectors = [
   "conservative", true;
 ]
 
-let enable_gc = param (enum collectors) ~default:true "gc"
+let enable_gc = param (enum collectors) ~default:false "gc"
     ~doc:"Picks a taint garbage collector"
 
 let () = when_ready (fun {get=(!!)} ->


### PR DESCRIPTION
The taint collector was always deemed as an optional feature, that at the cost of extra runtime cost, may increase the precision of the taint propagation engine. It is also not a feature, that everyone expects in a typical taint propagation engine so it might introduce unnecessary confusion. 

Note, the taint propagation garbage collector tracks the liveness of taints, and deletes (sanitizes) them as soon as they are not reachable anymore. 