### PR TITLE
adds an apline based dockerfile

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -3,8 +3,7 @@ FROM ocaml/opam2:alpine
 ENV HOME /home/opam
 WORKDIR $HOME
 
-RUN sudo apk update \
- && opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing \
+RUN opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing \
  && opam update \
  && opam depext --install bap --yes \
  && opam clean -acrs \

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -1,21 +1,10 @@
-FROM ocaml/opam2:alpine as bap-testing
+FROM ocaml/opam2:alpine
 
 ENV HOME /home/opam
 WORKDIR $HOME
 
 RUN sudo apk update \
- && sudo apk add \
-    binutils \
-    clang \
-    gmp-dev \
-    libzip-dev \
-    llvm-dev \
-    llvm-static \
-    m4 \
-    perl \
-    zlib-dev
-
-RUN opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing \
+ && opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing \
  && opam update \
  && opam depext --install bap --yes \
  && opam clean -acrs \

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -1,14 +1,13 @@
 FROM ocaml/opam2:alpine
 
-ENV HOME /home/opam
-WORKDIR $HOME
+WORKDIR /home/opam
 
 RUN opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing \
  && opam update \
  && opam depext --install bap --yes \
  && opam clean -acrs \
- && rm -rf .opam/4.0[2-6] \
- && rm -rf .opam/4.07/.opam-switch/sources/* \
- && rm -rf opam-repository
+ && rm -rf /home/opam/.opam/4.0[2-6] \
+ && rm -rf /home/opam/.opam/4.07/.opam-switch/sources/* \
+ && rm -rf /home/opam/opam-repository
 
 ENTRYPOINT ["opam", "config", "exec", "--"]

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -1,0 +1,26 @@
+FROM ocaml/opam2:alpine as bap-testing
+
+ENV HOME /home/opam
+WORKDIR $HOME
+
+RUN sudo apk update \
+ && sudo apk add \
+    binutils \
+    clang \
+    gmp-dev \
+    libzip-dev \
+    llvm-dev \
+    llvm-static \
+    m4 \
+    perl \
+    zlib-dev
+
+RUN opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing \
+ && opam update \
+ && opam depext --install bap --yes \
+ && opam clean -acrs \
+ && rm -rf .opam/4.0[2-6] \
+ && rm -rf .opam/4.07/.opam-switch/sources/* \
+ && rm -rf opam-repository
+
+ENTRYPOINT ["opam", "config", "exec", "--"]


### PR DESCRIPTION
This PR adds a docker file which builds the testing version of `bap` and is based on
`ocaml/opam2:alpine` image.