### PR TITLE
adds x86 stack pointer handling for external calls

### DIFF
--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -1116,6 +1116,16 @@ module Std : sig
          *)
         val return : (string * value list) observation
 
+        (** occurs when an externally linked primus stub is called.
+            Arguments values are specified in the same order as in
+            the [call] observation *)
+        val lisp_call : (string * value list) observation
+
+        (** occurs just before a lisp call from an external procedure
+            returns. Arguments values are specified in the same order as in
+            the [return] observation *)
+        val lisp_call_return : (string * value list) observation
+
         (** {3 Notification interface}
 
             Use [Machine.Observation.make] function, where [Machine]
@@ -1128,6 +1138,12 @@ module Std : sig
 
         (** the statement that makes [return] observations  *)
         val call_returned : (string * value list) statement
+
+        (** the statement that makes [lisp-call] observations  *)
+        val lisp_call_entered : (string * value list) statement
+
+        (** the statement that makes [lisp-call-return] observations  *)
+        val lisp_call_returned : (string * value list) statement
 
       end
 

--- a/lib/bap_primus/bap_primus_linker.ml
+++ b/lib/bap_primus/bap_primus_linker.ml
@@ -81,7 +81,7 @@ module Trace = struct
     Observation.provide ~inspect:sexp_of_call "call-return"
 
   let lisp_call,lisp_call_entered =
-    Observation.provide ~inspect:sexp_of_call "list-call"
+    Observation.provide ~inspect:sexp_of_call "lisp-call"
 
   let lisp_call_return,lisp_call_returned =
     Observation.provide ~inspect:sexp_of_call "lisp-call-return"

--- a/plugins/primus_x86/.merlin
+++ b/plugins/primus_x86/.merlin
@@ -1,0 +1,2 @@
+PKG bap-x86-cpu
+PKG bap-primus

--- a/plugins/primus_x86/primus_x86_loader.ml
+++ b/plugins/primus_x86/primus_x86_loader.ml
@@ -1,10 +1,13 @@
 open Core_kernel
 open Bap.Std
 open Bap_primus.Std
+open X86_cpu
 
 module Component(Machine : Primus.Machine.S) = struct
   open Machine.Syntax
   module Env = Primus.Env.Make(Machine)
+  module Value = Primus.Value.Make(Machine)
+  module Interpreter = Primus.Interpreter.Make(Machine)
 
   let zero = Primus.Generator.static 0
 
@@ -12,11 +15,22 @@ module Component(Machine : Primus.Machine.S) = struct
     Machine.Seq.iter (Set.to_sequence flags) ~f:(fun reg ->
         Env.add reg zero)
 
+  let correct_sp sp addend _ =
+    Env.get sp >>= fun x ->
+    Value.of_int ~width:(addend * 8) addend >>= fun addend ->
+    Interpreter.binop Bil.plus x addend >>= fun x ->
+    Env.set sp x
+
+  let correct_sp sp addend =
+    Primus.Linker.Trace.lisp_call_return >>> correct_sp sp addend
+
+  let seq = Machine.sequence
+
   let init () =
     Machine.get () >>= fun proj ->
     match Project.arch proj with
-    | `x86 -> initialize_flags (X86_cpu.IA32.flags)
-    | `x86_64 -> initialize_flags (X86_cpu.AMD64.flags)
+    | `x86 -> seq [initialize_flags IA32.flags; correct_sp IA32.sp 4]
+    | `x86_64 -> seq [initialize_flags AMD64.flags; correct_sp AMD64.sp 8]
     | _ -> Machine.return ()
 
 end


### PR DESCRIPTION
For x86 and x86_64 ABI it is the responsibility of the callee to pop the return address from the stack pointer and increase the stack pointer. Since the code of external functions is not present in the binary, every time an external function is called, the stack grows without being corrected. In case if the base pointer is not used (e.g., in optimized code, or if the no-frame-pointer option was specified) this will also lead to the stack corruption as all variables will shift. This corruption results in an incorrect interpretation of a program and in case of taint analysis will introduce aliasing between neighboring stack variables.

The solution is to appropriately increase the stack pointer every time we return from a call from the Lisp Machine back to the Primus Machine. This will correctly handle three cases:

1) an internal ABI comformant function is overridden by a lisp function
2) an external function is overridden by a lisp function
3) an external function which is not linked/overridden

In the latter will work correctly, because all external functions that are not linked explicitly, are implicitly linked to a special function __primus_linker_unresolved_call, which in turn is overridden by the primus:handle-unresolved-names function, therefore an unlinked external function will still end up with a Lisp machine call. The same is true, if a function is overridden without using the Lisp Machine, directly from the Linker.

Obviously, this patch relies on the presence of the Lisp machine and if the Lisp Machine is not loaded, the stack pointer will not be corrected.

This patch will also misbehave, if a local static function that is not ABI comformant is overridden by a Lisp stub. In that case it is the responsibility of the Lisp stub to properly correct the stack pointer.

A better solution is still being sought, but so far this is the best option we have. 
Resolves #879