### PR TITLE
preserves random values in Primus

### DIFF
--- a/lib/bap_primus/bap_primus_env.ml
+++ b/lib/bap_primus/bap_primus_env.ml
@@ -108,7 +108,10 @@ module Make(Machine : Machine) = struct
       | Type.Mem (_,_) -> null
       | Type.Imm width -> match Map.find t.random var with
         | None -> Machine.raise (Undefined_var var)
-        | Some gen -> gen_word gen width >>= Value.of_word
+        | Some gen ->
+           gen_word gen width >>= Value.of_word >>= fun x ->
+           set var x >>= fun () ->
+           !!x
 
   let has var =
     Machine.Local.get state >>| fun t ->


### PR DESCRIPTION
Primus generates a new random value every time `Env.get` is called with an unbound variable.

This PR changes this behavior and makes Primus remember the generated
value, i.e. bind such variable at first time its value was requested.