### PR TITLE
 limits the continuation at the call forkpoint in the promiscuous mode

### DIFF
--- a/plugins/primus_promiscuous/primus_promiscuous_main.ml
+++ b/plugins/primus_promiscuous/primus_promiscuous_main.ml
@@ -146,7 +146,9 @@ module Main(Machine : Primus.Machine.S) = struct
         Machine.Global.get state >>= fun {forkpoints} ->
         if Set.mem forkpoints dst
         then Eval.halt >>= never_returns
-        else Linker.exec (`tid dst)
+        else
+          Linker.exec (`tid dst) >>= fun () ->
+          Eval.halt >>= never_returns
     | _ -> Machine.return ()
 
   let fork_on_calls blk jmp = match Jmp.kind jmp with


### PR DESCRIPTION
## Context
In the promiscuous mode we fork a new machine on each new call, so that if the function doesn't return for any reason, we can continue exploration of the code located after the call. 

## Problem
The stored continuation wasn't limited and was capturing the whole execution path, including the path in which the function was actually returning. That lead to quite funny false positives in our analysis. 

## Solution

The continuation is now explicitly delimited with `halt`. 
