### PR TITLE
relaxes CFI check in the Primus Interpreter

### DIFF
--- a/lib/bap_primus/bap_primus_interpreter.ml
+++ b/lib/bap_primus/bap_primus_interpreter.ml
@@ -620,7 +620,7 @@ module Make (Machine : Machine) = struct
     push_prompt ret >>= fun () ->
     label cond (Call.target call) >>= fun () ->
     Machine.Local.get state >>= function
-    | {prompts=[]} -> trap_cfi_violation callsite
+    | {prompts=[]} -> Machine.return ()
     | {prompts=p::_} -> match ret with
       | None -> Machine.return ()
       | Some p' when Tid.(p <> p') ->


### PR DESCRIPTION
Do not raise a CFI viloation, when the continuation finishes but we
didn't issue any prompts. It usually corresponds just to an execution
of an arbitrary function from a top-level.

This also opens an avenue for making our CFI violation more
informational, since the only left case will have concrete instances
in a form of two destinations - expected vs taken.