### PR TITLE
parametrize Primus Lisp malloc with initialization strategy

### DIFF
--- a/plugins/primus_lisp/lisp/simple-memory-allocator.lisp
+++ b/plugins/primus_lisp/lisp/simple-memory-allocator.lisp
@@ -18,9 +18,19 @@
 (defparameter *malloc-guard-pattern* 0xA5
   "a byte that will be used to fill guard edges")
 
-
 (defparameter *malloc-zero-sentinel* 0
   "a pointer that is returned by (malloc 0)")
+
+(defparameter *malloc-initialize-memory* false
+  "if true then initialize allocated memory with *malloc-initial-value*")
+
+(defparameter *malloc-initial-value* 0
+  "initialize allocated memory with the said value")
+
+(defun memory/allocate (ptr len)
+  (if *malloc-initialize-memory*
+      (memory-allocate ptr n *malloc-initial-value*)
+    (memory-allocate ptr n)))
 
 (defun malloc (n)
   "allocates a memory region of size N"
@@ -29,11 +39,12 @@
     (if (malloc-will-reach-limit n) 0
       (let ((n (+ n (* 2 *malloc-guard-edges*)))
             (ptr brk)
-            (failed (memory-allocate ptr n 0)))
+            (failed (memory/allocate ptr n)))
         (if failed 0
           (set brk (+ brk n))
           (malloc/fill-edges ptr n)
           (+ ptr *malloc-guard-edges*))))))
+
 
 ;; in our simplistic malloc implementation, free is just a nop
 (defun free (p)


### PR DESCRIPTION
So far our simple-memory-allocator was always filling the allocated
memory with zeros. The proposed implementation adds two parameters
the first one, `*malloc-initialize-memory*` controls whether memory is
initialized at all, and the second one, `*malloc-initial-value*` is
the value that is used to fill in the allocated memory, when the first
parameter is set to `true`.

By default, we set `*malloc-initialize-memory*` to false, so that PR
changes the behavior of Primus. Now the heap memory is randomized, so
if it breaks your analysis the set `*malloc-initialize-memory*` to `true`.