### PR TITLE
`break` doesn't work in `case` for shell

### DIFF
--- a/configure
+++ b/configure
@@ -6,8 +6,7 @@ rm -f _oasis
 
 case "is$BAP_DEBUG" in
     is|isno|isfalse|isdisable|is0)
-        QUIET="-quiet";
-        break;;
+        QUIET="-quiet";;
     *)
         QUIET=""
 esac


### PR DESCRIPTION
It works only in the loops. Spotted the warning with [shellcheck](https://github.com/koalaman/shellcheck).
See [SC2105](https://github.com/koalaman/shellcheck/wiki/SC2105) explanation at their wiki:
> `break` or `continue` was found outside a loop. These statements are only valid in loops. In particular, `break` is not required in `case` statements as there is no implicit fall-through.