### PR TITLE
Adding edge functions to fixpoint algorithm

### DIFF
--- a/lib/graphlib/graphlib.mli
+++ b/lib/graphlib/graphlib.mli
@@ -1452,9 +1452,11 @@ module Std : sig
         approach where the constraint denotes only the input for the
         entry node).  *)
     val fixpoint : (module Graph with type t = 'c
-                                  and type node = 'n) ->
+                                  and type node = 'n
+                                  and type edge = 'e) ->
       ?steps:int -> ?start:'n -> ?rev:bool ->
       ?step:(int -> 'n -> 'd -> 'd -> 'd) ->
+      ?edge_fn:('e -> 'd -> 'd) ->
       init:('n,'d) Solution.t ->
       equal:('d -> 'd -> bool) ->
       merge:('d -> 'd -> 'd) -> f:('n -> 'd -> 'd) -> 'c -> ('n,'d) Solution.t

--- a/lib/graphlib/graphlib_graph.ml
+++ b/lib/graphlib/graphlib_graph.ml
@@ -1368,7 +1368,7 @@ module Fixpoint = struct
       | Some x -> x
       | None -> default in
     let get_edges ~start_node ~end_node =
-      let successors = if rev then G.Node.outputs start_node g else G.Node.inputs start_node g in
+      let successors = if rev then G.Node.inputs start_node g else G.Node.outputs start_node g in
       Seq.filter ~f:(fun edge -> (if rev then G.Edge.src edge else G.Edge.dst edge) = end_node) successors
     in
     let step visits works approx = match Set.min_elt works with
@@ -1383,7 +1383,7 @@ module Fixpoint = struct
               let ap' = match edge_fn with
                 | None -> merge out ap
                 | Some edge_function ->
-                  let edges = get_edges ~start_node:nodes.(current_node) ~end_node:nodes.(n) in (* TODO: Check whether I have to iterate over the nodes here instead *)
+                  let edges = get_edges ~start_node:nodes.(current_node) ~end_node:nodes.(n) in
                   Seq.fold ~f:(fun ap' edge -> merge ap' (edge_function edge out)) ~init:ap edges in
               let visits,ap' = user_step visits n ap ap' in
               if equal ap ap' then (visits,works,approx)

--- a/lib/graphlib/graphlib_graph.ml
+++ b/lib/graphlib/graphlib_graph.ml
@@ -1383,7 +1383,7 @@ module Fixpoint = struct
                       Option.value_exn (G.Node.edge nodes.(n) nodes.(current_node) g)
                     else
                       Option.value_exn (G.Node.edge nodes.(current_node) nodes.(n) g) in
-                  merge ap' (edge_function edge out) in
+                  merge (edge_function edge out) ap in
               let visits,ap' = user_step visits n ap ap' in
               if equal ap ap' then (visits,works,approx)
               else visits,

--- a/lib/graphlib/graphlib_graph.mli
+++ b/lib/graphlib/graphlib_graph.mli
@@ -250,9 +250,11 @@ end
 module Fixpoint : Solution
 
 val fixpoint : (module Graph with type t = 'c
-                              and type node = 'n) ->
+                              and type node = 'n
+                              and type edge = 'e) ->
   ?steps:int -> ?start:'n -> ?rev:bool ->
   ?step:(int -> 'n -> 'd -> 'd -> 'd) ->
+  ?edge_fn:('e -> 'd -> 'd) ->
   init:('n,'d) Fixpoint.t ->
   equal:('d -> 'd -> bool) ->
   merge:('d -> 'd -> 'd) -> f:('n -> 'd -> 'd) -> 'c -> ('n,'d) Fixpoint.t

--- a/lib_test/bap_types/test_graph.ml
+++ b/lib_test/bap_types/test_graph.ml
@@ -634,7 +634,7 @@ module Test_fixpoint = struct
     let fixpoint = Graphlib.fixpoint (module G) ~steps:20 ~rev:false ~init:start_solution ~equal:equal ~merge:merge ~f:(fun node value -> value + 1) !graph in
     assert_bool "failed" (Solution.get fixpoint (G.Node.create 3) = 2);
     let fixpoint = Graphlib.fixpoint (module G) ~steps:20 ~rev:true ~init:start_solution ~equal:equal ~merge:merge ~f:(fun node value -> value + 1) !graph in
-    assert_bool "failed" (Solution.get fixpoint (G.Node.create 3) = 8);
+    assert_bool "failed" (Solution.get fixpoint (G.Node.create 3) = 8)
 
   let suite () = [
     "Shortest path" >:: shortest_path_fixpoint_test

--- a/lib_test/bap_types/test_graph.ml
+++ b/lib_test/bap_types/test_graph.ml
@@ -635,8 +635,6 @@ module Test_fixpoint = struct
     assert_bool "failed" (Solution.get fixpoint (G.Node.create 3) = 2);
     let fixpoint = Graphlib.fixpoint (module G) ~steps:20 ~rev:true ~init:start_solution ~equal:equal ~merge:merge ~f:(fun node value -> value + 1) !graph in
     assert_bool "failed" (Solution.get fixpoint (G.Node.create 3) = 8);
-    (* checking whether these tests are actually run or not *)
-    assert_bool "canary failed" false
 
   let suite () = [
     "Shortest path" >:: shortest_path_fixpoint_test


### PR DESCRIPTION
This PR adds optional edge functions to the fixpoint algorithm. This is important for example in value set analysis, when one can gain knowledge on the current values depending on whether a conditional jump was taken or not.

Things that should be done before merging:
- [ ] Add tests
- [ ] Add documentation

Could you point me to the place to add both of these? For tests I suppose the *lib_tests* folder is right, but I don't know how one is supposed to compile and run these tests.