### PR TITLE
restores the old behavior of the Word.to_int* wrt to signed values

### DIFF
--- a/lib/bap_types/bap_bitvector.ml
+++ b/lib/bap_types/bap_bitvector.ml
@@ -293,9 +293,20 @@ include Cons
 
 let safe f t = try_with (fun () -> f t)
 
-let to_int_exn x = Bitvec.to_int (payload x)
-let to_int32_exn x = Bitvec.to_int32 (payload x)
-let to_int64_exn x = Bitvec.to_int64 (payload x)
+
+let convert cast_z cast_bitvec x =
+  if Packed.is_signed x
+  then
+    cast_z @@
+    Z.signed_extract (Bitvec.to_bigint (payload x))
+      0                         (* pos *)
+      (Packed.bitwidth x)       (* len *)
+  else
+    cast_bitvec (payload x)
+
+let to_int_exn x = convert Z.to_int Bitvec.to_int x
+let to_int32_exn x = convert Z.to_int32 Bitvec.to_int32 x
+let to_int64_exn x = convert Z.to_int64 Bitvec.to_int64 x
 let to_int   = safe to_int_exn
 let to_int32 = safe to_int32_exn
 let to_int64 = safe to_int64_exn


### PR DESCRIPTION
Previously, when a signed bitvector was converted to an OCaml integer
it was sign-extended. This behavior is now restored, e.g.,
```
 # let n_two = Word.of_int (-2) ~width:3;;
 val n_two : Bap.Std.Word.t = 6
 # n_two |> Word.signed |> Word.to_int_exn;;
 - : int = -2
 # n_two |> Word.to_int_exn;;
 - : int = 6
```

Note, also that the new implementation is still not exactly the same
as the old and subsumes the old, for example, in BAP 1.x the following
will raise an error:

```
Word.to_int64_exn (Word.of_int64 0x9a693d39c794d099L);;
```

and therefore the old code was using an explicit `Word.signed` to
trigger the signed extraction, which was probably wrong. In BAP 2.x
no matter whether the value is signed or not, if it fits the target
representation it will be converted, e.g.,
```
 # 0x9a693d39c794d099L;;
 - : int64 = -7320252400943181671
 # Word.of_int64 0x9a693d39c794d099L;;
 - : Bap.Std.Word.t = 0x9A693D39C794D099
 # Word.to_int64_exn (Word.of_int64 0x9a693d39c794d099L);;
 - : int64 = -7320252400943181671
 # Word.to_int64_exn (Word.signed (Word.of_int64 0x9a693d39c794d099L));;
 - : int64 = -7320252400943181671
```