### PR TITLE
fixes lisp `atexit` declaration

### DIFF
--- a/plugins/primus_lisp/lisp/stdlib.lisp
+++ b/plugins/primus_lisp/lisp/stdlib.lisp
@@ -25,7 +25,9 @@
 
 
 (defun atexit (cb)
-  (declare (external "atexit")))
+  (declare (external "atexit"))
+  0)
+
 
 (defun stub ()
   "stubs that does nothing"


### PR DESCRIPTION
`atexit` was declared as a function with no return value:
```
(defun atexit (cb)
  (declare (external "atexit")))
```
although it should return an integer.
And that could lead us to a type error in primus. So let's just asssume that `atexit` is always successful
and returns 0.