### PR TITLE
introduces a more fine-granular view on the image memory

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -5218,11 +5218,6 @@ module Std : sig
     (** symbol  *)
     type symbol [@@deriving bin_io, compare, sexp]
 
-    (** code region  *)
-    type code_region [@@deriving bin_io, compare, sexp]
-    (** data region *)
-    type data_region [@@deriving bin_io, compare, sexp]
-
     type path = string
 
     (** {2 Constructing}  *)
@@ -5278,14 +5273,6 @@ module Std : sig
     (** [symbols image] returns a mapping from addresses to symbols *)
     val symbols : t -> symbol table
 
-    (** [code_regions image] returns a mapping from address to a
-        region with code *)
-    val code_regions : t -> code_region table
-
-    (** [data_regions image] returns a mapping from address to a
-        region with data *)
-    val data_regions : t -> data_region table
-
     (** {2 Tags}  *)
 
     (** tags a segment  *)
@@ -5298,10 +5285,7 @@ module Std : sig
     val section : string tag
 
     (** tags a code region  *)
-    val code_region  : code_region tag
-
-    (** tags a data region  *)
-    val data_region  : data_region tag
+    val code_region  : unit tag
 
     (** an image specification in OGRE  *)
     val specification : Ogre.doc tag
@@ -5513,10 +5497,6 @@ module Std : sig
 
       val code_region :
         (addr * size * off, (addr -> size -> off -> 'a) -> 'a) Ogre.attribute
-
-      val data_region :
-        (addr * size * off * bool, (addr -> size -> off -> bool -> 'a) -> 'a) Ogre.attribute
-
     end
   end
 

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -5218,6 +5218,11 @@ module Std : sig
     (** symbol  *)
     type symbol [@@deriving bin_io, compare, sexp]
 
+    (** code region  *)
+    type code_region [@@deriving bin_io, compare, sexp]
+    (** data region *)
+    type data_region [@@deriving bin_io, compare, sexp]
+
     type path = string
 
     (** {2 Constructing}  *)
@@ -5273,6 +5278,14 @@ module Std : sig
     (** [symbols image] returns a mapping from addresses to symbols *)
     val symbols : t -> symbol table
 
+    (** [code_regions image] returns a mapping from address to a
+        region with code *)
+    val code_regions : t -> code_region table
+
+    (** [data_regions image] returns a mapping from address to a
+        region with data *)
+    val data_regions : t -> data_region table
+
     (** {2 Tags}  *)
 
     (** tags a segment  *)
@@ -5283,6 +5296,12 @@ module Std : sig
 
     (** tags a section  *)
     val section : string tag
+
+    (** tags a code region  *)
+    val code_region  : code_region tag
+
+    (** tags a data region  *)
+    val data_region  : data_region tag
 
     (** an image specification in OGRE  *)
     val specification : Ogre.doc tag
@@ -5491,6 +5510,13 @@ module Std : sig
       (** [base_address addr] this is the base address of an image,
           i.e., an address of a first byte of the image.  *)
       val base_address : (addr, (addr -> 'a) -> 'a) Ogre.attribute
+
+      val code_region :
+        (addr * size * off, (addr -> size -> off -> 'a) -> 'a) Ogre.attribute
+
+      val data_region :
+        (addr * size * off * bool, (addr -> size -> off -> bool -> 'a) -> 'a) Ogre.attribute
+
     end
   end
 

--- a/lib/bap/bap_project.ml
+++ b/lib/bap/bap_project.ml
@@ -103,8 +103,7 @@ module Input = struct
     Hashtbl.set loaders ~key:name ~data:loader
 
   let is_code v =
-    Value.get Image.segment v |>
-    Option.value_map ~default:false ~f:Image.Segment.is_executable
+    Value.get Image.code_region v |> Option.is_some
 
   let is_data v = not (is_code v)
 

--- a/lib/bap_image/bap_image.ml
+++ b/lib/bap_image/bap_image.ml
@@ -53,13 +53,15 @@ let pp_region fmt {name; locn={addr; size}} =
 
 let hash_region {locn={addr}} = Addr.hash addr
 
-module Segment = struct
+module Mapped_region(N : sig
+             val name : string
+           end) = struct
 
   module T = struct
     type t = mapped region [@@deriving bin_io, compare, sexp]
     let hash = hash_region
     let pp = pp_region
-    let module_name = Some "Bap.Std.Image.Segment"
+    let module_name = Some N.name
     let version = "2.0.0"
   end
 
@@ -72,6 +74,11 @@ module Segment = struct
   include T
   include Regular.Make(T)
 end
+
+module Segment = Mapped_region(struct let name = "Bap.Std.Image.Segment" end)
+module Data_region = Mapped_region(struct let name = "Bap.Std.Image.Data_region" end)
+module Code_region = Mapped_region(struct let name = "Bap.Std.Image.Code_region" end)
+
 
 module Symbol = struct
   open! Polymorphic_compare
@@ -90,6 +97,8 @@ end
 
 type segment = Segment.t [@@deriving bin_io, compare, sexp]
 type symbol = Symbol.t [@@deriving bin_io,compare, sexp]
+type data_region = Data_region.t [@@deriving bin_io, compare, sexp]
+type code_region = Code_region.t   [@@deriving bin_io, compare, sexp]
 
 module Spec = struct
   type t = {
@@ -98,6 +107,8 @@ module Spec = struct
     segments : segment list;
     symbols : symbol list;
     sections : unit region list;
+    data  : data_region list;
+    code  : code_region list;
   } [@@deriving bin_io, compare, sexp]
 end
 
@@ -120,6 +131,8 @@ type t = {
   data : Bigstring.t;
   symbols : symbol table;
   segments : segment table;
+  data_regions : data_region table;
+  code_regions : code_region table;
   memory : value memmap;
   words : words sexp_opaque;
   memory_of_segment : segment -> mem sexp_opaque;
@@ -152,6 +165,14 @@ let section  = Value.Tag.register (module String)
     ~name:"section"
     ~uuid:"4014408d-a3af-488f-865b-5413beaf198e"
 
+let data_region = Value.Tag.register (module Data_region)
+    ~name:"data-region"
+    ~uuid:"e9fe38cb-ca99-470d-a554-dbd494dd7ec2"
+
+let code_region = Value.Tag.register (module Code_region)
+    ~name:"code-region"
+    ~uuid:"5296b7e9-d5c3-40ce-98ba-7655ec68fad7"
+
 let file = Value.Tag.register (module String)
     ~name:"file"
     ~uuid:"c119f700-4069-47ad-ba99-fc29791e0d47"
@@ -159,7 +180,6 @@ let file = Value.Tag.register (module String)
 let specification = Value.Tag.register (module Bap_ogre.Doc)
     ~name:"image-specification"
     ~uuid:"a0c98f1f-3693-412a-a11a-2b6c3f6935a7"
-
 
 let mem_of_locn mem {addr;size} : mem Or_error.t =
   match Memory.view ~from:addr ~words:size mem with
@@ -198,6 +218,15 @@ let add_segment base memory segments seg =
   let memory = tag mem segment seg memory in
   Result.return (memory,segments)
 
+let add_region kind base memory regions reg =
+  map_region base reg >>= fun mem ->
+  Table.add regions mem reg >>= fun regions ->
+  let memory = tag mem kind reg memory in
+  Result.return (memory,regions)
+
+let add_code = add_region code_region
+let add_data = add_region data_region
+
 let add_sections_view segments sections memmap =
   List.fold sections ~init:(memmap,[])
     ~f:(fun (memmap,ers) {name; locn}  ->
@@ -214,7 +243,8 @@ let make_table add base memory =
 
 let make_symtab = make_table add_sym
 let make_segtab = make_table add_segment
-
+let make_codtab = make_table add_code
+let make_dattab = make_table add_data
 
 (** [words_of_table word_size table] maps all memory mapped by [table]
     to words of size [word_size]. If size of mapped region is not enough
@@ -255,11 +285,13 @@ let create_segment_of_symbol_table syms secs =
 
 let from_spec query base doc =
   Fact.eval query doc >>= function
-    {Spec.segments; symbols; sections} as spec ->
+    {Spec.segments; symbols; sections;data;code} as spec ->
     let memory = Memmap.empty in
     let memory,segs,seg_warns = make_segtab base memory segments in
     let memory,syms,sym_warns = make_symtab segs memory symbols in
     let memory,sec_warns = add_sections_view segs sections memory in
+    let memory,code_regs,creg_warns = make_codtab base memory code in
+    let memory,data_regs,dreg_warns = make_dattab base memory data in
     let words = create_words segs in
     Table.(rev_map ~one_to:one Segment.hashable (segs : segment table)) >>=
     fun (memory_of_segment : segment -> mem) ->
@@ -272,12 +304,14 @@ let from_spec query base doc =
     Result.return ({
         doc; spec;
         name = None; data=base; symbols=syms; segments=segs; words;
+        code_regions = code_regs;
+        data_regions = data_regs;
         memory_of_segment;
         memory;
         memory_of_symbol   = Lazy.from_fun memory_of_symbol;
         symbols_of_segment = Lazy.from_fun symbols_of_segment;
         segment_of_symbol  = Lazy.from_fun segment_of_symbol;
-      }, (seg_warns @ sym_warns @ sec_warns))
+      }, (seg_warns @ sym_warns @ sec_warns @ creg_warns @ dreg_warns))
 
 let data t = t.data
 let memory t = t.memory
@@ -302,6 +336,8 @@ let words t (size : size) : word table =
 let segments t = t.segments
 let symbols t = t.symbols
 let memory_of_segment t = t.memory_of_segment
+let data_regions t = t.data_regions
+let code_regions t = t.code_regions
 
 let memory_of_symbol {memory_of_symbol = lazy f} = f
 let symbols_of_segment {symbols_of_segment = lazy f} = f
@@ -343,6 +379,13 @@ module Scheme = struct
       (fun addr size r w x -> {addr; size; info=(r,w,x)})
   let mapped () = declare "mapped" (location () $off)
       (fun addr size off -> region addr size off)
+
+  let code_region () =
+    declare "code-region" (scheme addr $ size $ off) Tuple.T3.create
+
+  let data_region () =
+    declare "data-region" (scheme addr $ size $ off $ writable)
+      (fun addr size off wr -> addr,size,off,wr)
 
   let relocation () =
     declare "relocation" (scheme fixup $ addr) Tuple.T2.create
@@ -446,16 +489,44 @@ module Derive = struct
               })) >>=
     Fact.Seq.all >>| Seq.filter_opt
 
+  let code =
+    endian >>= fun endian ->
+    Fact.foreach Ogre.Query.(begin
+        select (from code_region $ named_region)
+          ~join:[[field addr];]
+      end) ~f:(fun (addr,size, off) {info=name} ->
+        location ~addr ~size >>= fun locn ->
+        int_of_int64 off  >>= fun off ->
+        int_of_int64 size >>| fun len ->
+        {locn; name; info={endian;off;len;r=true;w=false;x=true}}) >>=
+    Fact.Seq.all
+
+  let data =
+    endian >>= fun endian ->
+    Fact.foreach Ogre.Query.(begin
+        select (from data_region $ named_region)
+          ~join:[[field addr];]
+      end) ~f:(fun (addr, size, off, write) {info=name} ->
+        location ~addr ~size >>= fun locn ->
+        int_of_int64 off  >>= fun off ->
+        int_of_int64 size >>| fun len ->
+        {locn; name; info={endian;off;len;r=true;w=write;x=false}}) >>=
+    Fact.Seq.all
+
   let image =
     arch >>= fun arch ->
     entry    >>= fun entry ->
     segments >>= fun segments ->
     sections >>= fun sections ->
+    code >>= fun code ->
+    data >>= fun data ->
     symbols  >>| fun symbols  -> {
       Spec.arch; entry;
       segments = Seq.to_list_rev segments;
-      symbols = Seq.to_list_rev symbols;
+      symbols  = Seq.to_list_rev symbols;
       sections = Seq.to_list_rev sections;
+      data = Seq.to_list_rev data;
+      code = Seq.to_list_rev code;
     }
 end
 

--- a/lib/bap_image/bap_image.ml
+++ b/lib/bap_image/bap_image.ml
@@ -364,9 +364,6 @@ module Scheme = struct
   let code_region () =
     declare "code-region" (scheme addr $ size $ off) Tuple.T3.create
 
-  let data_region () =
-    declare "data-region" (scheme addr $ size $ off)  Tuple.T3.create
-
   let relocation () =
     declare "relocation" (scheme fixup $ addr) Tuple.T2.create
   let external_reference () =

--- a/lib/bap_image/bap_image.mli
+++ b/lib/bap_image/bap_image.mli
@@ -9,6 +9,8 @@ open Image_internal_std
 type t [@@deriving sexp_of]            (** image   *)
 type segment [@@deriving bin_io, compare, sexp]
 type symbol [@@deriving bin_io, compare, sexp]
+type data_region [@@deriving bin_io, compare, sexp]
+type code_region [@@deriving bin_io, compare, sexp]
 
 type path = string
 
@@ -30,11 +32,14 @@ val data : t -> Bigstring.t
 val words : t -> size -> word table
 val segments : t -> segment table
 val symbols : t -> symbol table
-
+val data_regions : t -> data_region table
+val code_regions : t -> code_region table
 
 val segment : segment tag
 val symbol  : string tag
 val section : string tag
+val code_region   : code_region tag
+val data_region   : data_region tag
 val specification : Ogre.doc tag
 
 val memory : t -> value memmap
@@ -118,4 +123,11 @@ module Scheme : sig
     (addr * string, (addr -> string -> 'a) -> 'a) Ogre.attribute
 
   val base_address : (addr, (addr -> 'a) -> 'a) Ogre.attribute
+
+  val code_region :
+    (addr * size * off, (addr -> size -> off -> 'a) -> 'a) Ogre.attribute
+
+  val data_region :
+    (addr * size * off * bool, (addr -> size -> off -> bool -> 'a) -> 'a) Ogre.attribute
+
 end

--- a/lib/bap_image/bap_image.mli
+++ b/lib/bap_image/bap_image.mli
@@ -9,8 +9,6 @@ open Image_internal_std
 type t [@@deriving sexp_of]            (** image   *)
 type segment [@@deriving bin_io, compare, sexp]
 type symbol [@@deriving bin_io, compare, sexp]
-type data_region [@@deriving bin_io, compare, sexp]
-type code_region [@@deriving bin_io, compare, sexp]
 
 type path = string
 
@@ -32,14 +30,11 @@ val data : t -> Bigstring.t
 val words : t -> size -> word table
 val segments : t -> segment table
 val symbols : t -> symbol table
-val data_regions : t -> data_region table
-val code_regions : t -> code_region table
 
 val segment : segment tag
 val symbol  : string tag
 val section : string tag
-val code_region   : code_region tag
-val data_region   : data_region tag
+val code_region   : unit tag
 val specification : Ogre.doc tag
 
 val memory : t -> value memmap
@@ -126,8 +121,5 @@ module Scheme : sig
 
   val code_region :
     (addr * size * off, (addr -> size -> off -> 'a) -> 'a) Ogre.attribute
-
-  val data_region :
-    (addr * size * off * bool, (addr -> size -> off -> bool -> 'a) -> 'a) Ogre.attribute
 
 end

--- a/lib/bap_llvm/bap_llvm_ogre_coff.ml
+++ b/lib/bap_llvm/bap_llvm_ogre_coff.ml
@@ -37,7 +37,7 @@ module Make(Fact : Ogre.S) = struct
           Fact.provide section addr size >>= fun () ->
           Fact.provide named_region addr size name)
 
-  let code =
+  let code_regions =
     Fact.require base_address >>= fun base ->
     Fact.foreach Ogre.Query.(
         select (from section_entry $ virtual_section_header $ code_entry)
@@ -49,22 +49,6 @@ module Make(Fact : Ogre.S) = struct
       ~f:(fun (addr, size, off) ->
         Fact.provide code_region addr size off)
 
-  let data =
-    Fact.require base_address >>= fun base ->
-    Fact.foreach Ogre.Query.(
-        select (from section_entry $ virtual_section_header $ data_entry)
-          ~join:[[field name];
-                 [field size ~from:section_entry;
-                  field size ~from:data_entry]])
-      ~f:(fun _ (_,addr,vsize) (_,off,_,w) -> Int64.(base + addr),vsize,off,w) >>= fun s ->
-    Fact.Seq.iter s
-      ~f:(fun (addr, size, off, w) ->
-        Fact.provide data_region addr size off w)
-
-  let regions =
-    code >>= fun () ->
-    data
-
   include Symbols(Fact)
 end
 
@@ -72,36 +56,37 @@ module Relocatable = struct
   module Make(Fact : Ogre.S) = struct
     open Fact.Syntax
 
+    module Base = Base_address(Fact)
+
     let segments =
-      Fact.require base_address >>= fun base ->
+      Base.from_sections_offset >>= fun base ->
       Fact.foreach Ogre.Query.(
           select (from section_entry
                   $ virtual_section_header
                   $ section_flags
                   $ code_entry)
             ~join:[[field name]])
-        ~f:(fun (_, _, size, start) (_,_,vsize) (_,rwx) _  ->
-            start,size,vsize,rwx) >>= fun s ->
+        ~f:(fun (_, _, size, start) (_,_,_) (_,rwx) _  ->
+            start,size,rwx) >>= fun s ->
       Fact.Seq.iter s
-        ~f:(fun (start, size, vsize, (r,w,x)) ->
+        ~f:(fun (start, size, (r,w,x)) ->
             let addr = Int64.(base + start) in
-            Fact.provide segment addr vsize r w x >>= fun () ->
+            Fact.provide segment addr size r w x >>= fun () ->
             Fact.provide mapped addr size start)
 
     let sections =
-      Fact.require base_address >>= fun base ->
+      Base.from_sections_offset >>= fun base ->
       Fact.foreach Ogre.Query.(
-          select (from section_entry $ virtual_section_header)
-            ~join:[[field name]])
-        ~f:(fun (name,_,_,off) (_,_,size) -> name,off,size) >>= fun s ->
+          select (from section_entry))
+        ~f:(fun (name,_,size,off) -> name,off,size) >>= fun s ->
       Fact.Seq.iter s
         ~f:(fun (name, off, size) ->
           let addr = Int64.(base + off) in
           Fact.provide section addr size >>= fun () ->
           Fact.provide named_region addr size name)
 
-    let code =
-      Fact.require base_address >>= fun base ->
+    let code_regions =
+      Base.from_sections_offset >>= fun base ->
       Fact.foreach Ogre.Query.(
         select (from section_entry $ code_entry)
           ~join:[[field name];
@@ -111,22 +96,6 @@ module Relocatable = struct
       Fact.Seq.iter s
         ~f:(fun (addr, size, off) ->
           Fact.provide code_region addr size off)
-
-    let data =
-      Fact.require base_address >>= fun base ->
-      Fact.foreach Ogre.Query.(
-        select (from section_entry $ data_entry)
-          ~join:[[field name];
-                 [field size ~from:section_entry;
-                  field size ~from:data_entry]])
-        ~f:(fun _ (_,off,size,w) -> Int64.(base + off),size,off,w) >>= fun s ->
-      Fact.Seq.iter s
-        ~f:(fun (addr, size, off, w) ->
-          Fact.provide data_region addr size off w)
-
-    let regions =
-      code >>= fun () ->
-      data
 
     include Relocatable_symbols(Fact)
 

--- a/lib/bap_llvm/bap_llvm_ogre_coff.ml
+++ b/lib/bap_llvm/bap_llvm_ogre_coff.ml
@@ -47,7 +47,7 @@ module Make(Fact : Ogre.S) = struct
       ~f:(fun _ (_,addr,vsize) (_,off,_) -> Int64.(base + addr),vsize,off) >>= fun s ->
     Fact.Seq.iter s
       ~f:(fun (addr, size, off) ->
-        Fact.provide code_region addr size off)
+          Fact.provide code_region addr size off)
 
   include Symbols(Fact)
 end
@@ -81,21 +81,21 @@ module Relocatable = struct
         ~f:(fun (name,_,size,off) -> name,off,size) >>= fun s ->
       Fact.Seq.iter s
         ~f:(fun (name, off, size) ->
-          let addr = Int64.(base + off) in
-          Fact.provide section addr size >>= fun () ->
-          Fact.provide named_region addr size name)
+            let addr = Int64.(base + off) in
+            Fact.provide section addr size >>= fun () ->
+            Fact.provide named_region addr size name)
 
     let code_regions =
       Base.from_sections_offset >>= fun base ->
       Fact.foreach Ogre.Query.(
-        select (from section_entry $ code_entry)
-          ~join:[[field name];
-                 [field size ~from:section_entry;
-                  field size ~from:code_entry]])
+          select (from section_entry $ code_entry)
+            ~join:[[field name];
+                   [field size ~from:section_entry;
+                    field size ~from:code_entry]])
         ~f:(fun _ (_,off,size) -> Int64.(base + off),size,off) >>= fun s ->
       Fact.Seq.iter s
         ~f:(fun (addr, size, off) ->
-          Fact.provide code_region addr size off)
+            Fact.provide code_region addr size off)
 
     include Relocatable_symbols(Fact)
 

--- a/lib/bap_llvm/bap_llvm_ogre_coff.ml
+++ b/lib/bap_llvm/bap_llvm_ogre_coff.ml
@@ -17,10 +17,10 @@ module Make(Fact : Ogre.S) = struct
                 $ section_flags
                 $ code_entry)
           ~join:[[field name]])
-      ~f:(fun (name, _, size, start) (_,addr,vsize) (_,rwx) _  ->
-          name,start,size,addr,vsize,rwx) >>= fun s ->
+      ~f:(fun (_, _, size, start) (_,addr,vsize) (_,rwx) _  ->
+          start,size,addr,vsize,rwx) >>= fun s ->
     Fact.Seq.iter s
-      ~f:(fun (name, start, size, addr, vsize, (r,w,x)) ->
+      ~f:(fun (start, size, addr, vsize, (r,w,x)) ->
           let addr = Int64.(base + addr) in
           Fact.provide segment addr vsize r w x >>= fun () ->
           Fact.provide mapped addr size start)
@@ -37,8 +37,35 @@ module Make(Fact : Ogre.S) = struct
           Fact.provide section addr size >>= fun () ->
           Fact.provide named_region addr size name)
 
-  include Symbols(Fact)
+  let code =
+    Fact.require base_address >>= fun base ->
+    Fact.foreach Ogre.Query.(
+        select (from section_entry $ virtual_section_header $ code_entry)
+          ~join:[[field name];
+                 [field size ~from:section_entry;
+                  field size ~from:code_entry]])
+      ~f:(fun _ (_,addr,vsize) (_,off,_) -> Int64.(base + addr),vsize,off) >>= fun s ->
+    Fact.Seq.iter s
+      ~f:(fun (addr, size, off) ->
+        Fact.provide code_region addr size off)
 
+  let data =
+    Fact.require base_address >>= fun base ->
+    Fact.foreach Ogre.Query.(
+        select (from section_entry $ virtual_section_header $ data_entry)
+          ~join:[[field name];
+                 [field size ~from:section_entry;
+                  field size ~from:data_entry]])
+      ~f:(fun _ (_,addr,vsize) (_,off,_,w) -> Int64.(base + addr),vsize,off,w) >>= fun s ->
+    Fact.Seq.iter s
+      ~f:(fun (addr, size, off, w) ->
+        Fact.provide data_region addr size off w)
+
+  let regions =
+    code >>= fun () ->
+    data
+
+  include Symbols(Fact)
 end
 
 module Relocatable = struct
@@ -53,10 +80,10 @@ module Relocatable = struct
                   $ section_flags
                   $ code_entry)
             ~join:[[field name]])
-        ~f:(fun (name, _, size, start) (_,_,vsize) (_,rwx) _  ->
-            name,start,size,vsize,rwx) >>= fun s ->
+        ~f:(fun (_, _, size, start) (_,_,vsize) (_,rwx) _  ->
+            start,size,vsize,rwx) >>= fun s ->
       Fact.Seq.iter s
-        ~f:(fun (name, start, size, vsize, (r,w,x)) ->
+        ~f:(fun (start, size, vsize, (r,w,x)) ->
             let addr = Int64.(base + start) in
             Fact.provide segment addr vsize r w x >>= fun () ->
             Fact.provide mapped addr size start)
@@ -69,9 +96,37 @@ module Relocatable = struct
         ~f:(fun (name,_,_,off) (_,_,size) -> name,off,size) >>= fun s ->
       Fact.Seq.iter s
         ~f:(fun (name, off, size) ->
-            let addr = Int64.(base + off) in
-            Fact.provide section addr size >>= fun () ->
-            Fact.provide named_region addr size name)
+          let addr = Int64.(base + off) in
+          Fact.provide section addr size >>= fun () ->
+          Fact.provide named_region addr size name)
+
+    let code =
+      Fact.require base_address >>= fun base ->
+      Fact.foreach Ogre.Query.(
+        select (from section_entry $ code_entry)
+          ~join:[[field name];
+                 [field size ~from:section_entry;
+                  field size ~from:code_entry]])
+        ~f:(fun _ (_,off,size) -> Int64.(base + off),size,off) >>= fun s ->
+      Fact.Seq.iter s
+        ~f:(fun (addr, size, off) ->
+          Fact.provide code_region addr size off)
+
+    let data =
+      Fact.require base_address >>= fun base ->
+      Fact.foreach Ogre.Query.(
+        select (from section_entry $ data_entry)
+          ~join:[[field name];
+                 [field size ~from:section_entry;
+                  field size ~from:data_entry]])
+        ~f:(fun _ (_,off,size,w) -> Int64.(base + off),size,off,w) >>= fun s ->
+      Fact.Seq.iter s
+        ~f:(fun (addr, size, off, w) ->
+          Fact.provide data_region addr size off w)
+
+    let regions =
+      code >>= fun () ->
+      data
 
     include Relocatable_symbols(Fact)
 

--- a/lib/bap_llvm/bap_llvm_ogre_elf.ml
+++ b/lib/bap_llvm/bap_llvm_ogre_elf.ml
@@ -31,6 +31,7 @@ module Make(Fact : Ogre.S) = struct
 
   include Sections(Fact)
   include Symbols(Fact)
+  include Regions(Fact)
 end
 
 module Relocatable = struct
@@ -55,5 +56,6 @@ module Relocatable = struct
 
     include Relocatable_symbols(Fact)
     include Relocatable_sections(Fact)
+    include Regions(Fact)
   end
 end

--- a/lib/bap_llvm/bap_llvm_ogre_elf.ml
+++ b/lib/bap_llvm/bap_llvm_ogre_elf.ml
@@ -31,15 +31,17 @@ module Make(Fact : Ogre.S) = struct
 
   include Sections(Fact)
   include Symbols(Fact)
-  include Regions(Fact)
+  include Code_regions(Fact)
 end
 
 module Relocatable = struct
   module Make(Fact : Ogre.S) = struct
     open Fact.Syntax
 
+    module Base = Base_address(Fact)
+
     let segments =
-      Fact.require base_address >>= fun base ->
+      Base.from_sections_offset >>= fun base ->
       Fact.foreach Ogre.Query.(begin
           select (from section_entry $ section_flags)
             ~join:[[field name]]
@@ -56,6 +58,6 @@ module Relocatable = struct
 
     include Relocatable_symbols(Fact)
     include Relocatable_sections(Fact)
-    include Regions(Fact)
+    include Code_regions(Fact)
   end
 end

--- a/lib/bap_llvm/bap_llvm_ogre_loader.ml
+++ b/lib/bap_llvm/bap_llvm_ogre_loader.ml
@@ -13,7 +13,7 @@ let image_base = ref None
 
 
 (** default image base for relocatable files *)
-let relocatable_base = 0xC0000000L
+let relocatable_base = 0x0L
 
 module Fact(M : Monad.S) = struct
   include Ogre.Make(M)

--- a/lib/bap_llvm/bap_llvm_ogre_loader.ml
+++ b/lib/bap_llvm/bap_llvm_ogre_loader.ml
@@ -80,7 +80,7 @@ module Make(M : Monad.S) = struct
     S.segments >>= fun () ->
     S.sections >>= fun () ->
     S.symbols  >>= fun () ->
-    S.regions
+    S.code_regions
 
   let image = Dispatcher.of_filetype >>= provide
 

--- a/lib/bap_llvm/bap_llvm_ogre_loader.ml
+++ b/lib/bap_llvm/bap_llvm_ogre_loader.ml
@@ -79,7 +79,8 @@ module Make(M : Monad.S) = struct
     provide_entry >>= fun () ->
     S.segments >>= fun () ->
     S.sections >>= fun () ->
-    S.symbols
+    S.symbols  >>= fun () ->
+    S.regions
 
   let image = Dispatcher.of_filetype >>= provide
 

--- a/lib/bap_llvm/bap_llvm_ogre_macho.ml
+++ b/lib/bap_llvm/bap_llvm_ogre_macho.ml
@@ -26,7 +26,7 @@ module Make(Fact : Ogre.S) = struct
 
   include Sections(Fact)
   include Symbols(Fact)
-
+  include Regions(Fact)
 end
 
 module Relocatable = struct
@@ -52,6 +52,6 @@ module Relocatable = struct
 
     include Relocatable_symbols(Fact)
     include Relocatable_sections(Fact)
-
+    include Regions(Fact)
   end
 end

--- a/lib/bap_llvm/bap_llvm_ogre_macho.ml
+++ b/lib/bap_llvm/bap_llvm_ogre_macho.ml
@@ -26,7 +26,7 @@ module Make(Fact : Ogre.S) = struct
 
   include Sections(Fact)
   include Symbols(Fact)
-  include Regions(Fact)
+  include Code_regions(Fact)
 end
 
 module Relocatable = struct
@@ -34,8 +34,10 @@ module Relocatable = struct
   module Make(Fact : Ogre.S) = struct
     open Fact.Syntax
 
+    module Base = Base_address(Fact)
+
     let segments =
-      Fact.require base_address >>= fun base ->
+      Base.from_sections_offset >>= fun base ->
       Fact.foreach Ogre.Query.(begin
           select (from section_entry $ code_entry)
             ~join:[[field name];
@@ -52,6 +54,6 @@ module Relocatable = struct
 
     include Relocatable_symbols(Fact)
     include Relocatable_sections(Fact)
-    include Regions(Fact)
+    include Code_regions(Fact)
   end
 end

--- a/lib/bap_llvm/bap_llvm_ogre_samples.ml
+++ b/lib/bap_llvm/bap_llvm_ogre_samples.ml
@@ -123,7 +123,7 @@ module Code_regions(Fact : Ogre.S) = struct
           ~join:[[field name];
                  [field size ~from:named_region;
                   field size ~from:code_entry]]
-    end)
+      end)
       ~f:(fun {addr; size;} (_,off,_) -> addr,size,off) >>= fun s ->
     Fact.Seq.iter s ~f:(fun (addr,size,off) ->
         Fact.provide code_region addr size off)

--- a/lib/bap_llvm/bap_llvm_ogre_samples.ml
+++ b/lib/bap_llvm/bap_llvm_ogre_samples.ml
@@ -22,7 +22,6 @@ module Symbols(Fact : Ogre.S) = struct
           else Fact.return ())
 end
 
-
 module Sections(Fact : Ogre.S) = struct
   open Scheme
   open Fact.Syntax
@@ -37,35 +36,23 @@ module Sections(Fact : Ogre.S) = struct
           Fact.provide named_region addr size name)
 end
 
-module Regions(Fact : Ogre.S) = struct
+
+module Base_address(Fact : Ogre.S) = struct
   open Scheme
   open Fact.Syntax
 
-  let code =
+  let from_sections_offset =
+    Fact.require base_address >>= fun base ->
     Fact.foreach Ogre.Query.(begin
-        select (from named_region $ code_entry)
+        select (from section_entry $ code_entry)
           ~join:[[field name];
-                 [field size ~from:named_region;
+                 [field size ~from:section_entry;
                   field size ~from:code_entry]]
-    end)
-      ~f:(fun {addr; size;} (_,off,_) -> addr,size,off) >>= fun s ->
-    Fact.Seq.iter s ~f:(fun (addr,size,off) ->
-        Fact.provide code_region addr size off)
-
-  let data =
-    Fact.foreach Ogre.Query.(begin
-        select (from named_region $ data_entry)
-          ~join:[[field name];
-                 [field size ~from:named_region;
-                  field size ~from:data_entry]]
-    end)
-      ~f:(fun {addr; size;} (_,off,_,w) -> addr,size,off,w) >>= fun s ->
-      Fact.Seq.iter s ~f:(fun (addr,size,off,w) ->
-          Fact.provide data_region addr size off w)
-
-  let regions =
-    code >>= fun () ->
-    data
+      end)
+      ~f:(fun (_,_,_,off) _ -> off) >>= fun s ->
+    match Seq.min_elt s ~compare:Int64.compare with
+    | None -> Fact.return base
+    | Some x -> Fact.return Int64.(base - x)
 
 end
 
@@ -73,8 +60,10 @@ module Relocatable_symbols(Fact : Ogre.S) = struct
   open Scheme
   open Fact.Syntax
 
+  module Base = Base_address(Fact)
+
   let relocations =
-    Fact.require base_address >>= fun base ->
+    Base.from_sections_offset >>= fun base ->
     Fact.collect
       Ogre.Query.(select (from ref_internal)) >>= fun ints ->
     Fact.Seq.iter ints ~f:(fun (sym_off, rel_off) ->
@@ -83,7 +72,7 @@ module Relocatable_symbols(Fact : Ogre.S) = struct
         Fact.provide relocation relocation_addr symbol_addr)
 
   let externals =
-    Fact.require base_address >>= fun base ->
+    Base.from_sections_offset >>= fun base ->
     Fact.collect
       Ogre.Query.(select (from ref_external)) >>= fun exts ->
     Fact.Seq.iter exts ~f:(fun (off, name) ->
@@ -92,7 +81,7 @@ module Relocatable_symbols(Fact : Ogre.S) = struct
   let symbols =
     relocations >>= fun () ->
     externals >>= fun () ->
-    Fact.require base_address >>= fun base ->
+    Base.from_sections_offset >>= fun base ->
     Fact.collect Ogre.Query.(select (from symbol_entry)) >>= fun s ->
     Fact.Seq.iter s ~f:(fun (name, _, size, off) ->
         if size = 0L then Fact.return ()
@@ -111,12 +100,32 @@ module Relocatable_sections(Fact : Ogre.S) = struct
   open Scheme
   open Fact.Syntax
 
+  module Base = Base_address(Fact)
+
   let sections =
-    Fact.require base_address >>= fun base ->
+    Base.from_sections_offset >>= fun base ->
     Fact.collect Ogre.Query.(select (from section_entry)) >>= fun s ->
     Fact.Seq.iter s
       ~f:(fun (name, _, size, off) ->
           let addr = Int64.(base + off) in
           Fact.provide section addr size >>= fun () ->
           Fact.provide named_region addr size name)
+end
+
+
+module Code_regions(Fact : Ogre.S) = struct
+  open Scheme
+  open Fact.Syntax
+
+  let code_regions =
+    Fact.foreach Ogre.Query.(begin
+        select (from named_region $ code_entry)
+          ~join:[[field name];
+                 [field size ~from:named_region;
+                  field size ~from:code_entry]]
+    end)
+      ~f:(fun {addr; size;} (_,off,_) -> addr,size,off) >>= fun s ->
+    Fact.Seq.iter s ~f:(fun (addr,size,off) ->
+        Fact.provide code_region addr size off)
+
 end

--- a/lib/bap_llvm/bap_llvm_ogre_samples.mli
+++ b/lib/bap_llvm/bap_llvm_ogre_samples.mli
@@ -8,6 +8,10 @@ module Sections(Fact : Ogre.S) : sig
   val sections : unit Fact.t
 end
 
+module Regions(Fact : Ogre.S) : sig
+  val regions : unit Fact.t
+end
+
 module Relocatable_symbols(Fact : Ogre.S) : sig
   val symbols : unit Fact.t
 end

--- a/lib/bap_llvm/bap_llvm_ogre_samples.mli
+++ b/lib/bap_llvm/bap_llvm_ogre_samples.mli
@@ -8,14 +8,18 @@ module Sections(Fact : Ogre.S) : sig
   val sections : unit Fact.t
 end
 
-module Regions(Fact : Ogre.S) : sig
-  val regions : unit Fact.t
-end
-
 module Relocatable_symbols(Fact : Ogre.S) : sig
   val symbols : unit Fact.t
 end
 
 module Relocatable_sections(Fact : Ogre.S) : sig
   val sections : unit Fact.t
+end
+
+module Code_regions(Fact : Ogre.S) : sig
+  val code_regions : unit Fact.t
+end
+
+module Base_address(Fact : Ogre.S) : sig
+  val from_sections_offset : int64 Fact.t
 end

--- a/lib/bap_llvm/bap_llvm_ogre_types.ml
+++ b/lib/bap_llvm/bap_llvm_ogre_types.ml
@@ -47,6 +47,11 @@ module Scheme = struct
   let code_entry () =
     Ogre.declare ~name:"code-entry" (scheme name $ off $ size) Tuple.T3.create
 
+  (** named entry that contains data *)
+  let data_entry () =
+    Ogre.declare ~name:"data-entry" (scheme name $ off $ size $ writable)
+      (fun name addr size w -> name, addr, size, w)
+
   (** symbol *)
   let symbol_entry () =
     Ogre.declare ~name:"symbol-entry"
@@ -60,6 +65,7 @@ module type S = sig
   val segments : unit m
   val sections : unit m
   val symbols  : unit m
+  val regions  : unit m
 end
 
 module type Rules = sig

--- a/lib/bap_llvm/bap_llvm_ogre_types.ml
+++ b/lib/bap_llvm/bap_llvm_ogre_types.ml
@@ -47,11 +47,6 @@ module Scheme = struct
   let code_entry () =
     Ogre.declare ~name:"code-entry" (scheme name $ off $ size) Tuple.T3.create
 
-  (** named entry that contains data *)
-  let data_entry () =
-    Ogre.declare ~name:"data-entry" (scheme name $ off $ size $ writable)
-      (fun name addr size w -> name, addr, size, w)
-
   (** symbol *)
   let symbol_entry () =
     Ogre.declare ~name:"symbol-entry"
@@ -65,7 +60,7 @@ module type S = sig
   val segments : unit m
   val sections : unit m
   val symbols  : unit m
-  val regions  : unit m
+  val code_regions : unit m
 end
 
 module type Rules = sig

--- a/lib/bap_llvm/llvm_coff_loader.hpp
+++ b/lib/bap_llvm/llvm_coff_loader.hpp
@@ -25,7 +25,6 @@ static const std::string coff_declarations =
     "(declare section-entry (name str) (relative-addr int) (size int) (off int))"
     "(declare virtual-section-header (name str) (relative-addr int) (size int))"
     "(declare code-entry (name str) (off int) (size int))"
-    "(declare data-entry (name str) (off int) (size int) (w bool))"
     "(declare section-flags (name str) (r bool) (w bool) (x bool))"
     "(declare symbol-entry (name str) (relative-addr int) (size int) (off int))"
     "(declare function (off int) (name str))"
@@ -49,8 +48,6 @@ void section(const coff_section &sec, uint64_t image_base,  ogre_doc &s) {
     s.entry("section-flags") << sec.Name << r << w << x;
     if (x)
         s.entry("code-entry") << sec.Name << sec.PointerToRawData << sec.SizeOfRawData;
-    else
-        s.entry("data-entry") << sec.Name << sec.PointerToRawData << sec.SizeOfRawData << w;
 }
 
 void symbol(const std::string &name, int64_t relative_addr, uint64_t size, uint64_t off, SymbolRef::Type typ, ogre_doc &s) {

--- a/lib/bap_llvm/llvm_elf_loader.hpp
+++ b/lib/bap_llvm/llvm_elf_loader.hpp
@@ -72,6 +72,7 @@ static const std::string elf_declarations =
     "(declare symbol-entry (name str) (relative-addr int) (size int) (off int))"
     "(declare plt-entry (name str) (relative-addr int) (size int) (off int))"
     "(declare code-entry (name str) (off int) (size int))"
+    "(declare data-entry (name str) (off int) (size int) (w bool))"
     "(declare ref-internal (sym-off int) (rel-off int))"
     "(declare ref-external (rel-off int) (name str))";
 
@@ -137,6 +138,10 @@ void section_header(const T &hdr, const std::string &name, uint64_t base, ogre_d
     bool w = static_cast<bool>(hdr.sh_flags & ELF::SHF_WRITE);
     bool x = static_cast<bool>(hdr.sh_flags & ELF::SHF_EXECINSTR);
     s.entry("section-flags") << name << w << x;
+    if (x)
+        s.entry("code-entry") << name << hdr.sh_offset << hdr.sh_size;
+    else
+        s.entry("data-entry") << name << hdr.sh_offset << hdr.sh_size << w;
 }
 
 template <typename T>

--- a/lib/bap_llvm/llvm_elf_loader.hpp
+++ b/lib/bap_llvm/llvm_elf_loader.hpp
@@ -72,7 +72,6 @@ static const std::string elf_declarations =
     "(declare symbol-entry (name str) (relative-addr int) (size int) (off int))"
     "(declare plt-entry (name str) (relative-addr int) (size int) (off int))"
     "(declare code-entry (name str) (off int) (size int))"
-    "(declare data-entry (name str) (off int) (size int) (w bool))"
     "(declare ref-internal (sym-off int) (rel-off int))"
     "(declare ref-external (rel-off int) (name str))";
 
@@ -140,8 +139,6 @@ void section_header(const T &hdr, const std::string &name, uint64_t base, ogre_d
     s.entry("section-flags") << name << w << x;
     if (x)
         s.entry("code-entry") << name << hdr.sh_offset << hdr.sh_size;
-    else
-        s.entry("data-entry") << name << hdr.sh_offset << hdr.sh_size << w;
 }
 
 template <typename T>


### PR DESCRIPTION
The current implementation is heavily influenced by the segmented view on the memory layout of a program. For historical reasons, the ELF representation of segments stopped to represent accurately the memory layout of the program, see #973 for more details. As a result, we ended up disassembling regions of memory which are clearly data (like `.rodata`) which reside in the executable segments. 

This PR introduces a new abstraction, called `code-region` since we don't want to overload the meaning of the segment/section anymore. All supported backends are implementing this abstraction in their specific manner (some are trivial, like COFF, some are not, like ELF)

The good thing about all the file types is that each of them has a section layout where sections have flags, that makes it possible to decide whether a section contains a code or not. Here is a short table for the different file types and sections flags that we are looking for.

File type  | Flags
-----------|--------
COFF       | IMAGE_SCN_CNT_CODE or IMAGE_SCN_MEM_EXECUTE
ELF        | SHF_EXECINSTR 
MACHO      | S_ATTR_PURE_INSTRUCTIONS or S_ATTR_SOME_INSTRUCTIONS

Given that, it's not that hard to define regions with an executable code.


### Bugs
There are few bugs that were fixed as well:
1) restores `-dasm` option for the coff object files.  
   COFF section header has two fields that denotates size: virtual size and raw data size.
   The virtual size is meaningful only for executable files and it's a size of the section when it's loaded
   into a memory.
   But for the object files this field doesn't have any sense and equal to zero. That's why we didn't mark memory in `Image` module correctly and didn't have any output for `-dasm` option. So we need to   use raw data size instead.

2) fixes wrong addresses for object files.
   Our llvm backend provides relative addresses for all the pieces of information (sections, symbols 
   etc.) and a default base address as well, so we can substitute a default if we need to.
   That works fine for executable files. But when we deal with the object files the problem becomes 
   visible, since we don't actually have any addresses at all and have to use offsets instead.
   Previously we were taking offsets as they are, and a first byte of code had an address equal to the 
   section offset where this byte belonged.
   This PR fixes this and use offsets relative to the offset of the first executable section, so the first byte 
   will have address 0,  as it's expected.
  


This PR fixes https://github.com/BinaryAnalysisPlatform/bap/issues/973