### PR TITLE
initializes PLT GOT in Primus

### DIFF
--- a/plugins/primus_x86/primus_x86_loader.ml
+++ b/plugins/primus_x86/primus_x86_loader.ml
@@ -99,8 +99,6 @@ module Component(Machine : Primus.Machine.S) = struct
       Value.of_int ~width addend >>= fun addend ->
       Primus.Linker.Trace.lisp_call_return >>> correct_sp sp addend
 
-  let seq = Machine.sequence
-
   let unresolve_plt_jumps p =
     Machine.Seq.iter (Plt.symbols p) ~f:Plt_entry.unresolve_jumps
 

--- a/plugins/primus_x86/primus_x86_loader.ml
+++ b/plugins/primus_x86/primus_x86_loader.ml
@@ -16,10 +16,7 @@ module Make_unresolved(Machine : Primus.Machine.S) = struct
 end
 
 module Plt_jumps(Machine : Primus.Machine.S) = struct
-  module Interp = Primus.Interpreter.Make(Machine)
   module Linker = Primus.Linker.Make(Machine)
-  module Value  = Primus.Value.Make(Machine)
-
   open Machine.Syntax
 
   let section_memory sec_name =

--- a/plugins/primus_x86/primus_x86_loader.ml
+++ b/plugins/primus_x86/primus_x86_loader.ml
@@ -8,27 +8,12 @@ let is_section name v =
   | Some x -> String.(x = name)
   | _ -> false
 
-let address_range mem arch =
-  let step = Arch.addr_size arch |> Size.in_bytes in
-  let rec loop acc n =
-    if Addr.(n > Memory.max_addr mem)
-    then acc
-    else
-      let next = Addr.(n ++ step) in
-      loop (n :: acc) next in
-  loop [] (Memory.min_addr mem)
-
 module Make_unresolved(Machine : Primus.Machine.S) = struct
   module Linker = Primus.Linker.Make(Machine)
 
   let exec =
     Linker.exec (`symbol Primus.Linker.unresolved_handler)
 end
-
-let try_load mem size addr =
-  match Memory.get ~scale:size ~addr mem with
-  | Ok data -> Some data
-  | _ -> None
 
 module Plt_jumps(Machine : Primus.Machine.S) = struct
   module Interp = Primus.Interpreter.Make(Machine)
@@ -41,46 +26,27 @@ module Plt_jumps(Machine : Primus.Machine.S) = struct
     Machine.get () >>| fun proj ->
     Memmap.filter (Project.memory proj) ~f:(is_section sec_name) |>
     Memmap.to_sequence |>
-    Seq.map ~f:fst |>
-    Seq.to_list
-
-  let got_cells =
-    Machine.arch >>= fun arch ->
-    section_memory ".got.plt" >>| fun memory ->
-    List.fold memory ~init:[]
-      ~f:(fun acc mem -> acc @ address_range mem arch)
-
-  let load_word addr =
-    Machine.arch >>= fun arch ->
-    Value.of_word addr >>= fun addr ->
-    Interp.load addr (Arch.endian arch)
-      (Arch.addr_size arch :> size) >>|
-    Value.to_word
-
-  let load_table =
-    got_cells >>=
-    Machine.List.map ~f:load_word
+    Seq.map ~f:fst
 
   let load_table =
     Machine.arch >>= fun arch ->
     section_memory ".got.plt" >>| fun memory ->
-    List.fold memory ~init:[]
+    Seq.fold memory ~init:[]
       ~f:(fun acc mem ->
-        let range = address_range mem arch in
-        acc @ List.filter_map range
-                ~f:(try_load mem (Arch.addr_size arch :> size)))
+          let step = (Arch.addr_size arch :> size) in
+          Memory.fold mem ~word_size:step ~init:[] ~f:(fun a w -> a :: w))
 
   let filter_plt addrs =
     section_memory ".plt" >>= fun memory ->
     Machine.return @@
     List.filter addrs ~f:(fun a ->
-        List.exists memory ~f:(fun mem -> Memory.contains mem a))
+        Seq.exists memory ~f:(fun mem -> Memory.contains mem a))
 
   let unlink addrs =
     Machine.List.iter addrs ~f:(fun addr ->
         Linker.link ~addr (module Make_unresolved))
 
-  let unresolve =
+  let unresolve  =
     load_table >>=
     filter_plt >>=
     unlink

--- a/plugins/primus_x86/primus_x86_loader.ml
+++ b/plugins/primus_x86/primus_x86_loader.ml
@@ -3,11 +3,84 @@ open Bap.Std
 open Bap_primus.Std
 open X86_cpu
 
+module Plt = struct
+  let is_plt_section v =
+    match Value.get Image.section v with
+    | Some x -> x = ".plt"
+    | _ -> false
+
+  let is_plt_symbol sec sym =
+    match Term.get_attr sym address with
+    | None -> false
+    | Some a -> Memmap.contains sec a
+
+  let symbols p =
+    let sec = Memmap.filter (Project.memory p) ~f:is_plt_section in
+    Term.to_sequence sub_t (Project.program p) |>
+    Seq.filter ~f:(is_plt_symbol sec)
+end
+
+module Got = struct
+
+  let cells plt_sym =
+    let find j =
+      match Jmp.kind j with
+      | Goto _ | Int _ | Ret _ -> None
+      | Call c ->
+        match Call.target c with
+        | Indirect Bil.(Load (_,Int addr,_,_)) -> Some addr
+        | _ -> None in
+    (object
+      inherit [addr list] Term.visitor
+
+      method! enter_jmp c acc =
+        match find c with
+        | None -> acc
+        | Some a -> a :: acc
+    end)#visit_sub plt_sym []
+end
+
+module Make_unresolved(Machine : Primus.Machine.S) = struct
+  module Linker = Primus.Linker.Make(Machine)
+  open Machine.Syntax
+
+  let exec =
+    Linker.exec (`symbol Primus.Linker.unresolved_handler)
+end
+
+module Plt_entry(Machine : Primus.Machine.S) = struct
+  module Memory = Primus.Memory.Make(Machine)
+  module Linker = Primus.Linker.Make(Machine)
+  open Machine.Syntax
+
+  let load bytes endian addr =
+    let concat = match endian with
+      | LittleEndian -> fun x y -> Addr.concat y x
+      | BigEndian -> Addr.concat in
+    let last = Addr.nsucc addr bytes in
+    let rec load data addr =
+      if Addr.(addr < last) then
+        Memory.load addr >>= fun x ->
+        load (concat data x) (Addr.succ addr)
+      else Machine.return data in
+    Memory.load addr >>= fun data ->
+    load data (Addr.succ addr)
+
+  let unresolve_jumps sym =
+    Machine.arch >>= fun arch ->
+    let endian = Arch.endian arch in
+    let size = Size.in_bytes (Arch.addr_size arch) in
+    Machine.List.iter (Got.cells sym) ~f:(fun cell ->
+        load size endian cell >>= fun addr ->
+        Linker.link ~addr (module Make_unresolved))
+end
+
 module Component(Machine : Primus.Machine.S) = struct
   open Machine.Syntax
   module Env = Primus.Env.Make(Machine)
   module Value = Primus.Value.Make(Machine)
   module Interpreter = Primus.Interpreter.Make(Machine)
+  module Plt_entry = Plt_entry(Machine)
 
   let zero = Primus.Generator.static 0
 
@@ -23,18 +96,26 @@ module Component(Machine : Primus.Machine.S) = struct
     match Var.typ sp with
     | Mem _ -> Machine.return ()
     | Imm width ->
-       Value.of_int ~width addend >>= fun addend ->
-       Primus.Linker.Trace.lisp_call_return >>> correct_sp sp addend
+      Value.of_int ~width addend >>= fun addend ->
+      Primus.Linker.Trace.lisp_call_return >>> correct_sp sp addend
 
   let seq = Machine.sequence
 
+  let unresolve_plt_jumps p =
+    Machine.Seq.iter (Plt.symbols p) ~f:Plt_entry.unresolve_jumps
+
   let init () =
     Machine.get () >>= fun proj ->
+    Machine.sequence @@
     match Project.arch proj with
     | `x86 ->
-       seq [initialize_flags IA32.flags; correct_sp IA32.sp 4]
+      [initialize_flags IA32.flags;
+       correct_sp IA32.sp 4;
+       unresolve_plt_jumps proj]
     | `x86_64 ->
-       seq [initialize_flags AMD64.flags; correct_sp AMD64.sp 8]
-    | _ -> Machine.return ()
+      [initialize_flags AMD64.flags;
+       correct_sp AMD64.sp 8;
+       unresolve_plt_jumps proj]
+    | _ -> []
 
 end


### PR DESCRIPTION
In BAP 2.0 we have a more conservative disassembler. And while previously, only the first instruction of a PLT entry was disassembled, now we're getting the whole entry.

Unfortunately, the more precise disassembly hits analyses based on Primus. At least on x86/x86-64 targets. Previously, we got an unresolved call exception as soon as we enter a PLT entry, while now Primus follows to the whole chain of PLT resolution mechanism, like in the next example with call to free:
```
400560: pushq  0x200aa2(%rip)     # 601008 <_GLOBAL_OFFSET_TABLE_+0x8
400566: jmpq   *0x200aa4(%rip)    # 601010 <_GLOBAL_OFFSET_TABLE_+0x10>
40056c: nopl   0x0(%rax)<free@plt>:
400570: jmpq   *0x200aa2(%rip)        # 601018 <_GLOBAL_OFFSET_TABLE_+0x18>
400576: pushq  $0x040057b: jmpq   400560 <_init+0x28>>

```
which does the following
```
400576: increase the stack
40057b: jump to the very first plt entry
400560: increase the stack
400566: load the target from GOT table
```
Finally, at `400566` we're getting an unresolved call exception. And in the Primus promiscuous mode, we continue the execution.
Here comes the crux of the problem, the stack is now broken: stack was increased twice and there wasn't any `pop` or `ret` instruction, so the following execution is wrong. The underlying problem is that the runtime function that performs lazy resolution of the
PLT GOT entry is not stubbed and therefore the arguments that are passed to it via the stack are not popped.

Probably the right solution would be to stub this function, but this is quite and involved process and it is not immediately obvious how to link it correctly (we do not know neither name nor an address).

Another option, which is proposed in this PR, is to stop Primus from going that deep into the PLT entry by linking all GOT entries, by default, as unresolved. The ratification is simple -- if we got to the PLT entry, then the address wasn't linked, so there is no need to
continue and we can raise an unresolved function asap.