### PR TITLE
preserves bir attributes

### DIFF
--- a/lib/bap_sema/bap_sema_lift.ml
+++ b/lib/bap_sema/bap_sema_lift.ml
@@ -9,10 +9,11 @@ open Bap_ir
 
 let update_jmp jmp ~f =
   f (Ir_jmp.dst jmp) (Ir_jmp.alt jmp) @@ fun ~dst ~alt ->
-  Ir_jmp.reify
-    ~tid:(Term.tid jmp)
-    ?cnd:(Ir_jmp.guard jmp)
-    ?dst ?alt ()
+  let jmp' = Ir_jmp.reify
+      ~tid:(Term.tid jmp)
+      ?cnd:(Ir_jmp.guard jmp)
+      ?dst ?alt () in
+  Term.with_attrs jmp' (Term.attrs jmp)
 
 let intra_fall cfg block =
   Seq.find_map (Cfg.Node.outputs block cfg) ~f:(fun e ->

--- a/lib/bap_types/bap_ir.ml
+++ b/lib/bap_types/bap_ir.ml
@@ -959,8 +959,9 @@ module Ir_jmp = struct
     }
   }
 
-
-  let with_kind t kind = create ~tid:t.tid ~cond:(cond t) kind
+  let with_kind t kind =
+    let t' = create ~tid:t.tid ~cond:(cond t) kind in
+    { t' with dict = t.dict }
 
   let exps (jmp : jmp term) : exp Sequence.t =
     let open Sequence.Generator in


### PR DESCRIPTION
This PR fixed a couple of minor bugs which were the reason why
in some cases, bir attributes weren't survived in map-alike
operations.

For example, `address` attribute was lost in case of conditional calls:

```
.address 0x401492
0000eeba: ZF := 0 = #1342
0000eec5: when ~ZF goto %0000d05b
0000fef4: goto %0000087d
```

And this PR fixes it:
```
.address 0x401492
0000eeba: ZF := 0 = #1342
.address 0x401496
0000eec5: when ~ZF goto %0000d05b
0000fef4: goto %0000087d
```