### PR TITLE
more precise subroutine packing

### DIFF
--- a/lib/bap_disasm/bap_disasm_calls.ml
+++ b/lib/bap_disasm/bap_disasm_calls.ml
@@ -1,7 +1,5 @@
 open Bap_core_theory
 
-module OCamlGraph = Graph
-
 open Core_kernel
 open Graphlib.Std
 
@@ -13,28 +11,93 @@ open KB.Syntax
 module Driver = Bap_disasm_driver
 module Insn = Bap_disasm_insn
 
+module Callgraph = struct
+  let entry = Word.b0
+  let exit = Word.b1
+  let is_entry = Word.equal entry
+  include Graphlib.Make(Addr)(Unit)
+  let mark_as_root n g =
+    if Word.equal n entry then g
+    else
+      let e = Edge.create entry n () in
+      Edge.insert e g
 
+  let init = Node.insert entry empty
+end
+
+(** Set of node parents.
+
+
+    A node [n] is a parent of node [m] iff [n <> m /\ n <> Entry] and
+    if every path from the [entry] node to [m] contains [n]. In other
+    words, if it [n] strictly dominates [m] and is not the entry node.
+
+    We compute parents using descending fixed point computation, with
+    lattice of subsets. In our representation we use [Top] to denote the
+    set of all nodes, and [Set xs] to denote a set of known nodes.
+
+    The merge (meet) operator is the set intersection. The transfer
+    function is defined as
+    {v
+      transfer Entry ps = ps
+      transfer node Top = Top
+      transfer node ps = (node) U ps
+    v}
+
+    Usually, dominators are computed using a transfer function that is
+    defined as [transfer node ps = (node) U ps], which our third node,
+    however we specialized our tranfer function for two reasons
+
+    1) efficiency - the first clause removes an explicit entry node,
+    which by dominates all nodes. So we can save some space, as well
+    as implement the [is_root] as little bit more efficient.
+
+    2) robustness - usually, the dominators are computed for graphs
+    where all nodes are dominated by the entry node. However, our case
+    is not general, and we have components which are not reachable
+    from the entry node. We do not want such componenets to change the
+    parent propery of any node, since there is no path from the [entry]
+    node to any other node, that will contain a node from an
+    unconnected component.
+*)
 module Parent = struct
-  let none = Word.b0
-  let unknown = Word.b1
-  let equal = Word.equal
-  let is_root p = equal p none
-  let is_known p = not (equal p unknown)
-  let merge x y =
-    if equal x unknown then y else
-    if equal y unknown then x else
-    if equal x y then x else none
+  type t = Top | Set of Word.Set.t [@@deriving compare, bin_io]
+  let none = Set Word.Set.empty
+  let unknown = Top
+  let equal x y = match x,y with
+    | Top,Top -> true
+    | Set x, Set y -> Set.equal x y
+    | _,_ -> false
 
-  let transfer self parent =
-    if equal parent none then self else parent
+  let is_root = function
+    | Top -> false
+    | Set x -> Set.is_empty x
+
+  let is_known p = Option.is_some p
+
+  let merge x y = match x,y with
+    | Top,x | x,Top -> x
+    | Set x, Set y -> Set (Set.inter x y)
+
+  let transfer self parents =
+    if Word.equal self Callgraph.entry
+    then parents
+    else match parents with
+      | Top -> Top
+      | Set parents -> Set (Set.add parents self)
+
+  let pp ppf parents = match parents with
+    | Top -> Format.fprintf ppf "Top"
+    | Set parents ->
+      Format.fprintf ppf "%a" Addr.pp_seq (Set.to_sequence parents)
 end
 
 module Parents = struct
-  type t = (word,word) Solution.t
+  type t = (word,Parent.t) Solution.t
   include Binable.Of_binable(struct
-      type t = (word * word) Seq.t [@@deriving bin_io]
+      type t = (word * Parent.t) Seq.t [@@deriving bin_io]
     end)(struct
-      type t = (word,word) Solution.t
+      type t = (word,Parent.t) Solution.t
       let to_binable = Solution.enum
       let of_binable xs =
         let init = ok_exn @@
@@ -52,17 +115,6 @@ type output = {
 
 type t = output [@@deriving bin_io]
 
-module Callgraph = struct
-  let entry = Word.b0
-  let exit = Word.b1
-  let is_entry = Word.equal entry
-  include Graphlib.Make(Addr)(Unit)
-  let mark_as_root n g =
-    if Word.equal n entry then g
-    else
-      let e = Edge.create entry n () in
-      Edge.insert e g
-end
 
 let string_of_node n =
   sprintf "%S" @@ if Callgraph.is_entry n
@@ -74,15 +126,14 @@ let pp_callgraph ppf graph =
     ~formatter:ppf
     ~string_of_node
 
-
 let pp_roots ppf graph =
   Graphlib.to_dot (module Callgraph) graph
     ~formatter:ppf
     ~string_of_node:(fun s ->
         sprintf "%S" (Addr.string_of_value s))
 
-let of_disasm disasm =
-  Driver.explore disasm ~init:Callgraph.empty
+let callgraph_of_disasm disasm =
+  Driver.explore disasm ~init:Callgraph.init
     ~block:(fun mem _ -> KB.return (Memory.min_addr mem))
     ~node:(fun n g ->
         let g = Callgraph.Node.insert n g in
@@ -102,47 +153,33 @@ let empty =
     entries = Set.empty (module Addr);
   }
 
-let connect_inputs g =
-  Callgraph.nodes g |>
-  Seq.fold ~init:g ~f:(fun g n ->
-      if Callgraph.Node.degree ~dir:`In n g = 0
-      then Callgraph.mark_as_root n g
-      else g)
+let belongs {parents} ~entry:parent addr =
+  Addr.equal parent addr || match Solution.get parents addr with
+  | Top -> false
+  | Set parents -> Set.mem parents parent
 
-let connect_unreachable_scc g =
-  Graphlib.depth_first_search (module Callgraph) g
-    ~start:Callgraph.entry
-    ~init:g
-    ~start_tree:Callgraph.mark_as_root
-
-let callgraph disasm =
-  of_disasm disasm >>|
-  connect_inputs >>|
-  connect_unreachable_scc
-
-let parent parents addr =
-  let parent = Solution.get parents addr in
-  if Parent.equal parent Parent.none then addr else parent
+let siblings {parents} x y =
+  Addr.equal x y ||
+  match Solution.get parents x, Solution.get parents y with
+  | Top,_|_,Top -> false
+  | Set p1, Set p2 ->
+    if Set.is_empty p1 then Set.mem p2 x else
+    if Set.is_empty p2 then Set.mem p1 x else
+      not @@ Set.is_empty (Set.inter p1 p2)
 
 let entries graph parents =
   let init = Set.empty (module Addr) in
   Callgraph.nodes graph |> Seq.fold ~init ~f:(fun entries n ->
-      if not (Parent.is_root n) && Parent.equal (parent parents n) n
-      then Set.add entries n
-      else entries)
-
-
-let pp_calls ppf (parents,graph) =
-  Graphlib.to_dot (module Callgraph) graph
-    ~formatter:ppf
-    ~string_of_node
-    ~node_attrs:(fun n ->
-        if parent parents n = n
-        then [`Shape `Diamond; `Style `Filled]
-        else [])
+      if Word.equal n Callgraph.entry then entries
+      else match Solution.get parents n with
+        | Parent.Top -> entries
+        | Set parents ->
+          if Set.is_empty parents
+          then Set.add entries n
+          else entries)
 
 let update {parents} disasm =
-  callgraph disasm >>| fun graph ->
+  callgraph_of_disasm disasm >>| fun graph ->
   Graphlib.fixpoint (module Callgraph) graph
     ~init:parents
     ~start:Callgraph.entry
@@ -155,13 +192,11 @@ let update {parents} disasm =
     entries = entries graph parents;
   }
 
-let entry {parents} addr = parent parents addr
-
 let entries {entries} = entries
 
 let equal s1 s2 =
   Set.equal s1.entries s2.entries &&
-  Solution.equal ~equal:Word.equal s1.parents s2.parents
+  Solution.equal ~equal:Parent.equal s1.parents s2.parents
 
 
 let domain = KB.Domain.flat ~empty ~equal "callgraph"

--- a/lib/bap_disasm/bap_disasm_calls.mli
+++ b/lib/bap_disasm/bap_disasm_calls.mli
@@ -9,6 +9,7 @@ type t [@@deriving bin_io]
 val empty : t
 val equal : t -> t -> bool
 val update : t -> Driver.state -> t KB.t
-val entry : t -> addr -> addr
+val belongs : t -> entry:addr -> addr -> bool
 val entries : t -> Set.M(Addr).t
+val siblings : t -> addr -> addr -> bool
 val domain : t KB.domain

--- a/lib_test/bap_project/test_project.ml
+++ b/lib_test/bap_project/test_project.ml
@@ -54,12 +54,14 @@ let test_substitute case =
   let min_addr = addr case.addr in
   let max_addr = addr (case.addr + String.length case.code - 1) in
   let base = Addr.of_int case.addr ~width:(addr_width case) in
+  let rooter = Rooter.create @@ Seq.of_list [base] in
   let symbolizer = Symbolizer.create @@ fun addr ->
     Option.some_if Addr.(base = addr) sub_name in
   let agent =
     let name = sprintf "test-project-symbolizer-for-%s" case.name in
     KB.Agent.register name in
   Symbolizer.provide agent symbolizer;
+  Rooter.provide rooter;
   let input =
     let file = "/dev/null" in
     let mem =


### PR DESCRIPTION
The subroutine packing algorithm is responsible for partitioning a set
of basic blocks into a set of disjoint sets each denoting a subroutine,
such that in each set there is a designated block called entry which
dominates all other blocks in this set.

In the ideal world, this partitioning is naturally induced by the
dominators tree of a graph. However, a dominator tree is undefined for
a graph that contains unreachable nodes.

Our new subroutine packing algorithm, introduced with BAP 2.0 alpha
release, solved this problem by connecting all unconnected components
to the root node, thus promoting entries of unconnected components to
subroutine entries. This led to a correct but very unprecise result,
e.g., for x86 we have x2 to x10 more partitions than true
subroutines. Mostly due to lots of unreachable small pieces of code,
which were inserted by the compiler after barries (for the alignment
purposes) - the issue that we underestimated.

Our original intent was to leave it as it is, assuming that later we
can implement analysis that will refine the packing, e.g., by
discovering switch tables or proving that paths are
infeasible. However, it turned out that it is very hard to refine the
partitioning, since this process couldn't be made iterative - i.e.,
the monotonicity requirement allows us only to add new paths in a
graph but not to remove existing. In other words we can't unwind the
damage introduced by connecting an unconnected component to the root
node, so we have to start from scratch every time. To summarize the
new algorithm produces a very conservative but unrepairable
disassembly.

The new algorithm is more precise (and therefore less efficient) and
instead of connecting the unconnected components to the root node we
postpone the decision until the later times. Unless there is no
explicit information in the knowledge base, that the node is a
subroutine start, we won't treat it as such. We are still
disassembling everything (using speculative disassembler), but when we
are reifying the knowledge into the IR graph, we only materialize
those subroutines which were present in the knowledge base. Therefore
letting the downstream analysis to discover more subroutines (or pieces
of code) and insert corresponding edges, so that the partitioning
could be monotonically refined.

The algorithm uses the fixed point solution of the domination
relationship, except that the node transfer function is not
transfering the node presence forward if the input is unknown (the
open circuit case). See the algorithm description in the diff section
for more details and formalization.