### PR TITLE
prunes Primus leave events on abnormal evaluation

### DIFF
--- a/lib/bap_primus/bap_primus_interpreter.ml
+++ b/lib/bap_primus/bap_primus_interpreter.ml
@@ -539,7 +539,7 @@ module Make (Machine : Machine) = struct
     !!pos_left curr
 
 
-  let term ?(cleanup=Machine.return ()) return cls f t =
+  let term return cls f t =
     Machine.Local.get state >>= fun s ->
     match Pos.next s.curr cls t with
     | Error err -> Machine.raise err
@@ -547,13 +547,8 @@ module Make (Machine : Machine) = struct
       update_pc t >>= fun () ->
       Machine.Local.update state (fun s -> {s with curr}) >>= fun () ->
       enter cls curr t >>= fun () ->
-      Machine.catch (f t)
-        (fun exn ->
-           leave cls curr t >>= fun () ->
-           cleanup >>= fun () ->
-           Machine.raise exn) >>= fun r ->
+      f t >>= fun r ->
       leave cls curr t >>= fun () ->
-      cleanup >>= fun () ->
       return r
 
   let normal = Machine.return


### PR DESCRIPTION
Before this PR we were emitting the `leave-*` events even when a term
didn't evaluate normally (but instead raised an exception). As a result
event handlers were invoked in the context where the term was partially
(if at all evaluate), while they were expecting that the evaluation was
successful. This led to a few undefined variables and other errors.

Even worse, since the `leave-*` events were posted in the exception
handler, it was possible for the event handler to raise an exception on
its own, which was escaping the original exception handler and breaking
havoc and significantly affecting performance.