### PR TITLE
runs ALL the unit tests on Travis

### DIFF
--- a/.run_travis_tests.sh
+++ b/.run_travis_tests.sh
@@ -17,6 +17,11 @@ fi
 
 if [ "$TASK" == "unit_tests" ]; then
     bap_run_tests
+    bap_future_tests
+    bap_x86_tests
+    bap_powerpc_tests
+    bap_piqi_tests
+    bap_traces_tests
 fi
 
 if [ "$TASK" == "veri" ]; then

--- a/opam/opam
+++ b/opam/opam
@@ -148,6 +148,11 @@ install: [
   ["ocamlfind" "remove" "bap-primus-machine"]
   [make "reinstall"]
   ["cp" "run_tests.native" "%{bin}%/bap_run_tests"]
+  ["cp" "run_future_tests.native" "%{bin}%/bap_future_tests"]
+  ["cp" "run_x86_tests.native" "%{bin}%/bap_x86_tests"]
+  ["cp" "run_powerpc_tests.native" "%{bin}%/bap_powerpc_tests"]
+  ["cp" "run_piqi_tests.native" "%{bin}%/bap_piqi_tests"]
+  ["cp" "run_traces_tests.native" "%{bin}%/bap_traces_tests"]
 ]
 remove: [
   ["ocamlfind" "remove" "bap"]
@@ -253,6 +258,11 @@ remove: [
   ["rm" "-f" "%{bin}%/bapbuild"]
   ["rm" "-f" "%{bin}%/baptop"]
   ["rm" "-f" "%{bin}%/bap_run_tests"]
+  ["rm" "-f" "%{bin}%/bap_future_tests"]
+  ["rm" "-f" "%{bin}%/bap_x86_tests"]
+  ["rm" "-f" "%{bin}%/bap_powerpc_tests"]
+  ["rm" "-f" "%{bin}%/bap_piqi_tests"]
+  ["rm" "-f" "%{bin}%/bap_traces_tests"]
 ]
 depexts: [
   [


### PR DESCRIPTION
It turned out that we are not running all the available unit tests on Travis.
We can't launch our unit tests just by running `make test` on Travis, because we use stages and don't even have a code on the stage with unit tests. Instead, we have to install test executables on the
build stage and then manually launch them on the next stage. And for some reason, we install and run only the most important one but not all of them.

This PR fixes it and run all the tests we currently have.