### PR TITLE
fixes issues in the oasis specification introduced by #1005

### DIFF
--- a/oasis/build
+++ b/oasis/build
@@ -1,9 +1,9 @@
-Flag bap_build
+Flag build
   Description: Build BAP build automation tools
   Default: false
 
 Library "bap-build"
-  Build$:          flag(everything) || flag(bap_build)
+  Build$:          flag(everything) || flag(build)
   Path: lib/bap_build
   FindlibName: bap-build
   CompiledObject: best
@@ -11,7 +11,7 @@ Library "bap-build"
   BuildDepends: findlib, ocamlbuild
 
 Executable "bapbuild"
-  Build$:         flag(everything) || flag(bap_build)
+  Build$:         flag(everything) || flag(build)
   Path:           tools
   MainIs:         bapbuild.ml
   Install:        true

--- a/oasis/bundle
+++ b/oasis/bundle
@@ -11,7 +11,7 @@ Library bundle
   InternalModules: Bap_bundle_config
 
 Executable "bapbundle"
-  Build$:          flag(everything) || flag(bundle)
+  Build$:         flag(everything) || flag(bundle)
   Path:           tools
   MainIs:         bapbundle.ml
   Install:        true

--- a/oasis/bundle
+++ b/oasis/bundle
@@ -1,9 +1,9 @@
-Flag bap_bundle
+Flag bundle
   Description: Build BAP bundler
   Default: false
 
 Library bundle
-  Build$:        flag(everything) || flag(bap_bundle)
+  Build$:        flag(everything) || flag(bundle)
   Path:          lib/bap_bundle
   FindlibName:   bap-bundle
   BuildDepends:  uri, camlzip, unix, core_kernel, ppx_jane
@@ -11,7 +11,7 @@ Library bundle
   InternalModules: Bap_bundle_config
 
 Executable "bapbundle"
-  Build$:          flag(everything) || flag(bap_bundle)
+  Build$:          flag(everything) || flag(bundle)
   Path:           tools
   MainIs:         bapbundle.ml
   Install:        true

--- a/oasis/common
+++ b/oasis/common
@@ -11,7 +11,7 @@ Plugins:     META (0.4)
 AlphaFeatures: ocamlbuild_more_args, compiled_setup_ml
 BuildTools: ocamlbuild
 XOCamlbuildExtraArgs:
-     -j 8
+     -j 2
      -use-ocamlfind
      -classic-display
      -plugin-tags "'package(findlib)'"

--- a/oasis/main
+++ b/oasis/main
@@ -7,6 +7,6 @@ Library bap_main
   Build$:          flag(everything) || flag(main)
   FindLibName:     bap-main
   CompiledObject:  best
-  BuildDepends:    base, stdio, cmdliner, bap-future, bap-plugins, bap-recipe
+  BuildDepends:    stdlib-shims, base, stdio, cmdliner, bap-future, bap-plugins, bap-recipe
   Modules:         Bap_main, Bap_main_config, Bap_main_event
   InternalModules: Bap_main_log

--- a/oasis/main
+++ b/oasis/main
@@ -1,10 +1,10 @@
-Flag bap_main
+Flag main
   Description: Build BAP Main Framework Configuration Library
   Default: false
 
 Library bap_main
   Path:            lib/bap_main
-  Build$:          flag(everything) || flag(bap_main)
+  Build$:          flag(everything) || flag(main)
   FindLibName:     bap-main
   CompiledObject:  best
   BuildDepends:    base, stdio, cmdliner, bap-future, bap-plugins, bap-recipe

--- a/oasis/plugins
+++ b/oasis/plugins
@@ -1,9 +1,9 @@
-Flag bap_plugins
+Flag plugins
   Description: Build BAP plugins support library
   Default: false
 
 Library bap_plugins
-  Build$:          flag(everything) || flag(bap_plugins)
+  Build$:          flag(everything) || flag(plugins)
   Path:            lib/bap_plugins
   FindLibName:     bap-plugins
   Modules:         Bap_plugins

--- a/oasis/recipe
+++ b/oasis/recipe
@@ -7,7 +7,7 @@ Library recipe
   Path: lib/bap_recipe
   FindlibName: bap-recipe
   CompiledObject: best
-  BuildDepends: base, stdio, parsexp, fileutils, camlzip, uuidm
+  BuildDepends: stdlib-shims, base, stdio, parsexp, fileutils, camlzip, uuidm
   Modules: Bap_recipe
   XMETADescription: stores command line parameters and resources in a single file
 

--- a/oasis/recipe
+++ b/oasis/recipe
@@ -10,17 +10,3 @@ Library recipe
   BuildDepends: stdlib-shims, base, stdio, parsexp, fileutils, camlzip, uuidm
   Modules: Bap_recipe
   XMETADescription: stores command line parameters and resources in a single file
-
-Flag recipe_cmd
-  Description: Build the BAP recipe command plugin
-  Default: false
-
-Library bap_recipe_command_plugin
-  Build$:           flag(everything) || flag(recipe_cmd)
-  Path:             plugins/recipe_command
-  FindlibName:      bap-plugin-recipe_command
-  CompiledObject:   best
-  BuildDepends:     bap, bap-recipe, bap-main, base, stdio
-  Modules:          Recipe_command_main
-  XMETADescription: manipulates bap recipes
-  XMETAExtraLines:  tags="recipe,command"

--- a/oasis/recipe
+++ b/oasis/recipe
@@ -11,8 +11,12 @@ Library recipe
   Modules: Bap_recipe
   XMETADescription: stores command line parameters and resources in a single file
 
+Flag recipe_cmd
+  Description: Build the BAP recipe command plugin
+  Default: false
+
 Library bap_recipe_command_plugin
-  Build$:           flag(everything) || flag(recipe)
+  Build$:           flag(everything) || flag(recipe_cmd)
   Path:             plugins/recipe_command
   FindlibName:      bap-plugin-recipe_command
   CompiledObject:   best

--- a/oasis/recipe-command
+++ b/oasis/recipe-command
@@ -1,9 +1,9 @@
-Flag recipe_cmd
+Flag recipe_command
   Description: Build the BAP recipe command plugin
   Default: false
 
 Library bap_recipe_command_plugin
-  Build$:           flag(everything) || flag(recipe_cmd)
+  Build$:           flag(everything) || flag(recipe_command)
   Path:             plugins/recipe_command
   FindlibName:      bap-plugin-recipe_command
   CompiledObject:   best

--- a/oasis/recipe-command
+++ b/oasis/recipe-command
@@ -1,0 +1,13 @@
+Flag recipe_cmd
+  Description: Build the BAP recipe command plugin
+  Default: false
+
+Library bap_recipe_command_plugin
+  Build$:           flag(everything) || flag(recipe_cmd)
+  Path:             plugins/recipe_command
+  FindlibName:      bap-plugin-recipe_command
+  CompiledObject:   best
+  BuildDepends:     bap, bap-recipe, bap-main, base, stdio
+  Modules:          Recipe_command_main
+  XMETADescription: manipulates bap recipes
+  XMETAExtraLines:  tags="recipe,command"

--- a/oasis/recipe-command
+++ b/oasis/recipe-command
@@ -7,7 +7,7 @@ Library bap_recipe_command_plugin
   Path:             plugins/recipe_command
   FindlibName:      bap-plugin-recipe_command
   CompiledObject:   best
-  BuildDepends:     bap, bap-recipe, bap-main, base, stdio
+  BuildDepends:     bap, bap-recipe, bap-main, base, stdio, stdlib-shims
   Modules:          Recipe_command_main
   XMETADescription: manipulates bap recipes
   XMETAExtraLines:  tags="recipe,command"


### PR DESCRIPTION
There are many new libraries after #1005. And this PR fixes some of their's
oasis files in order to install bap from `opam`