### PR TITLE
restores tags naming

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -4197,10 +4197,6 @@ module Std : sig
           functions will be used to print, compare and serialize
           values.
 
-          [uuid] and [name] parameters must be string literals, i.e.,
-          they must be known at compile time. This is to prevent the
-          abuse of type system.
-
           The returned value of type [T.t tag] is a special key that
           can be used with [create] and [get] functions to pack and
           unpack values of type [T.t] into [value]. *)

--- a/lib/bap_types/bap_attributes.ml
+++ b/lib/bap_types/bap_attributes.ml
@@ -51,13 +51,42 @@ end
 
 type color = Color.t [@@deriving bin_io, compare, sexp_poly]
 
-let comment = register (module String) ~name:"comment" ~uuid:"bap.std.attrs"
-let python = register (module String) ~name:"python" ~uuid:"bap.std.attrs"
-let shell = register (module String) ~name:"shell" ~uuid:"bap.std.attrs"
-let mark = register (module Unit) ~name:"mark" ~uuid:"bap.std.attrs"
-let color = register (module Color) ~name:"color" ~uuid:"bap.std.attrs"
-let weight = register (module Float) ~name:"weight" ~uuid:"bap.std.attrs"
-let address = register (module Bap_bitvector) ~name:"address" ~uuid:"bap.std.attrs"
-let filename = register (module String) ~name:"filename" ~uuid:"bap.std.attrs"
-let foreground = register (module Foreground) ~name:"foreground" ~uuid:"bap.std.attrs"
-let background = register (module Background) ~name:"background" ~uuid:"bap.std.attrs"
+let comment = register (module String)
+    ~name:"comment"
+    ~uuid:"4b974ab3-bf3b-4a83-8c62-299bca70f02a"
+
+let python = register (module String)
+    ~name:"python"
+    ~uuid:"831a6268-0ca8-4c1b-b4d6-076995f49d84"
+
+let shell = register (module String)
+    ~name:"shell"
+    ~uuid:"8c2c459d-6f3e-42f7-bce7-bf5cfa280f24"
+
+let mark = register (module Unit)
+    ~name:"mark"
+    ~uuid:"8e9801dc-0c64-4943-acf4-bfd02347af91"
+
+let color = register (module Color)
+    ~name:"color"
+    ~uuid:"1938c44a-149d-4c71-832a-7f484be800cc"
+
+let weight = register (module Float)
+    ~name:"weight"
+    ~uuid:"657366ea-9a28-4e5e-8341-c545d861732b"
+
+let address = register (module Bap_bitvector)
+    ~name:"address"
+    ~uuid:"7bcef7c0-0b37-4167-887a-eba0d68891fe"
+
+let filename = register (module String)
+    ~name:"filename"
+    ~uuid:"9701d189-24e3-4348-8610-0dedf780d06b"
+
+let foreground = register (module Foreground)
+    ~name:"foreground"
+    ~uuid:"56b29739-2df4-4e6c-9f63-15e20edf1857"
+
+let background = register (module Background)
+    ~name:"background"
+    ~uuid:"9a80a9cc-4106-48fc-abf3-55d7b333e734"

--- a/lib/bap_types/bap_value.ml
+++ b/lib/bap_types/bap_value.ml
@@ -41,7 +41,7 @@ type type_info = {
   compare : Value.t -> Value.t -> int;
 }
 
-let names : string Hash_set.t = Hash_set.create (module Typeid) ()
+let names : (string, string) Hashtbl.t = Hashtbl.create (module String)
 let types : (typeid, type_info) Hashtbl.t  =
   Hashtbl.create ~size:128 (module Typeid)
 
@@ -51,7 +51,7 @@ type ('a,'b) eq = ('a,'b) Type_equal.t = T : ('a,'a) eq
 
 let register_slot (type a) slot
     (module S : S with type t = a) : a tag =
-  let name = KB.Slot.name slot in
+  let name = KB.Slot.fullname slot in
   let key = Type_equal.Id.create name S.sexp_of_t in
   let pp ppf (Value.T (k,x)) =
     let T = Equal.proof k key in
@@ -85,8 +85,9 @@ let register_slot (type a) slot
     to_string;
     collect;
     compare;
-  } in
+    } in
   Hashtbl.add_exn types ~key:name ~data:info;
+  Hashtbl.add_exn names ~key:name ~data:(KB.Slot.name slot);
   {key; slot}
 
 let register (type a) ~name ~uuid (module S : S with type t = a) =
@@ -99,9 +100,12 @@ let register (type a) ~name ~uuid (module S : S with type t = a) =
       Theory.Program.cls name domain in
   register_slot slot (module S)
 
-let tagname (Value.T (k,_)) = Type_equal.Id.name k
+let key_name k = Hashtbl.find_exn names (Type_equal.Id.name k)
+let key_typeid k = Type_equal.Id.name k
 
-let typeid (Value.T (k,_)) = Type_equal.Id.name k
+let tagname (Value.T (k,_)) = key_name k
+
+let typeid (Value.T (k,_)) = key_typeid k
 
 let info typeid =
   Hashtbl.find_and_call types typeid
@@ -169,8 +173,8 @@ let get_exn
 
 module Tag = struct
   type 'a t = 'a tag
-  let name tag = Type_equal.Id.name tag.key
-  let typeid tag = name tag
+  let name tag = key_name tag.key
+  let typeid tag = key_typeid tag.key
   let key tag = tag.key
   let uid tag = uid tag.key
 

--- a/lib/bap_types/bap_value.ml
+++ b/lib/bap_types/bap_value.ml
@@ -99,15 +99,7 @@ let register (type a) ~name ~uuid (module S : S with type t = a) =
       Theory.Program.cls name domain in
   register_slot slot (module S)
 
-let find_separator s =
-  if String.is_empty s then None
-  else String.Escaping.index s ~escape_char:'\\' ':'
-
-let tagname (Value.T (k,_)) =
-  let fullname = Type_equal.Id.name k in
-  match find_separator fullname with
-  | None -> fullname
-  | Some len -> String.subo fullname ~pos:(len+1)
+let tagname (Value.T (k,_)) = Type_equal.Id.name k
 
 let typeid (Value.T (k,_)) = Type_equal.Id.name k
 

--- a/lib/knowledge/bap_knowledge.ml
+++ b/lib/knowledge/bap_knowledge.ml
@@ -1835,7 +1835,7 @@ module Knowledge = struct
       cls : ('a,unit) cls;
       dom : 'p Domain.t;
       key : 'p Dict.Key.t;
-      name : string;
+      name : fullname;
       desc : string option;
       promises : (pid, 'p promise) Hashtbl.t;
     }
@@ -1851,9 +1851,8 @@ module Knowledge = struct
     let enum {Class.id} = Hashtbl.find_multi repository id
 
     let declare ?desc ?persistent ?package cls name (dom : 'a Domain.t) =
-      let slot = Registry.add_slot ?desc ?package name in
-      let name = string_of_fname slot in
-      let key = Dict.Key.create ~name dom.inspect in
+      let name = Registry.add_slot ?desc ?package name in
+      let key = Dict.Key.create ~name:(string_of_fname name) dom.inspect in
       Option.iter persistent (Record.register_persistent key);
       Record.register_domain key dom;
       let promises = Hashtbl.create (module Pid) in
@@ -1864,7 +1863,8 @@ module Knowledge = struct
 
     let cls x = x.cls
     let domain x = x.dom
-    let name x = x.name
+    let name {name={name}} = name
+    let fullname {name} = string_of_fname name
     let desc x = match x.desc with
       | None -> "no description"
       | Some s -> s

--- a/lib/knowledge/bap_knowledge.mli
+++ b/lib/knowledge/bap_knowledge.mli
@@ -320,6 +320,7 @@ module Knowledge : sig
     val domain : ('a,'p) slot -> 'p domain
     val cls : ('a,_) slot -> ('a, unit) cls
     val name : ('a,'p) slot -> string
+    val fullname : ('a,'p) slot -> string
     val desc : ('a,'p) slot -> string
   end
 


### PR DESCRIPTION
In BAP 1.x the function `Tag.name` returned the name that was provided as an argument to the `name` parameter to the `register` function, which is not guaranteed to be unique, but is more human-readable.

In BAP 2.0 after values were reimplemented in terms of the Knowledge value, the identifier returned by the `Tag.name` function became the fully-qualified name with namespace included, which is less readable and, more importantly, breaks the `map-terms` facility on which we rely a lot on our IDA integration.

This PR restores the old behavior.