### PR TITLE
don't treat `jump next` as fall

### DIFF
--- a/lib/bap_disasm/bap_disasm_driver.ml
+++ b/lib/bap_disasm/bap_disasm_driver.ml
@@ -260,7 +260,6 @@ let new_insn arch mem insn =
 
 let collect_dests arch mem insn =
   let width = Size.in_bits (Arch.addr_size arch) in
-  let fall = Addr.to_bitvec (Addr.succ (Memory.max_addr mem)) in
   new_insn arch mem insn >>= fun code ->
   KB.collect Theory.Program.Semantics.slot code >>= fun insn ->
   let init = {
@@ -274,13 +273,11 @@ let collect_dests arch mem insn =
     Set.to_sequence dests |>
     KB.Seq.fold ~init ~f:(fun {barrier; indirect; resolved} label ->
         KB.collect Theory.Label.addr label >>| function
-        | Some d ->
-          if Bitvec.(d <> fall)
-          then {
+        | Some d -> {
             barrier;
             indirect;
             resolved = Set.add resolved (Word.create d width)
-          } else {barrier; indirect; resolved}
+          }
         | None ->
           {barrier; indirect=true; resolved}) >>= fun res ->
     KB.return res

--- a/plugins/ida/ida_main.ml
+++ b/plugins/ida/ida_main.ml
@@ -170,17 +170,12 @@ end = struct
 
   let of_brancher_info arch bf : t =
     let (!) = (int64_to_word arch) in
-    let normal_flow_to_dests = function
-      | Some _fall -> []
-      | None -> [] in
     let other_flows_to_dests flows =
       List.fold flows ~init:[] ~f:(fun acc addr ->
-          (Some !addr, `Jump)::acc)
-    in
-    let helper tab (addr,normal_flow,other_flows) =
+          (Some !addr, `Jump)::acc) in
+    let helper tab (addr,_normal_flow,other_flows) =
       Addr.Table.add_exn tab ~key:!addr
-        ~data:((normal_flow_to_dests normal_flow)
-               @ (other_flows_to_dests other_flows));
+        ~data:(other_flows_to_dests other_flows);
       tab
     in
     List.fold bf

--- a/plugins/ida/ida_main.ml
+++ b/plugins/ida/ida_main.ml
@@ -171,9 +171,8 @@ end = struct
   let of_brancher_info arch bf : t =
     let (!) = (int64_to_word arch) in
     let normal_flow_to_dests = function
-      | Some fall -> [Some !fall, `Fall]
-      | None -> []
-    in
+      | Some _fall -> []
+      | None -> [] in
     let other_flows_to_dests flows =
       List.fold flows ~init:[] ~f:(fun acc addr ->
           (Some !addr, `Jump)::acc)


### PR DESCRIPTION
TL;DR; Warning: this PR changes the semantics of BAP 1.x branchers, they shall not reference the fall-through destination in their outputs for non-control-flow affecting instructions. Please, consider updating your custom branchers, if you have one.

In BAP 2.0 a set of destinations of an instruction is stored in its `dests` slot. This set, if known, shouldn't include the fall-through destination and only control-flow instructions shall have a non-empty
set of destinations. Since previously our branchers were including all destinations, there was an extra filtering procedure in the disassembler, which was removing the fall-through destination, in case
if it still present, to prevent issues with old BAP 1.x branchers.

We had to remove this extra step since clang is using the `jmp next` instruction (where `next` is the address of the first byte following the instruction) a lot in its unoptimized output. Probably for instrumentation or as an initial step for jump relaxation. In any case, `jump next` is possible and is quite often, so we can't just remove the destination that looks like a fall-through destination, as it will lead to inconsistencies in the later stage of analysis, in particular, we will interpret `jump next` as `nop` instruction in the disassembler, but denote it as a control-flow term during the semantic analysis.

Our default jump-destinations analysis is already correct, i.e.,  it won't emit any false fall-through edges. The only brancher that should be updated is the IDA brancher. Fortunately, our interface with
IDA services is rich enough so we can distinguish which jump is which on the BAP side, so there is no need to update the `ida-python` package here.