### PR TITLE
fixes a plugin initialization issue in baptop, restores postinstall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ _oasis
 /lib/bap_bundle/bap_bundle_config.ml
 /lib/bap_plugins/bap_plugins_config.ml
 bap_main_config.ml
+tools/postinstall.ml

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ all:
 install:
 	$(SETUP) -install $(BAPINSTALLFLAGS)
 	sh tools/build_plugins.sh
+	[ -f ./postinstall.native ] && ./postinstall.native
 
 uninstall:
 	$(SETUP) -uninstall $(BAPUNINSTALLFLAGS)

--- a/oasis/bap-std
+++ b/oasis/bap-std
@@ -169,3 +169,11 @@ Library sema
                  Bap_sema_ssa,
                  Bap_sema_taint,
                  Bap_sema_free_vars
+
+Executable "postinstall"
+  Build$:         flag(everything) || flag(bap_std)
+  Path:           tools
+  MainIs:         postinstall.ml
+  Install:        false
+  CompiledObject: best
+  BuildDepends:   fileutils

--- a/oasis/bap-std.files.ab.in
+++ b/oasis/bap-std.files.ab.in
@@ -1,0 +1,1 @@
+        , tools/postinstall.ml.ab

--- a/oasis/toplevel
+++ b/oasis/toplevel
@@ -7,4 +7,4 @@ Executable "baptop"
   MainIs:         baptop.ml
   Build$:         flag(everything) || flag(toplevel)
   CompiledObject: byte
-  BuildDepends:   bap-main, bap, core_kernel, ppx_jane, utop, threads, findlib.dynload
+  BuildDepends:   utop, threads, findlib.dynload

--- a/src/bap_frontend.ml
+++ b/src/bap_frontend.ml
@@ -21,8 +21,7 @@ Report bugs to
 
 # SEE ALSO
 
-$(b,bapbundle)(1), $(b,bapbuild)(1), $(b,bap)(3)"
-
+$(b,bapbundle)(1), $(b,bapbuild)(1), $(b,bap)(3)
 |}
 open Bap.Std
 open Core_kernel

--- a/src/baptop.ml
+++ b/src/baptop.ml
@@ -1,28 +1,6 @@
-open Bap_plugins.Std
-
-
-let install_printer printer =
-  Topdirs.dir_install_printer Format.err_formatter
-    (Longident.parse printer)
-
-let install_printers () =
-  Core_kernel.Pretty_printer.all () |>
-  List.iter install_printer
-
 let main () =
-  let module Bap_std_is_required = Bap.Std in
-  let module Core_kernel_is_required = Core_kernel in
-  let loader = Topdirs.dir_load Format.err_formatter in
-  setup_dynamic_loader loader;
-  UTop.require ["bap"];
-  UTop.set_create_implicits true;
-  install_printers ();
-  match Bap_main.init ~argv: [|"baptop"|] () with
-  | Ok () -> UTop_main.main ()
-  | Error failed ->
-    Format.eprintf "Failed to initialize BAP: %a@\n%!"
-      Bap_main.Extension.Error.pp failed;
-    exit 1
+  UTop.require ["bap.top"];
+  UTop_main.main ()
 
 
 let () = main ()

--- a/tools/postinstall.ml.ab
+++ b/tools/postinstall.ml.ab
@@ -2,14 +2,10 @@ open Printf
 
 let (/) = Filename.concat
 
-(* TODO get it from bap_config *)
-let bindir = Bap_config.bindir
-let mandir = Bap_config.mandir
+let mandir = "$prefix" / "man" / "man1"
 
 let tools = [
-  "bap-mc";
   "bap";
-  "bap-byteweight";
 ]
 
 (** handwritten man pages *)
@@ -31,11 +27,8 @@ let create_man prog =
 
 
 let main () =
-  let utils = ["baptop"; "ppx-bap"] in
   let helps = List.map create_man tools |> List.concat in
   FileUtil.mkdir ~parent:true mandir;
-  FileUtil.cp (manpages @ helps) mandir;
-  FileUtil.cp (List.map (fun t -> "tools" / t) utils) bindir;
-  List.iter (fun name -> Unix.chmod (bindir / name) 0o770) utils
+  FileUtil.cp (manpages @ helps) mandir
 
 let () = main ()


### PR DESCRIPTION
For some yet to be discovered reasons plugins weren't evaluated during
the baptop utility startup. The were loaded, linked, but no
side-effects occured. Not sure what is going in utop internals, but
just loading the "bap.top" library works fine, and it is also
simplifies the implementation.

I've also restored the postinstall hook, that installs manpages for
bap and utilities. The utilities (such as old baptop script and
ppx-bap) are no longer installed, because they are obsolete, but the
man pages are now installed (and now in a proper place).

The postisntall hook is moved to the Makefile, since it has to be run
after plugins are installed. It is predicated with the existence, so
it won't be run on each package installation during opam installation,
only for the bap-std package which actually produces this file.

Right now, I've disabled the installation of the `bap-byteweight`
manpage, since it could be only installed if the corresponding utility
is installed (so we have to create a separate post-install for this package).