### PR TITLE
adds unknown architecture

### DIFF
--- a/lib/arm/arm_utils.ml
+++ b/lib/arm/arm_utils.ml
@@ -35,6 +35,9 @@ let assn d s =
 let bitlen = function
   | Type.Imm len -> len
   | Type.Mem (_,size) -> Size.in_bits size
+  | Type.Unk ->
+     fail [%here] "can't infer length from unknown type"
+
 
 let is_move = function
   | Bil.Move _ -> true

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -1955,8 +1955,17 @@ module Std : sig
     include Printable.S with type t := t
     include Data.S      with type t := t
 
+
+    (** Bil is an instance of Domain.
+
+        A flat domain with the empty Bil program being the empty element.
+     *)
     val domain : stmt list Knowledge.domain
+
+    (** Instance of the persistence class  *)
     val persistent : stmt list Knowledge.persistent
+
+    (** the BIL property  *)
     val slot : (Theory.Program.Semantics.cls, stmt list) Knowledge.slot
 
     (** [printf "%a" pp_binop op] prints a binary operation [op].  *)
@@ -2704,8 +2713,14 @@ module Std : sig
 
     type t = var
 
+
+    (** [reify v] reifies a core theory variable into the Bil variable. *)
     val reify : 'a Theory.var -> t
+
+    (** [ident v] is the identifier of the variable [v]  *)
     val ident : t -> Theory.Var.ident
+
+    (** [sort v] returns a core theory sort of the variable [v].  *)
     val sort  : t -> Theory.Value.Sort.Top.t
 
     (** [create ?register ?fresh name typ] creates a variable with
@@ -3312,6 +3327,10 @@ module Std : sig
   module Exp : sig
     type t = Bil.exp
 
+
+    (** the Exp.t property.
+
+        This property of a value denotes it in terms of Bil expressions.*)
     val slot : (Theory.Value.cls, exp) KB.slot
 
     (** All visitors provide some information about the current
@@ -3959,6 +3978,9 @@ module Std : sig
     type xcore = [`xcore]
     [@@deriving bin_io, compare, enumerate, sexp]
 
+    type unknown = [`unknown]
+    [@@deriving bin_io, compare, enumerate, sexp]
+
     type t = [
       | aarch64
       | arm
@@ -3974,6 +3996,7 @@ module Std : sig
       | systemz
       | x86
       | xcore
+      | unknown
     ] [@@deriving bin_io, compare, enumerate, sexp]
 
     (** [of_string s] will try to be clever and to capture all
@@ -3987,7 +4010,8 @@ module Std : sig
     (** [endian arch] returns a word endianness of the [arch]  *)
     val endian : t -> endian
 
-    val slot : (Theory.program, t option) Knowledge.slot
+    (** the architecture (ISA) of a program.  *)
+    val slot : (Theory.program, t) Knowledge.slot
 
     (** [arch] type implements [Regular]  interface  *)
     include Regular.S with type t := t
@@ -4203,10 +4227,11 @@ module Std : sig
       val register : name:string -> uuid:string ->
         (module S with type t = 'a) -> 'a tag
 
-
+      (** [register_slot slot (module T)] reflects Knowledge property into BAP value.  *)
       val register_slot : (Theory.program,'a option) KB.slot ->
         (module S with type t = 'a) -> 'a tag
 
+      (** [slot tag] returns a slot associated with the tag. *)
       val slot : 'a t -> (Theory.program, 'a option) KB.slot
 
       (** [name cons] returns a name of a constructor.  *)
@@ -4725,6 +4750,7 @@ module Std : sig
       addr ->
       Bigstring.t -> t Or_error.t
 
+    (** memory representation of a program  *)
     val slot : (Theory.program, mem option) Knowledge.slot
 
     (** [of_file endian start name] creates a memory region from file.
@@ -6032,6 +6058,7 @@ module Std : sig
 
         type ('a,'k) t = ('a,'k) insn
 
+        (** a decoded representa  *)
         val slot : (Theory.program, full_insn option) Knowledge.slot
 
         (** [sexp_of_t insn] returns a sexp representation of [insn]  *)
@@ -6168,12 +6195,27 @@ module Std : sig
 
     type t = Theory.Program.Semantics.t [@@deriving bin_io, compare, sexp]
 
+
+    (** Instruction properties.  *)
     module Slot : sig
       type 'a t = (Theory.Program.Semantics.cls, 'a) KB.slot
+
+      (** An opcode name,
+
+          Also accessible with [Insn.name].
+      *)
       val name : string t
+
+      (** An assembly representation.  *)
       val asm :  string t
+
+      (** a list of operands  *)
       val ops :  op array option t
+
+      (** the length of the delay slot. *)
       val delay : int option t
+
+      (** the set of destinations (not including the fall-through edge).  *)
       val dests : Set.M(Theory.Label).t option t
     end
 
@@ -7160,6 +7202,7 @@ module Std : sig
       ?jmp:(jmp term -> 'a) ->
       't term -> 'a
 
+    (** the graphical representation of the program  *)
     val slot : (Theory.Program.Semantics.cls, blk term list) Knowledge.slot
   end
 
@@ -7202,6 +7245,8 @@ module Std : sig
       (** fixes the result  *)
       val result : t -> program term
     end
+
+    (** [pp_slots names] prints slots that are in [names].  *)
     val pp_slots : string list -> Format.formatter -> t -> unit
     include Regular.S with type t := t
   end
@@ -7332,7 +7377,10 @@ module Std : sig
       (** returns current result  *)
       val result : t -> sub term
     end
+
+    (** [pp_slots names] prints slots that are in [names].  *)
     val pp_slots : string list -> Format.formatter -> t -> unit
+
     include Regular.S with type t := t
   end
 
@@ -7537,6 +7585,8 @@ module Std : sig
       (** returns current result  *)
       val result  : t -> blk term
     end
+
+    (** [pp_slots names] prints slots that are in [names].  *)
     val pp_slots : string list -> Format.formatter -> t -> unit
     include Regular.S with type t := t
   end
@@ -7552,12 +7602,14 @@ module Std : sig
 
     type t = def term
 
+    (** [reify v x] reifies Core Theory terms into the IR term.  *)
     val reify : ?tid:tid -> 'a Theory.var -> 'a Theory.value -> t
 
+    (** [var def] is the left-hand-side as a Core Theory variable.   *)
     val var : t -> unit Theory.var
 
+    (** [value def] is the right-hand-side as a Core Theory value.  *)
     val value : t -> unit Theory.value
-
 
     (** [create ?tid x exp] creates definition [x := exp]  *)
     val create : ?tid:tid -> var -> exp -> t
@@ -7587,6 +7639,7 @@ module Std : sig
         for more information.  *)
     val free_vars : t -> Var.Set.t
 
+    (** [pp_slots names] prints slots that are in [names].  *)
     val pp_slots : string list -> Format.formatter -> t -> unit
 
     include Regular.S with type t := t
@@ -7619,20 +7672,56 @@ module Std : sig
     type dst
 
 
+
+    (** [reify ()] reifies inputs into a jump term.
+
+       Calls and interrupt subroutines invocations are represented
+       with two edges: the normal edge (denoted [dst]) is the
+       intra-procedural edge which connects the callsite with the
+       fall-through destination (if such exists) and an alternative
+       destination (denoted with [alt]) which represents an
+       inter-procedural destination between the callsite and the
+       call destination.
+
+       @param cnd is a core theory term that denotes the
+       guard condition of a conditional jump.
+
+       @param alt is the alternative control flow destination.
+
+       @param dst is the direct control flow destination
+
+       @tid is the jump identifier, if not specified a fresh
+       new identifier is created.
+
+     *)
     val reify : ?tid:tid ->
       ?cnd:Theory.Bool.t Theory.value ->
       ?alt:dst -> ?dst:dst -> unit -> t
 
-
+    (** [guard jmp] if [jmp] is conditional, returns its condition.  *)
     val guard : t -> Theory.Bool.t Theory.value option
+
+    (** [with_guard jmp cnd] updates the jump condition of [jmp].  *)
     val with_guard : t -> Theory.Bool.t Theory.value option -> t
+
+    (** [dst jmp] returns the intra-procedural destination of [jmp].  *)
     val dst : t -> dst option
+
+    (** [alt jmp] returns the inter-procedural destination of [jmp].  *)
     val alt : t -> dst option
 
+    (** [resolved dst] creates a resolved destination.*)
     val resolved : tid -> dst
-    val indirect : 'a Theory.Bitv.t Theory.value -> dst
-    val resolve : dst -> (tid,'a Theory.Bitv.t Theory.value) Either.t
 
+
+    (** [indirect v] creates an indirect jump destination.
+
+        The destination (or a set of destinations) is encoded with
+        the Core Theory term [v]. *)
+    val indirect : 'a Theory.Bitv.t Theory.value -> dst
+
+    (** [resolve dst] resolves destination. *)
+    val resolve : dst -> (tid,'a Theory.Bitv.t Theory.value) Either.t
 
     (** [create ?cond kind] creates a jump of a given kind  *)
     val create : ?tid:tid -> ?cond:exp -> jmp_kind -> t
@@ -7679,6 +7768,7 @@ module Std : sig
     (** updated jump's kind  *)
     val with_kind : t -> jmp_kind -> t
 
+    (** [pp_slots names] prints slots that are in [names].  *)
     val pp_slots : string list -> Format.formatter -> t -> unit
     include Regular.S with type t := t
   end
@@ -7695,12 +7785,21 @@ module Std : sig
         incoming edge. *)
     type t = phi term
 
+
+    (** [reify v xs] reifies Core Theory terms into the phi term.   *)
     val reify : ?tid:tid ->
       'a Theory.var ->
       (tid * 'a Theory.value) list ->
       t
 
+    (** [var phi] is the left-hand-side of the [phi] term.  *)
     val var : t -> unit Theory.var
+
+    (** [options def] returns a list of possible values the term can take.
+
+        Values are predicated with the term identifiers of the paths (denoted
+        by the tid of the predecessor)
+    *)
     val options : t -> (tid * unit Theory.value) seq
 
 
@@ -7756,6 +7855,7 @@ module Std : sig
     (** [remove def id] removes definition with a given [id]  *)
     val remove : t -> tid -> t
 
+    (** [pp_slots names] prints slots that are in [names].  *)
     val pp_slots : string list -> Format.formatter -> t -> unit
     include Regular.S with type t := t
   end
@@ -7769,13 +7869,18 @@ module Std : sig
 
     type t = arg term
 
+
+    (** [reify v x] reifies Core Theory terms into an [arg] term.  *)
     val reify : ?tid:tid -> ?intent:intent ->
       'a Theory.var ->
       'a Theory.value -> t
 
-    val var : t -> unit Theory.var
-    val value : t -> unit Theory.value
 
+    (** [var arg] is the left-hand-side of the [arg] term.  *)
+    val var : t -> unit Theory.var
+
+    (** [value arg] is the right-hand-side of the [arg] term.  *)
+    val value : t -> unit Theory.value
 
     (** [create ?intent var exp] creates an argument. If intent is
         not specified it is left unknown.   *)

--- a/lib/bap_disasm/bap_disasm_rec.ml
+++ b/lib/bap_disasm/bap_disasm_rec.ml
@@ -112,11 +112,11 @@ let provide_arch arch mem =
   let width = Size.in_bits (Arch.addr_size arch) in
   KB.promise Arch.slot @@ fun label ->
   KB.collect Theory.Label.addr label >>| function
-  | None -> None
+  | None -> `unknown
   | Some p ->
     let p = Word.create p width in
-    if Memory.contains mem p then Some arch
-    else None
+    if Memory.contains mem p then arch
+    else `unknown
 
 let scan arch mem state =
   provide_arch arch mem;

--- a/lib/bap_disasm/bap_disasm_symbolizer.ml
+++ b/lib/bap_disasm/bap_disasm_symbolizer.ml
@@ -71,11 +71,11 @@ let provide agent (Symbolizer name) =
   KB.propose agent common_name @@ fun label ->
   KB.collect Arch.slot label >>= fun arch ->
   KB.collect Theory.Label.addr label >>| fun addr ->
-  match arch, addr with
-  | Some arch, Some addr ->
+  match addr with
+  | Some addr ->
     let width = Size.in_bits (Arch.addr_size arch) in
     name (Addr.create addr width)
-  | _ -> None
+  | None -> None
 
 
 let update_name_slot label name =

--- a/lib/bap_piqi/bil_piqi.ml
+++ b/lib/bap_piqi/bil_piqi.ml
@@ -70,11 +70,12 @@ let binop_of_piqi = function
 let rec type_to_piqi : typ -> Stmt_piqi.typ = function
   | Imm s ->  `imm s
   | Mem (t, t') -> `mem {Stmt_piqi.Mem.index_type = t; element_type = t';}
+  | Unk -> `unk
 
 let rec type_of_piqi = function
   | `imm n -> Imm n
   | `mem {P.Mem.index_type; element_type} -> Mem (index_type, element_type)
-
+  | `unk -> Type.Unk
 
 let var_to_piqi v =
   let module P = Stmt_piqi in {

--- a/lib/bap_piqi/type.piqi
+++ b/lib/bap_piqi/type.piqi
@@ -2,6 +2,7 @@
   .name typ
   .option [.type imm]
   .option [.type mem]
+  .option [.name unk]
 ]
 
 .variant [

--- a/lib/bap_primus/bap_primus_interpreter.ml
+++ b/lib/bap_primus/bap_primus_interpreter.ml
@@ -269,9 +269,8 @@ module Make (Machine : Machine) = struct
   let value = Value.of_word
 
   let word_of_type = function
-    | Type.Mem _ -> Word.b0
     | Type.Imm t -> Word.zero t
-  [@@warning "-8"]
+    | Type.Mem _ | Type.Unk -> Word.b0
 
   let undefined t =
     value (word_of_type t) >>= fun r ->
@@ -376,12 +375,10 @@ module Make (Machine : Machine) = struct
     }
 
   let memory typ name = match typ with
-    | Type.Imm _ as t -> failwithf "type error - load from %s:%a"
-                           name Type.pps t ()
     | Type.Mem (ks,vs) ->
       let ks = Size.in_bits ks and vs = Size.in_bits vs in
       Primus.Memory.Descriptor.create ks vs name
-  [@@warning "-8"]
+    | _ as t  -> failwithf "type error - load from %s:%a"  name Type.pps t ()
 
   let rec memory_of_storage : exp -> _ = function
     | Var v -> memory (Var.typ v) (Var.name v)

--- a/lib/bap_primus/bap_primus_interpreter.ml
+++ b/lib/bap_primus/bap_primus_interpreter.ml
@@ -271,6 +271,7 @@ module Make (Machine : Machine) = struct
   let word_of_type = function
     | Type.Mem _ -> Word.b0
     | Type.Imm t -> Word.zero t
+  [@@warning "-8"]
 
   let undefined t =
     value (word_of_type t) >>= fun r ->
@@ -380,6 +381,7 @@ module Make (Machine : Machine) = struct
     | Type.Mem (ks,vs) ->
       let ks = Size.in_bits ks and vs = Size.in_bits vs in
       Primus.Memory.Descriptor.create ks vs name
+  [@@warning "-8"]
 
   let rec memory_of_storage : exp -> _ = function
     | Var v -> memory (Var.typ v) (Var.name v)

--- a/lib/bap_primus/bap_primus_lisp_program.ml
+++ b/lib/bap_primus/bap_primus_lisp_program.ml
@@ -762,7 +762,8 @@ module Typing = struct
         match Var.typ v with
         | Type.Imm x ->
           Map.set vars ~key:(Var.name v) ~data:x
-        | Type.Mem _ -> vars)
+        | Type.Mem _
+        | Type.Unk -> vars)
 
   let make_prims {codes} =
     List.fold codes ~init:String.Map.empty ~f:(fun ps p ->

--- a/lib/bap_primus/bap_primus_memory.ml
+++ b/lib/bap_primus/bap_primus_memory.ml
@@ -113,7 +113,7 @@ let virtual_memory arch =
   let module Target = (val target_of_arch arch) in
   let mem = Target.CPU.mem in
   match Var.typ mem with
-  | Type.Imm _ as t ->
+  | Type.Imm _ | Type.Unk as t ->
     invalid_argf "The CPU.mem variable %a:%a is not a storage"
       Var.pps mem Type.pps t ()
   | Type.Mem (ks,vs) ->

--- a/lib/bap_types/bap_arch.ml
+++ b/lib/bap_types/bap_arch.ml
@@ -51,6 +51,7 @@ module T = struct
     | #arm | #armeb | #thumb | #thumbeb
     | `x86 | `ppc | `mips | `mipsel | `sparc
     | `nvptx | `hexagon |  `r600 | `xcore  -> `r32
+    | `unknown -> `r32
 
     | #aarch64 | `mips64el |`sparcv9|`ppc64le|`x86_64
     | `ppc64|`nvptx64 | `systemz | `mips64 -> `r64
@@ -59,19 +60,19 @@ module T = struct
     | #armeb  | `aarch64_be | #thumbeb -> BigEndian
     | `mipsel | `mips64el | `ppc64le -> LittleEndian
     | #arm | #thumb | #x86 | #aarch64 | #r600
-    | #hexagon | #nvptx | #xcore -> LittleEndian
+    | #hexagon | #nvptx | #xcore | #unknown -> LittleEndian
     | #ppc | #mips | #sparc | #systemz   -> BigEndian
 
   let equal x y = compare_arch x y = 0
 
   let domain =
-    KB.Domain.optional ~equal ~inspect:sexp_of_t "arch"
+    KB.Domain.flat ~empty:`unknown ~equal ~inspect:sexp_of_t "arch"
 
 
   let slot = KB.Class.property ~package:"bap.std"
       Theory.Program.cls "arch" domain
       ~persistent:(KB.Persistent.of_binable (module struct
-                     type t = arch option [@@deriving bin_io]
+                     type t = arch [@@deriving bin_io]
                    end))
       ~public:true
       ~desc:"an ISA of the program"

--- a/lib/bap_types/bap_arch.mli
+++ b/lib/bap_types/bap_arch.mli
@@ -9,6 +9,6 @@ val addr_size : arch -> addr_size
 
 val endian : arch -> endian
 
-val slot : (Theory.program, arch option) KB.slot
+val slot : (Theory.program, arch) KB.slot
 
 include Regular.S with type t := arch

--- a/lib/bap_types/bap_bil_adt.ml
+++ b/lib/bap_types/bap_bil_adt.ml
@@ -26,6 +26,7 @@ module Var = struct
   let pp_ty ch = function
     | Type.Imm n -> pr ch "Imm(%d)" n
     | Type.Mem (n,m) -> pr ch "Mem(%a,%a)" pp_size n pp_size m
+    | Type.Unk -> pr ch "Unk"
 
   let pp_var ch v =
     pr ch "Var(\"%a\",%a)" Bap_var.pp v  pp_ty Bap_var.(typ v)

--- a/lib/bap_types/bap_common.ml
+++ b/lib/bap_types/bap_common.ml
@@ -151,6 +151,9 @@ module Arch = struct
   type xcore = [`xcore]
   [@@deriving bin_io, compare, enumerate, sexp]
 
+  type unknown = [`unknown]
+  [@@deriving bin_io, compare, enumerate, sexp]
+
   type t = [
     | aarch64
     | arm
@@ -166,6 +169,7 @@ module Arch = struct
     | systemz
     | x86
     | xcore
+    | unknown
   ] [@@deriving bin_io, compare, enumerate, sexp]
 end
 

--- a/lib/microx/microx_concretizer.ml
+++ b/lib/microx/microx_concretizer.ml
@@ -55,7 +55,7 @@ class ['a] main
 
     method private emit policy = function
       | Type.Imm sz -> self#emit_const policy sz
-      | Type.Mem _  -> self#emit_empty
+      | Type.Mem _ | Type.Unk -> self#emit_empty
 
     method private emit_const policy sz =
       SM.get () >>= fun ctxt ->

--- a/lib/monads/monads_monad.ml
+++ b/lib/monads/monads_monad.ml
@@ -557,8 +557,8 @@ module ResultT = struct
   = struct
 
     include struct
-      let (>>=) m f = (M.bind [@inlined]) m f [@@inline]
-    let (>>|) m f = (M.map [@inlined]) m f [@@inline]
+      let (>>=) m f = M.bind m f [@@inline]
+      let (>>|) m f = M.map  m f [@@inline]
     end
 
     module Base = struct
@@ -997,8 +997,8 @@ module State = struct
      and type 'a env   := 'a Tp(T)(M).env
   = struct
     include struct
-      let (>>=) m f = (M.bind [@inlined]) m f [@@inline]
-    let (>>|) m f = (M.map [@inlined]) m f [@@inline]
+      let (>>=) m f = M.bind m f [@@inline]
+      let (>>|) m f = M.map  m f [@@inline]
     end
 
     let make run = State run [@@inline]
@@ -1006,7 +1006,7 @@ module State = struct
     type 'a result = 'a M.t
     module Basic = struct
       include Tp(T)(M)
-      let return x = (make [@inlined]) @@ fun s -> (M.return [@inlined]) {x;s} [@@inline]
+      let return x = (make [@inlined]) (fun s -> M.return {x;s}) [@@inline]
       let bind m f = make @@ fun s -> m=>s >>= fun {x;s} -> f x => s [@@inline]
       let map m ~f = make @@ fun s -> m=>s >>| fun {x;s} -> {x=f x;s} [@@inline]
       let map = `Custom map

--- a/lib_test/bap/run_tests.ml
+++ b/lib_test/bap/run_tests.ml
@@ -27,7 +27,7 @@ let load_plugins () =
                        Error.to_string_hum e))
 
 let run_unit_tests () =
-  match Bap_main.init () with
+  match Bap_main.init ~requires:["lifter"; "disassembler"; "semantics";] () with
   | Error err ->
     Format.eprintf "Failed to initialize BAP: %a@\n%!"
       Bap_main.Extension.Error.pp err;

--- a/plugins/bil/bil_lifter.ml
+++ b/plugins/bil/bil_lifter.ml
@@ -169,6 +169,9 @@ module BilParser = struct
     let set v x =
       let n = Var.name v in
       match Var.typ v with
+      | Unk ->
+         error "can't reify the variable %s: unknown type" (Var.name v);
+         S.error
       | Imm 1 -> S.set_bit n x
       | Imm m -> S.set_reg n m x
       | Mem (ks,vs) ->

--- a/plugins/bil/bil_lifter.ml
+++ b/plugins/bil/bil_lifter.ml
@@ -361,7 +361,7 @@ let provide_lifter ~with_fp () =
     | None -> KB.return unknown
     | Some x -> f x in
   let lifter obj =
-    Knowledge.collect Arch.slot obj >>? fun arch ->
+    Knowledge.collect Arch.slot obj >>= fun arch ->
     Theory.instance ~context:(context arch) () >>=
     Theory.require >>= fun (module Core) ->
     Knowledge.collect Memory.slot obj >>? fun mem ->
@@ -372,7 +372,7 @@ let provide_lifter ~with_fp () =
       Knowledge.return (Insn.of_basic insn)
     | Ok bil ->
       Bil_semantics.context >>= fun ctxt ->
-      Knowledge.provide Bil_semantics.arch ctxt (Some arch) >>= fun () ->
+      Knowledge.provide Bil_semantics.arch ctxt arch >>= fun () ->
       let module Lifter = Theory.Parser.Make(Core) in
       Optimizer.run BilParser.t bil >>= fun sema ->
       let bil = Insn.bil sema in

--- a/plugins/bil/bil_semantics.ml
+++ b/plugins/bil/bil_semantics.ml
@@ -473,14 +473,14 @@ module Basic : Theory.Basic = struct
 
   let arch lbl =
     KB.collect Arch.slot lbl >>= function
-    | Some _ as r -> !!r
-    | None -> context >>= KB.collect arch
+    | `unknown -> context >>= KB.collect arch
+    | r -> !!r
 
   let goto lbl =
     KB.collect Theory.Label.addr lbl >>= fun dst ->
     arch lbl >>= fun arch ->
-    match dst, arch with
-    | Some addr, Some arch ->
+    match dst with
+    | Some addr ->
       let size = Size.in_bits (Arch.addr_size arch) in
       let dst = Word.create addr size in
       ctrl Bil.[Jmp (Int dst)]

--- a/plugins/bil/bil_semantics.mli
+++ b/plugins/bil/bil_semantics.mli
@@ -3,7 +3,7 @@ open Bap_core_theory
 
 type context
 val context : context KB.obj KB.t
-val arch : (context, arch option) KB.slot
+val arch : (context, arch) KB.slot
 
 
 module Core : Theory.Core

--- a/plugins/elf_loader/elf_loader_main.ml
+++ b/plugins/elf_loader/elf_loader_main.ml
@@ -5,6 +5,7 @@ open Bap.Std
 open Bap_elf.Std
 open Bap_dwarf.Std
 open Backend
+[@@warning "-D"]
 
 open Elf
 
@@ -191,3 +192,4 @@ let () =
   | `Ok -> ()
   | `Duplicate ->
     eprintf "Elf_backend: name «%s» is already used\n" name
+[@@warning "-D"]

--- a/plugins/mc/mc_main.ml
+++ b/plugins/mc/mc_main.ml
@@ -201,7 +201,7 @@ let print_kinds formats insn =
 let new_insn arch mem insn =
   let open KB.Syntax in
   KB.Object.create Theory.Program.cls >>= fun code ->
-  KB.provide Arch.slot code (Some arch) >>= fun () ->
+  KB.provide Arch.slot code arch >>= fun () ->
   KB.provide Memory.slot code (Some mem) >>= fun () ->
   KB.provide Dis.Insn.slot code (Some insn) >>| fun () ->
   code

--- a/plugins/mips/mips.ml
+++ b/plugins/mips/mips.ml
@@ -93,7 +93,7 @@ let () =
   let provide_delay obj =
     let open KB.Syntax in
     KB.collect Arch.slot obj >>= function
-    | Some #Arch.mips ->
+    | #Arch.mips ->
       KB.collect Theory.Program.Semantics.slot obj >>| fun insn ->
       let name = KB.Value.get Insn.Slot.name insn in
       Hashtbl.find_and_call Std.delayed_opcodes name

--- a/plugins/primus_propagate_taint/primus_propagate_taint_main.ml
+++ b/plugins/primus_propagate_taint/primus_propagate_taint_main.ml
@@ -31,8 +31,8 @@ let mapper = Primus.Machine.State.declare
        })
 
 let is_mem v = match Var.typ v with
-  | Type.Imm _ -> false
   | Type.Mem _ -> true
+  | _ -> false
 
 
 module Intro(Machine : Primus.Machine.S) = struct

--- a/plugins/primus_x86/primus_x86_loader.ml
+++ b/plugins/primus_x86/primus_x86_loader.ml
@@ -69,7 +69,7 @@ module Component(Machine : Primus.Machine.S) = struct
 
   let correct_sp sp addend =
     match Var.typ sp with
-    | Mem _ -> Machine.return ()
+    | Unk | Mem _ -> Machine.return ()
     | Imm width ->
       Value.of_int ~width addend >>= fun addend ->
       Primus.Linker.Trace.lisp_call_return >>> correct_sp sp addend

--- a/plugins/x86/x86_utils.ml
+++ b/plugins/x86/x86_utils.ml
@@ -154,7 +154,7 @@ let unimplemented a s  = disfailwith a ("disasm x86: unimplemented feature: "^s)
 (* eflags *)
 let df_to_offset mode e =
   match type_of_mode mode with
-  | Type.Mem _ -> failwith "type_of_mode shouldn't be returning this"
+  | Type.Mem _ | Type.Unk -> failwith "type_of_mode shouldn't be returning this"
   | Type.Imm t ->
     let open Exp in
     Bil.(ite (e = exp_false) (int_exp 1 t) (int_exp (-1) t))


### PR DESCRIPTION
This PR introduces an `unknown` architecture to enable analysis of
programs that are not binary, such as JVM or CLR bytecodes. This
change is also in line with the LLVM which also has the unknown
architecture. Additionally, the unkwown architecture could be later
refined, since it is the minimal element of the architecture
domain. That let us develop analyses that will detect architectures,
thus making the architecture a target of analysis rather than a
constant input.

In general, in BAP 2.0 we're moving away from the Arch.t type for
encoding a wide range of arhictectual properties of computing units
which we model. Mostly because those properties are mostly structural
and could be hardly captured with jsut a nominal string (even if this
string is triple).

This PR also sweeps through code and removes some warnings as well as
documents the new functions in bap.mli.