### PR TITLE
BAP 2.0.0 release (candidate)

### DIFF
--- a/lib/bap_byteweight/bap_byteweight.mli
+++ b/lib/bap_byteweight/bap_byteweight.mli
@@ -1,6 +1,6 @@
 (** Byteweight library.
 
-    Byteweight is a function start identification mechanism [[1]]. This
+    Byteweight is a function start identification algorithm [[1]]. This
     library provides a functorized implementation.
 
     An auxiliary {!Bap_byteweight_signatures} library provides an
@@ -13,7 +13,6 @@
          23rd USENIX Security Symposium (USENIX Security 14). 2014.
     v}
 *)
-
 open Bap.Std
 
 

--- a/lib/bap_core_theory/bap_core_theory.ml
+++ b/lib/bap_core_theory/bap_core_theory.ml
@@ -53,6 +53,7 @@ module Theory = struct
   module type Trans = Bap_core_theory_definition.Trans
   module type Core = Bap_core_theory_definition.Core
 
+  type core = (module Core)
   module Basic = struct
     module Empty : Basic = Bap_core_theory_empty.Core
     module Make = Bap_core_theory_basic.Make

--- a/lib/bap_core_theory/bap_core_theory_manager.mli
+++ b/lib/bap_core_theory/bap_core_theory_manager.mli
@@ -7,7 +7,9 @@ val declare :
   ?context:string list ->
   ?provides:string list ->
   ?package:string ->
-  name:string -> (module Core) -> unit
+  name:string ->
+  (module Core) knowledge ->
+  unit
 
 val instance :
   ?context:string list ->

--- a/lib/bap_primus_machine/bap_primus_machine.mli
+++ b/lib/bap_primus_machine/bap_primus_machine.mli
@@ -1,82 +1,85 @@
-open Core_kernel
-open Monads.Std
-open Bap_knowledge
+(* Not yet released.
 
-(** Primus - A non-deterministic interpreter.
+   open Core_kernel
+   open Monads.Std
+   open Bap_knowledge
 
 
-*)
+   (** Primus - A non-deterministic interpreter.
 
-module Primus : sig
-  open Knowledge
-  type 'a machine
 
-  (** The Machine Exception.
+ *)
+
+   module Primus : sig
+   open Knowledge
+   type 'a machine
+
+   (** The Machine Exception.
 
       The exn type is an extensible variant, and components
       usually register their own error constructors. *)
-  type exn = ..
+   type exn = ..
 
-  (** [an observation] of a value of type [a].*)
-  type 'a observation
+   (** [an observation] of a value of type [a].*)
+   type 'a observation
 
 
-  type observed
+   type observed
 
-  (** Machine exit status.
+   (** Machine exit status.
         A machine may terminate normally, or abnormally with the
         specified exception. *)
-  type exit_status =
+   type exit_status =
     | Normal
     | Exn of exn
 
 
 
-  (** the machine computation  *)
-  type 'a t = 'a machine
+   (** the machine computation  *)
+   type 'a t = 'a machine
 
-  type 'a state
+   type 'a state
 
-  type project
+   type project
 
 
-  (** Machine identifier type.   *)
-  type id = Monad.State.Multi.id
+   (** Machine identifier type.   *)
+   type id = Monad.State.Multi.id
 
-  (** [raise exn] raises the machine exception [exn], intiating
+   (** [raise exn] raises the machine exception [exn], intiating
         an abonormal control flow *)
-  val raise : exn -> 'a t
+   val raise : exn -> 'a t
 
 
-  (** [catch x f] creates a computation that is equal to [x] if
+   (** [catch x f] creates a computation that is equal to [x] if
         it terminates normally, and to [f e] if [x] terminates
         abnormally with the exception [e]. *)
-  val catch : 'a t -> (exn -> 'a t) -> 'a t
+   val catch : 'a t -> (exn -> 'a t) -> 'a t
 
-  val collect : ('a,'p) slot -> 'a obj -> 'p t
-  val provide : ('a,'p) slot -> 'a obj -> 'p -> unit t
-  val project : project obj t
+   val collect : ('a,'p) slot -> 'a obj -> 'p t
+   val provide : ('a,'p) slot -> 'a obj -> 'p -> unit t
+   val project : project obj t
 
-  val die : id -> unit t
+   val die : id -> unit t
 
-  val conflict : conflict -> 'a t
+   val conflict : conflict -> 'a t
 
 
-  (** [fact x] make the fact [x] determined in the current machine.
+   (** [fact x] make the fact [x] determined in the current machine.
 
       This is the [pure] function w.r.t. to the non-determinism, also
       known as lift, since it lifts the inner knowledge monad into the
       outer machine monad.
   *)
-  val fact : 'a knowledge -> 'a t
+   val fact : 'a knowledge -> 'a t
 
 
-  (** [run comp project] runs the Primus system. *)
-  val run : unit t -> project obj -> unit knowledge
+   (** [run comp project] runs the Primus system. *)
+   val run : unit t -> project obj -> unit knowledge
 
 
-  (** Computation State *)
-  module State : sig
+   (** Computation State *)
+   module State : sig
     (** ['a t] is a type of state that holds a value of type
             ['a], and can be constructed from the base context of type
             ['c]. *)
@@ -102,15 +105,15 @@ module Primus : sig
 
     (** [name state] a state name that was given during the construction.  *)
     val name : 'a t -> string
-  end
+   end
 
 
 
-  (** An interface to the state.
+   (** An interface to the state.
 
       An interface gives an access to operations that query and
       modify machine state. *)
-  module type State = sig
+   module type State = sig
     (** [get state] extracts the state.  *)
     val get : 'a state -> 'a machine
 
@@ -119,9 +122,9 @@ module Primus : sig
 
     (** [update state ~f] updates a state using function [f]. *)
     val update : 'a state -> f:('a -> 'a) -> unit machine
-  end
+   end
 
-  (** Observations interface.
+   (** Observations interface.
 
       An observation is a named event, that can occur during the
       program execution. Observations could be provided (usually
@@ -153,78 +156,79 @@ module Primus : sig
       which is being notified. Here is an example, using our [sum]
       observation:
 
-      {[
-        Observation.make sum ~f:(fun observe ->
-            observe 1 2 3)
-      ]}
+   {[
+     Observation.make sum ~f:(fun observe ->
+         observe 1 2 3)
+]}
 
 
-      {3 Monitoring Observations}
+   {3 Monitoring Observations}
 
-      It is possible to register a function, which will be called
-      every time an observation is made via the [provide] function.
-      The monitor has a little bit more complicated type, as beyond
-      the actual payload (arguments of the observation), it takes a
-      [ctrl] instance, which should be used to return from the
-      observation, via [Observation.continue] or [Observation.stop]
-      functions.
+   It is possible to register a function, which will be called
+   every time an observation is made via the [provide] function.
+   The monitor has a little bit more complicated type, as beyond
+   the actual payload (arguments of the observation), it takes a
+   [ctrl] instance, which should be used to return from the
+   observation, via [Observation.continue] or [Observation.stop]
+   functions.
 
-  *)
-  module Observation : sig
-    type 'f t = 'f observation
-    type info = Info.t
-    type ctrl
+ *)
+   module Observation : sig
+   type 'f t = 'f observation
+   type info = Info.t
+   type ctrl
 
-    val declare :
-      ?inspect:((info -> observed machine) -> 'f) ->
-      ?package:string -> string ->
-      'f observation
+   val declare :
+   ?inspect:((info -> observed machine) -> 'f) ->
+   ?package:string -> string ->
+   'f observation
 
-    (** [provide obs f] provides the observation of [obs].
+   (** [provide obs f] provides the observation of [obs].
 
-        The function [f] takes one argument a function,
-        which accepts
-
-
-    *)
-    val provide : 'f observation -> f:('f -> observed machine) -> unit machine
-    val monitor : 'f observation -> f:(ctrl -> 'f) -> unit machine
-    val inspect : 'f observation -> f:(info -> observed machine) -> unit machine
-
-    val continue : ctrl -> observed machine
-    val stop : ctrl -> observed machine
-  end
-
-  (** [exn_raised exn] occurs every time an abnormal control flow
-        is initiated *)
-  val exn_raised : (exn -> observed machine) observation
+   The function [f] takes one argument a function,
+   which accepts
 
 
-  (** Computation Syntax.*)
-  module Syntax : sig
-    include Monad.Syntax.S with type 'a t := 'a t
+ *)
+   val provide : 'f observation -> f:('f -> observed machine) -> unit machine
+   val monitor : 'f observation -> f:(ctrl -> 'f) -> unit machine
+   val inspect : 'f observation -> f:(info -> observed machine) -> unit machine
 
-    (** [x-->p] is [collect p x] *)
-    val (-->) : 'a obj -> ('a,'p) slot -> 'p t
+   val continue : ctrl -> observed machine
+   val stop : ctrl -> observed machine
+   end
 
-    (** [c // s] is [Object.read c s]  *)
-    val (//) : ('a,_) cls -> string -> 'a obj t
-
-    (** [event >>> action] is the same as
-        [Observation.monitor event action] *)
-    val (>>>) : 'f observation -> (Observation.ctrl -> 'f) -> unit t
-  end
+   (** [exn_raised exn] occurs every time an abnormal control flow
+   is initiated *)
+   val exn_raised : (exn -> observed machine) observation
 
 
+   (** Computation Syntax.*)
+   module Syntax : sig
+   include Monad.Syntax.S with type 'a t := 'a t
 
-  include Monad.State.Multi.S with type 'a t := 'a t
-                               and type id := id
-                               and module Syntax := Syntax
+   (** [x-->p] is [collect p x] *)
+   val (-->) : 'a obj -> ('a,'p) slot -> 'p t
 
-  (** Local state of the machine.  *)
-  module Local  : State
+   (** [c // s] is [Object.read c s]  *)
+   val (//) : ('a,_) cls -> string -> 'a obj t
+
+   (** [event >>> action] is the same as
+   [Observation.monitor event action] *)
+   val (>>>) : 'f observation -> (Observation.ctrl -> 'f) -> unit t
+   end
 
 
-  (** Global state shared across all machine clones.  *)
-  module Global : State
-end
+
+   include Monad.State.Multi.S with type 'a t := 'a t
+                         and type id := id
+                         and module Syntax := Syntax
+
+   (** Local state of the machine.  *)
+   module Local  : State
+
+
+   (** Global state shared across all machine clones.  *)
+   module Global : State
+   end
+*)

--- a/oasis/common
+++ b/oasis/common
@@ -1,6 +1,6 @@
 OASISFormat: 0.4
 Name:        bap
-Version:     2.0.0-alpha
+Version:     2.0.0
 OCamlVersion: >= 4.04.1
 Synopsis:    BAP Core Library
 Authors:     BAP Team

--- a/plugins/bil/bil_ir.ml
+++ b/plugins/bil/bil_ir.ml
@@ -309,7 +309,7 @@ let reify = function
   | None -> []
   | Some g -> BIR.reify g
 
-let init () = Theory.declare (module IR)
+let init () = Theory.declare !!(module IR : Theory.Core)
     ~package:"bap.std" ~name:"bir"
     ~desc:"Builds the graphical representation of a program."
     ~provides:[

--- a/plugins/bil/bil_lifter.ml
+++ b/plugins/bil/bil_lifter.ml
@@ -390,7 +390,7 @@ let provide_lifter ~with_fp () =
 let init ~with_fp () =
   provide_lifter ~with_fp ();
   provide_bir ();
-  Theory.declare (module Brancher)
+  Theory.declare !!(module Brancher : Theory.Core)
     ~package:"bap.std" ~name:"jump-dests"
     ~desc:"an approximation of jump destinations"
     ~provides:[

--- a/plugins/bil/bil_main.ml
+++ b/plugins/bil/bil_main.ml
@@ -116,11 +116,13 @@ let () =
     Bil.select_passes (ctxt-->norml @ ctxt-->optim @ ctxt-->passes);
     Bil_lifter.init ~with_fp:(ctxt-->enable_fp_emu) ();
     Bil_ir.init();
-    Theory.declare (module Bil_semantics.Core)
+    let open KB.Syntax in
+    Theory.declare !!(module Bil_semantics.Core : Theory.Core)
       ~package:"bap.std" ~name:"bil"
       ~desc:"semantics in BIL"
       ~provides:["bil"; "lifter"];
-    Theory.declare (module Bil_semantics.Core_with_fp_emulation)
+
+    Theory.declare !!(module Bil_semantics.Core_with_fp_emulation : Theory.Core)
       ~package:"bap.std" ~name:"bil-fp-emu"
       ~extends:["bap.std:bil"]
       ~desc: "semantics in BIL, including FP emulation"


### PR DESCRIPTION
Polishes documentation as well as fixes the theory declaration
function. And finally bumps the version to 2.0.0.

Whle revising the documentation I've noticed that the interface of
theory declaration is not allowing references to other theories as it
isn't wrapped in the knowledge monad as it should be. I fixed it, but
immediately fell into the trap of a recursive instantiation. Indeed, a
theory may require itself as a base, which will lead to an infinite
recursion and runtime failure. Since it is so easy to fall into this
trap, the implementation has to be robust enough and either forbid
this, with an appropriate error message, or allow it, with an
appropriate semantics. We chose the latter, since our theories are
domains we have a sane semantics for recursive theories (well, this
is what denotational semantics was invented on the first hand). We
employed the same technique for recursive module instantiation as
OCaml does, i.e., first initialize the theory with an empty structure,
then overwrite it with the result.