### PR TITLE
makes Knowledge.run more efficeint, bumps version

### DIFF
--- a/lib/knowledge/bap_knowledge.ml
+++ b/lib/knowledge/bap_knowledge.ml
@@ -2654,10 +2654,11 @@ module Knowledge = struct
   let compute_value
     : type a p . (a,p) cls -> p obj -> unit knowledge
     = fun cls obj ->
-      Slot.enum cls |> List.iter ~f:(fun (Slot.Pack s) ->
-          collect s obj >>= fun v ->
-          provide s obj v)
-
+      Slot.enum cls |>
+      Base.List.filter ~f:(function Slot.Pack {promises} ->
+          not (Hashtbl.is_empty promises)) |>
+      List.iter ~f:(fun (Slot.Pack s) ->
+          ignore_m @@ collect s obj)
 
   let get_value cls obj =
     compute_value cls obj >>= fun () ->

--- a/oasis/common
+++ b/oasis/common
@@ -1,6 +1,6 @@
 OASISFormat: 0.4
 Name:        bap
-Version:     2.0.0
+Version:     2.1.0-alpha
 OCamlVersion: >= 4.04.1
 Synopsis:    BAP Core Library
 Authors:     BAP Team
@@ -11,7 +11,7 @@ Plugins:     META (0.4)
 AlphaFeatures: ocamlbuild_more_args, compiled_setup_ml
 BuildTools: ocamlbuild
 XOCamlbuildExtraArgs:
-     -j 2
+     -j 4
      -use-ocamlfind
      -classic-display
      -plugin-tags "'package(findlib)'"


### PR DESCRIPTION
The Knowlege.run was computing every possible slot of a value, to ensure that all stored computations are triggered. However, for classes that have a lot of slots it was unnecessary slow, especially when none of those slots are having any stored computations.

A simple fix, is to ignore slots without stored procedures turns out int x4 improvement of the run function for the program class. It doesn't affect the disassemble command, which wasn't using the run command, but affects `mc` and `objdump` which were using it.