### PR TITLE
compels plugins to respect the Bap_main rules

### DIFF
--- a/plugins/legacy_llvm/legacy_loader_main.ml
+++ b/plugins/legacy_llvm/legacy_loader_main.ml
@@ -3,6 +3,7 @@ open Bap.Std
 include Self()
 
 let () =
+  Config.when_ready @@ fun _ ->
   match Bap_llvm_loader.init () with
   | Ok () -> ()
   | Error er -> eprintf "%s\n" (Error.to_string_hum er)

--- a/plugins/map_terms/map_terms_main.ml
+++ b/plugins/map_terms/map_terms_main.ml
@@ -114,9 +114,11 @@ let unmarker attr = object
     Term.with_attrs t attrs
 end
 
-let () = Mappers.Unary.register "unset-attr" unmarker
-
-let () = Map_terms_features.init ()
+let () =
+  Bap_main.Extension.declare @@ fun _ctxt ->
+  Mappers.Unary.register "unset-attr" unmarker;
+  Map_terms_features.init ();
+  Ok ()
 
 let main patts file proj =
   let patts = match file with

--- a/plugins/mips/mips.ml
+++ b/plugins/mips/mips.ml
@@ -2,6 +2,7 @@ open Core_kernel
 open Bap.Std
 open Bap_core_theory
 
+
 (* This CPU model and instruction set is based on the
  * "MIPS Architecture For Programmers
  * Volume II-A: The MIPS64 Instruction Set Reference Manual"
@@ -101,4 +102,5 @@ let () =
             KB.Value.put Insn.Slot.delay insn (Some delay))
         ~if_not_found:(fun _ -> insn)
     | _ -> KB.return Insn.empty in
-  KB.promise Theory.Program.Semantics.slot provide_delay
+  Bap_main.Extension.declare @@ fun _ctxt ->
+  Ok (KB.promise Theory.Program.Semantics.slot provide_delay)

--- a/plugins/mips/mips_arithmetic.ml
+++ b/plugins/mips/mips_arithmetic.ml
@@ -221,6 +221,7 @@ let daddu cpu ops =
   ]
 
 let () =
+  Bap_main.Extension.declare @@ fun _ctxt ->
   "ADD" >> add;
   "ADDi" >> addi;
   "ADDiu" >> addiu;
@@ -240,3 +241,4 @@ let () =
   "DSUBu" >> dsubu;
   "DADDu" >> daddu;
   "DADDiu" >> daddiu;
+  Ok ()

--- a/plugins/mips/mips_branch.ml
+++ b/plugins/mips/mips_branch.ml
@@ -379,6 +379,7 @@ let nal cpu _ =
   ]
 
 let () =
+  Bap_main.Extension.declare @@ fun _ctxt ->
   let (>>) = register ~delay:1 in
   "BAL" >> bal;
   "BEQ" >> beq;
@@ -415,4 +416,5 @@ let () =
   "JIC" >> jic;
   "JR" >> jr;
   "NAL" >> nal;
-  "JALR64" >> jalr
+  "JALR64" >> jalr;
+  Ok ()

--- a/plugins/mips/mips_conditional.ml
+++ b/plugins/mips/mips_conditional.ml
@@ -91,9 +91,11 @@ let selnez cpu ops =
   ]
 
 let () =
+  Bap_main.Extension.declare @@ fun _ctxt ->
   "SLT"  >> slt;
   "SLTi" >> slti;
   "SLTu"  >> sltu;
   "SLTiu" >> sltiu;
   "SELEQZ" >> seleqz;
   "SELNEQ" >> selnez;
+  Ok ();

--- a/plugins/mips/mips_divide.ml
+++ b/plugins/mips/mips_divide.ml
@@ -115,6 +115,7 @@ let dmodulou cpu ops =
   ]
 
 let () =
+  Bap_main.Extension.declare @@ fun _ctxt ->
   "SDIV" >> div;
   "MOD"  >> modulo;
   "UDIV" >> divu;
@@ -123,3 +124,4 @@ let () =
   "DMOD" >> dmodulo;
   "DDIVu" >> ddivu;
   "DMODu" >> dmodulou;
+  Ok ()

--- a/plugins/mips/mips_load.ml
+++ b/plugins/mips/mips_load.ml
@@ -238,6 +238,7 @@ let lwupc cpu ops =
   ]
 
 let () =
+  Bap_main.Extension.declare @@ fun _ctxt ->
   "LB" >> lb;
   "LBE" >> lbe;
   "LBu" >> lbu;
@@ -259,5 +260,4 @@ let () =
   "LWPC" >> lwpc;
   "LWu" >> lwu;
   "LWupc" >> lwupc;
-
-
+  Ok ()

--- a/plugins/mips/mips_logic.ml
+++ b/plugins/mips/mips_logic.ml
@@ -174,6 +174,7 @@ let dbitswap cpu ops =
   ]
 
 let () =
+  Bap_main.Extension.declare @@ fun _ctxt ->
   "AND" >> mand;
   "ANDi" >> mandi;
   "NOP" >> nop;
@@ -187,3 +188,4 @@ let () =
   "DBITSWAP" >> dbitswap;
   "WSBH" >> wsbh;
   "DSBH" >> dsbh;
+  Ok ()

--- a/plugins/mips/mips_main.ml
+++ b/plugins/mips/mips_main.ml
@@ -42,5 +42,5 @@ let () =
       register_target `mips (module MIPS32);
       register_target `mipsel (module MIPS32_le);
       register_target `mips64 (module MIPS64);
-      register_target `mips64el (module MIPS64_le));
-  Mips_abi.setup ()
+      register_target `mips64el (module MIPS64_le);
+      Mips_abi.setup ());

--- a/plugins/mips/mips_multiply.ml
+++ b/plugins/mips/mips_multiply.ml
@@ -123,6 +123,7 @@ let multu cpu ops =
   ]
 
 let () =
+  Bap_main.Extension.declare @@ fun _ctxt ->
   "MUL" >> mul;
   "MUH" >> muh;
   "MULu" >> mulu;
@@ -133,3 +134,4 @@ let () =
   "DMUHu" >> dmuhu;
   "MULT" >> mult;
   "MULTu" >> multu;
+  Ok ()

--- a/plugins/mips/mips_shift_and_rot.ml
+++ b/plugins/mips/mips_shift_and_rot.ml
@@ -204,6 +204,7 @@ let dsrlv cpu ops =
   ]
 
 let () =
+  Bap_main.Extension.declare @@ fun _ctxt ->
   "ROTR" >> rotr;
   "ROTRV" >> rotrv;
   "SLL" >> sll;
@@ -221,3 +222,4 @@ let () =
   "DSRL" >> dsrl;
   "DSRL32" >> dsrl32;
   "DSRLV" >> dsrlv;
+  Ok ()

--- a/plugins/mips/mips_store.ml
+++ b/plugins/mips/mips_store.ml
@@ -152,6 +152,7 @@ let swe cpu ops =
 (* TODO: SWRE rt, offset(base) *)
 
 let () =
+  Bap_main.Extension.declare @@ fun _ctxt ->
   "SB" >> sb;
   "SBE" >> sbe;
   "SC" >> sc;
@@ -165,3 +166,4 @@ let () =
   "SHE" >> she;
   "SW" >> sw;
   "SWE" >> swe;
+  Ok ()

--- a/plugins/print/print_main.ml
+++ b/plugins/print/print_main.ml
@@ -479,6 +479,7 @@ let main attrs ansi_colors demangle symbol_fmts subs secs patterns doms =
     ~desc:"print the file specification in the OGRE format" ~ver "ogre" pp_spec
 
 let () =
+  Config.when_ready @@ fun _ ->
   let open Adt in
   let desc = "Abstract Data Type pretty printing format" in
   let ver = Program.version and name = "adt" in

--- a/plugins/run/run_main.ml
+++ b/plugins/run/run_main.ml
@@ -174,7 +174,6 @@ module Visited(Machine : Primus.Machine.S) = struct
   let init () = Primus.Interpreter.enter_sub >>> visit
 end
 
-let () = Primus.Machine.add_component (module Visited)
 
 let is_visited = function
   | `tid tid ->
@@ -248,4 +247,6 @@ let deps = [
 ]
 
 let () =
-  Config.when_ready (fun conf -> Project.register_pass ~deps (main conf))
+  Config.when_ready (fun conf ->
+      Project.register_pass ~deps (main conf);
+      Primus.Machine.add_component (module Visited))

--- a/plugins/x86/x86_btx.ml
+++ b/plugins/x86/x86_btx.ml
@@ -150,5 +150,7 @@ module IA32 = Make (X86_tools.IA32) (X86_backend.IA32)
 module AMD64 = Make (X86_tools.AMD64) (X86_backend.AMD64)
 
 let () =
+  Bap_main.Extension.declare @@ fun _ctxt ->
   IA32.register all_of_btx_ia32;
-  AMD64.register all_of_btx
+  AMD64.register all_of_btx;
+  Ok ()

--- a/plugins/x86/x86_cdq.ml
+++ b/plugins/x86/x86_cdq.ml
@@ -42,5 +42,7 @@ module IA32 = Make (X86_tools.IA32) (X86_backend.IA32)
 module AMD64 = Make (X86_tools.AMD64) (X86_backend.AMD64)
 
 let () =
+  Bap_main.Extension.declare @@ fun _ctxt ->
   IA32.register all_of_cdq;
-  AMD64.register all_of_cdq
+  AMD64.register all_of_cdq;
+  Ok ()

--- a/plugins/x86/x86_cmpxchg.ml
+++ b/plugins/x86/x86_cmpxchg.ml
@@ -79,7 +79,9 @@ module IA32 = Make (X86_tools.IA32) (X86_backend.IA32)
 module AMD64 = Make (X86_tools.AMD64) (X86_backend.AMD64)
 
 let () =
+  Bap_main.Extension.declare @@ fun _ctxt ->
   IA32.register all_of_cmpxchg_rr_ia32;
   IA32.register all_of_cmpxchg_rm_ia32;
   AMD64.register all_of_cmpxchg_rr;
-  AMD64.register all_of_cmpxchg_rm
+  AMD64.register all_of_cmpxchg_rm;
+  Ok ()

--- a/plugins/x86/x86_endbr.ml
+++ b/plugins/x86/x86_endbr.ml
@@ -10,6 +10,8 @@ type endbr = [ `ENDBR32 | `ENDBR64 ] [@@deriving bin_io, sexp, compare, enumerat
 let lift _mem _insn = Ok [ Bil.special "end-of-branch" ]
 
 let () =
+  Bap_main.Extension.declare @@ fun _ctxt ->
   let name op = sexp_of_endbr op |> Sexp.to_string in
   List.iter all_of_endbr ~f:(fun op -> IA32.register (name op) lift);
-  List.iter all_of_endbr ~f:(fun op -> AMD64.register (name op) lift)
+  List.iter all_of_endbr ~f:(fun op -> AMD64.register (name op) lift);
+  Ok ()

--- a/plugins/x86/x86_mov.ml
+++ b/plugins/x86/x86_mov.ml
@@ -107,5 +107,7 @@ module IA32 = Make (X86_tools.IA32) (X86_backend.IA32)
 module AMD64 = Make (X86_tools.AMD64) (X86_backend.AMD64)
 
 let () =
+  Bap_main.Extension.declare @@ fun _ctxt ->
   IA32.register all_of_mov_ia32;
-  AMD64.register all_of_mov_amd64
+  AMD64.register all_of_mov_amd64;
+  Ok ()

--- a/plugins/x86/x86_mov_offset.ml
+++ b/plugins/x86/x86_mov_offset.ml
@@ -194,6 +194,8 @@ module T = Make(Ver_common)
 module Self = Self ()
 
 let () =
+  Bap_main.Extension.declare @@ fun _ctxt ->
   let llvm_version = String.sub llvm_version 0 3 in
   if llvm_version = "3.4" then T_34.register ()
-  else T.register ()
+  else T.register ();
+  Ok ()


### PR DESCRIPTION
A few plugins weren't respecting the requirement for no side effects
on the load time and were registering their functions even when
explicitly disabled, e.g., --no-mips, --no-x86 didn't really work.