### PR TITLE
fixes taint garbage collector

### DIFF
--- a/lib/bap_taint/bap_taint.ml
+++ b/lib/bap_taint/bap_taint.ml
@@ -398,7 +398,7 @@ module Gc = struct
         ~f:(finish ~live:false) >>= fun () ->
       Machine.Local.put gc {old = cur}
 
-    let finalize _ =
+    let finalize () =
       Machine.Local.get tainter >>= fun cur ->
       Set.to_sequence (objects cur) |>
       Machine.Seq.iter ~f:(finish ~live:true)

--- a/lib/bap_taint/bap_taint.ml
+++ b/lib/bap_taint/bap_taint.ml
@@ -398,14 +398,14 @@ module Gc = struct
         ~f:(finish ~live:false) >>= fun () ->
       Machine.Local.put gc {old = cur}
 
-    let finalize () =
+    let finalize _ =
       Machine.Local.get tainter >>= fun cur ->
       Set.to_sequence (objects cur) |>
       Machine.Seq.iter ~f:(finish ~live:true)
 
     let init () = Machine.sequence Primus.Interpreter.[
         leave_blk >>> main;
-        Primus.Machine.finished >>> finalize;
+        Primus.Interpreter.halting >>> finalize;
       ]
 
 


### PR DESCRIPTION
The `finished` observation may not reach a receiver, because of unspecified order in which primus components are executed. E.g. greedy scheduler can intercept `finished` observation and kill a machine. As a result, no taint is ever finalized, which hits any analysis that depends on it. And this PR introduces taint finalization on the `halt` observation, which happens before `finished`.