### PR TITLE
adds bulk memory copying operation to Primus

### DIFF
--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -797,6 +797,17 @@ module Std : sig
           the address [addr] *)
       val stored : (value * value) observation
 
+      (** [filling (addr,len,value) happens before the memory [addr, addr + len)
+          is filled with [value]
+
+          @since 2.1.0 *)
+      val filling : (value * int * int) observation
+
+      (** [filled (addr,len,value) happens after the memory [addr, addr + len)
+          is filled with [value]
+
+          @since 2.1.0*)
+      val filled : (value * int * int) observation
 
       (** [reading x] happens before the variable [x] is read from the
           environment. *)
@@ -1071,6 +1082,18 @@ module Std : sig
             invoked and the operation is repeated. Otherwise the
             [Segmentation_fault] machine exception is raised.  *)
         val store : value -> value -> endian -> size -> unit m
+
+        (** [fill a len x] fills [len] bytes of the memory starting at
+            addres [a] with value [x]
+
+            If [a] is not mapped or not writable then the pagefault
+            trap is invoked. If the handler is provided, then it is
+            invoked and the operation is repeated. Otherwise the
+            [Segmentation_fault] machine exception is raised.
+
+            @since 2.1.0 *)
+        val fill : value -> len:int -> int -> unit m
+
       end
     end
 

--- a/lib/bap_primus/bap_primus_interpreter.mli
+++ b/lib/bap_primus/bap_primus_interpreter.mli
@@ -14,6 +14,9 @@ val loading : value observation
 val loaded : (value * value) observation
 val storing : value observation
 val stored : (value * value) observation
+val filling : (value * int * int) observation
+val filled : (value * int * int) observation
+
 val reading : var observation
 val read : (var * value) observation
 val writing : var observation
@@ -87,6 +90,7 @@ module Make (Machine : Machine) : sig
   val const : word -> value m
   val load : value -> endian -> size -> value m
   val store : value -> value -> endian -> size -> unit m
+  val fill : value -> len:int -> int -> unit m
 end
 
 

--- a/lib/bap_primus/bap_primus_memory.mli
+++ b/lib/bap_primus/bap_primus_memory.mli
@@ -47,4 +47,7 @@ module Make(Machine : Machine) : sig
   val is_mapped : addr -> bool Machine.t
 
   val is_writable : addr -> bool Machine.t
+
+  val fill : addr -> len:int -> int -> unit Machine.t
+
 end

--- a/plugins/primus_lisp/lisp/string.lisp
+++ b/plugins/primus_lisp/lisp/string.lisp
@@ -99,12 +99,9 @@
 
 (defun memset (p c n)
   (declare (external "memset"))
-  (let ((p p))
-    (while n
-      (memory-write p c)
-      (incr p)
-      (decr n)))
-  p)
+  (memory-fill p n c)
+  (+ p n))
+
 
 (defun memcmp (p1 p2 n)
   (declare (external "memcmp"))


### PR DESCRIPTION
The current `memset` works quite straightforward and for every byte in the
requested memory it:
1) casts a value to the size of a byte
2) makes an observation before storing
3) stores the byte
4) makes an observation after storing.

The problem is that in the primus-promiscuous mode we often can't aford this number of primitive operations for every single byte as the length could be a random value, and a primus machine reaches its limits very soon that makes any block after such `memset` unreachable.

As a solution, we add a new function (namely `fill`) into the primus interpreter, that will interact with the underlying memory without intermediate interpreter's calls, meaning that the number of expressions
we spend on `memset` is equal to zero.

A couple of observations is added as well, like usually: `filling` and `filled`