### PR TITLE
fixes arguments attributes in the `callsites` plugin

### DIFF
--- a/lib/bap_c/bap_c_attr.ml
+++ b/lib/bap_c/bap_c_attr.ml
@@ -69,5 +69,5 @@ module Gnu = struct
     register_attr "malloc" (set Sub.malloc);
     register_attr "noreturn" (set Sub.noreturn);
     register_attr "returns_twice" (set Sub.returns_twice);
-    register_attr "noreturn" (set Sub.nothrow)
+    register_attr "nothrow" (set Sub.nothrow)
 end

--- a/plugins/callsites/callsites_main.ml
+++ b/plugins/callsites/callsites_main.ml
@@ -30,11 +30,12 @@ let transfer_attr attr t1 t2 =
   | None -> t2
   | Some v -> Term.set_attr t2 attr v
 
-let transfer_attrs t1 t2 =
-  let t2 = Term.set_attr t2 Term.synthetic () in
-  Term.set_attr t2 Term.origin (Term.tid t1) |>
-  transfer_attr Disasm.insn t1 |>
-  transfer_attr address t1
+let transfer_attrs origin_arg call arg =
+  let arg = Term.with_attrs arg (Term.attrs origin_arg) in
+  let arg = Term.set_attr arg Term.synthetic () in
+  Term.set_attr arg Term.origin (Term.tid call) |>
+  transfer_attr Disasm.insn call |>
+  transfer_attr address call
 
 let add_def intent blk def =
   if intent = Out
@@ -44,7 +45,7 @@ let add_def intent blk def =
 let defs_of_args call intent args =
   List.filter_map args ~f:(fun arg ->
       require (intent_matches arg intent) >>= fun () ->
-      def_of_arg arg >>| transfer_attrs call)
+      def_of_arg arg >>| transfer_attrs arg call)
 
 let target intent sub blk call =
   if intent = Out


### PR DESCRIPTION
When attributes are assigned to a newly created synthetic argument term
in the `callsites` plugin, we don't take into consideration attributes
from the original argument term. This PR fixes this and now all the
attributes from origin argument term are assigned to the new one.