### PR TITLE
enables the Jane Street code style

### DIFF
--- a/lib/bap_future/bap_future.ml
+++ b/lib/bap_future/bap_future.ml
@@ -209,14 +209,14 @@ module Std = struct
       t.last_id
 
     let subscribe t f =
-      let f id x = f x in
+      let f _id x = f x in
       add t f
 
-    let watch s f = ignore (add s f)
+    let watch s f = ignore (add s f : id)
 
     let observe s f =
-      let f id x = f x in
-      ignore (add s f)
+      let f _id x = f x in
+      ignore (add s f : id)
 
     let unsubscribe t id =
       Hashtbl.remove t.subs id;
@@ -341,7 +341,8 @@ module Std = struct
       let q1 = Queue.create ~capacity () in
       let q2 = Queue.create ~capacity () in
       let drop () =
-        let drop q = ignore (Queue.dequeue_exn q) in
+        let drop : type a. a Queue.t -> unit = fun q ->
+          ignore (Queue.dequeue_exn q : a) in
         drop q1; drop q2 in
       let step src q x =
         Queue.enqueue q x;
@@ -395,7 +396,7 @@ module Std = struct
       link s s' step;
       s'
 
-    let listen x f = ignore (subscribe x f)
+    let listen x f = ignore (subscribe x f : id)
 
     let of_list xs = unfold_until ~init:xs ~f:(function
         | [] -> None
@@ -450,7 +451,7 @@ module Std = struct
       let buf = Queue.create () in
       let add_value x =
         if Queue.length buf >= n then
-          ignore (Queue.dequeue buf);
+          ignore (Queue.dequeue buf : 'a option);
         Queue.enqueue buf x in
       let id = subscribe xs add_value in
       let future, promise = Future.create () in

--- a/lib/bap_plugins/bap_plugins.ml
+++ b/lib/bap_plugins/bap_plugins.ml
@@ -327,7 +327,9 @@ module Plugins = struct
   let run ?argv ?env ?provides ?(don't_setup_handlers=false) ?library ?exclude () =
     if not don't_setup_handlers
     then setup_default_handler ();
-    load ?argv ?env ?provides ?library ?exclude () |> ignore
+    let _ : (Plugin.t, string * Error.t) result list =
+      load ?argv ?env ?provides ?library ?exclude ()  in
+    ()
 
   let events = Plugin.system_events
   type event = Plugin.system_event [@@deriving sexp_of]

--- a/lib/bap_types/bap_bitvector.ml
+++ b/lib/bap_types/bap_bitvector.ml
@@ -178,7 +178,7 @@ let pp_generic
     | `this x -> fprintf ppf "%s" x
     | `base -> pp_prefix ppf
     | `auto ->
-      if Z.Compare.(x >= (Z.min (word 10) base))
+      if Z.(geq x (min (word 10) base))
       then pp_prefix ppf in
   let fmt = format_of_string @@ match format, case with
     | `hex,`upper -> "%X"
@@ -186,7 +186,7 @@ let pp_generic
     | _ -> "%d" in
   let rec print x =
     let d = int Z.(x mod base) in
-    if Z.Compare.(x >= base)
+    if Z.geq x base
     then print Z.(x / base);
     fprintf ppf fmt d in
   print x;

--- a/lib/regular/regular_data_write.ml
+++ b/lib/regular/regular_data_write.ml
@@ -40,12 +40,12 @@ let blit_via_copy size copy ~dst x pos =
 
 let bytes_via_copy size copy x =
   let buf = Bytes.create (size x) in
-  let _ = copy buf x in
+  copy buf x;
   buf
 
 let bigstring_via_blit size blit x =
   let buf = Bigstring.create (size x) in
-  let _ = blit buf x in
+  blit buf x;
   buf
 
 let pp_bytes f x = Format.asprintf "%a" f x |> Bytes.of_string

--- a/oasis/common.tags.in
+++ b/oasis/common.tags.in
@@ -4,4 +4,3 @@ true: short_paths
 true: bin_annot
 true: debug
 true: warn(+a-4-6-7-9-27-29-32..42-44-45-48-50-60)
-true: ppxopt(ppx_jane,-dont-apply js_style)


### PR DESCRIPTION
Previously, we decided to disable the Jane Street code style checks as a fast solution, but it turned out that it is easier to adopt their style than to fight with it. To disable the checks, we used the _tags file,
but since we have a global repository the tags file affected all subprojects, even those that do not use the ppx-jane preprocessor, thus breaking packages that do not explicitly depend on ppx-jane.

Also, in #957 we accidentally introduced a dependency on a newer version of `zartith` by using the `Compare` module. We will now use plain compare et alas functions so that the old version of `zarith` could be still used with BAP.