### PR TITLE
fixes the visited attribute attaching in primus-mark-visited

### DIFF
--- a/plugins/primus_mark_visited/primus_mark_visited_main.ml
+++ b/plugins/primus_mark_visited/primus_mark_visited_main.ml
@@ -24,11 +24,15 @@ let state = Primus.Machine.State.declare
        })
 
 
+let mark_visited t = Term.set_attr t Term.visited ()
+
 let marker visited = object
   inherit Term.mapper as super
   method! map_blk t =
     if Set.mem visited (Term.tid t) then
-      Term.map def_t t ~f:(fun d -> Term.set_attr d Term.visited ())
+      mark_visited t |>
+      Term.map def_t ~f:mark_visited |>
+      Term.map jmp_t ~f:mark_visited
     else t
 end
 


### PR DESCRIPTION
Only defs of a visited block were marked as visited. The block itself
wasn't marked, neither anything was marked on blocks that didn't have
any definitions. In particular this was breaking Saluki, which totally
ignores unvisited blocks.