### PR TITLE
prevents cmdliner from fetching plugins path from environment

### DIFF
--- a/lib/bap_main/bap_main.ml
+++ b/lib/bap_main/bap_main.ml
@@ -467,9 +467,8 @@ module Pre = struct
 
   let plugin_locations =
     let doc = "Adds folder to the list of plugins search paths" in
-    let env = Term.env_info ~doc "BAP_PLUGIN_PATH" in
     Arg.(value & opt_all string [] &
-         info ~env ~doc ["L"; "plugin-path"; "load-path"])
+         info ~doc ["L"; "plugin-path"; "load-path"])
 
   let recipe =
     let doc = "Load the specified recipe" in


### PR DESCRIPTION
When this option is set, and the `-L` or `--plugin-path` option
is not used, then plugins path will be fetched from the enviroment
variable. However, the plugins library will also look at the same
variable and add the same set of paths to the search. Since this
variable should be local to the plugins library, and in fact is a
part of its interface we should just remove this from the bap-main
command line interface.

Fixes #1044