### PR TITLE
Revamps primus lisp type checker

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -56,6 +56,7 @@ B lib/bap_elf
 B lib/bap_future
 B lib/bap_image
 B lib/bap_plugins
+B lib/bap_primus
 B lib/bap_sema
 B lib/bap_types
 B lib/bap_core_theory

--- a/lib/bap_primus/.merlin
+++ b/lib/bap_primus/.merlin
@@ -1,4 +1,1 @@
 REC
-B ../../_build/lib/bap_primus
-B ../../_build/lib/bap_c
-B ../../_build/lib/bap_abi

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -2558,19 +2558,12 @@ ident ::= ?any atom that is not recognized as a <word>?
           val (@->) : [< parameters] -> t -> signature
         end
 
-
-        (** [infer ?externals arch globs program] infers typing environment.
-
-
-
-        *)
-        val infer : ?externals:(string * signature) list -> Arch.t ->
-          Var.t seq -> program -> env
+        val error : error observation
 
         val errors : env -> error list
 
         val check : Var.t seq -> program -> error list
-        [@@deprecated "[since 2020-02] use [infer] and [errors] instead"]
+        [@@deprecated "[since 2020-02] use [Make(Machine).types] [errors] instead"]
 
 
         (** [pp_error ppf err] prints a description of the type error
@@ -2640,6 +2633,8 @@ ident ::= ?any atom that is not recognized as a <word>?
 
         (** [program] is the current Machine program.  *)
         val program : program Machine.t
+
+        val types : Type.env Machine.t
 
         (** [define ?docs name code] defines a lisp primitive with
             the given [name] and an optional documentation string

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -2563,9 +2563,9 @@ ident ::= ?any atom that is not recognized as a <word>?
 
 
 
-         *)
+        *)
         val infer : ?externals:(string * signature) list -> Arch.t ->
-                    Var.t seq -> program -> env
+          Var.t seq -> program -> env
 
         val errors : env -> error list
 
@@ -2694,7 +2694,7 @@ ident ::= ?any atom that is not recognized as a <word>?
             @param doc optional documentation string
         *)
         val signal :
-          ?params:Type.parameters ->
+          ?params:[< Type.parameters] ->
           ?doc:string ->
           'a observation ->
           ('a -> value list Machine.t) -> unit Machine.t

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -2432,6 +2432,9 @@ ident ::= ?any atom that is not recognized as a <word>?
         type t
 
 
+        (** Typing environemnt is a mapping from expressions to types.  *)
+        type env
+
         (** Definition signature  *)
         type signature
 
@@ -2556,12 +2559,18 @@ ident ::= ?any atom that is not recognized as a <word>?
         end
 
 
-        (** [check env prog] type checks program in the environment
-            [env] and returns a list of errors. If the list is empty
-            the the program is well-typed.
+        (** [infer ?externals arch globs program] infers typing environment.
 
-            Note: this function is currently experimental *)
+
+
+         *)
+        val infer : ?externals:(string * signature) list -> Arch.t ->
+                    Var.t seq -> program -> env
+
+        val errors : env -> error list
+
         val check : Var.t seq -> program -> error list
+        [@@deprecated "[since 2020-02] use [infer] and [errors] instead"]
 
 
         (** [pp_error ppf err] prints a description of the type error

--- a/lib/bap_primus/bap_primus_lisp.ml
+++ b/lib/bap_primus/bap_primus_lisp.ml
@@ -653,8 +653,17 @@ module Type = struct
         let cod = cod arch in
         let rest = Option.map rest ~f:(fun t -> t arch) in
         Lisp.Type.signature args ?rest cod
-
   end
+
+
+  let invoke_subroutine_signature =
+    "invoke-subroutine", Spec.(one int // all any @-> any)
+
+  let infer ?(externals=[]) arch globs prog =
+    let externals = invoke_subroutine_signature :: externals |>
+                    List.map ~f:(fun (n,s) -> n,s arch) in
+    infer ~externals globs prog
+
 end
 
 

--- a/lib/bap_primus/bap_primus_lisp.ml
+++ b/lib/bap_primus/bap_primus_lisp.ml
@@ -548,7 +548,7 @@ module Make(Machine : Machine) = struct
 
   let link_program program =
     Machine.Local.get state >>= fun s ->
-    let program = copy_primitives s.program program in
+    let program = Lisp.Program.merge s.program program in
     Machine.Local.put state {s with program} >>= fun () ->
     link_features ()
 
@@ -570,17 +570,17 @@ module Make(Machine : Machine) = struct
     Machine.gets Project.arch >>= fun arch ->
     let specialize = List.map ~f:(fun p -> p arch) in
     let name = Bap_primus_observation.name obs in
-    let unit = Type 1 in
-    let default_types = Lisp.Type.signature [] ~rest:Any unit in
+    Format.eprintf "adding signal %S@\n%!" name;
+    let default_types = Lisp.Type.signature [] ~rest:Any Any in
     let types = match params with
       | None ->
         default_types
       | Some (`All t) ->
-        Lisp.Type.signature [] ~rest:(t arch) unit
+        Lisp.Type.signature [] ~rest:(t arch) Any
       | Some (`Tuple ts) ->
-        Lisp.Type.signature (specialize ts) unit
+        Lisp.Type.signature (specialize ts) Any
       | Some (`Gen (ts,t)) ->
-        Lisp.Type.signature (specialize ts) ~rest:(t arch) unit in
+        Lisp.Type.signature (specialize ts) ~rest:(t arch) Any in
     let r = Lisp.Def.Signal.create ~types ~docs:doc name in
     Machine.Local.update state ~f:(fun s -> {
           s with program = Lisp.Program.add s.program signal r

--- a/lib/bap_primus/bap_primus_lisp.ml
+++ b/lib/bap_primus/bap_primus_lisp.ml
@@ -570,7 +570,6 @@ module Make(Machine : Machine) = struct
     Machine.gets Project.arch >>= fun arch ->
     let specialize = List.map ~f:(fun p -> p arch) in
     let name = Bap_primus_observation.name obs in
-    Format.eprintf "adding signal %S@\n%!" name;
     let default_types = Lisp.Type.signature [] ~rest:Any Any in
     let types = match params with
       | None ->

--- a/lib/bap_primus/bap_primus_lisp.mli
+++ b/lib/bap_primus/bap_primus_lisp.mli
@@ -68,8 +68,8 @@ module Type : sig
     val (@->) : [< parameters] -> t -> signature
   end
 
-  val infer : ?externals:(string * signature) list ->
-    Arch.t -> Var.t seq -> program -> env
+  val error : error observation
+
   val errors : env -> error list
   val check : Var.t seq -> program -> error list
   val pp_error : Format.formatter -> error -> unit
@@ -103,6 +103,10 @@ module Make (Machine : Machine) : sig
   val link_program : program -> unit Machine.t
 
   val program : program Machine.t
+
+  val typecheck : unit Machine.t
+
+  val types : Type.env Machine.t
 
   val define : ?types:Type.signature -> ?docs:string -> string -> closure -> unit Machine.t
 

--- a/lib/bap_primus/bap_primus_lisp.mli
+++ b/lib/bap_primus/bap_primus_lisp.mli
@@ -37,6 +37,7 @@ end
 
 module Type : sig
   type t
+  type env
   type signature
   type error
 
@@ -67,6 +68,9 @@ module Type : sig
     val (@->) : [< parameters] -> t -> signature
   end
 
+  val infer : ?externals:(string * signature) list ->
+    Arch.t -> Var.t seq -> program -> env
+  val errors : env -> error list
   val check : Var.t seq -> program -> error list
   val pp_error : Format.formatter -> error -> unit
 end

--- a/lib/bap_primus/bap_primus_lisp.mli
+++ b/lib/bap_primus/bap_primus_lisp.mli
@@ -107,7 +107,7 @@ module Make (Machine : Machine) : sig
   val define : ?types:Type.signature -> ?docs:string -> string -> closure -> unit Machine.t
 
   val signal :
-    ?params:Type.parameters ->
+    ?params:[< Type.parameters] ->
     ?doc:string ->
     'a observation ->
     ('a -> value list Machine.t) -> unit Machine.t

--- a/lib/bap_primus/bap_primus_lisp_def.ml
+++ b/lib/bap_primus/bap_primus_lisp_def.ml
@@ -46,6 +46,8 @@ type para = {
   default : ast;
 }
 
+type signal = Type.signature
+
 type 'a primitive = (value list -> 'a)
 
 
@@ -93,6 +95,22 @@ module Func = struct
 end
 
 module Meth = Func
+
+module Signal = struct
+  type nonrec t = signal t
+
+  let create ?(docs="") ~types name : t = {
+    data = {
+      meta = {name; docs; attrs=Attribute.Set.empty};
+      code = types;
+    };
+    id = Source.Id.null;
+    eq = Source.Eq.null;
+  }
+
+  let signature {data={code}} = code
+end
+
 
 module Para =  struct
   let create : 'a def =
@@ -195,6 +213,7 @@ module Primitive = struct
 end
 
 
+
 module type Primitives = functor (Machine : Machine) ->  sig
   val defs : unit -> value Machine.t Primitive.t list
 end
@@ -219,6 +238,7 @@ module Closure = struct
     id = Id.null;
     eq = Eq.null;
   }
+
   let body p = p.data.code.lambda
 
   let signature p = p.data.code.types

--- a/lib/bap_primus/bap_primus_lisp_def.mli
+++ b/lib/bap_primus/bap_primus_lisp_def.mli
@@ -20,6 +20,7 @@ type prim
 type closure = (module Closure)
 type 'a primitive
 type para
+type signal
 
 type attrs = Attribute.set
 
@@ -85,6 +86,11 @@ module Closure : sig
   val create : ?types:Type.signature -> ?docs:string -> string -> closure -> prim t
   val signature : prim t -> Type.signature option
   val body : prim t -> closure
+end
+
+module Signal : sig
+  val create : ?docs:string -> types:Type.signature -> string -> signal t
+  val signature : signal t -> Type.signature
 end
 
 module type Primitives = functor (Machine : Machine) ->  sig

--- a/lib/bap_primus/bap_primus_lisp_program.ml
+++ b/lib/bap_primus/bap_primus_lisp_program.ml
@@ -1144,8 +1144,8 @@ module Typing = struct
 
     let pp_from_file_with_underline ppf
         {Loc.file; range={start_pos; end_pos}} =
+      let current = ref 0 in
       In_channel.with_file file ~f:(fun chan ->
-          let current = ref 0 in
           In_channel.iter_lines chan ~f:(fun line ->
               incr current;
               if current.contents = end_pos.line + 1
@@ -1157,7 +1157,10 @@ module Typing = struct
                         !current <= end_pos.line in
               if distance < context
               then fprintf ppf "%c %s@\n"
-                  (if bad then '>' else '|') line))
+                  (if bad then '>' else '|') line));
+      (* in case if the error was on the last line in a file *)
+      if current.contents = end_pos.line
+      then pp_print_underline ppf (start_pos.col,end_pos.col)
 
     let extract_from_file {Loc.file; range={start_pos; end_pos}} =
       In_channel.with_file file ~f:(fun chan ->

--- a/lib/bap_primus/bap_primus_lisp_program.ml
+++ b/lib/bap_primus/bap_primus_lisp_program.ml
@@ -1111,10 +1111,7 @@ module Typing = struct
       let gamma = infer externals vars program in
       {program; gamma }
 
-    let errors _ = []
-
-    let check vars program : error list =
-      let {program=prog; gamma} = infer vars program in
+    let errors {program=prog; gamma} =
       Gamma.partition gamma |>
       List.fold ~init:[] ~f:(fun errs g ->
           match Gamma.Group.values g with
@@ -1122,6 +1119,7 @@ module Typing = struct
             {prog; vals; exps = Gamma.Group.elements g} :: errs
           | _ -> errs)
 
+    let check vars program : error list = errors (infer vars program)
 
     let pp_env _ _ = ()
 
@@ -1161,7 +1159,7 @@ module Typing = struct
       | Some (Unresolved_variable name) ->
         fprintf ppf "\
 Type error. The following expressions@ are ill-typed because they
-depend on an unresolved free variable `%s:@\n%a@\n"
+depend on an unresolved free variable `%s':@\n%a@\n"
           name pp_exps (prog,exps)
       | Some (Unresolved_function (name,[])) ->
         fprintf ppf "\

--- a/lib/bap_primus/bap_primus_lisp_program.ml
+++ b/lib/bap_primus/bap_primus_lisp_program.ml
@@ -44,6 +44,16 @@ let empty = {
   consts=[];
 }
 
+let merge p1 p2 =
+  let p1,p2 = if Source.is_empty p1.sources then
+      p1,p2 else
+      p2,p1 in {
+    p2 with
+    sigs = p1.sigs @ p2.sigs;
+    codes = p1.codes @ p2.codes;
+  }
+
+
 type 'a item = ([`Read | `Set_and_create ], t, 'a Def.t list) Fieldslib.Field.t_with_perm
 
 module Items = struct

--- a/lib/bap_primus/bap_primus_lisp_program.ml
+++ b/lib/bap_primus/bap_primus_lisp_program.ml
@@ -157,10 +157,10 @@ let pp_callgraph ppf g =
     g
 
 let pp_term pp_exp ppf = function
-  | {data={exp; typ=Any}; id} ->
-    fprintf ppf "@[<v2>[%a %a]@]" Id.pp id pp_exp exp
-  | {data={exp; typ}; id} ->
-    fprintf ppf "@[<v2>[%a<%a> %a]@]" Id.pp id Lisp.Type.pp typ pp_exp exp
+  | {data={exp; typ=Any}} ->
+    fprintf ppf "@[<v2>%a@]" pp_exp exp
+  | {data={exp; typ}} ->
+    fprintf ppf "@[<v2>%a:%a@]" pp_exp exp Lisp.Type.pp typ
 let pp_word = pp_term Int64.pp
 let pp_var = pp_term String.pp
 
@@ -170,8 +170,8 @@ let rec concat_prog p =
       | x -> [x])
 
 module Ast = struct
-  let rec pp ppf {data;id} =
-    fprintf ppf "@[<v2>[%a: %a]@]" pp_exp data Id.pp id
+  let rec pp ppf {data} =
+    fprintf ppf "@[<v2>%a@]" pp_exp data
   and pp_exp ppf = function
     | Int x ->
       pp_word ppf x
@@ -212,11 +212,9 @@ module Ast = struct
 end
 
 let pp_def ppf d =
-  fprintf ppf "@[<2>(defun %s:%a @[<2>(%a)@][%a]@ %a)@]@,"
+  fprintf ppf "@[<2>(defun %s @[<2>(%a)@]@ %a)@]@,"
     (Def.name d)
-    Id.pp d.id
     (pp_print_list ~pp_sep:pp_print_space pp_var) (Def.Func.args d)
-    Id.pp ((Def.Func.body d).id)
     Ast.pp_prog (Def.Func.body d)
 
 let pp_met ppf d =

--- a/lib/bap_primus/bap_primus_lisp_program.ml
+++ b/lib/bap_primus/bap_primus_lisp_program.ml
@@ -26,6 +26,7 @@ type t = {
   defs : Def.func Def.t list;
   mets : Def.meth Def.t list;
   pars : Def.para Def.t list;
+  sigs : Def.signal Def.t list;
 } [@@deriving fields]
 
 type program = t
@@ -37,6 +38,7 @@ let empty = {
   defs = [];
   mets = [];
   pars = [];
+  sigs = [];
   macros=[];
   substs=[];
   consts=[];
@@ -52,6 +54,7 @@ module Items = struct
   let meth = Fields.mets
   let para = Fields.pars
   let primitive = Fields.codes
+  let signal = Fields.sigs
 end
 
 let add p (fld : 'a item) x =

--- a/lib/bap_primus/bap_primus_lisp_program.ml
+++ b/lib/bap_primus/bap_primus_lisp_program.ml
@@ -1002,6 +1002,7 @@ module Typing = struct
       | {data=Set (v,x); id} ->
         Gamma.unify_all id [v.id; x.id; varclass vs v] ++
         Gamma.constr v.id v.data.typ ++
+        constr_glob glob vs v ++
         infer vs x
       | {data=Rep (c,x); id} ->
         Gamma.unify c.id id ++

--- a/lib/bap_primus/bap_primus_lisp_program.mli
+++ b/lib/bap_primus/bap_primus_lisp_program.mli
@@ -26,6 +26,7 @@ module Items : sig
   val meth  : Def.meth  item
   val para  : Def.para item
   val primitive  : Def.prim item
+  val signal : Def.signal item
 end
 
 module Type : sig

--- a/lib/bap_primus/bap_primus_lisp_program.mli
+++ b/lib/bap_primus/bap_primus_lisp_program.mli
@@ -36,7 +36,6 @@ module Type : sig
   val infer : ?externals:(string * signature) list -> Var.t seq -> program -> env
   val check : Var.t seq -> program -> error list
   val errors : env -> error list
-  val pp_env : Format.formatter -> env -> unit
   val pp_error : Format.formatter -> error -> unit
 end
 

--- a/lib/bap_primus/bap_primus_lisp_program.mli
+++ b/lib/bap_primus/bap_primus_lisp_program.mli
@@ -1,6 +1,7 @@
 open Bap.Std
 
 open Bap_primus_lisp_types
+open Bap_primus_lisp_type
 module Def = Bap_primus_lisp_def
 module Context = Bap_primus_lisp_context
 
@@ -28,8 +29,12 @@ module Items : sig
 end
 
 module Type : sig
+  type env
   type error
+  val infer : ?externals:(string * signature) list -> Var.t seq -> program -> env
   val check : Var.t seq -> program -> error list
+  val errors : env -> error list
+  val pp_env : Format.formatter -> env -> unit
   val pp_error : Format.formatter -> error -> unit
 end
 

--- a/lib/bap_primus/bap_primus_lisp_program.mli
+++ b/lib/bap_primus/bap_primus_lisp_program.mli
@@ -10,6 +10,7 @@ type program = t
 type 'a item
 
 val empty : t
+val merge : t -> t -> t
 val add : t -> 'a item -> 'a Def.t -> t
 val get : t -> 'a item -> 'a Def.t list
 val context : t -> Context.t

--- a/lib/bap_primus/bap_primus_lisp_program.mli
+++ b/lib/bap_primus/bap_primus_lisp_program.mli
@@ -33,6 +33,7 @@ end
 module Type : sig
   type env
   type error
+  val empty : env
   val infer : ?externals:(string * signature) list -> Var.t seq -> program -> env
   val check : Var.t seq -> program -> error list
   val errors : env -> error list

--- a/lib/bap_primus/bap_primus_lisp_source.ml
+++ b/lib/bap_primus/bap_primus_lisp_source.ml
@@ -44,6 +44,8 @@ let empty = {
   rclass = Id.Map.empty;
 }
 
+let is_empty {lastid} = Id.equal Id.null lastid
+
 let nextid p = {
   p with lastid = Id.next p.lastid
 }

--- a/lib/bap_primus/bap_primus_lisp_source.mli
+++ b/lib/bap_primus/bap_primus_lisp_source.mli
@@ -70,7 +70,6 @@ val has_loc : t -> Id.t -> bool
     a bogus filename is returned. *)
 val filename : t -> Id.t -> string
 
-
 (** [fold source ~init ~f] iterates over all files loaded into the
     [source] repository.  *)
 val fold : t -> init:'a -> f:(string -> tree list -> 'a -> 'a) -> 'a
@@ -85,3 +84,24 @@ val lasteq : t -> Eq.t
 val pp_error : Format.formatter -> error -> unit
 
 val pp_tree : Format.formatter -> tree -> unit
+
+
+(** [pp_underline ?context src] creates an underlined source code printer.
+
+    [let pp_loc = pp_underline ~context:n src] creates a function that
+    takes a location and prints the corresponding original text of the
+    location with the location being underlined with ['^'] and
+    prefixed with ['>']. If context [n] is greater than [0], then [n]
+    closest lines to the position are printed also and prefixed with
+    ['|'].
+
+    If the printed location spans over more than one line, then only
+    the last line is underlined, however all lines are prefixed.*)
+val pp_underline : ?context:int -> t -> Format.formatter -> Loc.t -> unit
+
+(** [pp ?context src] creates a source code printer.
+
+    [let pp_loc = pp src] creates a function that takes a location and
+    prints the corresponding original text that is designated by the
+    location. *)
+val pp : t -> Format.formatter -> Loc.t -> unit

--- a/lib/bap_primus/bap_primus_lisp_source.mli
+++ b/lib/bap_primus/bap_primus_lisp_source.mli
@@ -37,6 +37,7 @@ and token = Atom of string | List of tree list
 (** [empty] source repository  *)
 val empty : t
 
+val is_empty : t -> bool
 
 (** [load source filename] loads the source code from the given
     [filename]. The source code should be a sequence of well-formed

--- a/lib/bap_primus/bap_primus_main.ml
+++ b/lib/bap_primus/bap_primus_main.ml
@@ -22,6 +22,7 @@ module Main(Machine : Machine) = struct
 
   module Mach = Bap_primus_machine
   module Link = Bap_primus_interpreter.Init(Machine)
+  module Lisp = Bap_primus_lisp.Make(Machine)
 
   let init_components () =
     Machine.List.iter !components ~f:(fun (module Component) ->
@@ -38,6 +39,7 @@ module Main(Machine : Machine) = struct
   let run ?(envp=[| |]) ?(args=[| |]) proj m =
     let comp =
       init_components () >>= fun () ->
+      Lisp.typecheck >>= fun () ->
       init () >>= fun () ->
       Link.run () >>= fun () ->
       Machine.catch m (fun err ->

--- a/lib/bap_taint/bap_taint.ml
+++ b/lib/bap_taint/bap_taint.ml
@@ -41,6 +41,8 @@ let kinds = Primus.Machine.State.declare
 module Object = struct
   type Primus.exn += Bad_object of Primus.value
 
+  let t = Primus.Lisp.Type.Spec.word 63
+
   module Make(Machine : Primus.Machine.S) = struct
     module Value = Primus.Value.Make(Machine)
 
@@ -253,12 +255,12 @@ module Taint = struct
       change v r ~f:(function
           | None -> None
           | Some ts ->
-             let ts = Set.filter ts ~f:(fun t ->
+            let ts = Set.filter ts ~f:(fun t ->
                 match Map.find objects t with
                 | None -> false
                 | Some k' -> Kind.(k <> k')) in
-             if Set.is_empty ts then None
-             else Some ts)
+            if Set.is_empty ts then None
+            else Some ts)
   end
 end
 

--- a/lib/bap_taint/bap_taint.mli
+++ b/lib/bap_taint/bap_taint.mli
@@ -160,7 +160,9 @@ module Std : sig
     module Object : sig
       type t
 
-      (** the Primus Lisp type of objects.  *)
+      (** the Primus Lisp type of objects.
+          [@since 2.1]
+      *)
       val t : Primus.Lisp.Type.t
 
       module Make(Machine : Primus.Machine.S) : sig

--- a/lib/bap_taint/bap_taint.mli
+++ b/lib/bap_taint/bap_taint.mli
@@ -160,6 +160,9 @@ module Std : sig
     module Object : sig
       type t
 
+      (** the Primus Lisp type of objects.  *)
+      val t : Primus.Lisp.Type.t
+
       module Make(Machine : Primus.Machine.S) : sig
 
 

--- a/plugins/primus_lisp/lisp/atoi.lisp
+++ b/plugins/primus_lisp/lisp/atoi.lisp
@@ -1,3 +1,4 @@
+(require types)
 (require ascii)
 
 (defmacro skip-all (pred s)
@@ -7,7 +8,7 @@
   (or (ascii-special s) (ascii-whitespace s)))
 
 (defun atoi-read-digit (s)
-  (coerce 0 (word-size) (- (memory-read s) ?0)))
+  (cast ptr_t (- (memory-read s) ?0)))
 
 (defun read-ascii-word (s)
   (skip-all atoi-prefix s)
@@ -18,6 +19,9 @@
       (incr s))
     (* sign v)))
 
-(defun atoi  (s) (c-int (read-ascii-word s)))
-(defun atol  (s) (c-long (read-ascii-word s)))
-(defun atoll (s) (c-long-long (read-ascii-word s)))
+(defmacro make-converter (type s)
+  (cast type (read-ascii-word s)))
+
+(defun atoi  (s) (make-converter int s))
+(defun atol  (s) (make-converter long s))
+(defun atoll (s) (make-converter long-long s))

--- a/plugins/primus_lisp/lisp/init.lisp
+++ b/plugins/primus_lisp/lisp/init.lisp
@@ -4,14 +4,49 @@
 (defconstant nil false "nil is another name for false")
 
 (defmacro when (cnd body)
-  "(when CND BODY) if CND is true then evaluates BODY and returns the
-   value of last expression in BODY, otherwise returns false."
+  "(when CND BODY) if CND evaluates to true, then BODY is evaluated and
+   the value of the last expression in BODY becomes the value of the
+   whole expression. Otherwise, if CND evaluates to false, nil is returned."
   (if cnd (prog body) ()))
 
+(defmacro unless (cnd body)
+  "(unless CND BODY) if CND evaluates to false, then BODY is evaluated and
+   the value of the last expression in BODY becomes the value of the
+   whole expression. Otherwise, if CND evaluates to true, nil is returned."
+  (if (not cnd) () body))
+
 (defmacro until (c b)
-  "(unit COND BODY) if CND is not true then evaluates BODY and returns
-   the value of the last expression in BODY, otherwise returns false. "
+  "(until COND BODY) if COND evaluates to true, then the whole expression
+   evaluates to nil and BODY is not evaluated. Otherwise, if COND evaluates
+   to false, then BODY is evaluated until COND evaluates to true and the value
+   of the last evaluation of BODY becomes the value of the whole expression."
   (while (not c) b))
+
+(defmacro case (k x xs)
+  "(case K K1 X1 K2 X2 ... Kn Xn [DEF]) evaluates K then consequently
+   evaluates keys K1 ...Kn until a key Ki such that (= K Ki) is found.
+   If such key is found then the whole form evaluates to Xi.
+   If no matching key was found, then if the number of keys is equal to
+   the number of expressions, nil is returned, otherwise, i.e., if an
+   extra expression DEF is provided, then it becomes the value of the
+   whole form.
+
+   Examples:
+
+       (defun dispatch-with-default-case (c)
+         (case c
+           1 'hello
+           2 'cruel
+           3 'world
+           'unknown))
+
+       (defun dispatch-with-no-default (c)
+         (case c
+           1 'hello
+           2 'cruel
+           3 'world))"
+  (let ((k k))
+    (case/dispatch k x xs)))
 
 (defun non-zero (x)
   "(non-zero X) is true if X is not zero"
@@ -94,3 +129,8 @@
   x)
 (defmacro max (p q)    (let ((x p) (y q)) (if (> x y) x y)))
 (defmacro max (x y ys) (max (max x y) ys))
+
+(defmacro case/dispatch (k x) x)
+(defmacro case/dispatch (k k' x) (when (= k k') x))
+(defmacro case/dispatch (k k' x xs)
+  (if (= k k') x (case/dispatch k xs)))

--- a/plugins/primus_lisp/lisp/libc-init.lisp
+++ b/plugins/primus_lisp/lisp/libc-init.lisp
@@ -24,9 +24,10 @@
   (declare (external "__libc_start_main")
            (context (abi "ppc32")))
   (set R2 (+ stack_on_entry 0x7008))
-  (let ((argc (read-word int32_t stack_on_entry))
-        (argv (ptr+1 int32_t stack_on_entry)))
-    (invoke-subroutine (read-word int32_t (+ stinfo 4)) argc argv)))
+  (let ((argc (read-word ptr_t stack_on_entry))
+        (argv (ptr+1 ptr_t stack_on_entry))
+        (main (read-word ptr_t (+ stinfo 4))))
+    (invoke-subroutine main argc argv)))
 
 
 (defun fini ()

--- a/plugins/primus_lisp/lisp/simple-memory-allocator.lisp
+++ b/plugins/primus_lisp/lisp/simple-memory-allocator.lisp
@@ -29,8 +29,8 @@
 
 (defun memory/allocate (ptr len)
   (if *malloc-initialize-memory*
-      (memory-allocate ptr n *malloc-initial-value*)
-    (memory-allocate ptr n)))
+      (memory-allocate ptr len *malloc-initial-value*)
+    (memory-allocate ptr len)))
 
 (defun malloc (n)
   "allocates a memory region of size N"

--- a/plugins/primus_lisp/lisp/stdio.lisp
+++ b/plugins/primus_lisp/lisp/stdio.lisp
@@ -109,6 +109,6 @@
   (declare (external "getchar"))
   (fgetc *standard-input*))
 
-(defmethod finished ()
+(defmethod fini ()
   (channel-flush *standard-output*)
   (channel-flush *standard-error*))

--- a/plugins/primus_lisp/lisp/stdlib.lisp
+++ b/plugins/primus_lisp/lisp/stdlib.lisp
@@ -2,6 +2,7 @@
 (require atoi)
 (require stdio)
 (require simple-memory-allocator)
+(require types)
 
 (defun getenv (name)
   "finds a value of an environment variable with the given name"
@@ -10,7 +11,7 @@
     (while (and (not (points-to-null p))
                 (/= (strcmp p name) 0))
       (ptr+1 ptr_t p))
-    (if p (strchr p ?=) p)))
+    (if p (strchr p (cast int ?=)) p)))
 
 
 (defun abort ()

--- a/plugins/primus_lisp/lisp/string.lisp
+++ b/plugins/primus_lisp/lisp/string.lisp
@@ -92,7 +92,7 @@
     (while (and
             (not (points-to-null p))
             (not found))
-      (set found (strchr s (memory-read p)))
+      (set found (strchr str (cast int (memory-read p))))
       (incr p))
     found))
 

--- a/plugins/primus_lisp/lisp/types.lisp
+++ b/plugins/primus_lisp/lisp/types.lisp
@@ -1,6 +1,90 @@
-(defun int () (abi-c-int-width))
-(defun long () (abi-c-long-width))
-(defun long-long () (abi-c-long-long-width))
+(defun model-ilp32 (type)
+  (case type
+    'char 8
+    'short 16
+    'int 32
+    'long 32
+    'ptr 32))
+
+(defun model-lp32 (type)
+  (case type
+    'char 8
+    'short 16
+    'int 16
+    'long 32
+    'ptr 32))
+
+(defun model-ilp64 (type)
+  (case type
+    'char 8
+    'short 16
+    'int 64
+    'long 64
+    'ptr 64))
+
+(defun model-llp64 (type)
+  (case type
+    'char 8
+    'short 16
+    'int 32
+    'long 32
+    'ptr 64))
+
+(defun model-lp64 (type)
+  (case type
+    'char 8
+    'short 16
+    'int 32
+    'long 64
+    'ptr 64))
+
+
+(defun char ()  (declare (context (abi eabi))) (model-ilp32 'char))
+(defun short () (declare (context (abi eabi))) (model-ilp32 'short))
+(defun int ()   (declare (context (abi eabi))) (model-ilp32 'long))
+(defun long ()  (declare (context (abi eabi))) (model-ilp32 'long))
+(defun ptr_t () (declare (context (abi eabi))) (model-ilp32 'ptr))
+
+(defun char ()  (declare (context (abi mips32))) (model-ilp32 'char))
+(defun short () (declare (context (abi mips32))) (model-ilp32 'short))
+(defun int ()   (declare (context (abi mips32))) (model-ilp32 'long))
+(defun long ()  (declare (context (abi mips32))) (model-ilp32 'long))
+(defun ptr_t () (declare (context (abi mips32))) (model-ilp32 'ptr))
+
+(defun char ()  (declare (context (abi mips64))) (model-ilp64 'char))
+(defun short () (declare (context (abi mips64))) (model-ilp64 'short))
+(defun int ()   (declare (context (abi mips64))) (model-ilp64 'long))
+(defun long ()  (declare (context (abi mips64))) (model-ilp64 'long))
+(defun ptr_t () (declare (context (abi mips64))) (model-ilp64 'ptr))
+
+(defun char ()  (declare (context (abi ppc32))) (model-ilp32 'char))
+(defun short () (declare (context (abi ppc32))) (model-ilp32 'short))
+(defun int ()   (declare (context (abi ppc32))) (model-ilp32 'long))
+(defun long ()  (declare (context (abi ppc32))) (model-ilp32 'long))
+(defun ptr_t () (declare (context (abi ppc32))) (model-ilp32 'ptr))
+
+(defun char ()  (declare (context (arch x86_64 sysv))) (model-lp64 'char))
+(defun short () (declare (context (arch x86_64 sysv))) (model-lp64 'short))
+(defun int ()   (declare (context (arch x86_64 sysv))) (model-lp64 'long))
+(defun long ()  (declare (context (arch x86_64 sysv))) (model-lp64 'long))
+(defun ptr_t () (declare (context (arch x86_64 sysv))) (model-lp64 'ptr))
+
+(defun char ()  (declare (context (arch x86_64 ms))) (model-llp64 'char))
+(defun short () (declare (context (arch x86_64 ms))) (model-llp64 'short))
+(defun int ()   (declare (context (arch x86_64 ms))) (model-llp64 'long))
+(defun long ()  (declare (context (arch x86_64 ms))) (model-llp64 'long))
+(defun ptr_t () (declare (context (arch x86_64 ms))) (model-llp64 'ptr))
+
+(defun char ()  (declare (context (arch x86))) (model-lp32 'char))
+(defun short () (declare (context (arch x86))) (model-lp32 'short))
+(defun int ()   (declare (context (arch x86))) (model-lp32 'long))
+(defun long ()  (declare (context (arch x86))) (model-lp32 'long))
+(defun ptr_t () (declare (context (arch x86))) (model-lp32 'ptr))
+
+;; fallback, in case if we can't guess the ABI
+(defun int () (word-width))
+(defun long () (word-width))
+(defun long-long () (word-width))
 (defun char () 8)
 (defun int32_t () 32)
 (defun int64_t () 64)

--- a/plugins/primus_lisp/primus_lisp_io.ml
+++ b/plugins/primus_lisp/primus_lisp_io.ml
@@ -264,7 +264,7 @@ let init redirections =
             channel that has the descriptor DESCR to be outputted to the
             associated destination. Returns -1 if no such channel exists or
             if in case of an IO error.|};
-        def "channel-input"  (one int @-> int) (module Input)
+        def "channel-input"  (one int @-> byte) (module Input)
           {|(channel-input DESC) reads one byte from a channel that
             has the descriptor DESC. Returns -1 if no such channel
             exists, or if any IO error occurs, if the channel is not

--- a/plugins/primus_lisp/primus_lisp_main.ml
+++ b/plugins/primus_lisp/primus_lisp_main.ml
@@ -200,7 +200,6 @@ module Typechecker(Machine : Primus.Machine.S) = struct
     Machine.get () >>= fun proj ->
     Lisp.program >>= fun prog ->
     Env.all >>| fun vars ->
-    Format.eprintf "Starting typechecking@\n%!";
     let externals = signatures_of_subs (Project.program proj) in
     let arch = Project.arch proj in
     let env = Primus.Lisp.Type.infer ~externals arch vars prog in

--- a/plugins/primus_taint/.merlin
+++ b/plugins/primus_taint/.merlin
@@ -2,3 +2,7 @@ REC
 B ../../_build/plugins/primus_taint
 B ../../_build/lib/bap_primus
 B ../../_build/lib/bap_taint
+
+B .
+B ../../lib/bap_primus
+B ../../lib/bap_taint

--- a/plugins/primus_taint/lisp/sensitive-sinks.lisp
+++ b/plugins/primus_taint/lisp/sensitive-sinks.lisp
@@ -6,6 +6,10 @@
 
 ;; mark all taints that affected branch control, this gives at least
 ;; a hope that the untrusted input was checked and validated.
+
+(require types)
+(require pointers)
+
 (defmethod eval-cond (c)
   (let ((t (taint-get-direct 'untrusted c)))
     (when t
@@ -71,10 +75,10 @@
 
 (defun must/trust-args (args)
   (while args
-    (must/trust-string (read_word ptr_t args))
+    (must/trust-string (read-word ptr_t args))
     (ptr+1 ptr_t args)))
 
 (defmethod call (name pid path fa attr args envp)
   (must/trust-string path)
   (must/trust-args args)
-  (must/trust-envp envp))
+  (must/trust-args envp))

--- a/plugins/primus_taint/lisp/taint-sources.lisp
+++ b/plugins/primus_taint/lisp/taint-sources.lisp
@@ -183,13 +183,4 @@
 ;; Do not trust data that require parsing
 (defmethod call (name str)
   (when (= name 'sscanf)
-    (untrust/string )))
-
-;; Rule:
-;; undefined-input (x) |- T(x)
-;;
-;; Motivation:
-;; We don't know anything about data that is defined externally, so we
-;; will assume, that it is also controlled by a user.
-(defmethod undefined-input (x)
-  (untrust/value x))
+    (untrust/string str)))

--- a/plugins/primus_taint/lisp/taint.lisp
+++ b/plugins/primus_taint/lisp/taint.lisp
@@ -1,11 +1,14 @@
 ;;; Taint Analysis Framework
 ;;;
 
+(defparameter *indirect-taint-size* nil)
 
 (defun taint-introduce (r k v)
   "(taint-introduce REL KIND VAL) associates a fresh new taint with
    the value VAL using the specified relation REL, that must be either
-   'directly or 'indirectly"
+   'directly or 'indirectly. If taint is introduced indirectly, then
+   *indirect-taint-size* number of bytes are tainted."
   (if (= r 'directly)
       (taint-introduce-directly k v)
-    (taint-introduce-indirectly k v)))
+    (let ((n (or *indirect-taint-size* (/ (word-width) 8))))
+      (taint-introduce-indirectly k v n))))

--- a/plugins/primus_taint/primus_taint_main.ml
+++ b/plugins/primus_taint/primus_taint_main.ml
@@ -179,8 +179,10 @@ module Signals(Machine : Primus.Machine.S) = struct
   let doc = "(taint-finalize T L) is emitted when the taint T is finilized
      while still live if L is true or dead if T is false."
 
+  let params = Primus.Lisp.Type.Spec.(tuple [Taint.Object.t; bool])
+
   let init () =
-    Lisp.signal ~doc Taint.Gc.taint_finalize @@ fun (t,live) ->
+    Lisp.signal ~params ~doc Taint.Gc.taint_finalize @@ fun (t,live) ->
     Machine.List.all [
       Object.to_value t;
       Value.of_bool live;

--- a/plugins/primus_taint/primus_taint_main.ml
+++ b/plugins/primus_taint/primus_taint_main.ml
@@ -179,13 +179,13 @@ module Signals(Machine : Primus.Machine.S) = struct
   let doc = "(taint-finalize T L) is emitted when the taint T is finilized
      while still live if L is true or dead if T is false."
 
-  let init () = Machine.sequence [
-      Lisp.signal ~doc Taint.Gc.taint_finalize @@ fun (t,live) ->
-      Machine.List.all [
-        Object.to_value t;
-        Value.of_bool live;
-      ]
+  let init () =
+    Lisp.signal ~doc Taint.Gc.taint_finalize @@ fun (t,live) ->
+    Machine.List.all [
+      Object.to_value t;
+      Value.of_bool live;
     ]
+
 end
 
 let set_default_policy name =

--- a/plugins/primus_test/lisp/check-value.lisp
+++ b/plugins/primus_test/lisp/check-value.lisp
@@ -51,7 +51,7 @@
       (check-value/unchecked pc)
       (dict-del 'check-value/required taint))))
 
-(defmethod enter-jmp (cnd dst)
+(defmethod eval-cond (cnd)
   (check-value-clear cnd))
 
 

--- a/plugins/primus_x86/primus_x86_loader.ml
+++ b/plugins/primus_x86/primus_x86_loader.ml
@@ -15,9 +15,13 @@ module Make_unresolved(Machine : Primus.Machine.S) = struct
     Linker.exec (`symbol Primus.Linker.unresolved_handler)
 end
 
-module Plt_jumps(Machine : Primus.Machine.S) = struct
+module SetupPLT(Machine : Primus.Machine.S) = struct
   module Linker = Primus.Linker.Make(Machine)
   open Machine.Syntax
+
+  module Value = Primus.Value.Make(Machine)
+  module Interpreter = Primus.Interpreter.Make(Machine)
+  module Env = Primus.Env.Make(Machine)
 
   let section_memory sec_name =
     Machine.get () >>| fun proj ->
@@ -43,25 +47,10 @@ module Plt_jumps(Machine : Primus.Machine.S) = struct
     Machine.List.iter addrs ~f:(fun addr ->
         Linker.link ~addr (module Make_unresolved))
 
-  let unresolve  =
+  let unresolve =
     load_table >>=
     filter_plt >>=
     unlink
-
-end
-
-module Component(Machine : Primus.Machine.S) = struct
-  open Machine.Syntax
-  module Env = Primus.Env.Make(Machine)
-  module Value = Primus.Value.Make(Machine)
-  module Interpreter = Primus.Interpreter.Make(Machine)
-  module Plt_jumps = Plt_jumps(Machine)
-
-  let zero = Primus.Generator.static 0
-
-  let initialize_flags flags =
-    Machine.Seq.iter (Set.to_sequence flags) ~f:(fun reg ->
-        Env.add reg zero)
 
   let correct_sp sp addend _ =
     Env.get sp >>= fun x ->
@@ -74,18 +63,34 @@ module Component(Machine : Primus.Machine.S) = struct
       Value.of_int ~width addend >>= fun addend ->
       Primus.Linker.Trace.lisp_call_return >>> correct_sp sp addend
 
-  let init () =
-    Machine.get () >>= fun proj ->
-    Machine.sequence @@
-    match Project.arch proj with
-    | `x86 ->
-      [initialize_flags IA32.flags;
-       correct_sp IA32.sp 4;
-       Plt_jumps.unresolve ]
-    | `x86_64 ->
-      [initialize_flags AMD64.flags;
-       correct_sp AMD64.sp 8;
-       Plt_jumps.unresolve ]
-    | _ -> []
+  let run () =
+    Machine.gets Project.arch >>= function
+    | `x86 -> Machine.sequence [
+        correct_sp IA32.sp 4;
+        unresolve
+      ]
+    | `x86_64 -> Machine.sequence [
+        correct_sp AMD64.sp 8;
+        unresolve
+      ]
+    | _ -> Machine.return ()
 
+  let init () = Primus.Machine.init >>> run
+
+end
+
+module InitializeFlags(Machine : Primus.Machine.S) = struct
+  open Machine.Syntax
+  module Env = Primus.Env.Make(Machine)
+
+  let zero = Primus.Generator.static 0
+
+  let initialize_flags flags =
+    Machine.Seq.iter (Set.to_sequence flags) ~f:(fun reg ->
+        Env.add reg zero)
+  let init () =
+    Machine.gets Project.arch >>= function
+    | `x86 -> initialize_flags IA32.flags
+    | `x86_64 -> initialize_flags AMD64.flags
+    | _ -> Machine.return ()
 end

--- a/plugins/primus_x86/primus_x86_loader.mli
+++ b/plugins/primus_x86/primus_x86_loader.mli
@@ -1,0 +1,4 @@
+open Bap_primus.Std
+
+module InitializeFlags : Primus.Machine.Component
+module SetupPLT : Primus.Machine.Component

--- a/plugins/primus_x86/primus_x86_main.ml
+++ b/plugins/primus_x86/primus_x86_main.ml
@@ -3,12 +3,13 @@ open Bap_primus.Std
 include Self()
 
 let init _ =
-  Primus.Machine.add_component (module Primus_x86_loader.Component);;
+  Primus.Machine.add_component (module Primus_x86_loader.InitializeFlags);
+  Primus.Machine.add_component (module Primus_x86_loader.SetupPLT);;
 
 Config.manpage [
   `S "DESCRIPTION";
   `P
-  "Performs the x86 target specific setup. So far it just initializes
+    "Performs the x86 target specific setup. So far it just initializes
   all flag registers to zero."
 ];;
 

--- a/plugins/run/run_main.ml
+++ b/plugins/run/run_main.ml
@@ -74,7 +74,7 @@ end
 open Machine.Syntax
 
 module Main = Primus.Machine.Main(Machine)
-module Interpreter = Primus.Interpreter.Make(Machine)
+module Eval = Primus.Interpreter.Make(Machine)
 module Linker = Primus.Linker.Make(Machine)
 module Env = Primus.Env.Make(Machine)
 module Lisp = Primus.Lisp.Make(Machine)
@@ -158,7 +158,6 @@ let exec x =
          (Primus.Exn.to_string exn);
        Machine.return ())
 
-module Eval = Primus.Interpreter.Make(Machine)
 
 let visited = Primus.Machine.State.declare
     ~uuid:"c6028425-a8c7-48cf-b6d9-57a44ed9a08a"

--- a/plugins/run/run_main.ml
+++ b/plugins/run/run_main.ml
@@ -209,10 +209,35 @@ let run need_repeat entries =
 let pp_var ppf v =
   fprintf ppf "%a" Sexp.pp (Var.sexp_of_t v)
 
+let signature_of_sub sub =
+  let module Lisp = Primus.Lisp.Type.Spec in
+  let lisp_type_of_arg arg = match Var.typ (Arg.lhs arg) with
+    | Type.Imm 1 -> Lisp.bool
+    | Type.Imm n -> Lisp.word n
+    | Type.Unk | Type.Mem _ -> Lisp.any in
+  if Term.length arg_t sub = 0
+  then Lisp.(all any @-> any)
+  else Term.enum ~rev:true arg_t sub |>
+       Seq.fold ~init:([],Lisp.any) ~f:(fun (args,ret) arg ->
+           match Arg.intent arg with
+           | Some Out -> args, lisp_type_of_arg arg
+           | _ -> lisp_type_of_arg arg :: args,ret) |> fun (args,ret) ->
+       Lisp.(tuple args @-> ret)
+
+
+let signatures_of_subs prog =
+  Term.enum sub_t prog |>
+  Seq.map ~f:(fun s -> Sub.name s, signature_of_sub s) |>
+  Seq.to_list
+
 let typecheck =
+  Machine.get () >>= fun proj ->
   Lisp.program >>= fun prog ->
   Env.all >>| fun vars ->
-  match Primus.Lisp.Type.check vars prog with
+  let externals = signatures_of_subs (Project.program proj) in
+  let arch = Project.arch proj in
+  let env = Primus.Lisp.Type.infer ~externals arch vars prog in
+  match Primus.Lisp.Type.errors env with
   | [] -> info "The Lisp Machine program is well-typed"
   | xs ->
     warning "The Lisp Machine program is ill-typed";


### PR DESCRIPTION
This PR fixes the long-broken Primus Lisp typechecker and fixes errors that the type checker was able to find. It also adds the `--primus-lisp-type-check` so that you can check the types without running the program. 

### Historical Context

Primus Lisp type checker was an experiment for building a soft type inference with intersecting types. It didn't work well and the error messages were useless, so it was more or less disabled. However, we have recently discovered, that (a) not all our Lisp codes are well-typed (no surprises) and (b) that ill-typed Lisp code not always evaluates to a type error, but instead exhibits weird behavior, e.g., when a lexically scoped suddenly becomes dynamically scoped. In other words, we couldn't trust our lisps anymore.

To reestablish the trust we decided to quickly fix the type checker. This (having to do this quickly) forced us to drop intersecting types and implement more or less common HM style inference (with a diverging type 'a.'a for gradual typing). The type checker still a flow-based and runs on the callgraph.  We also added a couple of checks:
1) for unbound variables
2) for unresolved functions
3) for unresolved overloaded functions
4) for unresolved signals
5) for not matching method for a signal
6) for an unbound parameter in a let-binding

The error messages are now much more readable and point to the origin of the problem, not miles away. It also features nice highlighting. 

To introduce more type sinks into the system (and find more type errors) we add type signatures to signals (methods are now also type-checked) and a translation of subroutine arguments into Lisp signatures (ideally, we should be able to parse header files, but so far we just rely on whatever is in program. 

The fixed type-checker found a few errors, which we fixed :) 


