### PR TITLE
prevents overwriting of a file in the input channel redirection

### DIFF
--- a/plugins/primus_lisp/lisp/stdio.lisp
+++ b/plugins/primus_lisp/lisp/stdio.lisp
@@ -1,5 +1,6 @@
 (require libc-init)
 (require memory)
+(require types)
 
 
 (defun fputc (char stream)
@@ -13,7 +14,7 @@
 (defun fputs (p stream)
   (declare (external "fputs"))
   (while (not (points-to-null p))
-    (fputc (memory-read p) stream)
+    (fputc (cast int (memory-read p)) stream)
     (incr p))
   (fputc 0xA stream))
 

--- a/plugins/primus_lisp/primus_lisp_io.ml
+++ b/plugins/primus_lisp/primus_lisp_io.ml
@@ -71,7 +71,7 @@ let init redirs = {
 
 let try_open path = Or_error.try_with (fun () -> {
       input = Some (In_channel.create path);
-      output = Some (Out_channel.create path)
+      output = Some (Out_channel.create ~append:true path)
     })
 
 let try_flush {output} = Or_error.try_with @@ fun () ->

--- a/plugins/primus_lisp/primus_lisp_main.ml
+++ b/plugins/primus_lisp/primus_lisp_main.ml
@@ -102,7 +102,7 @@ module Signals(Machine : Primus.Machine.S) = struct
         signal pc_change word one Type.(one int)
           {|(pc-change PC) is emitted when PC is updated|};
         signal eval_cond value one Type.(one bool)
-          {|(eval_cond V) is emitted after evaluating a conditional to V|};
+          {|(eval-cond V) is emitted after evaluating a conditional to V|};
         signal jumping (value,value) pair Type.(tuple [bool; int])
           {|(jumping C D) is emitted before jump to D occurs under the
           condition C|};


### PR DESCRIPTION
In Primus Lisp, we have channel redirection which makes files from the
host system visible to the emulation layer. Underneath the hood, we
use common OCaml channels to model files (and probably we should use
Unix file descriptors), and when a file is mapped, we open both input
and output channel. However, when we open the input channel, the file
is truncated, with all the ramifications.

The quickfix is to add the `append` flag. The long-term solution would
be switching to Unix file desciptors and passing flags to the `open(2)`
function, see #1050.