### PR TITLE
provides liveness analysis and uses liveness for Sub.free_vars

### DIFF
--- a/lib/bap_sema/bap_sema.ml
+++ b/lib/bap_sema/bap_sema.ml
@@ -34,6 +34,7 @@ module Std = struct
     let ssa = Ssa.sub
     let is_ssa = Ssa.is_transformed
     let free_vars = FV.free_vars_of_sub
+    let compute_liveness = FV.compute_liveness
   end
 
   module Taint = Bap_sema_taint

--- a/lib/bap_sema/bap_sema_free_vars.ml
+++ b/lib/bap_sema/bap_sema_free_vars.ml
@@ -4,7 +4,7 @@ open Graphlib.Std
 open Bap_ir
 
 module Ssa = Bap_sema_ssa
-module G = Bap_ir_graph
+module G = Bap_tid_graph
 
 let (++) = Set.union and (--) = Set.diff
 let blk = G.Node.label
@@ -20,93 +20,61 @@ let defined_by_blk b =
       | `Def def -> Set.add kill @@ Ir_def.lhs def
       | `Jmp _ -> kill)
 
-let free_vars_of_dom_tree dom root =
-  let rec bfs (vars,kill) root =
-    let cs = Tree.children dom root in
-    let vars = vars ++ Seq.fold cs ~init:Var.Set.empty ~f:(fun vars c ->
-        Ir_blk.free_vars (blk c) -- kill ++ vars) in
-    let kill = kill ++ defined_by_blk (blk root) in
-    Seq.fold cs ~init:(vars,kill) ~f:bfs in
-  fst @@ bfs (Var.Set.empty,Var.Set.empty) root
+type blk_transfer = {
+  defs : Var.Set.t;
+  uses : Var.Set.t;
+}
 
-let dom_free_vars sub =
-  match Term.first blk_t sub with
-  | None -> Var.Set.empty
-  | Some entry ->
-    let entry = G.Node.create entry in
-    let cfg = G.of_sub sub in
-    let dom = Graphlib.dominators (module G) cfg entry in
-    free_vars_of_dom_tree dom entry
+let blk_defs blk =
+  Term.enum def_t blk |>
+  Seq.fold ~init:Var.Set.empty  ~f:(fun defs def ->
+      Set.add defs (Ir_def.lhs def))
+
+let block_transitions sub =
+  Term.enum blk_t sub |>
+  Seq.fold ~init:Tid.Map.empty ~f:(fun fs blk ->
+      Map.add_exn fs (Term.tid blk) {
+        defs = blk_defs blk;
+        uses = Ir_blk.free_vars blk;
+      })
+
+let start = Tid.create ()
+let exit = Tid.create ()
+
+let connect_with_exit n g =
+  if Tid.equal n exit then g
+  else G.Edge.insert (G.Edge.create n exit exit) g
+
+let connect_with_start sub = match Term.first blk_t sub with
+  | None -> G.Node.insert start
+  | Some entry -> G.Edge.insert @@
+    G.Edge.create start (Term.tid entry) start
+
+(* post: all nodes are reachable from the exit node *)
+let graph_of_sub_with_exit sub =
+  let g = connect_with_start sub (G.create sub) in
+  G.nodes g |> Seq.fold ~init:g ~f:(fun g n ->
+      if G.Node.degree ~dir:`Out n g = 0
+      then connect_with_exit n g
+      else g) |> fun g ->
+  Graphlib.depth_first_search (module G) g
+    ~rev:true ~init:g ~start:exit
+    ~start_tree:connect_with_exit
+
+let liveness sub =
+  let g = graph_of_sub_with_exit sub in
+  let init = Solution.create Tid.Map.empty Var.Set.empty in
+  let tran = block_transitions sub in
+  Graphlib.fixpoint (module G) ~init ~start:exit ~rev:true g
+    ~merge:Set.union
+    ~equal:Var.Set.equal
+    ~f:(fun n vars ->
+        if Tid.equal n exit || Tid.equal n start  then vars
+        else
+          let {defs; uses} = Map.find_exn tran n in
+          vars -- defs ++ uses)
 
 let free_vars_of_sub sub  =
   if Ssa.is_transformed sub
   then ssa_free_vars sub
-  else dom_free_vars sub
-
-let has_sub_exp x = Exp.exists (object
-    inherit [unit] Exp.finder
-    method! enter_exp exp search =
-      if Exp.equal exp x then search.return (Some ())
-      else search
-  end)
-
-let substitute_exp x y = Exp.map (object
-    inherit Exp.mapper
-    method! map_exp exp =
-      if Exp.equal exp x then y else x
-  end)
-
-let substitute blk x y =
-  Ir_blk.elts blk |> Seq.fold ~init:(false,blk)
-    ~f:(fun (finished,blk) elt ->
-        if finished then finished,blk else match elt with
-          | `Phi phi ->
-            let exps = Ir_phi.values phi |> Seq.map ~f:snd in
-            if Seq.exists exps ~f:(has_sub_exp x) then
-              let phi = Ir_phi.map_exp phi ~f:(substitute_exp x y) in
-              true,Term.update phi_t blk phi
-            else false,blk
-          | `Def def ->
-            if has_sub_exp x (Ir_def.rhs def) then
-              let def = Ir_def.map_exp def ~f:(substitute_exp x y) in
-              true, Term.update def_t blk def
-            else false,blk
-          | `Jmp jmp ->
-            if Seq.exists (Ir_jmp.exps jmp) ~f:(has_sub_exp x) then
-              let jmp = Ir_jmp.map_exp jmp ~f:(substitute_exp x y) in
-              true, Term.update jmp_t blk jmp
-            else false,blk)
-
-exception Finished of sub term
-
-let finish sub blk =
-  Exn.raise_without_backtrace (Finished (Term.update blk_t sub blk))
-
-let dom_bind_arg dom root sub (var,exp) =
-  let x = Bil.var var in
-  let rec bfs root =
-    let subst root =
-      let blk = Term.find_exn blk_t sub root in
-      let finished,blk = substitute blk x exp in
-      if finished then finish sub blk in
-    subst root;
-    Seq.iter (Tree.children dom root) ~f:subst;
-    Seq.iter (Tree.children dom root) ~f:bfs in
-  try bfs root; sub with Finished sub -> sub
-
-let dom_bind_args sub entry args =
-  let module G = Bap_tid_graph in
-  let entry = Term.tid entry in
-  let cfg = G.create sub in
-  let dom = Graphlib.dominators (module G) cfg entry in
-  Seq.fold args ~init:sub ~f:(dom_bind_arg dom entry)
-
-(* we do not provide algorithm that will take advantage of SSA form,
-   since the latter will work only for variables, but the DOM tree
-   algorithm will work correctly for any kind of expression. *)
-let bind_args sub = match Term.first blk_t sub with
-  | None -> sub
-  | Some entry ->
-    Term.enum arg_t sub |>
-    Seq.map ~f:(fun arg -> Ir_arg.(lhs arg, rhs arg)) |>
-    dom_bind_args sub entry
+  else Solution.get (liveness sub) start

--- a/lib/bap_sema/bap_sema_free_vars.mli
+++ b/lib/bap_sema/bap_sema_free_vars.mli
@@ -1,5 +1,8 @@
 open Bap_types.Std
+open Graphlib.Std
 open Bap_ir
 
+val start : tid
+val exit : tid
+val liveness : sub term -> (tid, Var.Set.t) Solution.t
 val free_vars_of_sub : sub term -> Var.Set.t
-val bind_args : sub term -> sub term

--- a/lib/bap_sema/bap_sema_free_vars.mli
+++ b/lib/bap_sema/bap_sema_free_vars.mli
@@ -2,7 +2,5 @@ open Bap_types.Std
 open Graphlib.Std
 open Bap_ir
 
-val start : tid
-val exit : tid
-val liveness : sub term -> (tid, Var.Set.t) Solution.t
+val compute_liveness : sub term -> (tid, Var.Set.t) Solution.t
 val free_vars_of_sub : sub term -> Var.Set.t

--- a/lib/bap_types/bap_ir.ml
+++ b/lib/bap_types/bap_ir.ml
@@ -831,7 +831,7 @@ module Ir_phi = struct
       (String.concat ~sep:", " @@
        List.map ~f:(fun (id,exp) ->
            let exp = Rhs.exp exp in
-           Format.asprintf "[%a, %%%a]" Bap_exp.pp exp Tid.pp id)
+           Format.asprintf "[%a, %a]" Bap_exp.pp exp Tid.pp id)
          (Map.to_alist map))
 
   let pp_self_slots ds ppf {Phi.var; map} =

--- a/lib/bap_types/bap_tid_graph.ml
+++ b/lib/bap_types/bap_tid_graph.ml
@@ -2,20 +2,49 @@ open Core_kernel
 open Regular.Std
 open Graphlib.Std
 open Bap_ir
-open Bap_ir_graph
+
 
 module G = Graphlib.Make(Tid)(Tid)
 
-let create sub =
+let of_sub sub =
   Term.enum blk_t sub |> Seq.fold ~init:G.empty ~f:(fun g src ->
       let sid = Term.tid src in
       let g = G.Node.insert sid g in
       Term.enum jmp_t src |> Seq.fold ~init:g ~f:(fun g jmp ->
-          match succ_tid_of_jmp jmp with
+          match Bap_ir_graph.succ_tid_of_jmp jmp with
           | None -> g
           | Some did ->
             let jid = Term.tid jmp in
             let edge = G.Edge.create sid did jid in
             G.Edge.insert edge g))
+
+let start = Tid.for_name "%start-pseudo-node%"
+let exit = Tid.for_name "%exit-pseudo-node%"
+
+let connect_with_exit n =
+  if Tid.equal n exit then ident
+  else G.Edge.insert (G.Edge.create n exit exit)
+
+let connect_with_start n =
+  if Tid.equal n start then ident
+  else
+    G.Edge.insert @@
+    G.Edge.create start n start
+
+let create sub =
+  let g = of_sub sub in
+  G.nodes g |> Seq.fold ~init:g ~f:(fun g n ->
+      if G.Node.degree ~dir:`Out n g = 0
+      then connect_with_exit n g else
+      if G.Node.degree ~dir:`In n g = 0
+      then connect_with_start n g
+      else g) |> fun g ->
+  Graphlib.depth_first_search (module G) g
+    ~init:g ~start
+    ~start_tree:connect_with_start
+  |> fun g ->
+  Graphlib.depth_first_search (module G) g
+    ~rev:true ~init:g ~start:exit
+    ~start_tree:connect_with_exit
 
 include G

--- a/lib/bap_types/bap_tid_graph.mli
+++ b/lib/bap_types/bap_tid_graph.mli
@@ -5,5 +5,6 @@ include Graph with type node = tid
                and type Node.label = tid
                and type Edge.label = tid
 
-
+val start : node
+val exit : node
 val create : sub term -> t


### PR DESCRIPTION
1. implements liveness analysis for subroutines and provides it
as [Sub.compute_liveness] which returns a fixed point solution to
the variable liveness property.

2. uses liveness to compute free variables when a subroutime is not
in the SSA form

3. Sub.to_graph now returns a fully connected graph with two
pseudo-nodes, [start], and [exit] (we keep doing every time we need to
do some graph computation, so let's make it official). This
pseudo-nodes are constants defined in the [Graphs.Tid] interface.

Context
=======

We used to rely on the dominators tree to compute the set of free
variables when the SSA form is not available. It was an optimization,
as by that time we didn't have the fixpoint function and didn't want
to compute SSA just for getting free vars. It was also returning an
underapproximation, rather than overapproximation (i.e., was a must free
analysis), which was fine with some existing uses of the
[Sub.free_vars] function, but wasn't sufficient/correct for other
uses, e.g., in the promiscuous mode we were relying on it to turn a
subroutine into a closed form, to prevent failures in runtime with
undefined variable (we probably could just define all vars used in the
program, but this is a different story). Since [Sub.free_vars] were
returning an under-approximation we still experiences some runtime
failures, which were halting our machines that resulted in non-visited
code and missing vulnerabilities.