### PR TITLE
provides information about call destinations as soon as possible

### DIFF
--- a/lib/bap_disasm/bap_disasm_calls.ml
+++ b/lib/bap_disasm/bap_disasm_calls.ml
@@ -45,7 +45,7 @@ end
     v}
 
     Usually, dominators are computed using a transfer function that is
-    defined as [transfer node ps = (node) U ps], which our third node,
+    defined as [transfer node ps = (node) U ps], which our third clause,
     however we specialized our tranfer function for two reasons
 
     1) efficiency - the first clause removes an explicit entry node,


### PR DESCRIPTION
Until this PR we were marking call destinations as subroutines at the
same time as we were building the callgraph, therefore if a caller was
visited before callee (and the callee wasn't yet marked as a function
start) we were missing a valid function start and our partitioning of
the whole program CFG into subroutines was incorrect.

The reason why we were delaying this information until it is too late
was two-fold. First, we can't mark a callee as a function start as
soon as we have discovered an instruction that targets it, as this
instruction may not be a part of a valid code chain, so we may need
later to cancel this instruction, and therefore retract this
information. Since our knowledge base doesn't allow retracting or
negating, we were postponing this information until we finish
disassembling. However, after disassembling we didn't really have this
information anymore and it was suboptimal to scan the memory again and
push call destinations. Therefore we decided to provide this
information on-demand, as a (premature) optimization.

The proposed solution still delays this information just until the new
chunk of memory is scanned, but not later. We mark a set of
destinations as call targets when an instruction is disassembled, and
after the CFG is built for each survived call instruction we record
its destinations as function starts.