### PR TITLE
caches the disassembler state

### DIFF
--- a/plugins/disassemble/disassemble_main.ml
+++ b/plugins/disassemble/disassemble_main.ml
@@ -312,7 +312,7 @@ let _disassemble_command_registered : unit =
   import_knowledge_from_cache digest;
   let state = load_project_state_from_cache digest in
   let input = Project.Input.file ~loader ~filename:input in
-  Project.create
+  Project.create ?state
     input |> proj_error >>= fun proj ->
   if Option.is_none state then begin
     store_knowledge_in_cache digest;


### PR DESCRIPTION
The disassembler state was cached and even loaded from the
cache... but never used. It is now significantly faster :)