### PR TITLE
adds intrinsics

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -6079,6 +6079,13 @@ module Std : sig
             the opcode (and thus to [code]).  *)
         val name : ('a,'k) t -> string
 
+        (** returns the name of the backend that encoded this instruction.
+
+            @since 2.1.0
+        *)
+        val encoding : ('a,'k) t -> string
+
+
         (** [kinds insn] returns a high-level semantic information
             about the instruction. See {!Kind} for the description of
             semantic codes.  *)

--- a/lib/bap_core_theory/bap_core_theory_parser.ml
+++ b/lib/bap_core_theory/bap_core_theory_parser.ml
@@ -445,6 +445,7 @@ module Make(S : Core) = struct
         let call name =
           newlabel >>= fun lbl ->
           Label.for_name name >>= fun dst ->
+          Knowledge.provide Label.is_subroutine dst (Some true) >>= fun () ->
           seq (blk lbl pass (goto dst)) (next xs)
 
         let goto addr =

--- a/lib/bap_disasm/bap_disasm_basic.ml
+++ b/lib/bap_disasm/bap_disasm_basic.ml
@@ -274,6 +274,7 @@ let cpred_of_pred : pred -> C.pred = function
 
 module Insn = struct
   type ins_info = {
+    encoding : string;
     code : int;
     name : string;
     asm  : string;
@@ -326,8 +327,9 @@ module Insn = struct
           | C.Imm -> Op.Imm Imm.(create dis ~insn ~oper)
           | C.Fmm -> Op.Fmm Fmm.(create dis ~insn ~oper)
           | C.Insn -> assert false) in
-    {code; name; asm; kinds; opers }
+    {code; name; asm; kinds; opers; encoding = dis.name }
 
+  let encoding x = x.encoding
 
   let domain =
     KB.Domain.optional ~inspect:sexp_of_t "insn"
@@ -500,7 +502,7 @@ let back s data =
   step { s with current; history} data
 
 let create ?(debug_level=0) ?(cpu="") ?(backend="llvm") triple =
-  let name = sprintf "%s:%s%s" backend triple cpu in
+  let name = sprintf "%s-%s%s" backend triple cpu in
   match Hashtbl.find disassemblers name with
   | Some d ->
     d.users <- d.users + 1;

--- a/lib/bap_disasm/bap_disasm_basic.mli
+++ b/lib/bap_disasm/bap_disasm_basic.mli
@@ -85,6 +85,7 @@ module Insn : sig
   val compare : ('a,'k) t -> ('a,'k) t -> int
   val code : ('a,'k) t -> int
   val name : ('a,'k) t -> string
+  val encoding : ('a,'k) t -> string
   val kinds : ('a,kinds) t -> kind list
   val is : ('a,kinds) t -> kind -> bool
   val asm : (asm,'k) t -> string

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -2708,6 +2708,16 @@ ident ::= ?any atom that is not recognized as a <word>?
         val run : value list -> value Machine.t
       end
 
+
+      (** [(lisp-primitive <name> <arg1> ... <argM> <rval>)] is posted
+          when the Lisp primitive with the given <name> is called with
+          the list of arguments [(<arg1> .... <argM>)] and evaluates
+          to the [<rval>] value.
+
+          @since 2.1.0
+      *)
+      val primitive : (string * value list) observation
+
       (** a closure packed as an OCaml value *)
       type closure = (module Closure)
 

--- a/lib/bap_primus/bap_primus_linker.mli
+++ b/lib/bap_primus/bap_primus_linker.mli
@@ -1,3 +1,4 @@
+open Core_kernel
 open Bap.Std
 open Regular.Std
 open Bap_primus_types
@@ -17,6 +18,8 @@ val unresolved : name observation
 
 val unresolved_handler : string
 
+val sexp_of_call : string * value list -> Sexp.t
+
 module Trace : sig
   val call : (string * value list) observation
   val call_entered : (string * value list) statement
@@ -27,6 +30,7 @@ module Trace : sig
   val lisp_call_return : (string * value list) observation
   val lisp_call_returned : (string * value list) statement
 end
+
 module type Code = functor (Machine : Machine) -> sig
   val exec : unit Machine.t
 end

--- a/lib/bap_primus/bap_primus_lisp.ml
+++ b/lib/bap_primus/bap_primus_lisp.ml
@@ -345,7 +345,8 @@ module Interpreter(Machine : Machine) = struct
       Eval.const Word.b0 >>= fun init ->
       eval_advices Advice.Before init name args >>= fun _ ->
       Code.run args >>= fun r ->
-      Machine.Observation.make primitive_called (name,args@[r]) >>= fun () ->
+      Machine.Observation.post primitive_called ~f:(fun k ->
+          k (name,args@[r])) >>= fun () ->
       eval_advices Advice.After r name args
 
   and eval_exp exp  =

--- a/lib/bap_primus/bap_primus_lisp.ml
+++ b/lib/bap_primus/bap_primus_lisp.ml
@@ -233,7 +233,7 @@ module Interpreter(Machine : Machine) = struct
       Seq.find ~f:(fun sub -> match Term.get_attr sub address with
           | None -> false
           | Some addr -> Word.(addr = sub_addr.value)) |> function
-      | None ->
+      | None  ->
         failf "invoke-subroutine: no function for %a" Addr.pps
           sub_addr.value ()
       | Some sub ->

--- a/lib/bap_primus/bap_primus_lisp.ml
+++ b/lib/bap_primus/bap_primus_lisp.ml
@@ -63,6 +63,9 @@ let state = Bap_primus_state.declare ~inspect
        })
 
 
+let lisp_primitive,primitive_called = Bap_primus_observation.provide
+    ~inspect:Bap_primus_linker.sexp_of_call "lisp-primitive"
+
 module Errors(Machine : Machine) = struct
   open Machine.Syntax
 
@@ -342,6 +345,7 @@ module Interpreter(Machine : Machine) = struct
       Eval.const Word.b0 >>= fun init ->
       eval_advices Advice.Before init name args >>= fun _ ->
       Code.run args >>= fun r ->
+      Machine.Observation.make primitive_called (name,args@[r]) >>= fun () ->
       eval_advices Advice.After r name args
 
   and eval_exp exp  =
@@ -810,3 +814,5 @@ module Doc = struct
       index s.program
   end
 end
+
+let primitive = lisp_primitive

--- a/lib/bap_primus/bap_primus_lisp.mli
+++ b/lib/bap_primus/bap_primus_lisp.mli
@@ -96,6 +96,7 @@ end
 type primitives = (module Primitives)
 type exn += Runtime_error of string
 
+val primitive : (string * value list) observation
 
 module Make (Machine : Machine) : sig
   val failf : ('a, unit, string, unit -> 'b Machine.t) format4 -> 'a

--- a/lib/bap_primus/bap_primus_lisp_var.ml
+++ b/lib/bap_primus/bap_primus_lisp_var.ml
@@ -19,11 +19,19 @@ let read id eq = function
     Error Not_a_var
   | x -> match String.split x ~on:':' with
     | [] -> assert false
-    | _::_::_::_ -> Error Bad_format
+    | _::_::_::_::_ -> Error Bad_format
+    | [ns;name;sz] -> begin match Type.read sz with
+        | None -> Error Bad_type
+        | Some typ ->
+          let x = ns ^ ":" ^ name in
+          Ok {data={exp=x; typ}; id; eq}
+      end
     | [x] -> Ok {data={exp=x; typ=Any}; id; eq}
     | [x;sz] -> match Type.read sz with
-      | None -> Error Bad_type
       | Some typ -> Ok {data={exp=x; typ}; id; eq}
+      | None ->
+        let x = x ^ ":" ^ sz in
+        Ok {data={exp=x; typ=Any}; id; eq}
 
 include Comparable.Make_plain(struct
     type t = var [@@deriving compare,sexp_of]

--- a/oasis/primus-lisp
+++ b/oasis/primus-lisp
@@ -12,6 +12,7 @@ Library primus_lisp_library_plugin
   InternalModules: Primus_lisp_main,
                    Primus_lisp_config,
                    Primus_lisp_primitives,
+                   Primus_lisp_ieee754,
                    Primus_lisp_io
   XMETADescription: install and load Primus lisp libraries
   DataFiles:        lisp/*.lisp ($primus_lisp_library_path)

--- a/plugins/bil/bil_ir.ml
+++ b/plugins/bil/bil_ir.ml
@@ -137,8 +137,10 @@ module IR = struct
       blks = [{name=entry; jmps=[]; defs=[Def.reify ~tid v x]}]
     }
 
-  let goto ?cnd ~tid dst =
-    Jmp.reify ?cnd ~tid ~dst:(Jmp.resolved dst) ()
+  let goto ?(is_call=false) ?cnd ~tid dst =
+    if is_call
+    then Jmp.reify ?cnd ~tid ~alt:(Jmp.resolved dst) ()
+    else Jmp.reify ?cnd ~tid ~dst:(Jmp.resolved dst) ()
 
   (** reifies a [while (<cnd>) <body>] loop to
 
@@ -291,9 +293,10 @@ module IR = struct
   let do_goto dst =
     fresh >>= fun entry ->
     fresh >>= fun tid ->
+    KB.collect Theory.Label.is_subroutine dst >>= fun is_call ->
     ctrl {
       entry;
-      blks = [blk entry ++ goto ~tid dst]
+      blks = [blk entry ++ goto ?is_call ~tid dst]
     }
 
 

--- a/plugins/bil/bil_lifter.mli
+++ b/plugins/bil/bil_lifter.mli
@@ -1,1 +1,13 @@
-val init : with_intrinsics:bool -> with_fp:bool -> unit -> unit
+type ispec = [
+  | `any
+  | `unk
+  | `special
+  | `tag of string
+  | `asm of string
+  | `insn of string * string
+]
+
+
+val init :
+  enable_intrinsics:ispec list ->
+  with_fp:bool -> unit -> unit

--- a/plugins/bil/bil_lifter.mli
+++ b/plugins/bil/bil_lifter.mli
@@ -1,1 +1,1 @@
-val init : with_fp:bool -> unit -> unit
+val init : with_intrinsics:bool -> with_fp:bool -> unit -> unit

--- a/plugins/bil/bil_main.ml
+++ b/plugins/bil/bil_main.ml
@@ -137,7 +137,7 @@ let () =
             intrinsic functions. The option accepts a list of \
             instruction specifications and can be specified multiple \
             times. Each element of the list is either a keyword \
-            or a parametrized predicate. If an instuction matches any \
+            or a parametrized predicate. If an instruction matches any \
             of the specifications than it will be translated into a call to \
             an intrinsic function. The following keywords are \
             recognized, $(b,:any) - matches with any instruction, \

--- a/plugins/bil/bil_main.ml
+++ b/plugins/bil/bil_main.ml
@@ -151,7 +151,7 @@ let () =
             instructions that have a tag (kind) that starts with \
             $(b,<str>), $(b,<s1>:<s2>) - matches with instructions \
             that have opcodes starting with $(b,<s2>) in the \
-            encoding that starts with $(b,<s3>). For predicates, \
+            encoding that starts with $(b,<s1>). For predicates, \
             all string comparisons are made case-insensitive. \
             Example, $(b,:unknown,:special,asm:addsd,llvm:trap)." in
 

--- a/plugins/bil/bil_main.ml
+++ b/plugins/bil/bil_main.ml
@@ -109,12 +109,19 @@ let () =
       in terms of bitvector arithmetic. This may lead to very large
       denotations." in
 
+  let enable_intrinsics = Configuration.flag "lift-unknown"
+      ~doc:"Translate unknown instructions into intrinsic calls. \
+            Warning! This feature is experimental and could be \
+            renamed, moved, or removed in the future." in
+
   declare ~provides:["bil"; "core-theory"; "lifter"] @@ fun ctxt ->
   let open Syntax in
   if ctxt-->list_passes then print_passes ()
   else begin
     Bil.select_passes (ctxt-->norml @ ctxt-->optim @ ctxt-->passes);
-    Bil_lifter.init ~with_fp:(ctxt-->enable_fp_emu) ();
+    Bil_lifter.init ()
+      ~with_fp:(ctxt-->enable_fp_emu)
+      ~with_intrinsics:(ctxt-->enable_intrinsics);
     Bil_ir.init();
     let open KB.Syntax in
     Theory.declare !!(module Bil_semantics.Core : Theory.Core)

--- a/plugins/bil/bil_semantics.mli
+++ b/plugins/bil/bil_semantics.mli
@@ -5,6 +5,10 @@ type context
 val context : context KB.obj KB.t
 val arch : (context, arch) KB.slot
 
+module Call : sig
+  val create : string -> Stmt.t
+  val dst : Stmt.t -> string option
+end
 
 module Core : Theory.Core
 module Core_with_fp_emulation  : Theory.Core

--- a/plugins/primus_lisp/lisp/floats.lisp
+++ b/plugins/primus_lisp/lisp/floats.lisp
@@ -1,0 +1,1 @@
+(require llvm-x86-64-floats)

--- a/plugins/primus_lisp/lisp/init.lisp
+++ b/plugins/primus_lisp/lisp/init.lisp
@@ -45,8 +45,8 @@
            1 'hello
            2 'cruel
            3 'world))"
-  (let ((k k))
-    (case/dispatch k x xs)))
+  (let ((key k))
+    (case/dispatch key x xs)))
 
 (defun non-zero (x)
   "(non-zero X) is true if X is not zero"

--- a/plugins/primus_lisp/lisp/llvm-x86-64-floats.lisp
+++ b/plugins/primus_lisp/lisp/llvm-x86-64-floats.lisp
@@ -1,0 +1,100 @@
+(require posix)
+(require types)
+
+(defmacro lower-all (r) (set r false))
+(defmacro lower-all (r rs) (prog (set r false) (lower-all rs)))
+
+(defun ymm_t () 256)
+(defun xmm_t () 128)
+
+(defmacro sse-unpack (t n r)
+  "(sse-unpack T N R) unpacks the Nth word of type T from the register R"
+  (extract (-1 (* (+1 n) (t))) (* n (t)) r))
+
+(defmacro sse-pack-low (tr tv r v)
+  (concat (extract (-1 (tr)) (tv) r) (sse-unpack tv 0 v)))
+
+(defun reg-val (reg)
+  (case (reg-name reg)
+    'RIP (+ (get-current-program-counter) 8)
+    'RSP RSP
+    'RBP RBP
+    (error "unknown register")))
+
+(defmacro read-xmm (t op)
+  (case (reg-name op)
+    'XMM0 (sse-unpack t 0 YMM0)
+    'XMM1 (sse-unpack t 0 YMM1)
+    'XMM2 (sse-unpack t 0 YMM2)
+    'XMM3 (sse-unpack t 0 YMM3)
+    'XMM4 (sse-unpack t 0 YMM4)
+    'XMM5 (sse-unpack t 0 YMM5)
+    'XMM6 (sse-unpack t 0 YMM6)
+    'XMM7 (sse-unpack t 0 YMM7)
+    'XMM8 (sse-unpack t 0 YMM8)
+    'XMM9 (sse-unpack t 0 YMM9)
+    'XMM10 (sse-unpack t 0 YMM10)
+    'XMM11 (sse-unpack t 0 YMM11)
+    'XMM12 (sse-unpack t 0 YMM12)
+    'XMM13 (sse-unpack t 0 YMM13)
+    'XMM14 (sse-unpack t 0 YMM14)
+    'XMM15 (sse-unpack t 0 YMM15)
+    (error "unknown xmm register")))
+
+(defun xmm-parent (reg)
+  (case (reg-name reg)
+    'XMM0 'YMM0
+    'XMM1 'YMM1
+    'XMM2 'YMM2
+    'XMM3 'YMM3
+    'XMM4 'YMM4
+    'XMM5 'YMM5
+    'XMM6 'YMM6
+    'XMM7 'YMM7
+    'XMM8 'YMM8
+    'XMM9 'YMM9
+    'XMM10 'YMM10
+    'XMM11 'YMM11
+    'XMM12 'YMM12
+    'XMM13 'YMM13
+    'XMM14 'YMM14
+    'XMM15 'YMM15))
+
+(defmacro write-xmm (type dst val)
+  (let ((p (xmm-parent dst)))
+    (set-symbol-value p (sse-pack-low ymm_t type p val))))
+
+
+(defmacro fadd-scalar/rm (type)
+  (let ((dest insn:op1)
+        (src1 (read-xmm type insn:op2))
+        (src2 (read-word type (+ (reg-val insn:op3) insn:op6))))
+    (write-xmm type dest (ieee754-add (type) src1 src2))
+    (exec-addr insn:next_address)))
+
+(defmacro fdiv-scalar/rr (type)
+  (let ((dest insn:op1)
+        (src1 (read-xmm type insn:op2))
+        (src2 (read-xmm type insn:op3)))
+    (write-xmm type dest (ieee754-div (type) src1 src2))
+    (exec-addr insn:next_address)))
+
+(defmacro fcmp-scalar/rm (type)
+  (let ((x (read-xmm type insn:op1))
+        (y (read-word type (+ (reg-val insn:op2) insn:op5))))
+    (lower-all SF AF OF ZF CF PF)
+    (set ZF (ieee754-eq (type) x y))
+    (set CF (ieee754-lt (type) x y))
+    (exec-addr insn:next_address)))
+
+(defun fadd-scalar-double/rm ()
+  (declare (external llvm-x86_64:ADDSDrm))
+  (fadd-scalar/rm double))
+
+(defun fdiv-scalar-double/rr ()
+  (declare (external llvm-x86_64:DIVSDrr))
+  (fdiv-scalar/rr double))
+
+(defun fcmp-scalar-double/rm ()
+  (declare (external llvm-x86_64:UCOMISDrm))
+  (fcmp-scalar/rm double))

--- a/plugins/primus_lisp/lisp/types.lisp
+++ b/plugins/primus_lisp/lisp/types.lisp
@@ -89,6 +89,8 @@
 (defun int32_t () 32)
 (defun int64_t () 64)
 (defun ptr_t () (word-width))
+(defun double () 64)
+(defun float () 32)
 
 (defmacro cast (type x) (extract  (-1 (type)) 0 x))
 (defmacro bitwidth (type) (type))

--- a/plugins/primus_lisp/primus_lisp_ieee754.ml
+++ b/plugins/primus_lisp/primus_lisp_ieee754.ml
@@ -1,0 +1,140 @@
+open Core_kernel
+open Bap.Std
+open Bap_primus.Std
+
+
+let word_of_float width x = match width with
+  | 32 -> Word.of_int32 (Int32.bits_of_float x)
+  | 64 -> Word.of_int64 (Int64.bits_of_float x)
+  | _ -> invalid_arg "word_of_float"
+
+let float_of_word x = match Word.bitwidth x with
+  | 32 -> Int32.float_of_bits (Word.to_int32_exn x)
+  | 64 -> Int64.float_of_bits (Word.to_int64_exn x)
+  | d -> invalid_argf "float_of_word: %d" d ()
+
+module Primitives(Machine : Primus.Machine.S) = struct
+  module Lisp = Primus.Lisp.Make(Machine)
+
+  type 'a op =
+    | Inf : (float -> float -> float) op
+    | Pre : (float -> float) op
+    | Cti : (float -> int64) op
+    | Ord : (float -> float -> bool) op
+
+  let inf = Inf
+  let pre = Pre
+  let cti = Cti
+  let ord = Ord
+
+  let type_of_op (type a) (op : a op) =
+    let open Primus.Lisp.Type.Spec in
+    match op with
+    | Inf -> tuple [int; a] // all a @-> a
+    | Pre -> tuple [int; a; a] @-> a
+    | Cti -> tuple [int; a] @-> b
+    | Ord -> tuple [int; a; a] @-> bool
+
+  let desc_of_op (type a) (op : a op) name =
+    match op with
+    | Inf -> sprintf "reduces the list of operands with %s" name
+    | Pre -> sprintf "applies %s to the operand" name
+    | Cti -> sprintf "truncates to the nearest integer"
+    | Ord -> sprintf "returns true if all operands are ordered \
+                      with the %s order" name
+
+
+  let define (type f) (k : f op) name (f : f) =
+    let module Op(Machine : Primus.Machine.S) = struct
+      open Machine.Syntax
+
+      module Lisp = Primus.Lisp.Make(Machine)
+      module Value = Primus.Value.Make(Machine)
+
+      let if_empty ops f =
+        if List.is_empty ops
+        then f
+        else Lisp.failf "%s: expects exactly three arguments"
+            name ()
+
+      let rec ordered order = function
+        | [] | [_] -> true
+        | x :: (y :: _ as rest) -> order x y && ordered order rest
+
+      let value_of_word x = float_of_word (Value.to_word x)
+
+      let run = function
+        | [] | [_] | [_;_] ->
+          Lisp.failf "%s: type error - expects 2 or more arguments" name ()
+        | sz :: op :: ops -> match Word.to_int (Value.to_word sz) with
+          | Error _ ->
+            Lisp.failf "%s: expects format as the first a" name ()
+          | Ok n when n <> 32 && n <> 64 ->
+            Lisp.failf "%s: only 32 or 64 bit binary formats are supported"
+              name ()
+          | Ok width ->
+            let op = value_of_word op in
+            match k with
+            | Inf ->
+              List.fold ~init:op ops ~f:(fun res op ->
+                  f res (value_of_word op)) |>
+              word_of_float width |>
+              Value.of_word
+            | Pre ->
+              if_empty ops @@ Value.of_word @@
+              word_of_float width (f op)
+            | Cti ->
+              if_empty ops @@
+              Value.of_word @@
+              Word.of_int64 ~width (f op)
+            | Ord ->
+              Value.of_word @@
+              Word.of_bool @@
+              ordered f (op::List.map ~f:value_of_word ops)
+
+    end in
+    Lisp.define ("ieee754-" ^ name) (module Op)
+      ~docs:(desc_of_op k name)
+      ~types:(type_of_op k)
+
+  let init () = Machine.sequence Caml.[
+      define inf "add" ( +. );
+      define inf "sub" ( -. );
+      define inf "div" ( /. );
+      define inf "mul" ( *. );
+      define inf "pow" ( **);
+      define pre "sqrt" ( sqrt );
+      define pre "neg"  (~-.);
+      define pre "pos"  (~+.);
+      define pre "exp" exp;
+      define pre "expm1" expm1;
+      define pre "log" log;
+      define pre "log10" log10;
+      define pre "log1p" log1p;
+      define pre "cos" cos;
+      define pre "sin" sin;
+      define pre "tan" tan;
+      define pre "cosh" cosh;
+      define pre "sinh" sinh;
+      define pre "tanh" tanh;
+      define pre "acos" acos;
+      define pre "asin" asin;
+      define pre "atan" atan;
+      define inf "atan2" atan2;
+      define inf "hypot" hypot;
+      define pre "ceil" ceil;
+      define pre "floor" floor;
+      define pre "abs" abs_float;
+      define inf "mod" mod_float;
+      define cti "cti" Int64.of_float;
+      define ord "lt" (<.);
+      define ord "le" (<=.);
+      define ord "eq" (=.);
+      define ord "ne" (<>.);
+      define ord "gt" (>.);
+      define ord "ge" (>=.);
+    ]
+end
+
+
+let init () = Primus.Machine.add_component (module Primitives)

--- a/plugins/primus_lisp/primus_lisp_ieee754.mli
+++ b/plugins/primus_lisp/primus_lisp_ieee754.mli
@@ -1,0 +1,1 @@
+val init : unit -> unit

--- a/plugins/primus_lisp/primus_lisp_primitives.ml
+++ b/plugins/primus_lisp/primus_lisp_primitives.ml
@@ -2,13 +2,26 @@ open Core_kernel
 open Bap.Std
 open Bap_primus.Std
 
-module Lib(Machine : Primus.Machine.S) = struct
+let registers = Primus.Machine.State.declare
+    ~uuid:"3dd2b905-c019-4466-800f-95b13d7da85e"
+    ~name:"backend-registers" @@ fun proj ->
+  Project.disasm proj |> Disasm.insns |>
+  Seq.fold ~init:Int.Map.empty ~f:(fun regs (_,insn) ->
+      Insn.ops insn |>
+      Array.fold ~init:regs ~f:(fun regs -> function
+          | Op.Reg r ->
+            Map.set regs (Reg.code r) (Reg.name r)
+          | _ -> regs))
+
+module Make(Machine : Primus.Machine.S) = struct
   module Eval = Primus.Interpreter.Make(Machine)
   module Lisp = Primus.Lisp.Make(Machine)
   module Memory = Primus.Memory.Make(Machine)
   module Value = Primus.Value.Make(Machine)
   module Linker = Primus.Linker.Make(Machine)
-  include Machine.Syntax
+
+  open Machine.Syntax
+
   let all f args = List.exists args ~f |> Value.of_bool
   let addr_width =
     Machine.arch >>| Arch.addr_size >>| Size.in_bits
@@ -31,11 +44,28 @@ module Lib(Machine : Primus.Machine.S) = struct
       | [] | [_] -> true
       | x :: (y :: _ as rest) -> order x y && ordered rest in
     if ordered xs then true_ else false_
-
 end
 
+module RegName(Machine : Primus.Machine.S) = struct
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+  let run = function
+    | [] | _::_::_ ->
+      Lisp.failf "reg-name expects only one argument" ()
+    | [code] ->
+      Machine.Local.get registers >>= fun regs ->
+      let code = Word.to_int_exn @@ Primus.Value.to_word code in
+      match Map.find regs code with
+      | None -> Lisp.failf "unresolved intruction register %#x" code ()
+      | Some name -> Value.Symbol.to_value name
+end
+
+
 module ExecAddr(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
   let run = function
     | _ :: _ :: _ | [] ->
       Lisp.failf "Lisp Type Error: exec-address expects one argument" ()
@@ -46,7 +76,9 @@ module ExecAddr(Machine : Primus.Machine.S) = struct
 end
 
 module ExecSym(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
   let run = function
     | _ :: _ :: _ | [] ->
       Lisp.failf "Lisp Type Error: exec-address expects one argument" ()
@@ -58,22 +90,31 @@ module ExecSym(Machine : Primus.Machine.S) = struct
 end
 
 module IsZero(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
   let run = all Value.is_zero
 end
 
 module IsPositive(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
   let run = all Value.is_positive
 end
 
 module IsNegative(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
   let run = all Value.is_negative
 end
 
 module WordWidth(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run args =
     addr_width >>= fun width ->
     match args with
@@ -82,7 +123,10 @@ module WordWidth(Machine : Primus.Machine.S) = struct
 end
 
 module ExitWith(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = all Value.is_negative
   let run _ =
     Eval.halt >>|
@@ -91,7 +135,10 @@ module ExitWith(Machine : Primus.Machine.S) = struct
 end
 
 module MemoryAllocate(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let negone = Value.one 8
   let zero = Value.zero 8
 
@@ -118,7 +165,10 @@ end
 
 
 module MemoryRead(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = function
     | [x] ->
       endian >>= fun e -> Eval.load x e `r8
@@ -126,7 +176,10 @@ module MemoryRead(Machine : Primus.Machine.S) = struct
 end
 
 module MemoryWrite(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = function
     | [a;x] ->
       endian >>= fun e ->
@@ -136,7 +189,10 @@ module MemoryWrite(Machine : Primus.Machine.S) = struct
 end
 
 module GetPC(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = function
     | [] -> Eval.pc >>= Value.of_word
     | _ -> Lisp.failf
@@ -145,96 +201,147 @@ end
 
 
 module Add(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = reduce null (Eval.binop Bil.PLUS)
 end
 
 module Sub(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = reduce null (Eval.binop Bil.MINUS)
 end
 
 module Div(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = reduce null (Eval.binop Bil.DIVIDE)
 end
 
 module SDiv(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = signed_reduce null (Eval.binop Bil.SDIVIDE)
 end
 
 module Mul(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = reduce null (Eval.binop Bil.TIMES)
 end
 
 module Mod(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = reduce null (Eval.binop Bil.MOD)
 end
 
 module SignedMod(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = signed_reduce null (Eval.binop Bil.SMOD)
 end
 
 module Lshift(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = function
     | [x;y] -> Eval.binop Bil.lshift x y
     | _ -> Lisp.failf "Type error: lshift expects two arguments" ()
 end
 
 module Rshift(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = function
     | [x;y] -> Eval.binop Bil.rshift x y
     | _ -> Lisp.failf "Type error: rshift expects two arguments" ()
 end
 
 module Arshift(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = function
     | [x;y] -> Eval.binop Bil.arshift x y
     | _ -> Lisp.failf "Type error: arshift expects two arguments" ()
 end
 
 module Equal(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = function
     | [] -> true_
     | x :: xs -> all (Value.equal x) xs
 end
 
 module NotEqual(Machine : Primus.Machine.S) = struct
-  include Equal(Machine)
-  let run xs = run xs >>= (Eval.unop Bil.NOT)
+  module Lib = Make(Machine)
+  module Equal = Equal(Machine)
+  open Machine.Syntax
+
+  let run xs = Equal.run xs >>= (Lib.Eval.unop Bil.NOT)
 end
 
 
 module Logand(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = reduce negone (Eval.binop Bil.AND)
 end
 
 module Logor(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = reduce null (Eval.binop Bil.OR)
 end
 
 module Logxor(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = reduce null (Eval.binop Bil.XOR)
 end
 
 module Concat(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = reduce false_ Eval.concat
 end
 
 module Extract(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
 
   let to_int e = match Word.to_int (Value.to_word e) with
     | Ok x -> Machine.return x
@@ -249,56 +356,96 @@ module Extract(Machine : Primus.Machine.S) = struct
 end
 
 module Not(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = function
     | [x] -> if Value.is_zero x then Value.b1 else Value.b0
     | _ -> Lisp.failf "not expects only one argument" ()
 end
 
 module Lnot(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = function
     | [x] -> Eval.unop Bil.NOT x
     | _ -> Lisp.failf "lnot expects only one argument" ()
 end
 
 module Neg(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run = function
     | [x] -> Eval.unop Bil.NEG x
     | _ -> Lisp.failf "neg expects only one argument" ()
 end
 
 module Less(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let rec run = ordered Value.(<)
 end
 
 module Greater(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let rec run = ordered Value.(>)
 end
 
 module LessEqual(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let rec run = ordered Value.(<=)
 end
 
 module GreaterEqual(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let rec run = ordered Value.(>=)
 end
 
 module SymbolConcat(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
   let run syms =
     Machine.List.map syms ~f:Value.Symbol.of_value >>= fun strs ->
     Value.Symbol.to_value (String.concat strs)
-
 end
 
+module SetSymbol(Machine : Primus.Machine.S) = struct
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
+
+  let run = function
+    | [reg; x] ->
+      Value.Symbol.of_value reg >>= fun reg ->
+      let typ = Type.imm (Word.bitwidth (Value.to_word x)) in
+      let var = Var.create reg typ in
+      Eval.set var x >>| fun () -> x
+    | _ -> Lisp.failf "set-symbol-value expects exactly two arguments" ()
+end
+
+
 module Stub(Machine : Primus.Machine.S) = struct
-  include Lib(Machine)
+  module Lib = Make(Machine)
+  open Machine.Syntax
+  open Lib
   let run = Lisp.failf "not implemented"
 end
 
@@ -341,7 +488,7 @@ module Primitives(Machine : Primus.Machine.S) = struct
         "(- X Y Z ...) returns X - Y - Z - ..., or 0 if there are no
          arguments.";
       def "*" (all a @-> a) (module Mul)
-        "(* X Y Z ...) returns the product of arguments or 1 if the list
+        "(* X Y Z ...) returns the product of arguments or 0 if the list
         of arguments is empty";
       def "/" (all a @-> a) (module Div)
         "(/ X Y Z ...) returns X / Y / Z / ... or 0 if the list of
@@ -404,9 +551,16 @@ module Primitives(Machine : Primus.Machine.S) = struct
          descending chain or if it is empty";
       def "symbol-concat" (all sym @-> sym) (module SymbolConcat)
         "(symbol-concat X Y Z ...) returns a new symbol that is a
-        concatenation of symbols X,Y,Z,... "
+        concatenation of symbols X,Y,Z,... ";
+      def "set-symbol-value" (tuple [sym; a] @-> a) (module SetSymbol)
+        "(set-symbol-value S X) sets the value of the symbol S to X.
+         Returns X";
+      def "reg-name" (one int @-> sym) (module RegName)
+        "(reg-name N) returns the name of the register with the index N"
       ;
     ]
 end
 
-let init () = Primus.Machine.add_component (module Primitives)
+let init () =
+  Primus.Machine.add_component (module Primitives);
+  Primus_lisp_ieee754.init ()


### PR DESCRIPTION
TL;DR; This branch adds a new feature that allows us to stub instructions in Primus Lisp, by turning certain instructions (including those for which we do not know semantics) into calls to intrinsics. This gives us two important advantages:

1. we can now easily stub/lift unknown/unsupported instructions in Primus Lisp 
2. we can prune complex (read SSE/AVX,FP) instructions (which take megabytes of BIL code) and use the host CPU for the computation. That will vastly improve code coverage and analysis speed for programs that use floating-points and SSE extensions.

# Implementation details

The `--bil-enable-intrinsic` option specifies which instructions we would like to translate into the calls to intrinsics. A call to an intrinsic is no different from a normal call. For passing arguments we used a set of special variables (each of the size of a machine word) and having names `insn:op<N>` where `<N>` ranges from `1` to the number of operands in the instruction. To let the intrinsic control the flow of execution we pass the fall-through address through the specifically designated link register called `insn:next_address`. Since intrinsics are always leaves we do not need a stack of return links. We also assume on the CFG level, that an intrinsic has a fall edge. Example,
```
0000048a: insn:op1 := 0x7F
0000048d: insn:op2 := 0x7F
00000490: insn:op3 := 0x24
00000493: insn:op4 := 1
00000496: insn:op5 := 0
00000499: insn:op6 := 0xFFFFFFFFFFFFFFE8
0000049c: insn:op7 := 0
0000049f: insn:next_address := 0x40055F
000004a2: call @llvm-x86_64:ADDSDrm with return %000004a4
```

The instruction above is ADDSDrm (that, when lifted, takes more than 50k of BIL code), here is its assembler and llvm-encoding:

```
$ bap-mc --show-insn=asm,pretty --llvm-x86-syntax=intel -- f2 0f 58 45 e8
addsd xmm0, qword ptr [rbp - 0x18]
ADDSDrm(XMM0,XMM0,RBP,0x1,Nil,-0x18,Nil)
```
we have inferred, that the llvm encoding has the following meaning 
```fortran
ADDSDrm(DST,SRC,PTR,??,_,OFF,_):
   DST := SRC + PTR[OFF]
```
which we can represent in Primus Lisp as
```lisp
(defmacro fadd-scalar/rm (type)
  (let ((dest insn:op1)
        (src1 (read-xmm type insn:op2))
        (src2 (read-word type (+ (reg-val insn:op3) insn:op6))))
    (write-xmm type dest (ieee754-add (type) src1 src2))
    (exec-addr insn:next_address)))
```

In the code above, we use `ieee754-add` primitive which will use the host CPU to compute the result of the floating-point addition operation. We currently support only two IEEE754 encodings: binary32 (aka float) and IEEE754 (aka double).

# The impact on analyses

Turning an instruction into an intrinsic is akin to using an uninterpreted function, it abstracts the details which on one hand is good (we have to reason about the smaller thing), but, on the other hand, we are losing information during abstraction. In particular, for the `ieee754-add` primitive, which is now abstracted into a single call, we lost the knowledge worth of 50k expressions. It was too much detail for us, so we're happy with that, but in general, we would like to keep reasoning about those primitives, e.g., for the taint analysis we would like to propagate taint between inputs and outputs. To enable this, we published the `primitive` observation that has form `(lisp-primitive <name> <arg1> .... <argM> <rval>)`. Now it is possible to tune analysis to propagate taint (and other analyses too) and keep in mind the semantics of the operation.

The `lisp-primitive` observation has it problems also. It is so low-level and is posted very often, so it could be a better idea for each intrinsics to have their own specific to their theory observations. On the other hand, having `lisp-primitive` is quite convenient (and doesn't stop us from having specialized observations). 


# Roadmap

This branch is already functional and we're able to pass our floating-point test (that involves only three floating-point operations). But in general, this feature is not about floating-points, but about complex and missing instructions that we want to be able to analyze in Primus without hassle. So the plan is, to add a feature to our lifters that will disable certain instructions (or maybe a pass that will prune instructions after the got lifted and substitute it with calls to intrinsics). Anyway, finally, we will have complex instructions removed from the static representation and substituted with simple calls. The same is with missing instructions, which will now be just the calls. 

Also, in the long term, when we will introduce BAP Lisp (a version of Primus Lisp, that won't require Primus) we will be able to reify Primus Lisp stubs into static representation, so the stubs written for intrinsics will serve as lifters. 


# User interface

Intrinsics are currently enabled with  the `--bil-enable-intrinsics` option that has the following specification (excerpt from the `man bap` page)
```
       --bil-enable-intrinsics=VAL
           Translate the specified instructions into calls to intrinsic
           functions. The option accepts a list of instruction specifications
           and can be specified multiple times. Each element of the list is
           either a keyword or a parametrized predicate. If an instruction
           matches any of the specifications than it will be translated into a
           call to an intrinsic function. The following keywords are
           recognized, :any - matches with any instruction, :unknown - matches
           with instructions that have unknown (to our lifters) semantics,
           :special - matches with instructions that have special semantics
           (expressed with the special statement by our lifters). The
           following predicates are recognized, asm:<str> matches with
           instructions which assembly strings start with <str>, tag:<str> -
           matches with instructions that have a tag (kind) that starts with
           <str>, <s1>:<s2> - matches with instructions that have opcodes
           starting with <s2> in the encoding that starts with <s3>. For
           predicates, all string comparisons are made case-insensitive.
           Example, :unknown,:special,asm:addsd,llvm:trap.
```