### PR TITLE
optimizes Primus observations

### DIFF
--- a/lib/bap_primus/bap_primus.ml
+++ b/lib/bap_primus/bap_primus.ml
@@ -6,6 +6,7 @@ module Std = struct
     module Env = Bap_primus_env
     module Generator = Bap_primus_generator
     module Interpreter = Bap_primus_interpreter
+    module Time = Interpreter.Time
     module Linker = Bap_primus_linker
     module Machine = struct
       module type State = State

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -5,6 +5,8 @@ open Monads.Std
 open Bap_future.Std
 open Bap_strings.Std
 
+[@@@warning "-D"]
+
 module Std : sig
   (** Primus - The Microexecution Framework.
 
@@ -60,7 +62,6 @@ module Std : sig
       it can modify other components (depending on their interface).
 
   *)
-  [@@@warning "-D"]
 
   module Primus : sig
     (** Machine Exception.
@@ -99,7 +100,7 @@ module Std : sig
     (** Machine Observation.
 
         The Primus Framework is built on top of the Machine
-        observation. The Machine components make their own
+        observations. The Machine components make their own
         observations, based on observation made by other components.
 
         A value of type ['a observation] is a first-class
@@ -143,7 +144,7 @@ module Std : sig
       (** Data interface to the provider.
 
           This interface provides access to the data stream of all
-          providers expresses as a stream of s-expressions.
+          providers. The data stream is expressed as a stream of s-expressions.
       *)
       module Provider : sig
         type t = provider
@@ -154,7 +155,7 @@ module Std : sig
         (** a total number of observers that subscribed to this provider  *)
         val observers : t -> int
 
-        (** triggers a stream of occurrences of this observation  *)
+        (** a stream of occurrences of this observation  *)
         val triggers : t -> unit stream
 
         (** a data stream from this observation *)
@@ -359,6 +360,7 @@ module Std : sig
 
         (** Observations interface.  *)
         module Observation : sig
+          type posted
 
           (** [observe obs on_observation] subscribes to the given
               observation [obs]. Every time the observation [obs] is
@@ -374,6 +376,9 @@ module Std : sig
           (** [make observation event] make an [observation] of the
               given [event].  *)
           val make : 'a statement -> 'a -> unit t
+
+          val post : 'a statement -> f:(('a -> posted) -> posted) -> unit t
+
         end
 
 

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -360,7 +360,6 @@ module Std : sig
 
         (** Observations interface.  *)
         module Observation : sig
-          type posted
 
           (** [observe obs on_observation] subscribes to the given
               observation [obs]. Every time the observation [obs] is
@@ -377,7 +376,7 @@ module Std : sig
               given [event].  *)
           val make : 'a statement -> 'a -> unit t
 
-          val post : 'a statement -> f:(('a -> posted) -> posted) -> unit t
+          val post : 'a statement -> f:(('a -> unit t) -> unit t) -> unit t
 
         end
 

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -76,6 +76,8 @@ module Std : sig
     (** [a statement] is used to make an observation of type [a].    *)
     type 'a statement
 
+    type subscription
+
     (** a result of computation  *)
     type value [@@deriving bin_io, compare, sexp]
 
@@ -369,6 +371,9 @@ module Std : sig
               other components via their interfaces.  *)
           val observe : 'a observation -> ('a -> unit t) -> unit t
 
+          val subscribe : 'a observation -> ('a -> unit t) -> subscription t
+
+          val cancel : subscription -> unit t
 
           val watch : Observation.provider -> (Sexp.t -> unit t) -> unit t
 

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -779,6 +779,15 @@ module Std : sig
 
     end
 
+    module Time : sig
+      type t [@@deriving sexp_of]
+      val clocks : t -> int
+      val of_clocks : int -> t
+      val to_string : t -> string
+      val pp : Format.formatter -> t -> unit
+      include Base.Comparable.S with type t := t
+    end
+
 
     (** The Interpreter.
 
@@ -795,6 +804,8 @@ module Std : sig
         with the [(x,y,z)] tuple, that in fact corresponds to
         [observation >>> fun (x,y,z)] -> ... *)
     module Interpreter : sig
+
+      val clock : Time.t observation
 
       (** [pc_change x] happens every time a code at address [x] is executed.  *)
       val pc_change : addr observation
@@ -1017,6 +1028,8 @@ module Std : sig
           given [Machine].  *)
       module Make (Machine : Machine.S) : sig
         type 'a m = 'a Machine.t
+
+        val time : Time.t m
 
         (** [halt] halts the machine by raise the [Halt] exception.  *)
         val halt : never_returns m

--- a/lib/bap_primus/bap_primus_interpreter.ml
+++ b/lib/bap_primus/bap_primus_interpreter.ml
@@ -262,6 +262,8 @@ module Make (Machine : Machine) = struct
 
   let (!!) = Machine.Observation.make
 
+  let post = Machine.Observation.post
+
   let failf fmt = Format.ksprintf (fun msg ->
       fun () -> Machine.raise (Runtime_error msg)) fmt
 
@@ -279,13 +281,12 @@ module Make (Machine : Machine) = struct
   let set v x =
     !!on_writing v >>= fun () ->
     Env.set v x >>= fun () ->
-    !!on_written (v,x)
-
+    post on_written ~f:(fun k -> k (v,x))
 
   let get v =
     !!on_reading v >>= fun () ->
     Env.get v >>= fun r ->
-    !!on_read (v,r) >>| fun () -> r
+    post on_read ~f:(fun k -> k (v,r)) >>| fun () -> r
 
   let call_when_provided name =
     Code.is_linked (`symbol name) >>= fun provided ->
@@ -303,23 +304,23 @@ module Make (Machine : Machine) = struct
       else Machine.raise Division_by_zero
     | _ ->
       value (Bil.Apply.binop op x.value y.value) >>= fun r ->
-      !!on_binop ((op,x,y),r) >>| fun () -> r
+      post on_binop ~f:(fun k -> k ((op,x,y),r)) >>| fun () -> r
 
   let unop op x =
     value (Bil.Apply.unop op x.value) >>= fun r ->
-    !!on_unop ((op,x),r) >>| fun () -> r
+    post on_unop ~f:(fun k -> k ((op,x),r)) >>| fun () -> r
 
   let cast t s x =
     value (Bil.Apply.cast t s x.value) >>= fun r ->
-    !!on_cast ((t,s,x),r) >>| fun () -> r
+    post on_cast ~f:(fun k -> k ((t,s,x),r)) >>| fun () -> r
 
   let concat x y =
     value (Word.concat x.value y.value) >>= fun r ->
-    !!on_concat ((x,y),r) >>| fun () -> r
+    post on_concat ~f:(fun k -> k ((x,y),r)) >>| fun () -> r
 
   let extract ~hi ~lo x =
     value (Word.extract_exn ~hi ~lo x.value) >>= fun r ->
-    !!on_extract ((hi,lo,x),r) >>| fun () -> r
+    post on_extract ~f:(fun k -> k ((hi,lo,x),r)) >>| fun () -> r
 
   let const c =
     value c >>= fun r ->
@@ -339,16 +340,16 @@ module Make (Machine : Machine) = struct
   let load_byte a =
     !!on_loading a >>= fun () ->
     trapped_memory_access (Memory.get a.value) >>= fun r ->
-    !!on_loaded (a,r) >>| fun () -> r
+    post on_loaded ~f:(fun k -> k (a,r)) >>| fun () -> r
 
   let store_byte a x =
     !!on_storing a >>= fun () ->
     trapped_memory_access (Memory.set a.value x) >>= fun () ->
-    !!on_stored (a,x)
+    post on_stored ~f:(fun k -> k (a,x))
 
   let ite cond yes no =
     value (if Word.is_one cond.value then yes.value else no.value) >>= fun r ->
-    !!on_ite ((cond, yes, no), r) >>| fun () -> r
+    post on_ite ~f:(fun k -> k ((cond, yes, no), r)) >>| fun () -> r
 
 
   let get_lexical scope v =
@@ -564,7 +565,7 @@ module Make (Machine : Machine) = struct
     | None -> Machine.return ()
     | Some addr ->
       Value.of_word addr >>= fun addr ->
-      !!will_jump (cond,addr)
+      post will_jump ~f:(fun k -> k (cond,addr))
 
   let exec_to_prompt dst =
     Machine.Local.get state >>= function
@@ -578,7 +579,7 @@ module Make (Machine : Machine) = struct
       exec_to_prompt dst
     | Indirect x ->
       eval_exp x >>= fun ({value} as dst) ->
-      !!will_jump (cond,dst) >>= fun () ->
+      post will_jump ~f:(fun k -> k (cond,dst)) >>= fun () ->
       Code.resolve_tid (`addr value) >>= function
       | None -> Code.exec (`addr value)
       | Some dst -> exec_to_prompt dst
@@ -683,12 +684,12 @@ module Make (Machine : Machine) = struct
       let name = Sub.name t in
       iter_args t arg_def >>= fun () ->
       get_args ~input:true t >>| Seq.to_list_rev >>= fun inputs ->
-      !!Linker.Trace.call_entered (name,List.rev inputs) >>= fun () ->
+      post Linker.Trace.call_entered ~f:(fun k -> k (name,List.rev inputs)) >>= fun () ->
       blk entry >>= fun () ->
       iter_args t arg_use >>= fun () ->
       get_args ~input:false t >>| Seq.to_list >>= fun rets ->
       let args = List.rev_append inputs rets in
-      !!Linker.Trace.call_returned (name,args)
+      post Linker.Trace.call_returned ~f:(fun k -> k (name,args))
 
 
   let sub = term normal sub_t sub

--- a/lib/bap_primus/bap_primus_interpreter.ml
+++ b/lib/bap_primus/bap_primus_interpreter.ml
@@ -684,12 +684,14 @@ module Make (Machine : Machine) = struct
       let name = Sub.name t in
       iter_args t arg_def >>= fun () ->
       get_args ~input:true t >>| Seq.to_list_rev >>= fun inputs ->
-      post Linker.Trace.call_entered ~f:(fun k -> k (name,List.rev inputs)) >>= fun () ->
+      post Linker.Trace.call_entered ~f:(fun k ->
+          k (name,List.rev inputs)) >>= fun () ->
       blk entry >>= fun () ->
       iter_args t arg_use >>= fun () ->
-      get_args ~input:false t >>| Seq.to_list >>= fun rets ->
-      let args = List.rev_append inputs rets in
-      post Linker.Trace.call_returned ~f:(fun k -> k (name,args))
+      post Linker.Trace.call_returned ~f:(fun k ->
+          get_args ~input:false t >>| Seq.to_list >>= fun rets ->
+          let args = List.rev_append inputs rets in
+          k (name,args))
 
 
   let sub = term normal sub_t sub

--- a/lib/bap_primus/bap_primus_interpreter.mli
+++ b/lib/bap_primus/bap_primus_interpreter.mli
@@ -2,6 +2,16 @@ open Core_kernel
 open Bap.Std
 open Bap_primus_types
 
+module Time : sig
+  type t [@@deriving sexp_of]
+  val clocks : t -> int
+  val of_clocks : int -> t
+  val to_string : t -> string
+  val pp : Format.formatter -> t -> unit
+  include Base.Comparable.S with type t := t
+end
+
+val clock : Time.t observation
 val pc_change : addr observation
 val halting : unit observation
 val interrupt : int observation
@@ -87,6 +97,9 @@ module Make (Machine : Machine) : sig
   val const : word -> value m
   val load : value -> endian -> size -> value m
   val store : value -> value -> endian -> size -> unit m
+
+  val tick : unit m
+  val time : Time.t m
 end
 
 

--- a/lib/bap_primus/bap_primus_lisp.mli
+++ b/lib/bap_primus/bap_primus_lisp.mli
@@ -120,6 +120,8 @@ module Make (Machine : Machine) : sig
 
   val eval_method  : string -> value list -> unit Machine.t
 
+  val optimize : unit -> unit Machine.t
+
   (* deprecated *)
   val link_primitives : primitives -> unit Machine.t
 end

--- a/lib/bap_primus/bap_primus_main.ml
+++ b/lib/bap_primus/bap_primus_main.ml
@@ -35,11 +35,11 @@ module Main(Machine : Machine) = struct
   let finish () =
     Machine.Observation.make finish ()
 
-
   let run ?(envp=[| |]) ?(args=[| |]) proj m =
     let comp =
       init_components () >>= fun () ->
       Lisp.typecheck >>= fun () ->
+      Lisp.optimize () >>= fun () ->
       init () >>= fun () ->
       Link.run () >>= fun () ->
       Machine.catch m (fun err ->

--- a/lib/bap_primus/bap_primus_memory.ml
+++ b/lib/bap_primus/bap_primus_memory.ml
@@ -4,7 +4,6 @@ open Format
 
 open Bap_primus_types
 
-module Observation = Bap_primus_observation
 module Iterator = Bap_primus_iterator
 module Random  = Bap_primus_random
 module Generator = Bap_primus_generator
@@ -151,8 +150,6 @@ module Make(Machine : Machine) = struct
 
   module Generate = Generator.Make(Machine)
   module Value = Bap_primus_value.Make(Machine)
-  let (!!) = Machine.Observation.make
-
 
   let memory =
     Machine.Local.get state >>| fun s -> s.curr

--- a/lib/bap_primus/bap_primus_observation.mli
+++ b/lib/bap_primus/bap_primus_observation.mli
@@ -1,6 +1,7 @@
 open Core_kernel
 open Bap.Std
 open Bap_future.Std
+open Monads.Std
 
 type 'a t
 type 'a statement
@@ -16,14 +17,16 @@ val of_statement : 'a statement -> 'a t
 val add_observer : 'e observations -> 'a t -> ('a -> 'e) -> 'e observations
 val add_watcher : 'e observations -> provider -> (Sexp.t -> 'e) -> 'e observations
 
-val notify :
-  'e observations ->
-  'a statement -> 'a -> 'e seq
+module Make(Machine : Monad.S) : sig
+  val notify :
+    unit Machine.t observations ->
+    'a statement -> 'a -> unit Machine.t
 
-val notify_if_observed :
-  'e observations ->
-  'a statement -> (('a -> 'e seq) -> 'e seq) -> 'e seq
-
+  val notify_if_observed :
+    unit Machine.t observations ->
+    'a statement ->
+    (('a -> unit Machine.t) -> unit Machine.t) -> unit Machine.t
+end
 val empty : 'e observations
 
 val list_providers : unit -> provider list

--- a/lib/bap_primus/bap_primus_observation.mli
+++ b/lib/bap_primus/bap_primus_observation.mli
@@ -6,7 +6,9 @@ open Monads.Std
 type 'a t
 type 'a statement
 type 'e observations
+type subscription
 type provider
+
 
 val provide : ?inspect:('a -> Sexp.t) -> string -> 'a t * 'a statement
 
@@ -14,8 +16,12 @@ val name : 'a t -> string
 val inspect : 'a t -> 'a -> Sexp.t
 val of_statement : 'a statement -> 'a t
 
-val add_observer : 'e observations -> 'a t -> ('a -> 'e) -> 'e observations
-val add_watcher : 'e observations -> provider -> (Sexp.t -> 'e) -> 'e observations
+
+val add_observer : 'e observations -> 'a t -> ('a -> 'e) -> 'e observations * subscription
+val add_watcher : 'e observations -> provider -> (Sexp.t -> 'e) ->
+  'e observations * subscription
+
+val cancel : subscription -> 'e observations -> 'e observations
 
 module Make(Machine : Monad.S) : sig
   val notify :
@@ -27,6 +33,7 @@ module Make(Machine : Monad.S) : sig
     'a statement ->
     (('a -> unit Machine.t) -> unit Machine.t) -> unit Machine.t
 end
+
 val empty : 'e observations
 
 val list_providers : unit -> provider list

--- a/lib/bap_primus/bap_primus_observation.mli
+++ b/lib/bap_primus/bap_primus_observation.mli
@@ -20,6 +20,10 @@ val notify :
   'e observations ->
   'a statement -> 'a -> 'e seq
 
+val notify_if_observed :
+  'e observations ->
+  'a statement -> (('a -> 'e seq) -> 'e seq) -> 'e seq
+
 val empty : 'e observations
 
 val list_providers : unit -> provider list

--- a/lib/bap_primus/bap_primus_types.ml
+++ b/lib/bap_primus/bap_primus_types.ml
@@ -41,9 +41,11 @@ module type Machine = sig
   type 'a m
 
   module Observation : sig
+    type posted
     val observe : 'a observation -> ('a -> unit t) -> unit t
     val watch : provider -> (Sexp.t -> unit t) -> unit t
     val make : 'a statement -> 'a -> unit t
+    val post : 'a statement -> f:(('a -> posted) -> posted) -> unit t
   end
 
   module Syntax : sig

--- a/lib/bap_primus/bap_primus_types.ml
+++ b/lib/bap_primus/bap_primus_types.ml
@@ -12,6 +12,7 @@ type pos = Pos.t [@@deriving sexp_of]
 type 'a observation = 'a Bap_primus_observation.t
 type provider = Bap_primus_observation.provider
 type 'a statement = 'a Bap_primus_observation.statement
+type subscription = Bap_primus_observation.subscription
 type 'a state = 'a Bap_primus_state.t
 type exit_status =
   | Normal
@@ -42,6 +43,8 @@ module type Machine = sig
 
   module Observation : sig
     val observe : 'a observation -> ('a -> unit t) -> unit t
+    val subscribe : 'a observation -> ('a -> unit t) -> subscription t
+    val cancel : subscription -> unit t
     val watch : provider -> (Sexp.t -> unit t) -> unit t
     val make : 'a statement -> 'a -> unit t
     val post : 'a statement -> f:(('a -> unit t) -> unit t) -> unit t

--- a/lib/bap_primus/bap_primus_types.ml
+++ b/lib/bap_primus/bap_primus_types.ml
@@ -41,11 +41,10 @@ module type Machine = sig
   type 'a m
 
   module Observation : sig
-    type posted
     val observe : 'a observation -> ('a -> unit t) -> unit t
     val watch : provider -> (Sexp.t -> unit t) -> unit t
     val make : 'a statement -> 'a -> unit t
-    val post : 'a statement -> f:(('a -> posted) -> posted) -> unit t
+    val post : 'a statement -> f:(('a -> unit t) -> unit t) -> unit t
   end
 
   module Syntax : sig

--- a/lib/bap_primus/bap_primus_value.ml
+++ b/lib/bap_primus/bap_primus_value.ml
@@ -5,9 +5,6 @@ open Bap_strings.Std
 open Format
 open Bap_primus_types
 
-module Observation = Bap_primus_observation
-
-
 module Id = struct
   type t = Int63.t
   include Regular.Make(struct

--- a/lib/bap_taint/bap_taint.ml
+++ b/lib/bap_taint/bap_taint.ml
@@ -202,9 +202,9 @@ module Taint = struct
     let attach v r ts = change v r ~f:(function
         | None -> Some ts
         | Some ts' -> Some (Set.union ts ts')) >>= fun () ->
-      Set.to_sequence ts |>
-      Machine.Seq.iter ~f:(fun o ->
-          Machine.Observation.make attach (r,o,v))
+      Machine.Observation.post attach ~f:(fun report ->
+          Set.to_sequence ts |>
+          Machine.Seq.iter ~f:(fun o -> report (r,o,v)))
 
 
     let detach v r ts = change v r ~f:(function

--- a/plugins/primus_limit/primus_limit_main.ml
+++ b/plugins/primus_limit/primus_limit_main.ml
@@ -13,6 +13,7 @@ type counter =
   | Insn
   | Term
   | Exp
+  | Clk
 
 type bound = {
   counter : counter;
@@ -30,26 +31,28 @@ module Bound = struct
     | 'i' -> Some Insn
     | 't' -> Some Term
     | 'e' -> Some Exp
+    | 'c' -> Some Clk
     | _ -> None
 
   let suffix_of_counter = function
     | Blk -> "b"
     | Insn -> "i"
     | Term -> "t"
-    | Exp -> ""
+    | Exp -> "e"
+    | Clk -> ""
 
   let make_bound counter s = match parse_int s with
     | Ok limit -> `Ok {counter; limit}
     | Error s -> `Error s
 
   let parse s = match counter_of_suffix s with
-    | None -> make_bound Exp s
+    | None -> make_bound Clk s
     | Some cnt -> make_bound cnt s
 
   let print ppf {limit; counter} =
     Format.fprintf ppf "%d%s" limit (suffix_of_counter counter)
 
-  let converter = Config.converter parse print {limit=0; counter=Exp}
+  let converter = Config.converter parse print {limit=0; counter=Clk}
 end
 
 module Cfg = struct
@@ -102,27 +105,23 @@ module Main(Machine : Primus.Machine.S) = struct
     | Insn -> "instructions"
     | Term -> "terms"
     | Exp -> "expressions"
+    | Clk -> "clocks"
 
 
   let check_bound _ = match get Cfg.max_length with
     | None -> Machine.return ()
     | Some {limit; counter} ->
       Machine.Local.get state >>= fun s ->
-      report_progress ~task:"limit max path length" ~stage:s.length ~total:limit ();
       if s.length > limit
       then terminate (string_of_counter counter)
       else Machine.Local.put state {
           s with length = s.length + 1;
         }
 
-
-
   let check_max_visits name visited = match get Cfg.max_visited with
     | None -> Machine.return ()
     | Some max_visited -> match Map.find visited name with
       | Some visits ->
-        report_progress ~task:"limit max visits"
-          ~stage:visits ~total:max_visited ();
         if visits > max_visited
         then terminate
             (sprintf "visits of the %s destination" (Tid.name name))
@@ -143,16 +142,10 @@ module Main(Machine : Primus.Machine.S) = struct
     let open Primus.Interpreter in
     match get Cfg.max_length with
     | None -> Machine.return ()
+    | Some {counter=(Clk|Exp)}  -> clock >>> check_bound
     | Some {counter=Blk}  -> enter_blk >>> check_bound
     | Some {counter=Insn} -> pc_change >>> check_bound
     | Some {counter=Term} -> enter_term >>> check_bound
-    | Some {counter=Exp}  -> Machine.sequence [
-        loading >>> check_bound;
-        storing >>> check_bound;
-        binop >>> check_bound;
-        unop >>> check_bound;
-        Primus.Linker.exec >>> check_bound;
-      ]
 
   let init () =
     Machine.sequence [

--- a/plugins/primus_test/primus_test_main.ml
+++ b/plugins/primus_test/primus_test_main.ml
@@ -96,7 +96,8 @@ module Location = struct
       Machine.Global.put state {
         incidents = Map.set incidents ~key ~data:trace
       } >>= fun () ->
-      Machine.Observation.make report_location (key,trace) >>| fun () ->
+      Machine.Observation.post report_location ~f:(fun report ->
+          report (key,trace)) >>| fun () ->
       key
   end
 
@@ -120,8 +121,9 @@ module Incident = struct
 
     [@@@warning "-P"]
     let run (name :: locations) =
-      Value.Symbol.of_value name >>= fun name ->
-      Machine.Observation.make report (name,locations) >>= fun () ->
+      Machine.Observation.post report ~f:(fun report ->
+          Value.Symbol.of_value name >>= fun name ->
+          report (name,locations)) >>= fun () ->
       Value.b1
 
   end


### PR DESCRIPTION
This PR brings a few small optimizations that together make Primus run 3 to 4 times faster. E.g., in the current master branch, it takes more than 150 seconds to run the memcheck analysis on /bin/true, while in this branch it terminates in 40 seconds (with the same results, coverage, and the number of states). This is 3.5 improvement in speed. YMMV of course as it depends on the analysis and appetite. Speaking of the appetite, this branch implements lazy notifications, so that if an observation is not subscribed than it is not provided. Therefore, we don't have to pay for unused notifications. As a result, the fewer observations you watch the faster your analysis will run.

# Technical Details

Since Primus 2.0 is stall far from being ready, we decided to backport some of the ideas to the current version. In Primus 1.0 the observation are usually tuples (or other heap-allocated values), therefore every time we post an observation we have to allocate a new object even if nobody is interested in receiving it. In Primus 2.0 we changed the observation machiner, so that now each observation is parametrized by an arrow type and observers could receive their inputs in a curried (untupled) form, e.g.,

```ocaml
Observation.make binop ~f:(fun provide -> 
   provide lhs rhs result
```
This will still create a closure (as there are free variables in the continuation), but in this form the compiler has much more chances to optimize the closure allocation. Additionally, in this form the continuation `f` won't be called at all if the given observation has no subscribers. 

The latter feature is backported to the current version of Primus. We got the `post` function, that has the same interface (except that arguments are still tupled):
```ocaml
Observation.post binop ~f:(fun provide ->
   provide ((lhs,rhs),result)
```

It is already a little bit better, especially in case when the observation itself has to be computed (e.g., the taint-attached, incident, incident-location, calls (and the upcoming primitive from #1049) are pretty heavy-weight.

However, many of the observations are reflected to Primus Lisp signals, so that they could be watched and processed directly in Primus Lisp. Since signal reflection is implemented via observations, we have all of the reflected observations subscribed, that prevents the optimization above from kicking in. Even when there is no method for the given signal, it is still treated as it is being watched. To prevent this from happening, we provide a new interface of cancelable subscriptions, i.e., now it is possible to subscribe to an observation and the revoke your subscription. Using this new interface we unsubscribe in Primus Lisp from all reflected observations that do not have a corresponding method. 

Another culprit was the primus-limiter plugin which was subscribing to a lot of observations just to track the number of operations that the Primus machine performs. The plugin was ignoring the values associated with the observations and was just counting them. A much more natural solution would be to add a clock primus machine and corresponding observations, so that implementing such kind of alarms would be much easier. We also added the `time` operation to the interpreter interface, that gives read/only access to the machine's clock.

Finally, we removed the primus-limited notifications to the progress bar, as they were slowing down everything (especially on slow terminals) and wasn't really useful (we have basically 1k to 10k observations per second, probably too fine granular for being useful). 




