### PR TITLE
recalibrates Primus clocks

### DIFF
--- a/lib/bap_primus/bap_primus_lisp.ml
+++ b/lib/bap_primus/bap_primus_lisp.ml
@@ -345,6 +345,7 @@ module Interpreter(Machine : Machine) = struct
       Eval.const Word.b0 >>= fun init ->
       eval_advices Advice.Before init name args >>= fun _ ->
       Code.run args >>= fun r ->
+      Eval.tick >>= fun () ->
       Machine.Observation.post primitive_called ~f:(fun k ->
           k (name,args@[r])) >>= fun () ->
       eval_advices Advice.After r name args

--- a/opam/opam
+++ b/opam/opam
@@ -31,7 +31,7 @@ depends: [
   "conf-bap-llvm" {>= "1.1"}
   "parsexp"
   "bap-signatures"
-  "result" {= "1.4.0"}
+  "result" {= "1.4"}
 ]
 depopts: ["conf-ida" "conf-binutils"]
 flags: light-uninstall

--- a/opam/opam
+++ b/opam/opam
@@ -31,6 +31,7 @@ depends: [
   "conf-bap-llvm" {>= "1.1"}
   "parsexp"
   "bap-signatures"
+  "result" {< "1.5.0"}
 ]
 depopts: ["conf-ida" "conf-binutils"]
 flags: light-uninstall

--- a/opam/opam
+++ b/opam/opam
@@ -31,7 +31,7 @@ depends: [
   "conf-bap-llvm" {>= "1.1"}
   "parsexp"
   "bap-signatures"
-  "result" {< "1.5.0"}
+  "result" {= "1.4.0"}
 ]
 depopts: ["conf-ida" "conf-binutils"]
 flags: light-uninstall

--- a/plugins/primus_limit/primus_limit_main.ml
+++ b/plugins/primus_limit/primus_limit_main.ml
@@ -47,7 +47,8 @@ module Bound = struct
 
   let parse s = match counter_of_suffix s with
     | None -> make_bound Clk s
-    | Some cnt -> make_bound cnt s
+    | Some cnt ->
+      make_bound cnt (String.subo s ~len:(String.length s - 1))
 
   let print ppf {limit; counter} =
     Format.fprintf ppf "%d%s" limit (suffix_of_counter counter)


### PR DESCRIPTION
The new clocks, as introduced in #1061, were ticking too fast (roughly 3
to 5 times faster) so we recalibrated them to be closer to the old
clocks that were using binop/unop/load/store events

Also fixes a bug in the primus-limit command line parsing function. 