### PR TITLE
fixes the config and run tests

### DIFF
--- a/opam/opam
+++ b/opam/opam
@@ -31,7 +31,7 @@ depends: [
   "conf-bap-llvm" {>= "1.1"}
   "parsexp"
   "bap-signatures"
-  "result" {= "1.4.0"}
+  "result" {= "1.4"}
 ]
 depopts: ["conf-ida" "conf-binutils"]
 flags: light-uninstall

--- a/opam/opam
+++ b/opam/opam
@@ -31,6 +31,7 @@ depends: [
   "conf-bap-llvm" {>= "1.1"}
   "parsexp"
   "bap-signatures"
+  "result" {< "1.5.0"}
 ]
 depopts: ["conf-ida" "conf-binutils"]
 flags: light-uninstall

--- a/opam/opam
+++ b/opam/opam
@@ -31,7 +31,7 @@ depends: [
   "conf-bap-llvm" {>= "1.1"}
   "parsexp"
   "bap-signatures"
-  "result" {< "1.5"}
+  "result" {= "1.4.0"}
 ]
 depopts: ["conf-ida" "conf-binutils"]
 flags: light-uninstall

--- a/opam/opam
+++ b/opam/opam
@@ -31,7 +31,7 @@ depends: [
   "conf-bap-llvm" {>= "1.1"}
   "parsexp"
   "bap-signatures"
-  "result" {< "1.5.0"}
+  "result" {< "1.5"}
 ]
 depopts: ["conf-ida" "conf-binutils"]
 flags: light-uninstall


### PR DESCRIPTION
This PR:
- preserves user configuration file if exists in the config test
- applies `primus-lisp-type-check` option in run test

fixes #1065