### PR TITLE
fixes man pages installation

### DIFF
--- a/oasis/bap-std
+++ b/oasis/bap-std
@@ -195,11 +195,3 @@ Library sema
                  Bap_sema_ssa,
                  Bap_sema_taint,
                  Bap_sema_free_vars
-
-Executable "postinstall"
-  Build$:         flag(everything) || flag(bap_std)
-  Path:           tools
-  MainIs:         postinstall.ml
-  Install:        false
-  CompiledObject: best
-  BuildDepends:   fileutils

--- a/oasis/bap-std.files.ab.in
+++ b/oasis/bap-std.files.ab.in
@@ -1,1 +1,0 @@
-        , tools/postinstall.ml.ab

--- a/oasis/common
+++ b/oasis/common
@@ -24,3 +24,11 @@ Flag everything
 Flag development
   Description: Enable development mode
   Default: false
+
+
+Executable "postinstall"
+  Path:           tools
+  MainIs:         postinstall.ml
+  Install:        false
+  CompiledObject: best
+  BuildDepends:   fileutils

--- a/oasis/common.files.ab.in
+++ b/oasis/common.files.ab.in
@@ -1,2 +1,2 @@
-FilesAB:  tools/bap_config.ab,
-          tools/postinstall.ml.ab
+FilesAB:  tools/bap_config.ab
+        , tools/postinstall.ml.ab

--- a/oasis/common.files.ab.in
+++ b/oasis/common.files.ab.in
@@ -1,1 +1,2 @@
-FilesAB:  tools/bap_config.ab
+FilesAB:  tools/bap_config.ab,
+          tools/postinstall.ml.ab


### PR DESCRIPTION
The manpage is not installed when bap is installed via opam as when
post-install happens the bap frontend is not yet installed. We will
now update and install the manpage every time a new bap package is
installed.