### PR TITLE
drops fileutils from the postinstall script

### DIFF
--- a/oasis/common
+++ b/oasis/common
@@ -31,4 +31,3 @@ Executable "postinstall"
   MainIs:         postinstall.ml
   Install:        false
   CompiledObject: best
-  BuildDepends:   fileutils

--- a/tools/postinstall.ml.ab
+++ b/tools/postinstall.ml.ab
@@ -20,15 +20,16 @@ let man_of_help prog =
   man
 
 let bin_exists prog =
-  try ignore (FileUtil.which prog); true with Not_found -> false
+  Sys.command (sprintf "which %s" prog) = 0
 
 let create_man prog =
   if bin_exists prog then [man_of_help prog] else []
 
+let cp file = ignore @@ Sys.command (sprintf "cp %s %s" file mandir)
 
 let main () =
   let helps = List.map create_man tools |> List.concat in
-  FileUtil.mkdir ~parent:true mandir;
-  FileUtil.cp (manpages @ helps) mandir
+  if Sys.file_exists mandir && Sys.is_directory mandir then
+    List.iter cp (manpages @ helps)
 
 let () = main ()

--- a/tools/postinstall.ml.ab
+++ b/tools/postinstall.ml.ab
@@ -20,12 +20,12 @@ let man_of_help prog =
   man
 
 let bin_exists prog =
-  Sys.command (sprintf "which %s" prog) = 0
+  Sys.command (sprintf "which %S" prog) = 0
 
 let create_man prog =
   if bin_exists prog then [man_of_help prog] else []
 
-let cp file = ignore @@ Sys.command (sprintf "cp %s %s" file mandir)
+let cp file = ignore @@ Sys.command (sprintf "cp %S %S" file mandir)
 
 let main () =
   let helps = List.map create_man tools |> List.concat in


### PR DESCRIPTION
After #1073 the installation from `opam` on a fresh switch is broken due to the
dependency on `fileutils` in the `postinstall` script. This PR implements
`postinstall` without it.