### PR TITLE
adds the observation printer to all core systems

### DIFF
--- a/plugins/primus_print/primus_print_main.ml
+++ b/plugins/primus_print/primus_print_main.ml
@@ -185,9 +185,9 @@ let start_monitoring {Config.get=(!)} =
       Machine.return ()
   end in
   Primus.Machine.add_component (module Monitor) [@warning "-D"];
-  Primus.Components.register_generic "monitor" (module Monitor)
+  Primus.Components.register_generic "observation-printer" (module Monitor)
     ~package:"bap"
-    ~desc:"Monitors the specified set of observations and prints \
-           a trace of recorded observations when a machine finishes."
+    ~desc:"Prints the specified set of observations. Controlled via \
+           the primus-print plugin."
 
 let () = Config.when_ready start_monitoring

--- a/plugins/primus_systems/systems/core.asd
+++ b/plugins/primus_systems/systems/core.asd
@@ -3,7 +3,8 @@
   :components (bap:load-binary
                bap:program-loader
                bap:x86-flag-initializer
-               bap:powerpc-init))
+               bap:powerpc-init
+               bap:observation-printer))
 
 (defsystem bap:base-lisp-machine
   :description "Executes Primus Lisp program."

--- a/plugins/primus_test/lisp/memcheck-malloc.lisp
+++ b/plugins/primus_test/lisp/memcheck-malloc.lisp
@@ -34,9 +34,6 @@
   (when (is-in name 'memchr 'memrchr)
     (memcheck-bounds 'malloc ptr len)))
 
-
-
-
 (defun check/both (dst src len)
   (memcheck-bounds 'malloc src len)
   (memcheck-bounds 'malloc dst len))


### PR DESCRIPTION
This is an essential component that enables observation printing, so
we should probably have it in all our systems.

Also tweaked a bit the description of the component, the old one was
quite vague.