### PR TITLE
disables llvm (< 8.0) disassembler for aarch64

### DIFF
--- a/lib/bap_llvm/llvm_disasm.cpp
+++ b/lib/bap_llvm/llvm_disasm.cpp
@@ -615,7 +615,8 @@ private:
     }
 };
 
-
+// See https://github.com/BinaryAnalysisPlatform/bap/issues/1081
+// for details
 bool is_error_prone_arch(const char *triple) {
     if (LLVM_VERSION_MAJOR < 8)
         return std::string(triple) == "aarch64";

--- a/lib/bap_llvm/llvm_disasm.cpp
+++ b/lib/bap_llvm/llvm_disasm.cpp
@@ -617,11 +617,10 @@ private:
 
 
 bool is_error_prone_arch(const char *triple) {
-#if LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
-    return std::string(triple) == "aarch64";
-#else
-    return false;
-#endif
+    if (LLVM_VERSION_MAJOR < 8)
+        return std::string(triple) == "aarch64";
+    else
+        return false;
 }
 
 

--- a/lib/bap_llvm/llvm_disasm.cpp
+++ b/lib/bap_llvm/llvm_disasm.cpp
@@ -615,14 +615,30 @@ private:
     }
 };
 
+
+bool is_error_prone_arch(const char *triple) {
+#if LLVM_VERSION_MAJOR >= 4 && LLVM_VERSION_MAJOR < 8
+    return std::string(triple) == "aarch64";
+#else
+    return false;
+#endif
+}
+
+
 struct create_llvm_disassembler : disasm_factory {
     result<disassembler_interface>
     create(const char *triple, const char *cpu, int debug_level) {
-        auto llvm = llvm_disassembler::create(triple, cpu, debug_level);
         result<disassembler_interface> r;
-        r.dis = llvm.dis;
-        if (!r.dis)
-            r.err = llvm.err;
+        if (is_error_prone_arch(triple)) {
+            if (debug_level > 0)
+                output_error(triple, cpu, "unsupported target", "consider to update to llvm version >= 8.0");
+            r.err = bap_disasm_unsupported_target;
+        } else {
+            auto llvm = llvm_disassembler::create(triple, cpu, debug_level);
+            r.dis = llvm.dis;
+            if (!r.dis)
+                r.err = llvm.err;
+        }
         return r;
     }
 };


### PR DESCRIPTION
The LLVM disassembler is broken for aarch64 and segfaults with the NULL-pointer dereference (segmentation fault) on versions below 8.0. There is no clear mitigation (passing a non-NULL pointer for the symbolizer function results in unpredictable behavior) and given that aarch64 is not a first-tier architecture for us yet, we will just disable it for older versions of LLVM.

fixes #1081 