### PR TITLE
correct dockerfile typo

### DIFF
--- a/docker/xenial/testing/Dockerfile
+++ b/docker/xenial/testing/Dockerfile
@@ -14,4 +14,4 @@ RUN sudo apt-get update && sudo apt-get install --yes python-pip \
  && rm -rf /home/opam/opam-repository \
  && sudo pip install bap
 
-ENTRYPOINT ["opam", "config", "exec", "--]"
+ENTRYPOINT ["opam", "config", "exec", "--" ]


### PR DESCRIPTION
We need to move the quotation mark inside. Otherwise the docker image builds but then cannot be executed.