### PR TITLE
exports abi processors

### DIFF
--- a/lib/bap_c/bap_c_abi.ml
+++ b/lib/bap_c/bap_c_abi.ml
@@ -182,10 +182,9 @@ let stage2 stage1 = object
     else prog
 end
 
-module StringMap = Map.Make(String)
-let registry = ref StringMap.empty
-let register name abi = registry := StringMap.set !registry ~key:name ~data:abi
-let get_processor name = StringMap.find !registry name
+let registry = Hashtbl.create (module String)
+let register name abi = Hashtbl.set registry ~key:name ~data:abi
+let get_processor name = Hashtbl.find registry name
 
 let create_api_processor size abi : Bap_api.t =
   let addr_size = size#pointer in

--- a/lib/bap_c/bap_c_abi.ml
+++ b/lib/bap_c/bap_c_abi.ml
@@ -182,6 +182,11 @@ let stage2 stage1 = object
     else prog
 end
 
+module StringMap = Map.Make(String)
+let registry = ref StringMap.empty
+let register name abi = registry := StringMap.set !registry ~key:name ~data:abi
+let get_processor name = StringMap.find !registry name
+
 let create_api_processor size abi : Bap_api.t =
   let addr_size = size#pointer in
   let stage1 gamma = object(self)

--- a/lib/bap_c/bap_c_abi.mli
+++ b/lib/bap_c/bap_c_abi.mli
@@ -82,6 +82,14 @@ val data : #Bap_c_size.base -> Bap_c_type.t -> Bap_c_data.t
 *)
 val arg_intent : Bap_c_type.t -> intent
 
+(** [register name t] registers an abi processor [t] named [name] that
+    may be used by subroutines in this project.*)
+val register : string -> t -> unit
+
+(** [get_processor name] is used to access an abi processor with its
+    name.*)
+val get_processor : string -> t option
+
 
 (** An abstraction of a stack, commonly used in C compilers.   *)
 module Stack : sig

--- a/plugins/arm/arm_gnueabi.ml
+++ b/plugins/arm/arm_gnueabi.ml
@@ -61,6 +61,7 @@ let api arch = C.Abi.create_api_processor arch abi
 let main proj = match Project.arch proj with
   | #Arch.arm ->
     info "using armeabi ABI";
+    C.Abi.register "eabi" abi;
     Bap_api.process (api size);
     Project.set proj Bap_abi.name "eabi"
   | _ -> proj

--- a/plugins/mips/mips_abi.ml
+++ b/plugins/mips/mips_abi.ml
@@ -105,6 +105,7 @@ let set_abi proj m =
       insert_args = dispatch m (Project.arch proj);
       apply_attrs = fun _ -> ident
     } in
+  C.Abi.register A.name abi;
   let api = C.Abi.create_api_processor A.size abi in
   Bap_api.process api;
   let prog = Project.program proj in

--- a/plugins/powerpc/powerpc_abi.ml
+++ b/plugins/powerpc/powerpc_abi.ml
@@ -80,6 +80,7 @@ let main proj = match Project.arch proj with
         insert_args = dispatch (module Abi32);
         apply_attrs = fun _ -> ident
       } in
+    C.Abi.register Abi32.name abi;
     let api = C.Abi.create_api_processor Abi32.size abi in
     Bap_api.process api;
     let prog = Project.program proj in

--- a/plugins/x86/x86_abi.ml
+++ b/plugins/x86/x86_abi.ml
@@ -251,6 +251,7 @@ let setup ?(abi=fun _ -> None) () =
           insert_args = dispatch abi;
           apply_attrs = fun _ -> ident
         } in
+      C.Abi.register Abi.name abi;
       let api = C.Abi.create_api_processor Abi.size abi in
       Bap_api.process api;
       let prog = demangle Abi.demangle (Project.program proj) in


### PR DESCRIPTION
This adds 2 new functions to C.Abi, to be able to register a new abi processor
and then access it later.

The processors are stored in a mutable StringMap with the abi names as keys, using the function `C.Abi.register name abi`.
They can then be reached from any plugin using `C.Abi.get_processor name`.