### PR TITLE
prunes unreachable code in the optimization pass

### DIFF
--- a/oasis/optimization
+++ b/oasis/optimization
@@ -8,6 +8,6 @@ Library optimization_plugin
   Path: plugins/optimization
   FindlibName: bap-plugin-optimization
   CompiledObject: best
-  BuildDepends: bap, core_kernel, ppx_jane, regular
+  BuildDepends: bap, core_kernel, graphlib, ppx_jane, regular
   InternalModules: Optimization_main, Optimization_data
   XMETAExtraLines: tags="pass,analysis,optimization"

--- a/plugins/optimization/optimization_data.ml
+++ b/plugins/optimization/optimization_data.ml
@@ -49,13 +49,14 @@ let (++) = Set.union
 let dead_jmps_of_blk b =
   Term.to_sequence jmp_t b |>
   Seq.fold ~init:(Set.empty (module Tid), false)
-    ~f:(fun (deads, b1) jmp ->
-        if b1 then Set.add deads (Term.tid jmp), b1
+    ~f:(fun (deads, is_taken) jmp ->
+        if is_taken then Set.add deads (Term.tid jmp), is_taken
         else
           match Jmp.cond jmp with
           | Bil.Int x when x = Word.b1 -> deads, true
-          | Bil.Int x when x = Word.b0 -> Set.add deads (Term.tid jmp), b1
-          | _ -> deads, b1) |> fst
+          | Bil.Int x when x = Word.b0 ->
+            Set.add deads (Term.tid jmp), is_taken
+          | _ -> deads, is_taken) |> fst
 
 let dead_jmps sub =
   Term.to_sequence blk_t sub |>

--- a/plugins/optimization/optimization_data.ml
+++ b/plugins/optimization/optimization_data.ml
@@ -44,11 +44,6 @@ let updates_of_sub sub =
 
 let create ~deads sub = {deads; updates = updates_of_sub sub}
 
-let intra_dst jmp =
-  let open Option.Monad_infix in
-  Jmp.dst jmp >>= fun dst ->
-  Either.First.to_option (Jmp.resolve dst)
-
 let (++) = Set.union
 
 let dead_jmps_of_blk b =

--- a/plugins/optimization/optimization_data.ml
+++ b/plugins/optimization/optimization_data.ml
@@ -49,14 +49,14 @@ let (++) = Set.union
 let dead_jmps_of_blk b =
   Term.to_sequence jmp_t b |>
   Seq.fold ~init:(Set.empty (module Tid), false)
-    ~f:(fun (deads, is_taken) jmp ->
-        if is_taken then Set.add deads (Term.tid jmp), is_taken
-        else
-          match Jmp.cond jmp with
+    ~f:(fun (deads, is_unreachable) jmp ->
+        if is_unreachable
+        then Set.add deads (Term.tid jmp), is_unreachable
+        else match Jmp.cond jmp with
           | Bil.Int x when x = Word.b1 -> deads, true
           | Bil.Int x when x = Word.b0 ->
-            Set.add deads (Term.tid jmp), is_taken
-          | _ -> deads, is_taken) |> fst
+            Set.add deads (Term.tid jmp), is_unreachable
+          | _ -> deads, is_unreachable) |> fst
 
 let dead_jmps sub =
   Term.to_sequence blk_t sub |>

--- a/plugins/optimization/optimization_data.mli
+++ b/plugins/optimization/optimization_data.mli
@@ -10,4 +10,12 @@ val create : deads:Tid.Set.t -> sub term -> t
 
 val apply : sub term -> t -> sub term
 
+
+val update : sub term -> t -> sub term
+
+val find_unreachable : sub term -> t -> t
+
+val remove_dead_code : sub term -> t -> sub term
+
+
 include Data.S with type t := t

--- a/plugins/optimization/optimization_main.ml
+++ b/plugins/optimization/optimization_main.ml
@@ -150,7 +150,7 @@ let digest_of_sub sub level =
   let digest = Set.fold addrs ~init:digest ~f:(fun d a ->
       Digest.add d "%a" Addr.pp a) in
   let digest = Digest.add digest "%s" (Sub.name sub) in
-  Digest.add digest "%s" (string_of_int level)
+  Digest.add digest "%d" level
 
 let run level proj =
   let arch = Project.arch proj in

--- a/plugins/optimization/optimization_main.ml
+++ b/plugins/optimization/optimization_main.ml
@@ -145,6 +145,39 @@ let digest_of_sub sub level =
   let digest = Digest.add digest "%s" (Sub.name sub) in
   Digest.add digest "%s" (string_of_int level)
 
+let first = Either.First.to_option
+
+let blks sub =
+  let blks = Hashtbl.create (module Tid) in
+  Seq.iter (Term.to_sequence blk_t sub) ~f:(fun blk ->
+      match Term.get_attr blk address with
+      | None -> ()
+      | Some a -> Hashtbl.add_exn blks (Term.tid blk) a);
+  Hashtbl.find blks
+
+let digest_of_sub sub level =
+  let open Option.Monad_infix in
+  let find_addr = blks sub in
+  let digest =
+    (object
+      inherit [Digest.t] Term.visitor
+      method! enter_blk t digest =
+        match find_addr (Term.tid t) with
+        | None -> digest
+        | Some addr -> Digest.add digest "%a" Addr.pp addr
+      method! enter_jmp t digest =
+        Option.value ~default:digest @@
+        begin
+          Term.get_attr t address >>= fun from ->
+          Jmp.dst t >>= fun dst ->
+          first (Jmp.resolve dst) >>= fun tid ->
+          find_addr tid >>= fun to_ ->
+          Some (Digest.add digest "%a%a" Addr.pp from Addr.pp to_)
+        end
+    end)#visit_sub sub (Digest.create ~namespace:"optimization") in
+  let digest = Digest.add digest "%s" (Sub.name sub) in
+  Digest.add digest "%s" (string_of_int level)
+
 let run level proj =
   let arch = Project.arch proj in
   let can_touch = is_optimization_allowed (is_flag arch) level in
@@ -153,13 +186,14 @@ let run level proj =
   Project.with_program proj @@
   Term.map sub_t prog ~f:(fun sub ->
       let digest = digest_of_sub sub level in
-      let data = match O.Cache.load digest with
-        | Some data -> data
-        | None ->
-          let data = process_sub free can_touch sub in
-          O.Cache.save digest data;
-          data in
-      O.apply sub data)
+      match O.Cache.load digest with
+      | Some data -> O.apply sub data
+      | None ->
+        let data = process_sub free can_touch sub in
+        let sub = O.update sub data in
+        let data = O.find_unreachable sub data in
+        O.Cache.save digest data;
+        O.remove_dead_code sub data)
 
 let () =
   Config.manpage [


### PR DESCRIPTION
This PR fixes #1092 :
The optimization pass may make some code unreachable, propagating a constant value to a branch guard.

For example, some code can become unreachable due to jumps that are
never taken because of condition:
```
0000046a: when 0 goto %0000045b
```

Or due to the previous jump that is taken always:
```
00000471:
00000473: goto %00000451
00000474: goto %00000455
```

This PR fixes this problem and removes blocks that are unreachable due to infeasible jumps and these jumps as well.

Also, this PR fixes the computation of digest in the optimization pass. Previously, digest for each subroutine contained tids, that is not quite right, because a program can have different tids on each bap execution, and actually it happens quite often. And it leads to the cache explosion since instead of loading from cache we store some duplicated data that are different only by the tids values. This PR solves this problem and uses addresses instead.