### PR TITLE
updates floats intrinsics

### DIFF
--- a/plugins/primus_lisp/lisp/llvm-x86-64-floats.lisp
+++ b/plugins/primus_lisp/lisp/llvm-x86-64-floats.lisp
@@ -88,11 +88,11 @@
     (exec-addr insn:next_address)))
 
 (defun fadd-scalar-double/rm ()
-  (declare (external llvm-x86_64:ADDSDrm))
+  (declare (external llvm-x86_64:ADDSDrm llvm-x86_64:ADDSDrm_Int))
   (fadd-scalar/rm double))
 
 (defun fdiv-scalar-double/rr ()
-  (declare (external llvm-x86_64:DIVSDrr))
+  (declare (external llvm-x86_64:DIVSDrr llvm-x86_64:DIVSDrr_Int))
   (fdiv-scalar/rr double))
 
 (defun fcmp-scalar-double/rm ()


### PR DESCRIPTION
x86 floating-point instructions names differ between different llvm versions.
For example, here are the results for llvm 6.0 and llvm 9.0:

```
echo 'addsd -24(%ebp), %xmm0' | llvm-mc-6.0 --arch=x86-64 --show-inst
	.text
	addsd	-24(%ebp), %xmm0        # <MCInst #219 ADDSDrm
                                        #  <MCOperand Reg:127>
                                        #  <MCOperand Reg:127>
                                        #  <MCOperand Reg:20>
                                        #  <MCOperand Imm:1>
                                        #  <MCOperand Reg:0>
                                        #  <MCOperand Imm:-24>
                                        #  <MCOperand Reg:0>>
```

```
echo 'addsd -24(%ebp), %xmm0' | llvm-mc --arch=x86-64 --show-inst
	.section	__TEXT,__text,regular,pure_instructions
	addsd	-24(%ebp), %xmm0        ## <MCInst #328 ADDSDrm_Int
                                        ##  <MCOperand Reg:142>
                                        ##  <MCOperand Reg:142>
                                        ##  <MCOperand Reg:23>
                                        ##  <MCOperand Imm:1>
                                        ##  <MCOperand Reg:0>
                                        ##  <MCOperand Imm:-24>
                                        ##  <MCOperand Reg:0>>
```
The latter instruction has the `_Int` suffix, while the former does not.
As a result, our tests don't pass when this suffix presents.
This PR fixes this problem and stubs the suffixed names also.