### PR TITLE
adds limit malloc

### DIFF
--- a/plugins/primus_lisp/lisp/limit-malloc.lisp
+++ b/plugins/primus_lisp/lisp/limit-malloc.lisp
@@ -1,0 +1,8 @@
+;; up to 4 Mb each chunk, up to 128 Mbytes total
+
+(defmethod init ()
+  (set *malloc-max-chunk-size* (* 4 1024 1024))
+  (set *malloc-guard-edges* 0)
+  (set *malloc-max-arena-size* (* 32 *malloc-max-chunk-size*))
+  (set *malloc-arena-start* brk)
+  (set *malloc-zero-sentinel* 0))


### PR DESCRIPTION
This PR sets malloc parameters to limit the maximum size of the memory
that can be allocated by malloc. This feature is used frequently in analysis so it's time to move it to the main bap repository.