### PR TITLE
fixes bug with llvm version in x86 lifter 

### DIFF
--- a/lib/bap_llvm/llvm_loader_stubs.c
+++ b/lib/bap_llvm/llvm_loader_stubs.c
@@ -1,3 +1,5 @@
+#include <string.h>
+
 #include <caml/memory.h>
 #include <caml/fail.h>
 #include <caml/alloc.h>
@@ -24,7 +26,7 @@ value bap_llvm_load_stub(value arg, value pdb_path) {
     const struct caml_ba_array* array = Caml_ba_array_val(arg);
     if ((!array->dim[0]) || (array->num_dims != 1))
         failn(1);
-    const char * pdb = strdup(String_val(pdb_path));
+    char * pdb = strdup(String_val(pdb_path));
     const struct bap_llvm_loader *loader =
         bap_llvm_loader_create((const char*)(array->data), array->dim[0], pdb);
     if (bap_llvm_file_not_supported(loader))

--- a/plugins/x86/x86_mov_offset.ml
+++ b/plugins/x86/x86_mov_offset.ml
@@ -193,9 +193,15 @@ module T = Make(Ver_common)
 
 module Self = Self ()
 
+let normalize ver =
+  match String.index ver '.' with
+  | None -> ver
+  | Some i -> String.sub ver 0 (i + 2)
+
 let () =
   Bap_main.Extension.declare @@ fun _ctxt ->
-  let llvm_version = String.sub llvm_version 0 3 in
-  if String.equal llvm_version "3.4" then T_34.register ()
+  let ver = normalize llvm_version in
+  if String.equal ver "3.4"
+  then T_34.register ()
   else T.register ();
   Ok ()

--- a/plugins/x86/x86_mov_offset.ml
+++ b/plugins/x86/x86_mov_offset.ml
@@ -196,7 +196,9 @@ module Self = Self ()
 let normalize ver =
   match String.index ver '.' with
   | None -> ver
-  | Some i -> String.sub ver 0 (i + 2)
+  | Some i -> match String.sub ver 0 (i + 2) with
+    | x -> x
+    | exception _ -> ver
 
 let () =
   Bap_main.Extension.declare @@ fun _ctxt ->


### PR DESCRIPTION
This PR fixes:
1) a bug with llvm version normalization in x86 lifter
2) warnings in our llvm backend