### PR TITLE
updates to OCaml 4.{10,11}, drops 4.07, and switches to core_kernel v0.14

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,11 @@ jobs:
          - name: Install OCaml
            uses: avsm/setup-ocaml@v1
            with:
-             ocaml-version: 4.07.1
+             ocaml-version: 4.08.1
+
+         - name: Add the testing Repository
+           run: opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
+
 
          - name: Pin OASIS
            run: opam pin add oasis https://github.com/BinaryAnalysisPlatform/oasis.git

--- a/.github/workflows/build-dev-repo.yml
+++ b/.github/workflows/build-dev-repo.yml
@@ -11,9 +11,10 @@ jobs:
             - ubuntu-latest
             - macos-latest
           ocaml-version:
+            - 4.11.1
+            - 4.10.1
             - 4.09.1
             - 4.08.1
-            - 4.07.1
 
     runs-on: ${{ matrix.os }}
 
@@ -32,6 +33,9 @@ jobs:
         uses: avsm/setup-ocaml@v1
         with:
           ocaml-version: ${{ matrix.ocaml-version }}
+
+      - name: Add the testing Repository
+        run: opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
 
       - name: Pin BAP
         run: opam pin add bap . --no-action

--- a/.github/workflows/build-dev-repo.yml
+++ b/.github/workflows/build-dev-repo.yml
@@ -12,8 +12,6 @@ jobs:
             - macos-latest
           ocaml-version:
             - 4.11.1
-            - 4.10.1
-            - 4.09.1
             - 4.08.1
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-from-opam.yml
+++ b/.github/workflows/build-from-opam.yml
@@ -7,9 +7,8 @@ jobs:
     strategy:
       matrix:
           ocaml-version:
-            - 4.09.1
+            - 4.11.1
             - 4.08.1
-            - 4.07.1
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/check-the-style.yml
+++ b/.github/workflows/check-the-style.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup OCaml
         uses: avsm/setup-ocaml@v1
         with:
-          ocaml-version: 4.07.1
+          ocaml-version: 4.08.1
 
       - name: Check the Style
         run: opam install -y ocp-indent && opam exec -- make check-style

--- a/.github/workflows/nightly-testing.yml
+++ b/.github/workflows/nightly-testing.yml
@@ -10,11 +10,9 @@ jobs:
       matrix:
           os:
             - ubuntu-latest
-            - macos-latest
           ocaml-version:
-            - 4.09.1
+            - 4.11.1
             - 4.08.1
-            - 4.07.1
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
          - name: Install OCaml
            uses: avsm/setup-ocaml@v1
            with:
-             ocaml-version: 4.09.1+flambda
+             ocaml-version: 4.11.1+flambda
 
          - name: Build deb packages
            run: ./tools/release.sh ${{ env.VERSION }}

--- a/.github/workflows/weekly-regress.yml
+++ b/.github/workflows/weekly-regress.yml
@@ -10,9 +10,8 @@ jobs:
     strategy:
       matrix:
           ocaml-version:
-            - 4.09.1
+            - 4.11.1
             - 4.08.1
-            - 4.07.1
 
     runs-on: ubuntu-latest
 

--- a/.merlin
+++ b/.merlin
@@ -3,9 +3,10 @@ FLG -w +a-4-6-7-9-29-32..42-44-45-48-50-60
 FLG -safe-string
 
 PKG core_kernel
+PKG core_kernel.caml_unix
 PKG fileutils
 PKG uri
-PKG ppx_jane
+PKG ppx_bap
 PKG camlzip
 PKG uuidm
 

--- a/lib/arm/arm_target.ml
+++ b/lib/arm/arm_target.ml
@@ -4,6 +4,7 @@ open Core_kernel
 open Bap_core_theory
 open Bap.Std
 open KB.Syntax
+open Poly
 
 module CT = Theory
 
@@ -348,7 +349,7 @@ module Encodings = struct
   let empty = Map.empty (module Bitvec_order)
 
   let lsb x = Int64.(x land 1L)
-  let is_thumb x = lsb x = 1L
+  let is_thumb x = Int64.equal (lsb x) 1L
 
   let symbols_encoding spec =
     symbol_values spec |>

--- a/lib/bap_build/bap_build.ml
+++ b/lib/bap_build/bap_build.ml
@@ -10,7 +10,7 @@ module Plugin_rules = struct
 
   let (/) = Pathname.concat
 
-  let default_packages = ["bap"; "core_kernel"; "ppx_jane"]
+  let default_packages = ["bap"; "core_kernel"; "ppx_bap"]
   let default_predicates = [
     "custom_ppx";
     "ppxlib";
@@ -20,7 +20,6 @@ module Plugin_rules = struct
     "thread";
     "debug";
     "custom";
-    "pp(ppx-jane -dump-ast -inline-test-drop)"
   ] @ List.map default_predicates ~f:(sprintf "predicate(%s)")
 
   let needs_threads ~predicates pkgs =

--- a/lib/bap_bundle/bap_bundle.ml
+++ b/lib/bap_bundle/bap_bundle.ml
@@ -16,20 +16,20 @@ module Std = struct
       main : string;
       author : string;
       date : float;
-      requires : string sexp_list;
-      provides : string sexp_list;
-      url : string sexp_option;
-      license : string sexp_option;
-      copyrights : string sexp_option;
-      tags : string sexp_list;
-      cons : string sexp_list;
+      requires : string list;
+      provides : string list;
+      url : string option;
+      license : string option;
+      copyrights : string option;
+      tags : string list;
+      cons : string list;
     } [@@deriving bin_io, compare, fields, sexp]
 
     let create
         ?(author=getenv "USER")
         ?(version="1.0.0")
         ?main
-        ?(date=Unix.time ())
+        ?(date=Caml_unix.time ())
         ?(desc = "description not provided")
         ?(requires=[])
         ?(provides=[])

--- a/lib/bap_core_theory/bap_core_theory_target.ml
+++ b/lib/bap_core_theory/bap_core_theory_target.ml
@@ -41,7 +41,7 @@ module Enum = struct
   module Make() = struct
     type t = Name.t [@@deriving bin_io, sexp]
 
-    let elements = Hash_set.create (module Name) ()
+    let elements = Hash_set.create (module Name)
     let declare ?package name =
       let name = Name.create ?package name in
       if Hash_set.mem elements name
@@ -234,7 +234,7 @@ let options t = (info t).options
 
 let parents target =
   let rec closure ps p =
-    if p = unknown.parent
+    if Name.equal unknown.parent p
     then List.rev (p::ps)
     else closure (p::ps) (parent p) in
   closure [] (parent target)

--- a/lib/bap_core_theory/bap_core_theory_value.ml
+++ b/lib/bap_core_theory/bap_core_theory_value.ml
@@ -53,7 +53,7 @@ end
 
   type name = KB.Name.t [@@deriving bin_io, compare, sexp]
 
-  let names = Hash_set.create (module KB.Name) ()
+  let names = Hash_set.create (module KB.Name)
   let short_names = Hashtbl.create (module String)
 
   let cls = KB.Class.declare ~package:"core-theory" "value" ()
@@ -153,11 +153,13 @@ end
         let to_sexpable x = x
         let of_sexpable x = x
       end)
+
     include Binable.Of_binable(Exp)(struct
         type t = top
         let to_binable x = x
         let of_binable x = x
-      end)
+      end)[@@warning "-D"]
+
     include Base.Comparable.Inherit(Exp)(struct
         type t = top
         let sexp_of_t x = Exp.sexp_of_t x

--- a/lib/bap_disasm/bap_disasm_calls.ml
+++ b/lib/bap_disasm/bap_disasm_calls.ml
@@ -104,6 +104,7 @@ module Parents = struct
             (module Word) xs in
         Solution.create init Parent.unknown
     end)
+  [@@warning "-D"]
 end
 
 type input = Driver.state

--- a/lib/bap_disasm/bap_disasm_insn.ml
+++ b/lib/bap_disasm/bap_disasm_insn.ml
@@ -53,7 +53,9 @@ module Props = struct
     type t = Z.t
     include Sexpable.Of_stringable(Bits)
     include Binable.Of_stringable(Bits)
+    [@@warning "-D"]
   end
+
 
   let name = snd
 

--- a/lib/bap_dwarf/dwarf_fbi.ml
+++ b/lib/bap_dwarf/dwarf_fbi.ml
@@ -33,7 +33,7 @@ type table = scheme Table.t
 module Fn = struct
   module T = struct
     type t = {
-      pc_hi: addr sexp_option;
+      pc_hi: addr option;
       pc_lo: addr;
     } [@@deriving sexp, bin_io, compare, fields]
 

--- a/lib/bap_image/bap_fileutils.ml
+++ b/lib/bap_image/bap_fileutils.ml
@@ -1,5 +1,6 @@
 open Core_kernel
 open Option.Monad_infix
+module Unix = Caml_unix
 
 let mapfile path : Bigstring.t option =
   let fd = Unix.(openfile path [O_RDONLY] 0o400) in

--- a/lib/bap_image/bap_image.ml
+++ b/lib/bap_image/bap_image.ml
@@ -197,6 +197,7 @@ type words = {
 }
 
 let sexp_of_doc doc = Sexp.Atom (Ogre.Doc.to_string doc)
+let sexp_of_words = sexp_of_opaque
 
 type t = {
   doc  : doc;
@@ -206,11 +207,11 @@ type t = {
   symbols : symbol table;
   segments : segment table;
   memory : value memmap;
-  words : words sexp_opaque;
-  memory_of_segment : segment -> mem sexp_opaque;
-  memory_of_symbol : (symbol -> mem * mem seq) Lazy.t sexp_opaque;
-  symbols_of_segment : (segment -> symbol seq) Lazy.t sexp_opaque;
-  segment_of_symbol : (symbol -> segment) Lazy.t sexp_opaque;
+  words : words [@sexp.opaque];
+  memory_of_segment : segment -> mem [@sexp.opaque];
+  memory_of_symbol : (symbol -> mem * mem seq) Lazy.t [@sexp.opaque];
+  symbols_of_segment : (segment -> symbol seq) Lazy.t [@sexp.opaque];
+  segment_of_symbol : (symbol -> segment) Lazy.t [@sexp.opaque];
 } [@@deriving sexp_of]
 
 

--- a/lib/bap_image/bap_memory.ml
+++ b/lib/bap_image/bap_memory.ml
@@ -48,6 +48,7 @@ include Binable.Of_binable(Repr)(struct
       size = Bigstring.length data;
     }
   end)
+[@@warning "-D"]
 
 
 let sexp_of_t mem = Sexp.List [

--- a/lib/bap_llvm/bap_llvm_disasm.ml
+++ b/lib/bap_llvm/bap_llvm_disasm.ml
@@ -12,7 +12,7 @@ module X86_syntax = struct
 end
 
 let putenv s =
-  Unix.putenv
+  Caml_unix.putenv
     "BAP_LLVM_OPTIONS" ("-x86-asm-syntax=" ^ X86_syntax.to_string s)
 
 let init ?(x86_syntax=`att) () =

--- a/lib/bap_llvm/bap_llvm_loader.ml
+++ b/lib/bap_llvm/bap_llvm_loader.ml
@@ -3,6 +3,8 @@ open Bap.Std
 open Monads.Std
 open Or_error
 
+module Unix = Caml_unix
+
 module Primitive = struct
   (** [bap_llvm_load data pdb_path] analyzes [data] and builds an llvm
       specification of the discovered meta-data.
@@ -146,10 +148,10 @@ let provide_entry =
 let provide_symbols =
   iter_rows LLVM.symbol_entry @@ fun bias (name, addr, size, off, value) ->
   let addr = Int64.(addr + bias) in
-  provide_if (size > 0L) [
+  provide_if Poly.(size > 0L) [
     Ogre.provide symbol_chunk addr size addr;
     Ogre.request LLVM.code_entry ~that:(fun (n,o,s) ->
-        o = off && n = name && s = size) >>= fun entry ->
+        Poly.(o = off && n = name && s = size)) >>= fun entry ->
     if Option.is_some entry then Ogre.provide code_start addr
     else Ogre.return ()
   ] @ [

--- a/lib/bap_main/bap_main.ml
+++ b/lib/bap_main/bap_main.ml
@@ -1198,8 +1198,8 @@ let init
     let result = Plugins.load ?env:features ?provides:requires ~library () in
     let plugins,failures =
       List.partition_map result ~f:(function
-          | Ok p -> `Fst p
-          | Error (p,e) -> `Snd (p,e)) in
+          | Ok p -> First p
+          | Error (p,e) -> Second (p,e)) in
     let version = match Bap_main_config.build_id with
       | "" -> version
       | id -> sprintf "%s+%s" version id in

--- a/lib/bap_main/bap_main_log.ml
+++ b/lib/bap_main/bap_main_log.ml
@@ -5,6 +5,7 @@ open Format
 
 module Event = Bap_main_event
 module Filename = Caml.Filename
+module Unix = Caml_unix
 
 let perm = 0o770
 let getenv opt = try Some (Sys.getenv opt) with Caml.Not_found -> None

--- a/lib/bap_primus/bap_primus_memory.ml
+++ b/lib/bap_primus/bap_primus_memory.ml
@@ -286,7 +286,7 @@ module Make(Machine : Machine) = struct
 
   let initialize values lower upper f =
     let rec loop values addr =
-      if addr < upper
+      if Addr.(addr < upper)
       then f addr >>= fun data ->
         Value.of_word data >>= fun data ->
         loop (Map.set values ~key:addr ~data) (Addr.succ addr)

--- a/lib/bap_primus/bap_primus_observation.ml
+++ b/lib/bap_primus/bap_primus_observation.ml
@@ -60,7 +60,12 @@ let inspect = Univ_map.Key.to_sexp
 let name = Univ_map.Key.name
 let of_statement = ident
 
-module Map = Univ_map.Make1(struct
+module Key = struct
+  type 'a t = 'a Type_equal.Id.t [@@deriving sexp_of]
+  let to_type_id = ident
+end
+
+module Map = Univ_map.Make1(Key)(struct
     type ('a,'m) t = ('a,'m) observers
     let sexp_of_t _ _ = sexp_of_opaque
   end)

--- a/lib/bap_sema/bap_sema_lift.ml
+++ b/lib/bap_sema/bap_sema_lift.ml
@@ -299,7 +299,7 @@ let program symtab =
   let b = Ir_program.Builder.create () in
   let sub_of_blk = Hashtbl.create (module Tid) in
   let tid_for_sub =
-    let tids = Hash_set.create (module Tid) () in
+    let tids = Hash_set.create (module Tid) in
     fun name ->
       let tid = Tid.for_name name in
       match Hash_set.strict_add tids tid with

--- a/lib/bap_traces/bap_trace.ml
+++ b/lib/bap_traces/bap_trace.ml
@@ -5,6 +5,7 @@ open Bap.Std
 
 module Id = Bap_trace_id
 module Tab = String.Caseless.Table
+module Unix = Caml_unix
 
 type event = value [@@deriving bin_io, sexp, compare]
 
@@ -96,7 +97,7 @@ let find_proto uri : 'a result =
   match protocols_of_uri uri with
   | [] -> make_error `No_provider
   | p::[] -> Ok p
-  | protos -> make_error `Ambiguous_uri
+  | _ -> make_error `Ambiguous_uri
 
 let find_by_proto tab proto : 'a result =
   match Hashtbl.find tab proto with

--- a/lib/bap_traces/bap_trace.mli
+++ b/lib/bap_traces/bap_trace.mli
@@ -2,6 +2,8 @@ open Core_kernel
 open Regular.Std
 open Bap.Std
 
+module Unix = Caml_unix
+
 type event = value [@@deriving bin_io, sexp, compare]
 type monitor
 type proto

--- a/lib/bap_traces/bap_trace_binprot.ml
+++ b/lib/bap_traces/bap_trace_binprot.ml
@@ -6,6 +6,7 @@ open Result
 open Bin_prot
 
 module Trace = Bap_trace
+module Unix = Caml_unix
 
 module Proto = struct
 

--- a/lib/bap_traces/bap_trace_id.ml
+++ b/lib/bap_traces/bap_trace_id.ml
@@ -10,6 +10,7 @@ module Bin = Bin_prot.Utils.Make_binable(struct
       | None -> invalid_arg "Bad UUID format"
       | Some uuid -> uuid
   end)
+[@@warning "-D"]
 
 module Stringable = struct
   type t = Uuidm.t

--- a/lib/bap_traces/bap_trace_meta.ml
+++ b/lib/bap_traces/bap_trace_meta.ml
@@ -4,6 +4,7 @@ open Bap.Std
 open Format
 
 open Bap_trace_meta_types
+module Unix = Caml_unix
 
 module Envp = struct
   let pp ppf env =

--- a/lib/bap_traces/bap_traces.ml
+++ b/lib/bap_traces/bap_traces.ml
@@ -1,1 +1,2 @@
+module Unix = Caml_unix
 module Std = Bap_trace_std

--- a/lib/bap_traces/bap_traces.mli
+++ b/lib/bap_traces/bap_traces.mli
@@ -1,6 +1,7 @@
 open Core_kernel
 open Regular.Std
 open Bap.Std
+module Unix = Caml_unix
 
 (** Traces of execution. *)
 module Std : sig

--- a/lib/bap_types/bap_bitvector.ml
+++ b/lib/bap_types/bap_bitvector.ml
@@ -125,7 +125,7 @@ end = struct
     let of_string s = {packed = Z.of_bits s}
   end
 
-  include Binable.Of_stringable(Stringable)
+  include Binable.Of_stringable(Stringable) [@@warning "-D"]
   include Sexpable.Of_stringable(Stringable)
 end
 
@@ -642,7 +642,7 @@ module V1 = struct
     end
     include Z
     include Sexpable.Of_stringable(Repr)
-    include Binable.Of_stringable(Repr)
+    include Binable.Of_stringable(Repr) [@@warning "-D"]
   end
 
   type t = {
@@ -672,7 +672,7 @@ module Stable = struct
         type t = Packed.t
         let to_binable = to_legacy
         let of_binable = of_legacy
-      end)
+      end) [@@warning "-D"]
 
     include Sexpable.Of_sexpable(V1)(struct
         type t = Packed.t

--- a/lib/bap_types/bap_ir.ml
+++ b/lib/bap_types/bap_ir.ml
@@ -321,7 +321,8 @@ end = struct
     {s with self}
 
   let fix_names news =
-    let is_new sub = sub.tid <> Tid.for_name sub.self.name in
+    let is_new sub =
+      not @@ Tid.equal sub.tid (Tid.for_name sub.self.name) in
     let keep_name tids name tid = Map.set tids ~key:name ~data:tid in
     let tids = Array.fold news ~init:String.Map.empty ~f:(fun tids sub ->
         match Map.find tids sub.self.name with

--- a/lib/bap_types/bap_ogre.ml
+++ b/lib/bap_types/bap_ogre.ml
@@ -16,7 +16,7 @@ end
 
 let pp = Ogre.Doc.pp
 include Sexpable.Of_stringable(Stringable)
-include Binable.Of_stringable(Stringable)
+include Binable.Of_stringable(Stringable) [@@warning "-D"]
 
 type KB.Conflict.t += Spec_inconsistency of Error.t
 

--- a/lib/bap_types/bap_value.ml
+++ b/lib/bap_types/bap_value.ml
@@ -155,7 +155,7 @@ module Univ = struct
         }
       let of_binable {Repr.typeid; data} =
         (info typeid).of_string data
-    end)
+    end) [@@warning "-D"]
 end
 
 let create  {key} x = Value.T (key,x)
@@ -265,7 +265,7 @@ module Dict = struct
       type t = Univ_map.t
       let to_binable = Data.of_dict
       let of_binable = Data.to_dict
-    end)
+    end) [@@warning "-D"]
   include Sexpable.Of_sexpable(Data)(struct
       type t = Univ_map.t
       let to_sexpable = Data.of_dict

--- a/lib/bap_types/bap_var.ml
+++ b/lib/bap_types/bap_var.ml
@@ -114,7 +114,7 @@ module T = struct
       type t = var
       let to_binable = Repr.of_var
       let of_binable = Repr.to_var
-    end)
+    end) [@@warning "-D"]
 
   let compare x y =
     Theory.Var.Ident.compare (ident x) (ident y)

--- a/lib/graphlib/graphlib_graph.ml
+++ b/lib/graphlib/graphlib_graph.ml
@@ -984,6 +984,7 @@ end
 
 type 'a path = 'a Path.t
 
+module Heap = Pairing_heap
 let shortest_path
     (type t) (type n) (type e)
     (module G : Graph with type t = t

--- a/lib/text_tags/text_tags.ml
+++ b/lib/text_tags/text_tags.ml
@@ -1,6 +1,8 @@
 open Core_kernel
 open Format
 
+module Unix = Caml_unix
+
 type mode = string
 exception Unknown_mode of string
 

--- a/lib/x86_cpu/x86_asm_reg.ml
+++ b/lib/x86_cpu/x86_asm_reg.ml
@@ -20,5 +20,5 @@ let decode reg =
   match Reg.name reg |> Sexp.of_string |> spec_of_sexp with
   | `Nil -> None
   | #t as r -> Some r
-  | exception exn -> Error.failwiths "unknown register"
-                       reg Reg.sexp_of_t
+  | exception _ ->
+    failwithf "unknown register %s" (Reg.name reg) ()

--- a/lib_test/powerpc/powerpc_load_tests.ml
+++ b/lib_test/powerpc/powerpc_load_tests.ml
@@ -381,8 +381,9 @@ let lbrx name opt_opcode size arch ctxt =
     List.fold ~init:None ~f:(fun acc b ->
         match acc with
         | None -> Some b
-        | Some p -> Some (Word.concat p b)) |>
-    Option.value_exn in
+        | Some p -> Some (Word.concat p b)) |> function
+    | None -> assert false
+    | Some x -> x in
   let expected = Word.extract_exn ~hi:(width -1) expected in
   check_gpr init bytes r1 expected arch ctxt
 

--- a/lib_test/powerpc/powerpc_store_tests.ml
+++ b/lib_test/powerpc/powerpc_store_tests.ml
@@ -250,8 +250,8 @@ let stbrx name opt_opcode size arch ctxt =
     List.fold ~init:None ~f:(fun acc b ->
         match acc with
         | None -> Some b
-        | Some p -> Some (Word.concat p b)) |>
-    Option.value_exn |>
+        | Some p -> Some (Word.concat p b)) |> fun x ->
+    Option.value_exn x |>
     Word.extract_exn ~hi:(width -1) ~lo:(width - Size.in_bits size) in
   check_mem init bytes mem ~addr:ea ~size expected arch ctxt
 

--- a/oasis/abi
+++ b/oasis/abi
@@ -7,7 +7,7 @@ Library bap_abi
   Path:             lib/bap_abi
   FindlibName:      bap-abi
   CompiledObject:   best
-  BuildDepends:     bap, core_kernel, ppx_jane
+  BuildDepends:     bap, core_kernel, ppx_bap
   Modules:          Bap_abi
 
 Library abi_plugin

--- a/oasis/analyze
+++ b/oasis/analyze
@@ -7,7 +7,7 @@ Library analyze_plugin
   Path: plugins/analyze
   FindlibName: bap-plugin-analyze
   CompiledObject: best
-  BuildDepends: core_kernel, monads, ppx_jane, linenoise,
+  BuildDepends: core_kernel, monads, ppx_bap, linenoise,
                 bap-knowledge, bap-core-theory, bap-main, bap,
                 bitvec
   InternalModules: Analyze_main, Analyze_core_commands

--- a/oasis/api
+++ b/oasis/api
@@ -7,7 +7,7 @@ Library bap_api
   Path:             lib/bap_api
   FindlibName:      bap-api
   CompiledObject:   best
-  BuildDepends:     bap, core_kernel, ppx_jane
+  BuildDepends:     bap, core_kernel, ppx_bap
   Modules:          Bap_api
 
 
@@ -16,7 +16,7 @@ Library api_plugin
   Path:             plugins/api
   FindlibName:      bap-plugin-api
   CompiledObject:   best
-  BuildDepends:     bap, bap-api, fileutils, core_kernel, ppx_jane, regular
+  BuildDepends:     bap, bap-api, fileutils, core_kernel, ppx_bap, regular
   InternalModules:  Api_main, Api_config
   XMETADescription: add parameters to subroutines based on known API
   DataFiles:        api/c/*.h ($datadir/bap-api/c)

--- a/oasis/arm
+++ b/oasis/arm
@@ -6,7 +6,7 @@ Library "bap-arm"
  XMETADescription: arm lifting
  Path:             lib/arm
  Build$:           flag(everything) || flag(arm)
- BuildDepends:     bap, core_kernel, ppx_jane, regular,
+ BuildDepends:     bap, core_kernel, ppx_bap, regular,
                    bap-core-theory, bap-knowledge, ogre,
                    bitvec, bitvec-order
  FindlibName:      bap-arm

--- a/oasis/bap-std
+++ b/oasis/bap-std
@@ -20,11 +20,12 @@ Library bap
                    graphlib,
                    regular,
                    core_kernel,
-                   ppx_jane,
+                   ppx_bap,
                    monads,
                    bitvec,
                    ogre,
-                   fileutils
+                   fileutils,
+                   core_kernel.caml_unix
   Modules:         Bap
   InternalModules: Bap_project, Bap_self
 
@@ -59,8 +60,7 @@ Library types
                    bap-knowledge,
                    bap-core-theory,
                    core_kernel,
-                   ppx_jane
-
+                   ppx_bap
   InternalModules:
                    Bap_addr,
                    Bap_arch,
@@ -114,7 +114,8 @@ Library bap_image
   FindlibParent: bap
   FindlibName:   image
   BuildDepends:  bap.types, ogre, mmap, monads, core_kernel, regular,
-                 bap-core-theory, ppx_jane, bap-knowledge
+                 bap-core-theory, bap-knowledge, ppx_bap, core_kernel.caml_unix
+
   InternalModules:
                  Bap_fileutils,
                  Bap_image,
@@ -143,12 +144,12 @@ Library disasm
                  regular,
                  bap-core-theory,
                  bap-knowledge,
-                 ppx_jane,
                  zarith,
                  bitvec,
                  bitvec-order,
                  bap-relation,
-                 bap-main
+                 bap-main,
+                 ppx_bap
   InternalModules:
                  Bap_disasm,
                  Bap_disasm_backend_types,
@@ -187,7 +188,7 @@ Library sema
                  bap.image,
                  monads,
                  core_kernel,
-                 ppx_jane,
+                 ppx_bap,
                  graphlib,
                  regular,
                  bap-knowledge,

--- a/oasis/beagle
+++ b/oasis/beagle
@@ -7,7 +7,7 @@ Library beagle_plugin
   Path: plugins/beagle
   FindlibName: bap-plugin-beagle
   BuildDepends: bap, bap-microx, bap-beagle-prey, bap-strings,
-                regular, monads, bap-future, core_kernel, ppx_jane,
+                regular, monads, bap-future, core_kernel, ppx_bap,
                 bap-primus
   InternalModules: Beagle_main
   XMETADescription: microx powered obfuscated string solver
@@ -18,5 +18,5 @@ Library beagle_prey
   Path: lib/beagle
   FindlibName: bap-beagle-prey
   Modules: Beagle_prey
-  BuildDepends: bap, bap-primus, core_kernel, ppx_jane, monads, regular
+  BuildDepends: bap, bap-primus, core_kernel, ppx_bap, monads, regular
   XMETADescription: beagle attributes

--- a/oasis/bil
+++ b/oasis/bil
@@ -8,6 +8,6 @@ Library bil_plugin
   Build$:           flag(everything) || flag(bil)
   FindlibName:      bap-plugin-bil
   BuildDepends:     bap, bap-core-theory, bap-knowledge, core_kernel,
-                    ppx_jane, bap-future, monads, bitvec, bitvec-order, ogre, bap-main
+                    ppx_bap, bap-future, monads, bitvec, bitvec-order, ogre, bap-main
   XMETAExtraLines:  tags="bil,analysis,semantics"
   InternalModules:  Bil_main, Bil_lifter, Bil_semantics, Bil_ir, Bil_float

--- a/oasis/bitvec-binprot
+++ b/oasis/bitvec-binprot
@@ -7,5 +7,5 @@ Library bitvec_binprot
   Path: lib/bitvec_binprot
   FindlibName: bitvec-binprot
   CompiledObject: best
-  BuildDepends: bitvec, bin_prot, ppx_jane
+  BuildDepends: bitvec, bin_prot, ppx_bap
   Modules: Bitvec_binprot

--- a/oasis/build
+++ b/oasis/build
@@ -16,4 +16,4 @@ Executable "bapbuild"
   MainIs:         bapbuild.ml
   Install:        true
   CompiledObject: best
-  BuildDepends:   core_kernel, ocamlbuild, bap-build, compiler-libs, ppx_jane
+  BuildDepends:   core_kernel, ocamlbuild, bap-build, compiler-libs, ppx_bap

--- a/oasis/bundle
+++ b/oasis/bundle
@@ -6,7 +6,7 @@ Library bundle
   Build$:        flag(everything) || flag(bundle)
   Path:          lib/bap_bundle
   FindlibName:   bap-bundle
-  BuildDepends:  uri, camlzip, unix, core_kernel, ppx_jane
+  BuildDepends:  uri, camlzip, unix, core_kernel, core_kernel.caml_unix, ppx_bap
   Modules:       Bap_bundle
   InternalModules: Bap_bundle_config
 

--- a/oasis/byteweight
+++ b/oasis/byteweight
@@ -8,14 +8,14 @@ Library bap_byteweight
   Build$:          flag(everything) || flag(byteweight)
   CompiledObject:  best
   Modules:         Bap_byteweight, Bap_byteweight_signatures
-  BuildDepends:    bap, core_kernel, uri, regular, camlzip, ppx_jane
+  BuildDepends:    bap, core_kernel, uri, regular, camlzip, ppx_bap
 
 Library byteweight_plugin
   Path:             plugins/byteweight
   FindlibName:      bap-plugin-byteweight
   Build$:           flag(everything) || flag(byteweight)
   CompiledObject:   best
-  BuildDepends:     bap, bap-byteweight, core_kernel, regular, ppx_jane, bap-future
+  BuildDepends:     bap, bap-byteweight, core_kernel, regular, ppx_bap, bap-future
   InternalModules:  Byteweight_main
   XMETADescription: find function starts using Byteweight algorithm
   XMETAExtraLines:  tags="pass, rooter"

--- a/oasis/byteweight-frontend
+++ b/oasis/byteweight-frontend
@@ -10,4 +10,4 @@ Executable "bap-byteweight"
   Install:        true
   CompiledObject: best
   BuildDepends:   bap, bap-byteweight,
-                  cmdliner, curl, fileutils, re.posix, findlib.dynload, ppx_jane
+                  cmdliner, curl, fileutils, re.posix, findlib.dynload, ppx_bap

--- a/oasis/c
+++ b/oasis/c
@@ -8,7 +8,7 @@ Library bap_c
   Path: lib/bap_c
   FindlibName: bap-c
   CompiledObject: best
-  BuildDepends: bap, bap-api, core_kernel, ppx_jane, monads, regular
+  BuildDepends: bap, bap-api, core_kernel, ppx_bap, monads, regular
   Modules: Bap_c,
            Bap_c_abi,
            Bap_c_attr,

--- a/oasis/cache
+++ b/oasis/cache
@@ -6,7 +6,8 @@ Library cache_plugin
   Build$:           flag(everything) || flag(cache)
   Path:             plugins/cache
   FindlibName:      bap-plugin-cache
-  BuildDepends:     bap, bap-main, core_kernel, regular, ppx_jane, mmap, fileutils, uuidm
+  BuildDepends:     bap, bap-main, regular, ppx_bap, mmap, fileutils, uuidm,
+                    core_kernel, core_kernel.caml_unix
   InternalModules:  Bap_cache, Bap_cache_gc, Bap_cache_main, Bap_cache_types, Bap_cache_utils
   XMETADescription: provide caching services
   XMETAExtraLines:  tags="cache"

--- a/oasis/callgraph-collator
+++ b/oasis/callgraph-collator
@@ -5,7 +5,7 @@ Flag callgraph_collator
 Library callgraph_collator_plugin
   Build$:       flag(everything) || flag(callgraph_collator)
   Path:         plugins/callgraph_collator
-  BuildDepends: bap-main, bap, core_kernel, graphlib, ppx_jane, re.pcre
+  BuildDepends: bap-main, bap, core_kernel, graphlib, ppx_bap, re.pcre
   FindlibName:     bap-plugin-callgraph_collator
   CompiledObject:  best
   InternalModules: Callgraph_collator_main

--- a/oasis/core-theory
+++ b/oasis/core-theory
@@ -7,8 +7,8 @@ Library bap_core_theory
   Path: lib/bap_core_theory
   FindlibName: bap-core-theory
   CompiledObject: best
-  BuildDepends: bap-knowledge, core_kernel,
-                bitvec, bitvec-order, bitvec-sexp, bitvec-binprot, ppx_jane
+  BuildDepends: bap-knowledge, core_kernel, core_kernel.caml_unix,
+                bitvec, bitvec-order, bitvec-sexp, bitvec-binprot, ppx_bap
   Modules: Bap_core_theory
   InternalModules:
         Bap_core_theory_basic,

--- a/oasis/cxxfilt
+++ b/oasis/cxxfilt
@@ -7,7 +7,7 @@ Library "cxxfilt_plugin"
   Build$: flag(everything) || flag(cxxfilt)
   FindlibName: bap-plugin-cxxfilt
   CompiledObject: best
-  BuildDepends: core_kernel, bap-demangle, bap
+  BuildDepends: core_kernel, bap-demangle, bap, core_kernel.caml_unix
   InternalModules: Cxxfilt_main, Cxxfilt_config
   XMETADescription: provide c++filt based demangler
   XMETAExtraLines: tags="c++, c++filt, demangler"

--- a/oasis/disassemble
+++ b/oasis/disassemble
@@ -10,6 +10,6 @@ Library disassemble_plugin
   CompiledObject: best
   BuildDepends: bap, bap-knowledge, bap-core-theory, core_kernel,
                 regular, monads, bap-plugins, bap-bundle, bap-main,
-                ppx_jane
+                ppx_bap
   InternalModules: Disassemble_main
   XMETAExtraLines: tags="command, analysis, disassemble"

--- a/oasis/dump-symbols
+++ b/oasis/dump-symbols
@@ -7,7 +7,7 @@ Library dump_symbols_plugin
   Path:             plugins/dump_symbols
   FindlibName:      bap-plugin-dump_symbols
   CompiledObject:   best
-  BuildDepends:     bap, core_kernel, ppx_jane, graphlib, regular
+  BuildDepends:     bap, core_kernel, ppx_bap, graphlib, regular
   InternalModules:  Dump_symbols_main
   XMETADescription: dump symbol information as a list of blocks
   XMETAExtraLines:  tags="printer"

--- a/oasis/dwarf
+++ b/oasis/dwarf
@@ -7,7 +7,7 @@ Library dwarf
   Path:          lib/bap_dwarf
   FindlibName:   bap-dwarf
   Build$:        flag(everything) || flag(dwarf)
-  BuildDepends:  bap, core_kernel, core_kernel.binary_packing, ppx_jane, regular
+  BuildDepends:  bap, core_kernel, core_kernel.binary_packing, ppx_bap, regular
   Modules:       Bap_dwarf
 
   InternalModules:

--- a/oasis/elf-loader
+++ b/oasis/elf-loader
@@ -7,7 +7,7 @@ Library elf
   Path:          lib/bap_elf
   Build$:        flag(everything) || flag(elf_loader)
   FindlibName:   bap-elf
-  BuildDepends:  bitstring, bitstring.ppx, regular, core_kernel, ppx_jane
+  BuildDepends:  bitstring, bitstring.ppx, regular, core_kernel, ppx_bap
   Modules: Bap_elf
   InternalModules:
                  Elf_parse,
@@ -22,7 +22,7 @@ Library elf_loader_plugin
   Build$:           flag(everything) || flag(elf_loader)
   FindlibName:      bap-plugin-elf_loader
   CompiledObject:   best
-  BuildDepends:     bap, bap-elf, bap-dwarf, core_kernel, regular, ppx_jane
+  BuildDepends:     bap, bap-elf, bap-dwarf, core_kernel, regular, ppx_bap
   InternalModules:  Elf_loader_main
   XMETADescription: read ELF and DWARF formats in a pure OCaml
   XMETAExtraLines:  tags="legacy, loader, elf, dwarf"

--- a/oasis/emit-ida-script
+++ b/oasis/emit-ida-script
@@ -6,7 +6,7 @@ Library emit_ida_script_plugin
   Build$:           flag(everything) || flag(emit_ida_script)
   Path:             plugins/emit_ida_script
   FindlibName:      bap-plugin-emit_ida_script
-  BuildDepends:     bap, core_kernel, ppx_jane, regular
+  BuildDepends:     bap, core_kernel, ppx_bap, regular
   Modules:          Emit_ida_script_main
   XMETADescription: extract a IDA python script from bap
   XMETAExtraLines:  tags="ida, python"

--- a/oasis/frontc-parser
+++ b/oasis/frontc-parser
@@ -8,6 +8,6 @@ Library frontc_parser_plugin
   Path: plugins/frontc_parser
   FindlibName: bap-plugin-frontc_parser
   CompiledObject: best
-  BuildDepends: bap, bap-c, FrontC, core_kernel, ppx_jane
+  BuildDepends: bap, bap-c, FrontC, core_kernel, ppx_bap
   InternalModules: Frontc_parser_main
   XMETAExtraLines: tags="api,c,parser"

--- a/oasis/frontend
+++ b/oasis/frontend
@@ -9,4 +9,4 @@ Executable "bap"
   NativeOpt: -thread
   CompiledObject: best
   BuildDepends:   bap-main, bap, bap-core-theory, bap-knowledge,
-                  core_kernel, ppx_jane, findlib.dynload, regular
+                  core_kernel, ppx_bap, findlib.dynload, regular

--- a/oasis/graphlib
+++ b/oasis/graphlib
@@ -7,7 +7,8 @@ Library graphlib
   FindlibName:     graphlib
   Build$:          flag(everything) || flag(graphlib)
   CompiledObject:  best
-  BuildDepends:    core_kernel, regular, ocamlgraph, ppx_jane
+  BuildDepends:    core_kernel, regular, ocamlgraph, ppx_bap,
+                   core_kernel.pairing_heap
   Modules:         Graphlib
   InternalModules:
                    Graphlib_graph,

--- a/oasis/ida
+++ b/oasis/ida
@@ -10,7 +10,7 @@ Library bap_ida
   CompiledObject:   best
   Build$:           flag(everything) || flag(ida)
   Modules:          Bap_ida
-  BuildDepends:     fileutils, re.posix, core_kernel, ppx_jane
+  BuildDepends:     fileutils, re.posix, core_kernel, ppx_bap
   XMETADescription: make calls into IDA
 
 Library bap_ida_plugin
@@ -18,8 +18,9 @@ Library bap_ida_plugin
   Path:             plugins/ida
   FindlibName:      bap-plugin-ida
   CompiledObject:   best
-  BuildDepends:     bap, bap-ida, core_kernel, ppx_jane, fileutils,
-                    re.posix, bap-knowledge, graphlib, regular, bap-future, mmap
+  BuildDepends:     bap, bap-ida, core_kernel, ppx_bap, fileutils,
+                    re.posix, bap-knowledge, graphlib, regular, bap-future, mmap,
+                    core_kernel.caml_unix
   Modules:          Ida_main
   InternalModules:  Bap_ida_config, Bap_ida_service, Bap_ida_info
   XMETADescription: use ida to provide rooter, symbolizer and reconstructor

--- a/oasis/knowledge
+++ b/oasis/knowledge
@@ -7,5 +7,5 @@ Library knowledge
   Path: lib/knowledge
   FindlibName: bap-knowledge
   CompiledObject: best
-  BuildDepends: core_kernel, monads, ppx_jane
+  BuildDepends: core_kernel, core_kernel.caml_unix, monads, ppx_bap
   Modules: Bap_knowledge

--- a/oasis/lisp
+++ b/oasis/lisp
@@ -9,7 +9,7 @@ Library bap_lisp
   FindlibName: bap-lisp
   CompiledObject: best
   BuildDepends: parsexp, bap-strings, bap-knowledge, bap-core-theory,
-                graphlib, ppx_jane, core_kernel, bitvec, bitvec-order,
+                graphlib, ppx_bap, core_kernel, bitvec, bitvec-order,
                 bitvec-binprot, regular, monads
   Modules: Bap_lisp
   InternalModules:

--- a/oasis/llvm
+++ b/oasis/llvm
@@ -10,7 +10,7 @@ Flag llvm_static
 Library bap_llvm
   Path:          lib/bap_llvm
   Build$:        flag(everything) || flag(llvm)
-  BuildDepends:  bap, ogre, monads, core_kernel, ppx_jane, mmap
+  BuildDepends:  bap, ogre, monads, core_kernel, ppx_bap, mmap, core_kernel.caml_unix
   FindlibName:   bap-llvm
   Modules:       Bap_llvm,
                  Bap_llvm_loader

--- a/oasis/main
+++ b/oasis/main
@@ -9,6 +9,6 @@ Library bap_main
   CompiledObject:  best
   BuildDepends:    stdlib-shims, base, stdio, cmdliner, bap-future,
                    bap-bundle, bap-plugins, bap-recipe, core_kernel,
-                   fileutils
+                   fileutils, core_kernel.caml_unix
   Modules:         Bap_main, Bap_main_config, Bap_main_event
   InternalModules: Bap_main_log

--- a/oasis/map-terms
+++ b/oasis/map-terms
@@ -6,7 +6,7 @@ Library "bap-bml"
   XMETADescription: BAP Mapping Language
   Path: lib/bap_bml
   Build$: flag(everything) || flag(map_terms)
-  BuildDepends: bap, core_kernel, ppx_jane
+  BuildDepends: bap, core_kernel, ppx_bap
   FindlibName: bap-bml
   Modules: Bap_bml
 
@@ -14,7 +14,7 @@ Library map_terms_plugin
   Build$: flag(everything) || flag(map_terms)
   Path: plugins/map_terms
   FindlibName: bap-plugin-map_terms
-  BuildDepends: bap, bap-bml, core_kernel, ppx_jane, regular, bap-main
+  BuildDepends: bap, bap-bml, core_kernel, ppx_bap, regular, bap-main
   InternalModules: Map_terms_main, Map_terms_features
   XMETADescription: map terms using BML DSL
   XMETAExtraLines:  tags="pass"

--- a/oasis/mc
+++ b/oasis/mc
@@ -9,7 +9,7 @@ Library mc_plugin
   CompiledObject:  best
   Modules:         Mc_main
   BuildDepends:    core_kernel, bap-main, bap, regular, bap-plugins,
-                   bap-core-theory, bap-knowledge, ppx_jane, bitvec,
+                   bap-core-theory, bap-knowledge, ppx_bap, bitvec,
                    ogre
   XMETAExtraLines: tags="command, disassemble"
 

--- a/oasis/microx
+++ b/oasis/microx
@@ -6,5 +6,5 @@ Library microx
   Build$:       flag(everything) || flag(microx)
   Path:         lib/microx
   FindlibName:  bap-microx
-  BuildDepends: bap, monads, core_kernel, ppx_jane
+  BuildDepends: bap, monads, core_kernel, ppx_bap
   Modules:      Microx, Microx_concretizer, Microx_conqueror

--- a/oasis/mips
+++ b/oasis/mips
@@ -6,7 +6,7 @@ Library "bap-mips"
  Build$:           flag(everything) || flag(mips)
  XMETADescription: common definitions for MIPS targets
  Path: lib/bap_mips
- BuildDepends: core_kernel, ppx_jane,
+ BuildDepends: core_kernel, ppx_bap,
                ogre, bap-knowledge, bap-core-theory, bap
  FindlibName: bap-mips
  Modules: Bap_mips_target
@@ -17,7 +17,7 @@ Library mips_plugin
   FindlibName:          bap-plugin-mips
   Build$:               flag(everything) || flag (mips)
   BuildDepends:         bap, bap-mips, bap-abi, bap-c, bap-core-theory, core_kernel,
-                        ppx_jane, regular, zarith, bap-knowledge, bap-main, bap-api
+                        ppx_bap, regular, zarith, bap-knowledge, bap-main, bap-api
   InternalModules:
                         Mips,
                         Mips_main,

--- a/oasis/monads
+++ b/oasis/monads
@@ -7,7 +7,7 @@ Library monads
   Path: lib/monads
   FindlibName: monads
   CompiledObject: best
-  BuildDepends: core_kernel, ppx_jane, core_kernel.rope
+  BuildDepends: core_kernel, ppx_bap, core_kernel.rope
   Modules: Monads
   InternalModules: Monads_monad,
                    Monads_monoid,

--- a/oasis/objdump
+++ b/oasis/objdump
@@ -10,7 +10,8 @@ Library objdump_plugin
   BuildDepends:     re.pcre, bap-core-theory,
                     core_kernel, bap-knowledge,
                     bitvec, bitvec-order, bitvec-sexp,
-                    bap-main, bap-relation
+                    bap-main, bap-relation,
+                    core_kernel.caml_unix
   InternalModules:  Objdump_main, Objdump_config
   XMETADescription: use objdump to provide a symbolizer
   XMETAExtraLines:  tags="objdump, symbolizer"

--- a/oasis/ogre
+++ b/oasis/ogre
@@ -9,4 +9,4 @@ Library ogre
   Path:         lib/ogre
   FindlibName:  ogre
   Modules:      Ogre
-  BuildDepends: core_kernel, monads, ppx_jane
+  BuildDepends: core_kernel, monads, ppx_bap

--- a/oasis/optimization
+++ b/oasis/optimization
@@ -8,6 +8,6 @@ Library optimization_plugin
   Path: plugins/optimization
   FindlibName: bap-plugin-optimization
   CompiledObject: best
-  BuildDepends: bap, core_kernel, graphlib, ppx_jane, regular
+  BuildDepends: bap, core_kernel, graphlib, ppx_bap, regular
   InternalModules: Optimization_main, Optimization_data
   XMETAExtraLines: tags="pass,analysis,optimization"

--- a/oasis/phoenix
+++ b/oasis/phoenix
@@ -7,7 +7,7 @@ Library phoenix_plugin
   Path:             plugins/phoenix
   FindlibName:      bap-plugin-phoenix
   BuildDepends:     bap, text-tags, ocamlgraph, ezjsonm, core_kernel, graphlib,
-                    regular, ppx_jane
+                    regular, ppx_bap, core_kernel.caml_unix
   InternalModules:  Phoenix_main,
                     Phoenix_dot,
                     Phoenix_helpers,

--- a/oasis/plugins
+++ b/oasis/plugins
@@ -12,4 +12,4 @@ Library bap_plugins
                    Bap_plugins_units_fallback,
                    Bap_plugins_units_intf
   BuildDepends:    core_kernel, dynlink, fileutils, findlib, bap-bundle, bap-future,
-                   uri, ppx_jane
+                   uri, ppx_bap

--- a/oasis/powerpc
+++ b/oasis/powerpc
@@ -6,7 +6,7 @@ Library "bap-powerpc"
  Build$:           flag(everything) || flag(powerpc)
  XMETADescription: common definitions for PowerPC targets
  Path: lib/bap_powerpc
- BuildDepends: core_kernel, ppx_jane,
+ BuildDepends: core_kernel, ppx_bap,
                ogre, bap-knowledge, bap-core-theory, bap
  FindlibName: bap-powerpc
  Modules: Bap_powerpc_target
@@ -16,7 +16,7 @@ Library powerpc_plugin
   Path:             plugins/powerpc
   Build$:           flag(everything) || flag(powerpc)
   BuildDepends:     bap, bap-abi, bap-c, zarith, monads, core_kernel,
-                    ppx_jane, regular, bap-api, bap-powerpc
+                    ppx_bap, regular, bap-api, bap-powerpc
   FindlibName:      bap-plugin-powerpc
   InternalModules:  Powerpc,
                     Powerpc_cpu,
@@ -46,7 +46,7 @@ Library powerpc_test
   Path:           lib_test/powerpc
   Build$:         flag(tests) && (flag(everything) || flag(powerpc))
   CompiledObject: best
-  BuildDepends:   bap, oUnit, core_kernel, ppx_jane
+  BuildDepends:   bap, oUnit, core_kernel, ppx_bap
   Install:        false
   Modules:        Powerpc_add_tests,
                   Powerpc_arith_tests,

--- a/oasis/primus
+++ b/oasis/primus
@@ -9,8 +9,9 @@ Library bap_primus
   FindlibName: bap-primus
   CompiledObject: best
   BuildDepends: bap, bap-abi, bap-c, uuidm, bap-future, parsexp, bap-strings,
-                core_kernel, ppx_jane, regular, monads, graphlib, bap-knowledge,
-                zarith, bitvec, zarith
+                core_kernel, regular, monads, graphlib, bap-knowledge,
+                zarith, bitvec, zarith, ppx_bap
+
   Modules: Bap_primus
   InternalModules:
            Bap_primus_env,

--- a/oasis/primus-lisp
+++ b/oasis/primus-lisp
@@ -6,7 +6,7 @@ Flag primus_lisp
 Library primus_lisp_library_plugin
   Build$:       flag(everything) || flag(primus_lisp)
   Path:         plugins/primus_lisp
-  BuildDepends: bap-primus, core_kernel, bap, ppx_jane, monads, regular,
+  BuildDepends: bap-primus, core_kernel, bap, ppx_bap, monads, regular,
                 bap-knowledge, bap-main
   FindlibName:     bap-plugin-primus_lisp
   CompiledObject:  best

--- a/oasis/primus-loader
+++ b/oasis/primus-loader
@@ -7,7 +7,7 @@ Library primus_loader_plugin
   Build$: flag(everything) || flag(primus_loader)
   FindlibName: bap-plugin-primus_loader
   CompiledObject: best
-  BuildDepends: bap, bap-primus, core_kernel, ogre, ppx_jane
+  BuildDepends: bap, bap-primus, core_kernel, ogre, ppx_bap
   XMETADescription: generic program loader for Primus
   Modules: Primus_loader_main
   InternalModules: Primus_loader_basic

--- a/oasis/primus-machine
+++ b/oasis/primus-machine
@@ -9,5 +9,5 @@ Library bap_primus_machine
   Path: lib/bap_primus_machine
   FindlibName: bap-primus-machine
   CompiledObject: best
-  BuildDepends: bap-knowledge, core_kernel, monads, ppx_jane
+  BuildDepends: bap-knowledge, core_kernel, monads, ppx_bap
   Modules: Bap_primus_machine

--- a/oasis/primus-print
+++ b/oasis/primus-print
@@ -7,7 +7,7 @@ Library primus_print_plugin
   Build$: flag(everything) || flag(primus_print)
   FindlibName: bap-plugin-primus_print
   CompiledObject: best
-  BuildDepends: bap-primus, bare, bap, core_kernel, ppx_jane, bap-future, monads
+  BuildDepends: bap-primus, bare, bap, core_kernel, ppx_bap, bap-future, monads
   XMETADescription: prints Primus states and observations
   Modules: Primus_print_main
   XMETAExtraLines: tags="primus, printer"

--- a/oasis/primus-propagate-taint
+++ b/oasis/primus-propagate-taint
@@ -8,7 +8,7 @@ Library primus_propagate_taint_plugin
   Build$: flag(everything) || flag(primus_propagate_taint)
   FindlibName: bap-plugin-primus_propagate_taint
   CompiledObject: best
-  BuildDepends: bap-primus, bap-taint, core_kernel, bap, monads, ppx_jane
+  BuildDepends: bap-primus, bap-taint, core_kernel, bap, monads, ppx_bap
   XMETADescription: a compatibility layer between different taint analysis frameworks
   InternalModules: Primus_propagate_taint_main
   XMETAExtraLines:  tags="dataflow, pass, taint, primus"

--- a/oasis/primus-random
+++ b/oasis/primus-random
@@ -5,7 +5,7 @@ Flag primus_random
 Library primus_random_library_plugin
   Build$:       flag(everything) || flag(primus_random)
   Path:         plugins/primus_random
-  BuildDepends: bap-primus, bap, core_kernel, ppx_jane, bap-main,
+  BuildDepends: bap-primus, bap, core_kernel, ppx_bap, bap-main,
                 bitvec, bitvec-sexp, zarith
   FindlibName:     bap-plugin-primus_random
   CompiledObject:  best

--- a/oasis/primus-region
+++ b/oasis/primus-region
@@ -5,7 +5,7 @@ Flag primus_region
 Library primus_region_library_plugin
   Build$:       flag(everything) || flag(primus_region)
   Path:         plugins/primus_region
-  BuildDepends: bap-primus, bap, core_kernel, ppx_jane, monads
+  BuildDepends: bap-primus, bap, core_kernel, ppx_bap, monads
   FindlibName:     bap-plugin-primus_region
   CompiledObject:  best
   InternalModules: Primus_region_main

--- a/oasis/primus-symbolic-executor
+++ b/oasis/primus-symbolic-executor
@@ -6,7 +6,7 @@ Flag primus_symbolic_executor
 Library primus_symbolic_executor_plugin
   Build$:       flag(everything) || flag(primus_symbolic_executor)
   Path:         plugins/primus_symbolic_executor
-  BuildDepends: bap-primus, bap, core_kernel, bitvec, ppx_jane,
+  BuildDepends: bap-primus, bap, core_kernel, bitvec, ppx_bap,
                 zarith, z3, regular, bap-main, monads,
                 bap-primus-track-visited
   FindlibName:     bap-plugin-primus_symbolic_executor

--- a/oasis/primus-track-visited
+++ b/oasis/primus-track-visited
@@ -7,7 +7,7 @@ Library bap_primus_track_visited
   Build$: flag(everything) || flag(primus_track_visited)
   FindlibName: bap-primus-track-visited
   CompiledObject: best
-  BuildDepends: bap-primus, bap, core_kernel, ppx_jane
+  BuildDepends: bap-primus, bap, core_kernel, ppx_bap
   XMETADescription: tracks basic blocks visited by Primus
   Modules: Bap_primus_track_visited
   XMETAExtraLines: tags="primus"

--- a/oasis/print
+++ b/oasis/print
@@ -10,7 +10,7 @@ Library print_plugin
   FindlibName:      bap-plugin-print
   BuildDepends:     bap, text-tags, bap-demangle, core_kernel,
                     bap-core-theory, regular, graphlib, re.pcre,
-                    ogre, bap-knowledge
+                    ogre, bap-knowledge, core_kernel.caml_unix
   InternalModules:  Print_main
   XMETADescription: print project in various formats
   XMETAExtraLines:  tags="printer"

--- a/oasis/propagate-taint
+++ b/oasis/propagate-taint
@@ -6,7 +6,7 @@ Library propagate_taint_plugin
   Build$:  flag(everything) || flag(propagate_taint)
   Path: plugins/propagate_taint
   FindlibName: bap-plugin-propagate_taint
-  BuildDepends: bap, bap-microx, core_kernel, ppx_jane, monads, regular, graphlib
+  BuildDepends: bap, bap-microx, core_kernel, ppx_bap, monads, regular, graphlib
   InternalModules: Propagate_taint_main, Propagator
   XMETADescription: propagate taints through a program
   XMETAExtraLines:  tags="dataflow, pass, taint"

--- a/oasis/radare2
+++ b/oasis/radare2
@@ -9,7 +9,8 @@ Library radare2_plugin
   CompiledObject:   best
   BuildDepends:     bap, re.pcre, regular, bap-core-theory,
                     bap-future, core_kernel, bap-knowledge,
-                    zarith, bitvec, yojson, bap-relation, bap-arm
+                    zarith, bitvec, yojson, bap-relation, bap-arm,
+                    core_kernel.caml_unix
   InternalModules:  Radare2_main
   XMETADescription: use radare2 to provide a symbolizer
   XMETAExtraLines:  tags="symbolizer, radare2"

--- a/oasis/raw
+++ b/oasis/raw
@@ -7,5 +7,5 @@ Library bap_raw_plugin
   Path:             plugins/raw
   FindlibName:      bap-plugin-raw
   CompiledObject:   best
-  BuildDepends:     bap, core_kernel, ppx_jane, bap-main, bitvec, ogre
+  BuildDepends:     bap, core_kernel, ppx_bap, bap-main, bitvec, ogre, core_kernel.caml_unix
   Modules:          Raw_main

--- a/oasis/read-symbols
+++ b/oasis/read-symbols
@@ -6,7 +6,7 @@ Library read_symbols_plugin
   Build$:           flag(everything) || flag(read_symbols)
   Path:             plugins/read_symbols
   FindlibName:      bap-plugin-read_symbols
-  BuildDepends:     bap, core_kernel, ppx_jane, bap-knowledge, regular, bap-future
+  BuildDepends:     bap, core_kernel, ppx_bap, bap-knowledge, regular, bap-future
   Modules:          Read_symbols_main
   XMETADescription: read symbol information from file
   XMETAExtraLines:  tags="reconstructor, rooter, symbolizer"

--- a/oasis/regular
+++ b/oasis/regular
@@ -7,7 +7,7 @@ Library regular
   Path:            lib/regular
   FindlibName:     regular
   CompiledObject:  best
-  BuildDepends:    core_kernel, ppx_jane
+  BuildDepends:    core_kernel, ppx_bap
   Modules:         Regular
   InternalModules:
                    Regular_bytes,

--- a/oasis/relocatable
+++ b/oasis/relocatable
@@ -9,6 +9,6 @@ Library relocatable_plugin
   FindlibName:     bap-plugin-relocatable
   InternalModules: Rel_symbolizer
   BuildDepends:    bap, ogre, bap-knowledge, core_kernel, monads,
-                   bitvec, bitvec-order, bitvec-sexp, bap-core-theory, ppx_jane,
+                   bitvec, bitvec-order, bitvec-sexp, bap-core-theory, ppx_bap,
                    bap-main, bap-arm, bap-powerpc, bap-x86-cpu
   XMETAExtraLines: tags="brancher, loader, ogre"

--- a/oasis/report
+++ b/oasis/report
@@ -7,7 +7,7 @@ Library report_plugin
   Path:             plugins/report
   FindlibName:      bap-plugin-report
   CompiledObject:   best
-  BuildDepends:     bap, core_kernel, bap-future
+  BuildDepends:     bap, core_kernel, bap-future, core_kernel.caml_unix
   InternalModules:  Report_main
   XMETADescription: reports program status
   XMETAExtraLines:  tags="report, visualization"

--- a/oasis/strings-library
+++ b/oasis/strings-library
@@ -7,7 +7,7 @@ Library bap_strings
   Build$:       flag(everything) || flag(strings_library)
   Path:         lib/bap_strings
   FindlibName:  bap-strings
-  BuildDepends: core_kernel,ppx_jane
+  BuildDepends: core_kernel,ppx_bap
   Modules:      Bap_strings,
                 Bap_strings_detector,
                 Bap_strings_index,

--- a/oasis/stub-resolver
+++ b/oasis/stub-resolver
@@ -7,7 +7,7 @@ Library bap-plugin-stub_resolver
   Path:         plugins/stub_resolver/
   BuildDepends: bap, bap-abi, bap-knowledge, bap-core-theory, core_kernel,
                 bitvec, bitvec-order, bitvec-sexp,
-                bap-main, ppx_jane, ogre
+                bap-main, ppx_bap, ogre
   FindlibName:     bap-plugin-stub_resolver
   CompiledObject:  best
   Modules:         Stub_resolver
@@ -23,7 +23,7 @@ Library stub_resolver_tests
   FindlibName:    tests
   Build$:         flag(tests) && (flag(everything) || flag(stub_resolver))
   CompiledObject: best
-  BuildDepends:   bap, oUnit, core_kernel, ppx_jane, bap-plugin-stub_resolver
+  BuildDepends:   bap, oUnit, core_kernel, ppx_bap, bap-plugin-stub_resolver
   Install:        false
   Modules:        Stub_resolver_tests
 

--- a/oasis/systemz
+++ b/oasis/systemz
@@ -14,7 +14,7 @@ Library systemz_plugin
   XMETADescription: provide Systemz lifter
   Path:             plugins/systemz
   Build$:           flag(everything) || flag(systemz)
-  BuildDepends:     core_kernel, ppx_jane, ogre,
+  BuildDepends:     core_kernel, ppx_bap, ogre,
                     bap-core-theory, bap-knowledge, bap-main,
                     bap, bap-systemz
   FindlibName:      bap-plugin-systemz

--- a/oasis/taint
+++ b/oasis/taint
@@ -7,14 +7,14 @@ Library taint
   Path: lib/bap_taint
   FindlibName: bap-taint
   CompiledObject: best
-  BuildDepends: core_kernel, bap, bap-primus, monads, ppx_jane, bap-strings, regular
+  BuildDepends: core_kernel, bap, bap-primus, monads, ppx_bap, bap-strings, regular
   Modules: Bap_taint
 
 Library taint_plugin
   Build$:  flag(everything) || flag(taint)
   Path: plugins/taint
   FindlibName: bap-plugin-taint
-  BuildDepends: bap, core_kernel, ppx_jane, regular
+  BuildDepends: bap, core_kernel, ppx_bap, regular
   InternalModules: Taint_main
   XMETADescription: taint specified terms
   XMETAExtraLines:  tags="dataflow, pass, taint"

--- a/oasis/tests
+++ b/oasis/tests
@@ -3,7 +3,7 @@ Library types_test
   Build$:         (flag(everything) || flag(bap_std)) && flag(tests)
   Install:        false
   CompiledObject: best
-  BuildDepends:   bap, oUnit, core_kernel, regular, graphlib, ocamlgraph, bap-future, ppx_jane
+  BuildDepends:   bap, oUnit, core_kernel, regular, graphlib, ocamlgraph, bap-future, ppx_bap
   Modules:        Test_bitvector,
                   Test_bili,
                   Test_bytes,
@@ -33,7 +33,7 @@ Library disasm_test
   Path:           lib_test/bap_disasm
   Build$:         (flag(everything) || flag(bap_std)) && flag(tests)
   CompiledObject: best
-  BuildDepends:   bap, oUnit, str, core_kernel, regular, ppx_jane
+  BuildDepends:   bap, oUnit, str, core_kernel, regular, ppx_bap
   Install:        false
   Modules:        Test_disasm
 

--- a/oasis/text-tags
+++ b/oasis/text-tags
@@ -7,5 +7,5 @@ Library "text-tags"
   Build$: flag(everything) || flag(text_tags)
   FindlibName: text-tags
   CompiledObject: best
-  BuildDepends: core_kernel
+  BuildDepends: core_kernel, core_kernel.caml_unix
   Modules: Text_tags

--- a/oasis/thumb
+++ b/oasis/thumb
@@ -6,7 +6,7 @@ Library thumb_plugin
   XMETADescription: provide Thumb lifter
   Path:             plugins/thumb
   Build$:           flag(everything) || flag(thumb)
-  BuildDepends:     core_kernel, ppx_jane, ogre,
+  BuildDepends:     core_kernel, ppx_bap, ogre,
                     bap-core-theory, bap-knowledge, bap-main,
                     bap, bap-arm, bitvec
   FindlibName:      bap-plugin-thumb

--- a/oasis/trace
+++ b/oasis/trace
@@ -8,7 +8,7 @@ Library trace_plugin
   FindlibName:    bap-plugin-trace
   CompiledObject: best
   Modules: Trace_main
-  BuildDepends:   bap, bap-traces, core_kernel, ppx_jane, bap-plugins,
-                  bap-future, uri, regular
+  BuildDepends:   bap, bap-traces, core_kernel, ppx_bap, bap-plugins,
+                  bap-future, uri, regular, core_kernel.caml_unix
   XMETADescription: manage execution traces
   XMETAExtraLines:  tags="dynamic, pass, printer, trace"

--- a/oasis/traces
+++ b/oasis/traces
@@ -18,7 +18,7 @@ Library traces
                    Bap_trace_std,
                    Bap_trace_traces,
                    Bap_trace
-  BuildDepends:    bap, core_kernel, uri, uuidm, regular, ppx_jane
+  BuildDepends:    bap, core_kernel, uri, uuidm, regular, ppx_bap, core_kernel.caml_unix
 
 Library traces_test
   Path:            lib_test/bap_traces
@@ -26,7 +26,7 @@ Library traces_test
   Install:         false
   CompiledObject:  best
   Modules:         Test_traces
-  BuildDepends:    bap, bap-traces, oUnit, core_kernel, uri, ppx_jane
+  BuildDepends:    bap, bap-traces, oUnit, core_kernel, uri, ppx_bap
 
 
 Executable run_traces_tests

--- a/oasis/x86
+++ b/oasis/x86
@@ -7,7 +7,7 @@ Library "bap-x86-cpu"
  XMETADescription: provide x86 lifter
  Path:             lib/x86_cpu
  FindlibName:      bap-x86-cpu
- BuildDepends:     bap, core_kernel, ppx_jane,
+ BuildDepends:     bap, core_kernel, ppx_bap,
                    bap-core-theory, ogre, bap-knowledge
  Modules:          X86_cpu,
                    X86_env,
@@ -24,7 +24,7 @@ Library x86_plugin
  Path:             plugins/x86
  FindlibName:      bap-plugin-x86
  BuildDepends:     bap, bap-abi, bap-c, bap-x86-cpu, bap-llvm, core_kernel,
-                   ppx_jane, bap-main, bap-future, bap-api, ogre
+                   ppx_bap, bap-main, bap-future, bap-api, ogre
  Modules:          X86_backend, X86_prefix
  InternalModules:  X86_abi,
                    X86_btx,

--- a/opam/opam
+++ b/opam/opam
@@ -13,8 +13,8 @@ depends: [
   "camlzip"
   "linenoise" {>= "1.1" & < "2.0"}
   "cmdliner" {>= "1.0" & < "2.0"}
-  "ppx_jane" {>= "v0.12" & < "v0.13"}
-  "core_kernel" {>= "v0.12" & < "v0.13"}
+  "ppx_bap"  {= "master"}
+  "core_kernel" {>= "v0.14" & < "v0.15"}
   "ezjsonm"
   "fileutils"
   "FrontC"
@@ -281,7 +281,6 @@ remove: [
   ["ocamlfind" "remove" "bap-lisp"]
   ["ocamlfind" "remove" "bap-primus-machine"]
   ["rm" "-f" "%{prefix}%/bin/baptop"]
-  ["rm" "-f" "%{prefix}%/bin/ppx-bap"]
   ["rm" "-rf" "%{prefix}%/share/bap"]
   ["rm" "-f" "%{man}%/man1/bap-mc.1"]
   ["rm" "-f" "%{man}%/man1/bap.1"]

--- a/plugins/analyze/analyze_core_commands.ml
+++ b/plugins/analyze/analyze_core_commands.ml
@@ -52,7 +52,7 @@ let find_entry subrs name_or_addr =
   Set.to_sequence |>
   KB.Seq.find ~f:(fun addr ->
       let addr = Word.to_bitvec addr in
-      if Bitvec.to_string addr = name_or_addr
+      if Poly.(Bitvec.to_string addr = name_or_addr)
       then KB.return true
       else Theory.Label.for_addr addr >>= fun label ->
         KB.collect Theory.Label.name label >>| function

--- a/plugins/analyze/analyze_main.ml
+++ b/plugins/analyze/analyze_main.ml
@@ -251,7 +251,7 @@ let complete ctxt prefix completions =
       let pkg = Knowledge.Name.package name in
       let short = Knowledge.Name.unqualified name in
       let full = Knowledge.Name.to_string name in
-      if pkg = ctxt.package && matches short
+      if String.equal pkg ctxt.package && matches short
       then LNoise.add_completion completions short
       else if matches full || matches short
       then LNoise.add_completion completions full)

--- a/plugins/cache/bap_cache.ml
+++ b/plugins/cache/bap_cache.ml
@@ -7,6 +7,7 @@ include Self ()
 
 module Filename = Caml.Filename
 module Random = Caml.Random
+module Unix = Caml_unix
 module Utils = Bap_cache_utils
 
 let (//) = Filename.concat

--- a/plugins/cache/bap_cache_gc.ml
+++ b/plugins/cache/bap_cache_gc.ml
@@ -80,6 +80,7 @@ include Self ()
 
 module Cache = Bap_cache
 module CDF = Int.Map
+module Unix = Caml_unix
 
 type entry = {
   path : string;

--- a/plugins/cache/bap_cache_utils.ml
+++ b/plugins/cache/bap_cache_utils.ml
@@ -2,6 +2,7 @@ open Core_kernel
 open Regular.Std
 
 module Filename = Caml.Filename
+module Unix = Caml_unix
 
 let ( / ) = Filename.concat
 

--- a/plugins/cxxfilt/cxxfilt_main.ml
+++ b/plugins/cxxfilt/cxxfilt_main.ml
@@ -14,7 +14,7 @@ let () = Config.manpage [
 
 let demangle prog name =
   let command = sprintf "%s -p %s" prog name in
-  let inp = Unix.open_process_in command in
+  let inp = Caml_unix.open_process_in command in
   let r = In_channel.input_all inp in
   In_channel.close inp;
   String.strip r

--- a/plugins/elf_loader/elf_loader_main.ml
+++ b/plugins/elf_loader/elf_loader_main.ml
@@ -56,7 +56,7 @@ let create_symtab data endian elf  =
   let module Buffer = Dwarf.Buffer in
   let create name s =
     match section_data data s with
-    | Error err -> None          (* TODO something *)
+    | Error _ -> None          (* TODO something *)
     | Ok data ->   Some (name, Buffer.create data) in
   let sections = Seq.filter_map elf.e_sections ~f:(fun s ->
       let name =
@@ -151,9 +151,9 @@ let img_of_elf data elf : Img.t Or_error.t =
     Seq.filter_mapi elf.e_segments (create_segment addr) |>
     Seq.to_list |>
     List.partition_map ~f:(function
-        | Ok s    -> `Fst s
-        | Error e -> `Snd e) in
-  let symbols,errors =
+        | Ok s    -> First s
+        | Error e -> Second e) in
+  let symbols,_ =
     match create_symtab data endian elf with
     | Ok syms -> syms,errors
     | Error err ->

--- a/plugins/glibc_runtime/glibc_runtime_main.ml
+++ b/plugins/glibc_runtime/glibc_runtime_main.ml
@@ -18,7 +18,7 @@ let references_glib_start_main doc =
   let open Ogre.Syntax in
   let query =
     Ogre.request Image.Scheme.external_reference
-      ~that:(fun (_,name) -> name = "__libc_start_main")
+      ~that:(fun (_,name) -> Poly.(name = "__libc_start_main"))
     >>| Option.is_some in
   match Ogre.eval query doc with
   | Ok r -> r

--- a/plugins/ida/bap_ida_service.ml
+++ b/plugins/ida/bap_ida_service.ml
@@ -6,6 +6,7 @@ include Self ()
 
 module Buffer = Caml.Buffer
 module Filename = Caml.Filename
+module Unix = Caml_unix
 
 module Info = Bap_ida_info
 

--- a/plugins/ida/ida_main.ml
+++ b/plugins/ida/ida_main.ml
@@ -7,6 +7,7 @@ open Bap_ida.Std
 
 open Format
 open Result.Monad_infix
+module Unix = Caml_unix
 
 include Self()
 

--- a/plugins/objdump/objdump_main.ml
+++ b/plugins/objdump/objdump_main.ml
@@ -31,6 +31,7 @@ open Objdump_config
 open Bap_main
 
 module Log = Bap_main_event.Log
+module Unix = Caml_unix
 
 open KB.Syntax
 

--- a/plugins/optimization/optimization_data.ml
+++ b/plugins/optimization/optimization_data.ml
@@ -53,8 +53,8 @@ let dead_jmps_of_blk b =
         if is_unreachable
         then Set.add deads (Term.tid jmp), is_unreachable
         else match Jmp.cond jmp with
-          | Bil.Int x when x = Word.b1 -> deads, true
-          | Bil.Int x when x = Word.b0 ->
+          | Bil.Int x when Word.(x = b1) -> deads, true
+          | Bil.Int x when Word.(x = b0) ->
             Set.add deads (Term.tid jmp), is_unreachable
           | _ -> deads, is_unreachable) |> fst
 

--- a/plugins/phoenix/phoenix_options.ml
+++ b/plugins/phoenix/phoenix_options.ml
@@ -6,7 +6,7 @@ type label_format = [ `with_asm | `with_bil | `with_name ]
 
 type t = {
   output_folder : string;
-  cfg_format : label_format sexp_list;
+  cfg_format : label_format list;
   no_resolve : bool;
   keep_alive : bool;
   no_inline : bool;

--- a/plugins/phoenix/phoenix_root.ml
+++ b/plugins/phoenix/phoenix_root.ml
@@ -1,5 +1,7 @@
 open Core_kernel
 
+module Unix = Caml_unix
+
 exception Target_directory_is_a_file
 
 type t = string * string

--- a/plugins/primus_lisp/primus_lisp_ieee754.ml
+++ b/plugins/primus_lisp/primus_lisp_ieee754.ml
@@ -127,12 +127,12 @@ module Primitives(Machine : Primus.Machine.S) = struct
       define pre "abs" abs_float;
       define inf "mod" mod_float;
       define cti "cti" Int64.of_float;
-      define ord "lt" (<.);
-      define ord "le" (<=.);
-      define ord "eq" (=.);
-      define ord "ne" (<>.);
-      define ord "gt" (>.);
-      define ord "ge" (>=.);
+      define ord "lt" Float.((<));
+      define ord "le" Float.((<=));
+      define ord "eq" Float.((=));
+      define ord "ne" Float.((<>));
+      define ord "gt" Float.((>));
+      define ord "ge" Float.((>=));
     ]
 end
 

--- a/plugins/primus_random/primus_random_main.ml
+++ b/plugins/primus_random/primus_random_main.ml
@@ -409,7 +409,7 @@ let main ctxt =
     Seq.fold ~init:{args=Var.Map.empty} ~f:(fun init sub ->
         Term.enum arg_t sub |>
         Seq.fold ~init ~f:(fun {args} arg ->
-            if Arg.intent arg = Some In then {args}
+            if Poly.(Arg.intent arg = Some In) then {args}
             else match Var.typ (Arg.lhs arg) with
               | Unk | Mem _ -> {args}
               | Imm width ->

--- a/plugins/print/print_main.ml
+++ b/plugins/print/print_main.ml
@@ -511,7 +511,7 @@ let () =
   let ansi_colors : bool Config.param =
     let doc =
       "Allow coloring output with ansi color escape sequences" in
-    let default = Unix.isatty Unix.stdout in
+    let default = Caml_unix.(isatty stdout) in
     Config.(param bool ~default "with-colors" ~doc) in
   let print_symbols : _ list Config.param =
     let opts = [

--- a/plugins/radare2/radare2_main.ml
+++ b/plugins/radare2/radare2_main.ml
@@ -4,6 +4,8 @@ open Bap_future.Std
 open Bap.Std
 include Self()
 
+module Unix = Caml_unix
+
 open KB.Syntax
 
 let agent =
@@ -93,7 +95,7 @@ let provide_radare2 file =
   let rels =
     let init = Bap_relation.empty Z.compare String.compare in
     List.fold ~init (extract_symbols file) ~f: (fun rels (name,addr,typ) ->
-        if typ = "FUNC" then match strip name with
+        if String.equal typ "FUNC" then match strip name with
           | None -> rels
           | Some name -> Bap_relation.add rels addr name
         else rels) in

--- a/plugins/raw/raw_main.ml
+++ b/plugins/raw/raw_main.ml
@@ -13,7 +13,7 @@ open Core_kernel
 open Extension.Syntax
 
 module Buffer = Caml.Buffer
-
+module Unix = Caml_unix
 
 module Spec = struct
   open Extension

--- a/plugins/report/report_main.ml
+++ b/plugins/report/report_main.ml
@@ -5,6 +5,8 @@ open Format
 
 include Self()
 
+module Unix = Caml_unix
+
 type slot = {
   note : string option;
   stage : int option;

--- a/plugins/stub_resolver/stub_resolver.ml
+++ b/plugins/stub_resolver/stub_resolver.ml
@@ -69,8 +69,8 @@ let unite_names t groups =
 let pick_representative = function
   | [] -> assert false
   | groups ->
-    List.min_elt groups ~compare:Int.compare |>
-    Option.value_exn
+    Option.value_exn (List.min_elt groups ~compare:Int.compare)
+
 
 let redirect t ~from ~to_ =
   Map.map t.groups ~f:(fun id ->

--- a/plugins/stub_resolver/stub_resolver_main.ml
+++ b/plugins/stub_resolver/stub_resolver_main.ml
@@ -186,7 +186,7 @@ end = struct
 
   let parse_line s = match String.strip s with
     | "" -> Empty
-    | s when s.[0] = ';' -> Comment
+    | s when Char.equal s.[0] ';' -> Comment
     | s when String.for_all s ~f:Char.is_whitespace -> Empty
     | s ->
       let s = String.strip @@

--- a/plugins/stub_resolver/stub_resolver_tests.ml
+++ b/plugins/stub_resolver/stub_resolver_tests.ml
@@ -102,10 +102,11 @@ let tid_for_name_exn prog name =
   Term.to_sequence sub_t prog |>
   Seq.find_map
     ~f:(fun s ->
-        if Sub.name s = name
+        if String.equal (Sub.name s) name
         then Some (Term.tid s)
-        else None) |>
-  Option.value_exn
+        else None) |> function
+  | None -> failwithf "no tid for name %s" name ()
+  | Some s -> s
 
 let run name symbols expected should_fail _ctxt =
   let syms =

--- a/plugins/thumb/thumb_main.ml
+++ b/plugins/thumb/thumb_main.ml
@@ -60,7 +60,7 @@ module Thumb(CT : Theory.Core) = struct
     | _ -> failwith "expected a condition code"
 
 
-  let is_pc v = Theory.Var.name v = "PC"
+  let is_pc v = String.equal (Theory.Var.name v) "PC"
   let has_pc = List.exists ~f:is_pc
   let remove_pc = List.filter ~f:(Fn.non is_pc)
 

--- a/plugins/trace/trace_main.ml
+++ b/plugins/trace/trace_main.ml
@@ -7,6 +7,7 @@ open Format
 open Result.Monad_infix
 include Self()
 
+module Unix = Caml_unix
 
 let print_meta trace =
   Trace.meta trace |>

--- a/plugins/x86/x86_abi.ml
+++ b/plugins/x86/x86_abi.ml
@@ -211,7 +211,7 @@ let name (module Abi : abi) = Abi.name
 let arch (module Abi : abi) = Abi.arch
 let find name = supported () |> List.find ~f:(fun abi -> is_named_after abi name)
 
-let auto proj = supported () |> List.find ~f:(fun (module Abi) ->
+let auto proj = supported () |> List.find ~f:(fun (module Abi : abi) ->
     Abi.autodetect proj)
 
 let api abi proto =

--- a/plugins/x86/x86_btx.ml
+++ b/plugins/x86/x86_btx.ml
@@ -57,8 +57,8 @@ module Make (Tools : X86_tools.S) (Backend : X86_backend.S) = struct
     X86_operands.ri ~f:(fun _mem base offset ->
         let base = RR.of_mc_exn base in
         let size = RR.width base in
-        let o = Imm.to_word offset ~width:(offset_width size) |>
-                Option.value_exn in
+        let o =
+          Option.value_exn (Imm.to_word offset ~width:(offset_width size)) in
         let base = RR.var base in
         let bil =
           let flags = set_flags op (Bil.var base) (Bil.int o) in
@@ -77,8 +77,7 @@ module Make (Tools : X86_tools.S) (Backend : X86_backend.S) = struct
           | `BT16mi8 | `BTC16mi8 | `BTR16mi8 | `BTS16mi8 -> `r16 in
         let a = local_var "a" @@ Size.in_bits MM.addr_size in
         let d = local_var "d" @@ Size.in_bits size in
-        let o = Imm.to_word offset ~width:(offset_width size) |>
-                Option.value_exn in
+        let o = Option.value_exn (Imm.to_word offset ~width:(offset_width size)) in
         let bil =
           let load = Bil.[
               a := MM.addr base_mem;

--- a/plugins/x86/x86_tools_imm.ml
+++ b/plugins/x86/x86_tools_imm.ml
@@ -7,6 +7,4 @@ let of_imm imm = imm
 
 let get ~width t =
   Imm.to_word t ~width:(Size.in_bits width) |>
-  Option.value_exn |>
-  Bil.int
-
+  fun x -> Bil.int (Option.value_exn x)

--- a/plugins/x86/x86_tools_reg.ml
+++ b/plugins/x86/x86_tools_reg.ml
@@ -15,9 +15,9 @@ module Make(CPU : X86CPU) : RR = struct
         | #X86_asm.reg as t -> of_asm t
         | _ -> None)
 
-  let of_asm_exn reg = of_asm reg |> Option.value_exn
+  let of_asm_exn reg = Option.value_exn (of_asm reg)
 
-  let of_mc_exn reg = of_mc reg |> Option.value_exn
+  let of_mc_exn reg = Option.value_exn (of_mc reg)
 
   let to_asm t = t
 
@@ -71,10 +71,12 @@ module Make(CPU : X86CPU) : RR = struct
     | `XMM14 | `YMM14 -> CPU.ymms.(14)
     | `XMM15 | `YMM15 -> CPU.ymms.(15)
 
+  let here = Lexing.dummy_pos
 
   let var t =
     if CPU.avaliable t then var_all t
-    else Error.failwiths "invalid reg variable"
+    else Error.failwiths ~here
+        "invalid reg variable"
         t X86_asm.sexp_of_reg
 
   let bvar r = var r |> Bil.var
@@ -106,7 +108,7 @@ module Make(CPU : X86CPU) : RR = struct
       | #Reg.r32, `x86_64 -> Bil.(cast unsigned bitsize e)
       | #Reg.r32, `x86 | #Reg.r64, `x86_64 | #Reg.segment_base, _
       | #Reg.segment, _ | #Reg.r256, _ -> e
-      | #Reg.r64, `x86 -> Error.failwiths "invalid reg"
+      | #Reg.r64, `x86 -> Error.failwiths ~here "invalid reg"
                             r X86_asm.sexp_of_reg
     in
     Bil.(lhs := rhs)

--- a/src/bap_byteweight_main.ml
+++ b/src/bap_byteweight_main.ml
@@ -120,7 +120,7 @@ let load_or_create_signatures ?comp ?path operation arch =
     | Error e,_ -> fail (Sigs e)
 
 let oracle_of_image img =
-  let starts = Hash_set.create (module Addr) () in
+  let starts = Hash_set.create (module Addr) in
   Image.symbols img |> Table.iteri ~f:(fun mem _ ->
       Hash_set.add starts (Memory.min_addr mem));
   fun mem -> Hash_set.mem starts (Memory.min_addr mem)
@@ -157,7 +157,6 @@ let train loader operation length comp db paths _ctxt =
   let init = Map.empty (module String) in
   let files = List.fold ~init paths ~f:add_path in
   let total = Map.length files in
-  let start = Unix.gettimeofday () in
   let errors = ref 0 in
   let step = ref 0 in
   Map.iter files ~f:(fun path ->
@@ -170,8 +169,6 @@ let train loader operation length comp db paths _ctxt =
         printf "%6s\n%!" "SKIPPED";
         eprintf "Error: %a\n%!" Extension.Error.pp err;
         (incr errors));
-  printf "Processed %d files out of %d in %g seconds\n"
-    (total - !errors) total (Unix.gettimeofday () -. start);
   printf "Signatures were stored in %s\n%!" db;
   Ok ()
 


### PR DESCRIPTION
There's a few changes in here due to API incompatibility with the Jane Street libraries (but nothing that changes bap's own APIs), so you'll either want to make them conditional on version (not sure there's an easy way to do this in e.g. the `oasis` file that needed changing) or just wait to merge this for the next release of bap.

---

Thanks to ppx_js_style (sigh), this also depends on:

* ocaml/ocamlfind#9
* alavrik/piqi-ocaml#15