### PR TITLE
fixes an infinite loop in certain Primus Lisp analyses

### DIFF
--- a/plugins/primus_taint/lisp/sensitive-sinks.lisp
+++ b/plugins/primus_taint/lisp/sensitive-sinks.lisp
@@ -10,11 +10,10 @@
 (require types)
 (require pointers)
 
-(defmethod eval-cond (c)
+(defmethod jumping (c _)
   (let ((t (taint-get-direct 'untrusted c)))
     (when t
       (dict-add 'untrusted/checked t (incident-location)))))
-
 
 (defun must/check (v)
   (let ((t (taint-get-direct 'untrusted v))

--- a/plugins/primus_test/lisp/check-value.lisp
+++ b/plugins/primus_test/lisp/check-value.lisp
@@ -51,7 +51,7 @@
       (check-value/unchecked pc)
       (dict-del 'check-value/required taint))))
 
-(defmethod eval-cond (cnd)
+(defmethod jumping (cnd _)
   (check-value-clear cnd))
 
 


### PR DESCRIPTION
Since now Primus Lisp operations are expressed in terms of the Primus
interpreter (in order to enable analysis of the code that is stubbed
in Primus Lisp), we have the `eval-cond` signal sent every time we
make any comparison operation in Lisp, e.g., `if`, `when`, `or`,
`and`, etc. Therefore, any method for `eval-cond` that does any
comparison operation (branching) will stall in an infinite loop.

A workaround is to use another observation that occurs only on jumps
that are situated in the binary code, but in general we shall address
it and make sure that `eval-cond` method is usable.

fixes (as a workaround) #1121 