### PR TITLE
handles correctly XDG_CACHE_HOME

### DIFF
--- a/plugins/cache/bap_cache.ml
+++ b/plugins/cache/bap_cache.ml
@@ -60,7 +60,7 @@ let root () =
   let root = match !default_root with
     | Some dir -> dir // ".cache" // "bap"
     | None -> match getenv "XDG_CACHE_HOME" with
-      | Some cache -> cache
+      | Some cache -> cache // "bap"
       | None -> match getenv "HOME" with
         | None -> Filename.get_temp_dir_name () // "bap" // "cache"
         | Some home -> home // ".cache" // "bap" in


### PR DESCRIPTION
we shall not take the whole chaching directory, but create a subfolder there.