### PR TITLE
fixes getenv Lisp stub

### DIFF
--- a/plugins/primus_lisp/lisp/stdlib.lisp
+++ b/plugins/primus_lisp/lisp/stdlib.lisp
@@ -7,11 +7,15 @@
 (defun getenv (name)
   "finds a value of an environment variable with the given name"
   (declare (external "getenv"))
-  (let ((p environ))
+  (let ((p environ)
+        (n (strlen name)))
     (while (and (not (points-to-null p))
-                (/= (strcmp p name) 0))
-      (ptr+1 ptr_t p))
-    (if p (strchr p (cast int ?=)) p)))
+                (/= (memcmp (read-word ptr_t p) name n) 0))
+      (set p (ptr+1 ptr_t p)))
+    (if (and (not (points-to-null p)) (/= p environ))
+        (let ((p (read-word ptr_t p)))
+          (if (= (memory-read (+ p n)) ?=) (+ p n 1) 0))
+      0)))
 
 
 (defun abort ()


### PR DESCRIPTION
The implementation was missing the fact that envp is an array of
pointers to string, not an array of pointers.

Also, not sure if it is a bug or abi-specific, but env is not set,
then it is not null. Probably, it should be double-checked in the
loader part.