### PR TITLE
Tweak jumping and eval cond

### DIFF
--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -1668,15 +1668,43 @@ module Std : sig
 
       (** [jumping (cond,dest)] happens just before a jump to [dest]
           is taken under the specified condition [cond].
-          Note: [cond] is always [true]
+          Note: the [cond] expression is always [true] and is computed
+          from the path constraints of all outcoming edges of a
+          block.
 
-          @since 1.5.0 *)
+          @since 1.5.0
+          @since 2.2.0 the condition is built from all edge
+          constraints. *)
       val jumping : (value * value) observation
 
-      (** [eval_cond v] occurs every time the [cond] part of a jump is
-          evaluated.
+      (** [eval_cond c] occurs on every decision making operation.
 
-          @since 1.5.0 *)
+          The conditional expression is a one bit wide bitvector
+          could be true or false (contrary to the jumping
+          observation).
+
+          The [eval_cond] observation is posted for all outcoming
+          edges of a basic block with proper edge constraints.
+
+          For example, for a block
+
+          {v
+           when c1 goto d1
+           when c2 goto d2
+                   goto d3
+          v}
+
+          which has three edges with constraints, correspondingly,
+
+          - [c1]
+          - [not c1 && c2]
+          - [not c1 && not c2 && true]
+
+          @since 1.5.0 introduced
+          @since 2.1.0 is posted by [branch] and [repeat] operations
+          @since 2.2.0 the condition is a disjunction of negations
+          of the previous conditions.
+      *)
       val eval_cond : value observation
 
       (** [undefined x] happens when a computation produces an

--- a/plugins/primus_lisp/primus_lisp_main.ml
+++ b/plugins/primus_lisp/primus_lisp_main.ml
@@ -101,8 +101,6 @@ module Signals(Machine : Primus.Machine.S) = struct
           {|(written V X) is emitted when X is written to V|};
         signal pc_change word one Type.(one int)
           {|(pc-change PC) is emitted when PC is updated|};
-        signal eval_cond value one Type.(one bool)
-          {|(eval-cond V) is emitted after evaluating a conditional to V|};
         signal jumping (value,value) pair Type.(tuple [bool; int])
           {|(jumping C D) is emitted before jump to D occurs under the
           condition C|};


### PR DESCRIPTION
The semantics of eval-cond and jumping observations is corrected. The conditional expression of the `eval-cond` observation now takes into account preceding guard conditions, which fixes wrong path constraints created by the symbolic executor as well as simplifies the symbolic executor code (which no longer requires the analysis of which branch is taken and which is not).

The conditional expression of the `jumping` expression, which is still always true, is now computed from all path constraints of the outcoming edges of the basic block, which simplifies taint analysis. 

Finally, we implement the `on-cond` Lisp signal in terms of the `jumping` observation. And while it sounds bad, as we broke the one-to-one correspondence between observation name and signal name, it restores the previous semantics of the `on-cond` signal and makes it safe to use it in the Lisp code. It is very tempting though, to try to implement a safe `on-cond` signal with 2.1.0 semantics, which will enable tracking conditional expressions that happen in Lisp code and primitives and improve analysis precision. But it may require a substantial amount of work so at the end we may decide to remove the `on-cond` signal at all. 

Addresses #1124 