### PR TITLE
fixes the `fgetc` stub and the `channel-input` primitive return type

### DIFF
--- a/plugins/primus_lisp/lisp/stdio.lisp
+++ b/plugins/primus_lisp/lisp/stdio.lisp
@@ -99,9 +99,9 @@
   (declare (external "read"))
   (fread buf 1 n fd))
 
+
 (defun fgetc (stream)
   (declare (external "fgetc" "getc"))
-  (msg "the concrete fgets is called")
   (channel-input stream))
 
 (defun terminate-string-and-return-null (ptr)
@@ -119,7 +119,7 @@
           (if (= c -1)
               (set continue false)
             (memory-write (+ ptr i) (cast char c))
-            (set continue (/= c 0xA:8))
+            (set continue (/= c 0xA))
             (incr i))))
       (if (= i 0)
           (terminate-string-and-return-null ptr)

--- a/plugins/primus_lisp/primus_lisp_io.ml
+++ b/plugins/primus_lisp/primus_lisp_io.ml
@@ -105,6 +105,7 @@ let init redirections =
     let nil = Value.b0
     let error = addr_width >>= fun w -> Value.of_word (Word.ones w)
     let ok = addr_width >>= Value.zero
+    let int x = addr_width >>= fun width -> Value.of_int ~width x
 
     let value_to_fd fd =
       Value.to_word fd |> Word.to_int |> function
@@ -211,7 +212,7 @@ let init redirections =
         | Some {input=Some ch} -> match input_byte ch with
           | Error _ -> error
           | Ok None -> error
-          | Ok (Some ch) -> Value.of_int ~width:8 ch
+          | Ok (Some ch) -> int ch
   end in
 
   let module Primitives(Machine : Primus.Machine.S) = struct
@@ -264,7 +265,7 @@ let init redirections =
             channel that has the descriptor DESCR to be outputted to the
             associated destination. Returns -1 if no such channel exists or
             if in case of an IO error.|};
-        def "channel-input"  (one int @-> byte) (module Input)
+        def "channel-input"  (one int @-> int) (module Input)
           {|(channel-input DESC) reads one byte from a channel that
             has the descriptor DESC. Returns -1 if no such channel
             exists, or if any IO error occurs, if the channel is not

--- a/plugins/primus_symbolic_executor/lisp/symbolic-stdio.lisp
+++ b/plugins/primus_symbolic_executor/lisp/symbolic-stdio.lisp
@@ -99,7 +99,7 @@
           (data (dict-get 'symbolic-open-data fd)))
       (if (= fpos size) -1
         (dict-add 'symbolic-open-fpos fd (+1 fpos))
-        (symbolic-memory-read data fpos))))))
+        (cast int (symbolic-memory-read data fpos)))))))
 
 (defun getchar ()
   (declare (external "getchar"))


### PR DESCRIPTION
Both shall return a value of type `int` but were returning a value of
type char. Not only it provoked type errors when the real `fgetc` was
linked to the binary, but it also was incorrect, since the actual
primitive was returning a value of type `int`.