### PR TITLE
removes the buffer tracking

### DIFF
--- a/plugins/primus_test/lisp/memcheck.lisp
+++ b/plugins/primus_test/lisp/memcheck.lisp
@@ -51,11 +51,7 @@
   (when (and beg len)
     (let ((end (-1 (+ beg len)))
           (r1 (region-contains (symbol-concat 'memcheck/live heap) beg))
-          (r2 (region-contains (symbol-concat 'memcheck/live heap) end))
-          (b1 (region-contains 'buffer beg))
-          (b2 (region-contains 'buffer end)))
-      (unless b1
-        (memcheck-acquire 'buffer beg len))
+          (r2 (region-contains (symbol-concat 'memcheck/live heap) end)))
       (when (/= b1 b2)
         (memcheck/report-out-of-bound b1 b2))
       (when (/= r1 r2)


### PR DESCRIPTION
It didn't prove to really have any benefits but clashes with regular heap overflow tracking. Fixes #1152.