### PR TITLE
makes build_plugin.sh more portable

### DIFF
--- a/tools/build_plugins.sh
+++ b/tools/build_plugins.sh
@@ -42,7 +42,7 @@ count_jobs() {
 }
 
 start_job() {
-    realpath $(mktemp -p $jobs_folder XXX)
+    mktemp $PWD/$jobs_folder/XXX
 }
 
 finish_job() {


### PR DESCRIPTION
on vanilla MacOS there is no `realpath` or `mktemp` that accepts
`-p`, but we can make it simpler and even nicer withour relying on
such an advanced and moder technology.

Note, a problem with github runners is that they are very far from
being clean systems, they have a lot of software preinstalled, so if
something works on them it doesn't really imply that it will work on
real systems.

Given that we need to add more docker images and test them at least
weekly.