### PR TITLE
tweaks nightly and weekly builds - do not install bap twice 

### DIFF
--- a/.github/workflows/nightly-testing.yml
+++ b/.github/workflows/nightly-testing.yml
@@ -52,7 +52,7 @@ jobs:
 
         - name: Install Extra System Dependencies
           run: |
-              opam pin add bap .
+              opam pin add bap . -n
               opam depext -u bap
 
         - name: Run Functional Tests

--- a/.github/workflows/weekly-regress.yml
+++ b/.github/workflows/weekly-regress.yml
@@ -51,7 +51,7 @@ jobs:
 
         - name: Install Extra System Dependencies
           run: |
-              opam pin add bap .
+              opam pin add bap . -n
               opam depext -u bap
 
         - name: Run Functional Tests


### PR DESCRIPTION
We pin bap's repo to portably grab extra system dependencies needed for running the testsuite, but accidentally also reinstall bap.