### PR TITLE
prevents delay slots from becoming a basic block start

### DIFF
--- a/lib/bap_disasm/bap_disasm_driver.ml
+++ b/lib/bap_disasm/bap_disasm_driver.ml
@@ -33,10 +33,11 @@ module Machine : sig
   type state = private {
     stop : bool;
     work : task list;           (* work list*)
-    debt : task list;
+    debt : task list;           (* work that we can't finish *)
     curr : task;
     addr : addr;                (* current address *)
-    begs : Set.M(Addr).t;       (* begins of basic blocks *)
+    dels : Set.M(Addr).t;
+    begs : task list Map.M(Addr).t;       (* begins of basic blocks *)
     jmps : dsts Map.M(Addr).t;  (* jumps  *)
     code : Set.M(Addr).t;       (* all valid instructions *)
     data : Set.M(Addr).t;       (* all non-instructions *)
@@ -84,7 +85,8 @@ end = struct
     debt : task list;
     curr : task;
     addr : addr;                (* current address *)
-    begs : Set.M(Addr).t;       (* begins of basic blocks *)
+    dels : Set.M(Addr).t;
+    begs : task list Map.M(Addr).t;       (* begins of basic blocks *)
     jmps : dsts Map.M(Addr).t;  (* jumps  *)
     code : Set.M(Addr).t;       (* all valid instructions *)
     data : Set.M(Addr).t;       (* all non-instructions *)
@@ -100,7 +102,7 @@ end = struct
   let mark_data s addr = {
     s with
     data = Set.add s.data addr;
-    begs = Set.remove s.begs addr;
+    begs = Map.remove s.begs addr;
     usat = Set.remove s.usat addr;
     code = Set.remove s.code addr;
     jmps = Map.filter_map (Map.remove s.jmps addr) ~f:(fun dsts ->
@@ -137,21 +139,33 @@ end = struct
         | Fall _ | Dest _ -> cancel parent (mark_data s src)
         | Jump _ -> assert false
 
+  let cancel_beg s addr = match Map.find s.begs addr with
+    | None -> s
+    | Some tasks ->
+      List.fold_right tasks ~f:cancel ~init:{
+        s with begs = Map.remove s.begs addr;
+      }
+
+  let is_slot s addr = Set.mem s.dels addr
+
   let rec step s = match s.work with
     | [] ->
       if Set.is_empty s.usat then {s with stop = true}
       else step {s with work = [
           Dest {dst=Set.min_elt_exn s.usat; parent=None}
         ]}
-    | Dest {dst=next} as curr :: work when is_data s next ->
+    | Dest {dst=next} as curr :: work
+      when is_data s next || is_slot s next ->
       step @@ cancel curr {s with work}
     | Dest {dst=next} as curr :: work ->
-      let s = {s with begs = Set.add s.begs next} in
+      let s = {s with begs = Map.add_multi s.begs next curr} in
       if is_visited s next then step {s with work}
       else {s with work; addr=next; curr}
     | Fall {dst=next} as curr :: work ->
       if is_code s next
-      then step {s with begs = Set.add s.begs next; work}
+      then
+        if is_slot s next then step @@ cancel curr {s with work}
+        else step {s with begs = Map.add_multi s.begs next curr; work}
       else if is_data s next then step @@ cancel curr {s with work}
       else {s with work; addr=next; curr}
     | (Jump {src; dsts} as jump) :: ([] as work)
@@ -164,17 +178,18 @@ end = struct
         let init = {s with jmps = Map.add_exn s.jmps src dsts; work} in
         step @@
         Set.fold resolved ~init ~f:(fun s next ->
-            if not (is_visited s next)
-            then {s with work = Dest {dst=next; parent = Some jump} ::
-                                s.work}
-            else {s with begs = Set.add s.begs next})
+            {s with work = Dest {dst=next; parent = Some jump} ::
+                           s.work})
     | Jump jmp as self :: Fall ({dst=next} as slot) :: work ->
+      let s = cancel_beg s next in
       let delay = if jmp.age = 1 then Ready (Some self) else Delay in
+      let jump = Jump {
+          jmp with age = jmp.age-1; src = next;
+        } in
       step {
         s with
-        work = Fall {slot with delay} :: Jump {
-            jmp with age = jmp.age-1; src = next;
-          } :: work
+        work = Fall {slot with delay} :: jump :: work;
+        dels = Set.add s.dels next;
       }
     | Jump jmp :: work -> step {
         s with work = Jump {jmp with age=0} :: work
@@ -251,7 +266,8 @@ end = struct
       debt = [];
       curr = Dest {dst = start; parent = None};
       stop = false;
-      begs = Set.empty (module Addr);
+      dels = Set.empty (module Addr);
+      begs = Map.empty (module Addr);
       jmps = Map.empty (module Addr);
       code = Set.empty (module Addr);
     } mem
@@ -320,13 +336,12 @@ let classify_mem mem =
         | Some true -> (code,data,Set.add root addr)
         | _ -> (code,data,root))
 
-let scan_mem arch disasm debt base : Machine.state KB.t =
-  classify_mem base >>= fun (code,data,init) ->
+let scan_mem ~code ~data ~funs arch disasm debt base : Machine.state KB.t =
   let step d s =
     if Machine.is_ready s then KB.return s
     else Machine.view s base ~ready:(fun s mem -> Dis.jump d mem s)
         ~empty:KB.return in
-  Machine.start base ~debt ~code ~data ~init
+  Machine.start base ~debt ~code ~data ~init:funs
     ~ready:(fun init mem ->
         Dis.run disasm mem ~stop_on:[`Valid]
           ~return:KB.return ~init
@@ -347,6 +362,7 @@ let scan_mem arch disasm debt base : Machine.state KB.t =
 type insns = Theory.Label.t list
 
 type state = {
+  funs : Addr.Set.t;
   begs : Addr.Set.t;
   jmps : dsts Addr.Map.t;
   data : Addr.Set.t;
@@ -355,6 +371,7 @@ type state = {
 } [@@deriving bin_io]
 
 let init = {
+  funs = Set.empty (module Addr);
   begs = Set.empty (module Addr);
   jmps = Map.empty (module Addr);
   data = Set.empty (module Addr);
@@ -373,14 +390,15 @@ let already_scanned addr s =
 
 let commit_calls {jmps} =
   Map.to_sequence jmps |>
-  KB.Seq.iter ~f:(fun (_,dsts) ->
+  KB.Seq.fold ~init:Addr.Set.empty ~f:(fun calls (_,dsts) ->
       if dsts.call then
         Set.to_sequence dsts.resolved |>
-        KB.Seq.iter ~f:(fun addr ->
+        KB.Seq.fold ~init:calls ~f:(fun calls addr ->
             Theory.Label.for_addr (Word.to_bitvec addr) >>= fun dst ->
             KB.provide Theory.Label.is_valid dst (Some true) >>= fun () ->
-            KB.provide Theory.Label.is_subroutine dst (Some true))
-      else KB.return ())
+            KB.provide Theory.Label.is_subroutine dst (Some true) >>| fun () ->
+            Set.add calls addr)
+      else KB.return calls)
 
 let scan mem s =
   let open KB.Syntax in
@@ -392,16 +410,21 @@ let scan mem s =
     match Dis.create (Arch.to_string arch) with
     | Error _ -> KB.return s
     | Ok dis ->
-      scan_mem arch dis s.debt mem >>= fun {Machine.begs; jmps; data; debt} ->
+      classify_mem mem >>= fun (code,data,funs) ->
+      scan_mem ~code ~data ~funs arch dis s.debt mem >>=
+      fun {Machine.begs; jmps; data; debt; dels} ->
       let jmps = Map.merge s.jmps jmps ~f:(fun ~key:_ -> function
           | `Left dsts | `Right dsts | `Both (_,dsts) -> Some dsts) in
-      let begs = Set.union s.begs begs in
+      let begs = Set.of_map_keys begs in
+      let funs = Set.union s.funs funs in
+      let begs = Set.(diff (union s.begs begs) dels) in
       let data = Set.union s.data data in
-      let s = {begs; data; jmps; mems = mem :: s.mems; debt} in
-      commit_calls s >>| fun () ->
-      s
+      let s = {funs; begs; data; jmps; mems = mem :: s.mems; debt} in
+      commit_calls s >>| fun funs ->
+      {s with funs = Set.(diff (union s.funs funs) dels)}
 
 let merge t1 t2 = {
+  funs = Set.union t1.funs t2.funs;
   begs = Set.union t1.begs t2.begs;
   data = Set.union t1.data t2.data;
   mems = List.rev_append t2.mems t1.mems;
@@ -441,13 +464,10 @@ let with_disasm beg cfg f =
 
 let explore
     ?entry:start ?(follow=always) ~block ~node ~edge ~init
-    {begs; jmps; data; mems} =
+    ({begs; jmps; data; mems} as state) =
   let find_base addr =
     if Set.mem data addr then None
     else List.find mems ~f:(fun mem -> Memory.contains mem addr) in
-  let may_fall jmp = match Map.find jmps jmp with
-    | None -> true
-    | Some {barrier} -> not barrier in
   let blocks = Hashtbl.create (module Addr) in
   let edge_insert cfg src dst = match dst with
     | None -> KB.return cfg
@@ -464,8 +484,8 @@ let explore
           | None -> KB.return (cfg,None)
           | Some base ->
             Dis.run dis (view beg base) ~stop_on:[`Valid]
-              ~init:(beg,0,[],true) ~return:KB.return
-              ~hit:(fun s mem insn (curr,len,insns,_) ->
+              ~init:(beg,0,[]) ~return:KB.return
+              ~hit:(fun s mem insn (curr,len,insns) ->
                   new_insn arch mem insn >>= fun insn ->
                   let len = Memory.length mem + len in
                   let last = Memory.max_addr mem in
@@ -473,32 +493,31 @@ let explore
                   if Set.mem begs next || Map.mem jmps curr
                   then
                     KB.return
-                      (curr, len, insn::insns,may_fall curr)
+                      (curr, len, insn::insns)
                   else Dis.jump s (view next base)
-                      (next, len, insn::insns,true))
-            >>= fun (fin,len,insns,may_fall) ->
+                      (next, len, insn::insns))
+            >>= fun (fin,len,insns) ->
             let mem = view ~len beg base in
             block mem insns >>= fun block ->
             let fall = Addr.succ (Memory.max_addr mem) in
             Hashtbl.add_exn blocks beg block;
             node block cfg >>= fun cfg ->
             match Map.find jmps fin with
-            | None when may_fall ->
+            | None ->
               build cfg fall >>= fun (cfg,dst) ->
-              edge_insert cfg block dst >>= fun cfg ->
-              KB.return (cfg, Some block)
-            | None -> KB.return (cfg, Some block)
-            | Some {resolved=dsts} ->
-              let dsts = if may_fall
-                then Set.add dsts fall else dsts in
+              edge_insert cfg block dst >>| fun cfg ->
+              cfg, Some block
+            | Some {resolved=dsts; barrier} ->
+              let dsts = if barrier then dsts
+                else Set.add dsts fall in
               Set.to_sequence dsts |>
               KB.Seq.fold ~init:cfg ~f:(fun cfg dst ->
                   build cfg dst >>= fun (cfg,dst) ->
-                  edge_insert cfg block dst) >>= fun cfg ->
-              KB.return (cfg,Some block)  in
+                  edge_insert cfg block dst) >>| fun cfg ->
+              cfg,Some block in
   match start with
   | None ->
-    Set.to_sequence begs |>
+    Set.to_sequence state.funs |>
     KB.Seq.fold ~init ~f:(fun cfg beg ->
         build cfg beg >>| fst)
   | Some start -> build init start >>| fst

--- a/lib/bap_disasm/bap_disasm_driver.ml
+++ b/lib/bap_disasm/bap_disasm_driver.ml
@@ -517,7 +517,7 @@ let explore
               cfg,Some block in
   match start with
   | None ->
-    Set.to_sequence state.funs |>
+    Set.to_sequence state.begs |>
     KB.Seq.fold ~init ~f:(fun cfg beg ->
         build cfg beg >>| fst)
   | Some start -> build init start >>| fst

--- a/lib/bap_disasm/bap_disasm_driver.ml
+++ b/lib/bap_disasm/bap_disasm_driver.ml
@@ -379,6 +379,8 @@ let init = {
   debt = [];
 }
 
+let subroutines {funs} = funs
+
 let query_arch addr =
   KB.Object.scoped Theory.Program.cls @@ fun obj ->
   KB.provide Theory.Label.addr obj (Some addr) >>= fun () ->

--- a/lib/bap_disasm/bap_disasm_driver.mli
+++ b/lib/bap_disasm/bap_disasm_driver.mli
@@ -12,6 +12,8 @@ val init : state
 val scan : mem -> state -> state knowledge
 val merge : state -> state -> state
 
+val subroutines : state -> Set.M(Addr).t
+
 val explore :
   ?entry:addr ->
   ?follow:(addr -> bool knowledge) ->


### PR DESCRIPTION
Our control-flow graph representation is unable to handle cases when a
delay slot of some branching instruction becomes a target of a call or
a jump, because we do not allow the same instruction to belong to
several basic blocks (aka instruction sharing). When we encounter such a
case, our control-flow invariants are broken which leads to failures
downstream (e.g., we have duplicating term identifiers).

While it is possible that a delay slot might become a target of a
jump, in reality compilers are not generating such code (well, at
least we are not aware of such compilers) and the main source of calls
that target delays slots is Byteweight, which false positively
identifies them as function starts.

Since we don't have an option to represent such graphs right now, to
preserve our invariants, we cancel all disassembling chains that end
up in classifying some delay slots as function starts or targets of
a jump or call. To implement this, we remember each task that lead to
a creating of a new basic block. When we discover a new basic block we
check if its start is a known delay slot, and if it is , we cancel the
chain. If later we discover jump whose delay slot is a start of a
basic block we cancel all chains that were responsible for the
creation of that basic block and continue. To summarize, the invariant
is that a delay slot may never be a start of a basic block.

Another change, which is more of an optimization, that bundled with
this commit, is that we now track the function starts and use them
as the starting points to build the whole program CFG. Before we were
using all basic blocks, when we build the whole program CFG which
ended up in lots of unreachable code, which was ignored by
the subroutine partitoning algorithm, so there is no need to
disassemble them anyways.