### PR TITLE
enables unallocated memories in symbolic executor

### DIFF
--- a/plugins/primus_symbolic_executor/primus_symbolic_executor_main.ml
+++ b/plugins/primus_symbolic_executor/primus_symbolic_executor_main.ml
@@ -88,7 +88,7 @@ end = struct
         let name = Primus.Memory.Descriptor.name bank in
         Machine.Global.get memories >>= fun memories ->
         match Map.find memories name with
-        | None -> Lisp.failf "unknown symbolic memory %s" name ()
+        | None -> Machine.return ()
         | Some {lower; upper} -> allocate bank lower upper
 
     let set input value = match input with


### PR DESCRIPTION
When the symbolic executor tries to initialize a memory location that is not yet
mapped it fails with an error, when the location belongs to a memory
that wasn't set as symbolic (which is most likely just the default
virtual memory). Instead of failing, we shall just intialize the
memory location and let the pagefault handler of the memory randomizer
to map it for us.