### PR TITLE
fixes build on Archlinux

### DIFF
--- a/docker/archlinux/Dockerfile
+++ b/docker/archlinux/Dockerfile
@@ -9,7 +9,7 @@ USER bap
 WORKDIR /home/bap
 
 RUN sudo pacman -S --noconfirm m4 git unzip make curl wget \
-         diffutils patch make gcc pkgconfig llvm9 python2 \
+         diffutils patch make gcc pkgconfig llvm python2 \
          which clang \
   && wget https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh \
   && echo "" | sudo sh install.sh \


### PR DESCRIPTION
Looks like that the`llvm9` package was removed and it's the reason the build fails on `Archlinux`. This PR fixes it and installs `llvm` package that now provides the 10th version.
