### PR TITLE
restores the default objdump configuration as before #1179

### DIFF
--- a/oasis/objdump.setup.ml.in
+++ b/oasis/objdump.setup.ml.in
@@ -1,5 +1,5 @@
 let () =
   add_variable  ~doc:"A list (OCaml syntax) of paths to all discovered objdumps" "objdump_paths"
     ~define:(function
-        | None -> "[]"
+        | None -> "[\"objdump\"]"
         | Some xs -> xs)


### PR DESCRIPTION
By default, if no objdump was configured we should use `objdump`.

Note: was broken in #1179 