### PR TITLE
enables interworking

### DIFF
--- a/lib/bap/bap_project.ml
+++ b/lib/bap/bap_project.ml
@@ -92,17 +92,6 @@ module Spec = struct
     | Ok doc -> doc
 end
 
-let with_arch arch mems =
-  let open KB.Syntax in
-  let width = Size.in_bits (Arch.addr_size arch) in
-  KB.promising Arch.slot ~promise:(fun label ->
-      KB.collect Theory.Label.addr label >>| function
-      | None -> `unknown
-      | Some p ->
-        let p = Word.create p width in
-        if Memmap.contains mems p
-        then arch
-        else `unknown)
 
 let with_filename spec arch data code path =
   let open KB.Syntax in
@@ -185,7 +174,6 @@ module State = struct
     let run spec arch ~code ~data file k =
       let result = Toplevel.var "disassembly-result" in
       Toplevel.put result begin
-        with_arch arch code @@ fun () ->
         with_filename spec arch code data file @@ fun () ->
         k
       end;
@@ -948,13 +936,4 @@ let () =
            comment {|
 On [Project.create input] provides [path] for the address [x]
 if [x] in [data] or [x] in [code].
-|});
-  KB.Rule.(declare ~package:"bap" "project-arch" |>
-           dynamic ["input"] |>
-           dynamic ["arch"; "code"] |>
-           require Theory.Label.addr |>
-           provide Arch.slot |>
-           comment {|
-On [Project.create input] provides [arch] for the address [x]
-if [x] in [code].
 |})

--- a/lib/bap_disasm/bap_disasm_basic.ml
+++ b/lib/bap_disasm/bap_disasm_basic.ml
@@ -403,6 +403,7 @@ let create_state ?(backlog=8) ?(stop_on=[]) ?stopped ?invalid ?hit dis
   insns = [| |] ;
 }
 
+
 let insn_mem s ~insn : mem =
   let off = C.insn_offset !!(s.dis) ~insn in
   let words = C.insn_size !!(s.dis) ~insn in
@@ -539,6 +540,8 @@ let with_disasm ?debug_level ?cpu ?backend triple ~f =
   f dis >>| fun res -> close dis; res
 
 type ('a,'k) t = dis
+
+let switch : ('a,'k,'s,'r) state -> ('a,'k) t -> ('a,'k,'s,'r) state = fun s dis -> {s with dis}
 
 let run ?backlog ?(stop_on=[]) ?invalid ?stopped ?hit dis ~return ~init mem =
   let state =

--- a/lib/bap_disasm/bap_disasm_basic.mli
+++ b/lib/bap_disasm/bap_disasm_basic.mli
@@ -59,6 +59,7 @@ val stop : (_,_,'s,'r) state -> 's -> 'r
 val step : (_,_,'s,'r) state -> 's -> 'r
 val jump : (_,_,'s,'r) state -> mem -> 's -> 'r
 val back : (_,_,'s,'r) state -> 's -> 'r
+val switch : ('a,'k,'s,'r) state -> ('a,'k) t -> ('a,'k,'s,'r) state
 
 module Op : sig
   type t =

--- a/lib/bap_image/bap_image.ml
+++ b/lib/bap_image/bap_image.ml
@@ -180,7 +180,7 @@ let tag mem tag value memmap =
 let map_region data {locn={addr}; info={off; len; endian}} =
   Memory.create ~pos:off ~len endian addr data
 
-let static_view segments = function {addr} as locn ->
+let static_view segments = function {addr; size} as locn ->
 match Table.find_addr segments addr with
 | Some (segmem,_) -> mem_of_locn segmem locn
 | None -> Result.failf "region %a is not mapped to memory"

--- a/lib/bap_types/bap_arch.ml
+++ b/lib/bap_types/bap_arch.ml
@@ -95,7 +95,9 @@ module T = struct
     KB.promise slot @@ fun obj ->
     KB.collect Theory.Label.unit obj >>=? fun unit ->
     KB.collect Theory.Unit.Target.arch unit >>=? fun arch ->
-    KB.return (from_string arch)
+    KB.return @@ match from_string arch with
+    | #arm -> `unknown
+    | arch -> arch
 
 
 end

--- a/oasis/arm
+++ b/oasis/arm
@@ -34,7 +34,8 @@ Library arm_plugin
   Build$:           flag(everything) || flag(arm)
   Path:             plugins/arm
   FindlibName:      bap-plugin-arm
-  BuildDepends:     bap, bap-abi, bap-arm, bap-c, core_kernel, bap-future, bap-api, regular
+  BuildDepends:     bap, bap-abi, bap-arm, bap-c, core_kernel, bap-future, bap-api,
+                    regular, bap-core-theory, ogre, bap-knowledge, bitvec, bitvec-order
   InternalModules:  Arm_main, Arm_gnueabi
   XMETADescription: provide ARM lifter
   XMETAExtraLines:  tags="arm, lifter"

--- a/plugins/arm/arm_main.ml
+++ b/plugins/arm/arm_main.ml
@@ -1,5 +1,7 @@
 open Core_kernel
 open Bap.Std
+open Bap_future.Std
+open Bap_core_theory
 include Self()
 
 let () = Config.manpage [
@@ -32,9 +34,57 @@ module ARM = struct
         Error (Error.of_string "type error")
 end
 
+let symbol_values doc =
+  let field = Ogre.Query.(select (from Image.Scheme.symbol_value)) in
+  match Ogre.eval (Ogre.collect field) doc with
+  | Ok syms -> syms
+  | Error err -> error "the file specification is ill-formed: %a"
+                   Error.pp err;
+    failwith "broken file specification"
+
+
+
+let compute_arch_from_symbol_table file spec =
+  let open KB.Syntax in
+  let init = Map.empty (module Bitvec_order) in
+  let (>>=?) x f = x >>= function
+    | None -> KB.return `unknown
+    | Some x -> f x in
+  let require_arm unit f =
+    KB.collect Theory.Unit.Target.arch unit >>|?
+    Arch.of_string >>=? function
+    | #Arch.arm as arch -> f arch
+    | _ -> KB.return `unknown in
+  let symbols =
+    symbol_values spec |>
+    Seq.fold ~init ~f:(fun symbols (addr,value) ->
+        let arch = match Int64.(value land 1L) with
+          | 0L -> `armv7
+          | _ -> `thumbv7 in
+        let addr = Bitvec.M32.int64 addr in
+        Map.add_exn symbols addr arch) in
+  KB.promise Arch.slot @@ fun label ->
+  KB.collect Theory.Label.unit label >>=? fun unit ->
+  require_arm unit @@ fun arch ->
+  KB.collect Theory.Unit.path unit >>= function
+  | None -> KB.return arch
+  | Some path when path <> file -> KB.return `unknown
+  | Some _ ->
+    KB.collect Theory.Label.addr label >>=? fun addr ->
+    KB.return @@ match Map.find symbols addr with
+    | Some arch -> arch
+    | None ->
+      if Map.is_empty symbols then arch else `unknown
+
+
 
 let () =
-  Config.when_ready (fun _ ->
-      List.iter Arch.all_of_arm ~f:(fun arch ->
-          register_target (arch :> arch) (module ARM);
-          Arm_gnueabi.setup ()))
+  Config.when_ready @@ fun _ ->
+  List.iter Arch.all_of_arm ~f:(fun arch ->
+      register_target (arch :> arch) (module ARM);
+      Arm_gnueabi.setup ());
+  let inputs = Stream.merge ~f:Tuple.T2.create
+      Project.Info.file Project.Info.spec  in
+  Stream.observe inputs @@ fun (file,spec) ->
+  info "computing arch from symbol table";
+  compute_arch_from_symbol_table file spec


### PR DESCRIPTION
What is interworking
--------------------

Interworking is a feature of some architectures that enables mixing
several instruction sets in the same compilation unit. For example, arm
and thumb interworking that this branch is trying to add. See also microMIPS,

What is done
-------------

1. We add the switch primitive to the basic interface that changes the
disassembler in the current disassembling state. It is a bold move
and can have consequences, should be carefully reviewed

2. Attributes each destination in the disassembler driver state with
the architecture and calls switch every time we are going to
disassemble the next chunk of memory.

3. The default rule that extends the unit architecture to all
instructions in that unit is disabled for ARM/Thumb and is overridden
in the arm plugin with the following behavior, if an arm unit has a file
and that file has a symbol table then we provide information based on
the last bit of that symbol table (todo: we should also check for
abi), otherwise, we propagate the unit arch to instructions.

What is to be done
------------------

Next, the arm lifter shall provide a promise to compute
destinations (which itself will require destinations because we don't
really want to compute them) and provide the destination architecture,
based on the source encoding. We can safely examine any representation
of the instruction since it is already will be lifted by that moment.


See also the tightly PR #1178.