### PR TITLE
fixes nightly tests

### DIFF
--- a/.github/workflows/nightly-testing.yml
+++ b/.github/workflows/nightly-testing.yml
@@ -28,9 +28,12 @@ jobs:
           with:
             ocaml-version: ${{ matrix.ocaml-version }}
 
-        - name: Configure Homebrew LLVM
+        - name: Configure Homebrew
           if: matrix.os == 'macos-latest'
-          run: echo '::set-env name=LLVM_CONFIG::/usr/local/opt/llvm@9/bin/llvm-config'
+          run: |
+            brew update
+            brew upgrade
+            echo '::set-env name=LLVM_CONFIG::/usr/local/opt/llvm@9/bin/llvm-config'
 
         - name: Add the Testing Repository
           run: opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing


### PR DESCRIPTION
Our nightly tests on macOS fail with the next error while executing `opam depext -u bap` command:
```
Error: python@3.8 3.8.4 is already installed
To upgrade to 3.8.5, run `brew upgrade python@3.8`.
```
The `-u` flag in `opam depext -u bap` updates OS packages sets. In this case, `brew` becomes aware of the new available python version. Then, `opam depext` calls `brew install` with all the packages we depend on including `python`.

`macOS` on GHA comes with preinstalled `python 3.8.4` formula and the problem is that `brew install` fails if another version of the same formula is installed. The GitHub runner detects a non-zero exit code and the whole workflow is failed.

This PR fixes this problem by upgrading all the installed formulae via `brew update && brew upgrade` before calling `opam depext -u bap`. Now we can be sure that all the system packages we depend on have the most modern versions.