### PR TITLE
calls radare2 directly

### DIFF
--- a/oasis/radare2
+++ b/oasis/radare2
@@ -9,7 +9,7 @@ Library radare2_plugin
   CompiledObject:   best
   BuildDepends:     bap, re.pcre, regular, bap-core-theory,
                     bap-future, core_kernel, bap-knowledge,
-                    zarith, bitvec, radare2, yojson
+                    zarith, bitvec, yojson
   InternalModules:  Radare2_main
   XMETADescription: use radare2 to provide a symbolizer
   XMETAExtraLines:  tags="symbolizer, radare2"

--- a/opam/opam
+++ b/opam/opam
@@ -33,7 +33,7 @@ depends: [
   "bap-signatures"
   "result"
   "z3"
-  "radare2"
+  "conf-radare2"
   "yojson"
   "result" {= "1.4"}
 ]

--- a/plugins/radare2/.merlin
+++ b/plugins/radare2/.merlin
@@ -1,4 +1,4 @@
 PKG bap
-PKG radare2
+PKG yojson
 B ../../_build/plugins/radare2
 REC

--- a/plugins/radare2/radare2_main.ml
+++ b/plugins/radare2/radare2_main.ml
@@ -28,40 +28,37 @@ let provide_roots file funcs =
   promise_property Theory.Label.is_valid;
   promise_property Theory.Label.is_subroutine
 
-module Field = struct
-  (* unfortunately, we can't use Yojson.*.Utils because they are
-     undefined for the Yojson type *)
-
-  let member name = function
-    | `Assoc xs -> List.Assoc.find xs ~equal:String.equal name
-    | _ -> invalid_arg "expects and assoc list"
-
-  let string = function
-    | `String x -> x
-    | x -> invalid_argf "expects a string got %s"
-             (Yojson.to_string x) ()
-
-  let number = function
-    | `Int i -> Z.of_int i
-    | `Intlit s -> Z.of_string s
-    | s -> invalid_argf "expected an address got %s"
-             (Yojson.to_string s) ()
-
-  let field name parse obj = match member name obj with
-    | None -> invalid_argf "expected member %S in the object %s"
-                name (Yojson.to_string obj) ()
-    | Some field -> parse field
-
-  let addr = field "vaddr" number
-  let name = field "name" string
-  let kind = field "type" string
-end
-
 let strip str =
   if String.is_prefix ~prefix:"func." str then None
   else Option.some @@ match String.chop_prefix str ~prefix:"imp." with
     | Some str -> str
     | None -> str
+
+let to_zarith = function
+  | `Int i -> Z.of_int i
+  | `Intlit s -> Z.of_string s
+  | s -> invalid_argf "expected an address got %s"
+           (Yojson.Safe.to_string s) ()
+
+let parse =
+  let open Yojson.Safe.Util in
+  convert_each @@ fun x ->
+  to_string @@ member "name" x,
+  to_zarith @@ member "vaddr" x,
+  to_string @@ member "type" x
+
+let extract_symbols file =
+  let cmd = sprintf "radare2 %s -2 -q -cisj" file in
+  let input = Unix.open_process_in cmd in
+  let out = parse@@Yojson.Safe.from_channel input in
+  match Unix.close_process_in input with
+  | Unix.WEXITED 0 -> out
+  | WEXITED n ->
+    warning "radare2 failed with the exit code %d" n;
+    out
+  | WSIGNALED _ | WSTOPPED _ ->
+    warning "radare2 was interrupted with a signal";
+    out
 
 let provide_radare2 file =
   let funcs = Hashtbl.create (module struct
@@ -70,15 +67,9 @@ let provide_radare2 file =
       let sexp_of_t x = Sexp.Atom (Z.to_string x)
     end) in
   let accept name addr =  Hashtbl.set funcs addr name in
-  let symbols = match R2.with_command_j "isj" file with
-    | `List list -> Some list
-    | s -> warning "unexpected radare2 output: %a" Yojson.pp s; None
-    | exception Invalid_argument msg ->
-      warning "failed to get symbols: %s" msg; None in
-  Option.iter symbols ~f:(List.iter ~f:(fun s ->
-      match Field.name s, Field.addr s, Field.kind s with
-      | name,addr, "FUNC" -> accept (strip name) addr
-      | _ -> debug "skipping json item %a" Yojson.pp s));
+  List.iter (extract_symbols file) ~f:(function
+      | (name,addr,"FUNC") -> accept (strip name) addr
+      | _ -> ());
   if Hashtbl.length funcs = 0
   then warning "failed to obtain symbols";
   let symbolizer = Symbolizer.create @@ fun addr ->


### PR DESCRIPTION
The ocaml-radare2 library is suffering from a few issues and it is
easier and much more efficient to call radare2 directly.

Here the list of issues that we have with ocaml-radare2
1) leaking file descriptors (they are never closed)
2) suboptimal inter-process communication (to get a 100 bytes
ocaml-radare makes a hundred system calls)
3) lingering processes (partially fixed)

In fact, we don't really need to keep the process open as we run
radare2 once and immediately close, so it is much easier for us just
to pass the command using the `-c` command line option.

@Xvilka, I saw your fix and it is not yet working, the output channels
should be closed and exhausted for waitpid to return (or NOHANG)
should be passed. Also, without NOHANG, the code that sends signals is
actually unreachable. I've started [fixing][1] this and the other issues,
but later decided that for us it is much easier and much-much more
efficient to call radare2 directly.

@gitoleg, please update the corresponding opam package and drop the
dependency on ocaml-radare2. The new implementation also lacks the
version check as I hope that the new implementation will not hang even
with the older versions of radare2. If that is true, then it will help
us with #1161. Also, please add the conf-radare2 package to the
upstream repo and add it as a depenedency to the bap-radare2. Please,
merge this PR after that.

Fixes #1184.

[1]: https://github.com/fxfactorial/ocaml-radare2/pull/13