### PR TITLE
implements support for ARM Modified Immediate Constants

### DIFF
--- a/lib/arm/arm_mov.ml
+++ b/lib/arm/arm_mov.ml
@@ -9,6 +9,32 @@ open Arm_flags
 module Env = Arm_env
 module Shift = Arm_shift
 
+let width = 32
+
+
+(** Modified Immediate Constants  *)
+module MIC : sig
+  val decode : exp -> exp
+end = struct
+  let ror value bits =
+    let p1 = Word.(value lsr bits) in
+    let rs = Word.(of_int ~width 32 - bits) in
+    let p2 = Word.(value lsl rs) in
+    Word.(p1 lor p2)
+
+  let mic x =
+    let shift = Word.extract_exn ~hi:11 ~lo:8 x
+    and value = Word.extract_exn ~hi:7 ~lo:0 x in
+    if Word.is_zero shift then x
+    else
+      let shift = Word.extract_exn ~hi:31 shift in
+      let value = Word.extract_exn ~hi:31 value in
+      ror value Word.(shift + shift)
+
+  let decode = function
+    | Bil.Int x -> Bil.Int (mic x)
+    | other -> other
+end
 
 let lift ?dest src1 ?src2 (itype ) ?sreg ?simm raw ~wflag cond =
   let dest : var = match dest with
@@ -45,7 +71,7 @@ let lift ?dest src1 ?src2 (itype ) ?sreg ?simm raw ~wflag cond =
       let shifted, carry = Shift.lift_i
           ~src:Bil.(var unshifted) simm reg32_t in
       s1, shifted, [Bil.move unshifted s2], carry
-    | _ -> s1, s2, [], Bil.var Env.cf in
+    | _ -> s1, (MIC.decode s2), [], Bil.var Env.cf in
 
   let stmts, flags = match itype, src1, src2 with
     | `MOV, `Imm i64, _


### PR DESCRIPTION
Apparently, we did not support them so far and they are being used extensively in the PLT sequences thus preventing us from properly applying the relocations.

For the reference, see the ARM Architecture Reference Manual, ARMv7-A and ARMv7-R edition, section A4.4.1 ("Standard data-processing instructions").