### PR TITLE
stores log files for functional test

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -76,4 +76,6 @@ jobs:
            if: ${{ always() }}
            with:
              name: fun-tests-log
-             path: testsuite/*.log
+             path: |
+               testsuite/*.log
+               testsuite/logs

--- a/.github/workflows/build-dev-repo.yml
+++ b/.github/workflows/build-dev-repo.yml
@@ -54,5 +54,5 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
-          name: opam-log
+          name: opam-log-${{ matrix.os }}-${{ matrix.ocaml-version }}
           path: ~/.opam/log

--- a/.github/workflows/build-from-opam.yml
+++ b/.github/workflows/build-from-opam.yml
@@ -40,5 +40,5 @@ jobs:
         - uses: actions/upload-artifact@v2
           if: ${{ always() }}
           with:
-            name: opam-log
+            name: opam-log-${{ matrix.ocaml-version }}
             path: ~/.opam/log

--- a/.github/workflows/nightly-testing.yml
+++ b/.github/workflows/nightly-testing.yml
@@ -64,23 +64,25 @@ jobs:
         - uses: actions/upload-artifact@v2
           if: ${{ always() }}
           with:
-            name: opam-log
+            name: opam-log-${{ matrix.os }}-${{ matrix.ocaml-version }}
             path: ~/.opam/log
 
         - uses: actions/upload-artifact@v2
           if: ${{ always() }}
           with:
-            name: ~/.local/state/bap
-            path: /tmp/bap/log
+            name: bap-log-${{ matrix.os }}-${{ matrix.ocaml-version }}
+            path: ~/.local/state/bap
 
         - uses: actions/upload-artifact@v2
           if: ${{ always() }}
           with:
-            name: unit-tests-log
+            name: unit-tests-log-${{ matrix.os }}-${{ matrix.ocaml-version }}
             path: _build/oUnit-*.log
 
         - uses: actions/upload-artifact@v2
           if: ${{ always() }}
           with:
-            name: fun-tests-log
-            path: testsuite/*.log
+            name: fun-tests-log-${{ matrix.os }}-${{ matrix.ocaml-version }}
+            path: |
+              testsuite/*.log
+              testsuite/logs

--- a/.github/workflows/weekly-regress.yml
+++ b/.github/workflows/weekly-regress.yml
@@ -60,23 +60,25 @@ jobs:
         - uses: actions/upload-artifact@v2
           if: ${{ always() }}
           with:
-            name: opam-log
+            name: opam-log-${{ matrix.os }}-${{ matrix.ocaml-version }}
             path: ~/.opam/log
 
         - uses: actions/upload-artifact@v2
           if: ${{ always() }}
           with:
-            name: ~/.local/state/bap
-            path: /tmp/bap/log
+            name: bap-log-${{ matrix.os }}-${{ matrix.ocaml-version }}
+            path: ~/.local/state/bap
 
         - uses: actions/upload-artifact@v2
           if: ${{ always() }}
           with:
-            name: unit-tests-log
+            name: unit-tests-log-${{ matrix.os }}-${{ matrix.ocaml-version }}
             path: _build/oUnit-*.log
 
         - uses: actions/upload-artifact@v2
           if: ${{ always() }}
           with:
-            name: fun-tests-log
-            path: testsuite/*.log
+            name: fun-tests-log-${{ matrix.os }}-${{ matrix.ocaml-version }}
+            path: |
+              testsuite/*.log
+              testsuite/logs


### PR DESCRIPTION
fixes https://github.com/BinaryAnalysisPlatform/bap/issues/1201

For every functional test, we create a folder in which we store log files. And in case of any fail, it will be easier to find a problem since we'll able to find a corresponded log file for the failed test.

Also, this PR fixes a minor bug in our Github Actions workflows: when we use `matrix`, we don't have multiple artifacts, depending
on matrix size. Instead, for every `upload-artifact` action we have only one artifact per workflow, i.e. artifacts are overridden.
This PR fixes this problem and names artifact according to the matrix element it is uploaded for, e.g. `log-ubuntu-4.07`