### PR TITLE
prevents BAP from failing when radare2 fails

### DIFF
--- a/plugins/radare2/radare2_main.ml
+++ b/plugins/radare2/radare2_main.ml
@@ -48,9 +48,12 @@ let parse =
   to_string @@ member "type" x
 
 let extract_symbols file =
-  let cmd = sprintf "radare2 %s -2 -q -cisj" file in
+  let cmd = sprintf "radare2 -2 -q -cisj %s" file in
   let input = Unix.open_process_in cmd in
-  let out = parse@@Yojson.Safe.from_channel input in
+  let out = try parse@@Yojson.Safe.from_channel input with
+    | exn ->
+      warning "failed to extract symbols: %s" (Exn.to_string exn);
+      [] in
   match Unix.close_process_in input with
   | Unix.WEXITED 0 -> out
   | WEXITED n ->


### PR DESCRIPTION
It looks like that radare2 command line interface varies a bit across
versions and we certainly shouldn't really fail if the radare2 process
has failed.

Also, sometimes, radare2 tries to take -isj as the name of the file,
instead of the file itself. So I moved it forward.

Fixes #1203