### PR TITLE
enables enumeration of objects in the knowledge base

### DIFF
--- a/lib/knowledge/bap_knowledge.ml
+++ b/lib/knowledge/bap_knowledge.ml
@@ -2889,6 +2889,10 @@ module Knowledge = struct
               Format.fprintf ppf "@,%a)@]@\n"
                 (Sexp.pp_hum_indent 2) (Dict.sexp_of_t data)))
 
+  let objects cls = objects cls >>| fun {vals} ->
+    Map.to_sequence vals |>
+    Sequence.map ~f:fst
+
   module Rule = struct
     type def = Registry.def
     type doc = Registry.doc

--- a/lib/knowledge/bap_knowledge.mli
+++ b/lib/knowledge/bap_knowledge.mli
@@ -152,6 +152,10 @@ module Knowledge : sig
   (** a fully qualified name  *)
   type name
 
+  (** [objects cls] is a seqeuence of all objects of the class [cls].
+      @since 2.2.0  *)
+  val objects : ('a,_) cls -> 'a obj Sequence.t t
+
   (** [collect p x] collects the value of the property [p].
 
       If the object [x] doesn't have a value for the property [p] and


### PR DESCRIPTION
Adds the `objects` function that returns a sequence of all objects in
the knowledge base.

Note, the interface is subject to change, but it looks good so far. We might also add some more low-level iterators, e.g., `Object.next : 'a obj -> 'a obj option` and `Object.first : 'a obj -> 'a obj option`, we will see if we really need them.