### PR TITLE
knowledge base improvements

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,14 +52,6 @@ jobs:
          - name: Run Functional Tests
            run: opam exec -- make check
 
-         - name: Run BIL verification tool
-           run: |
-             opam install --fake bap
-             opam pin add bap-veri testsuite/veri/bap-veri/ -n
-             opam depext bap-veri
-             opam install bap-veri
-             opam exec -- make -C testsuite veri
-
          - uses: actions/upload-artifact@v2
            if: ${{ always() }}
            with:

--- a/lib/bap/bap_project.ml
+++ b/lib/bap/bap_project.ml
@@ -851,13 +851,15 @@ module Analysis = struct
 
   let parse_object cls ~fail:_ x = KB.Object.read cls x
 
-  let object_of cls =
+  let program =
     argument "<label>"
-      ~parse:(parse_object cls)
-      ~desc:(sprintf "an object of the %s" name)
+      ~parse:(parse_object Theory.Program.cls)
+      ~desc:(sprintf "an object of the core-theory:program class")
 
-  let program = object_of Theory.Program.cls
-  let unit = object_of Theory.Unit.cls
+  let unit =
+    argument "<unit>"
+      ~parse:(parse_object Theory.Unit.cls)
+      ~desc:(sprintf "an object of the core-theory:unit class")
 
   let parse_bitvec ~fail str =
     try !!(Bitvec.of_string str)

--- a/lib/bap/bap_project.ml
+++ b/lib/bap/bap_project.ml
@@ -124,42 +124,70 @@ let with_filename spec arch data code path =
 
 module State = struct
   open KB.Syntax
-  module Driver = Bap_disasm_driver
-  module Calls = Bap_disasm_calls
-  module Disasm = Disasm_expert.Recursive
+  module Dis = Bap_disasm_driver
+  module Sub = Bap_disasm_calls
+  module Rec = Disasm_expert.Recursive
 
   type t = {
-    default : arch;
-    package : string option;
-    state : Driver.state;
-    calls : Calls.t;
+    disassembly : Dis.state;
+    subroutines : Sub.t;
   } [@@deriving bin_io]
 
-  let empty ?package arch = {
-    default = arch;
-    package;
-    state = Driver.init;
-    calls = Calls.empty;
+  let empty = {
+    disassembly = Dis.init;
+    subroutines = Sub.empty;
   }
 
-  let update self mem =
-    Driver.scan mem self.state >>= fun state ->
-    Calls.update self.calls state >>| fun calls ->
-    {self with state; calls}
+  let equal x y =
+    Dis.equal x.disassembly y.disassembly &&
+    Sub.equal x.subroutines y.subroutines
 
-  let symtab {state; calls} = Symtab.create state calls
-  let disasm {state} =
-    Disasm_expert.Recursive.global_cfg state
+
+  let disassemble self mem =
+    Dis.scan mem self.disassembly >>| fun disassembly ->
+    {self with disassembly}
+
+  let partition self =
+    Sub.update self.subroutines self.disassembly >>| fun subroutines ->
+    {self with subroutines}
+
+  let symbols {disassembly; subroutines} =
+    Symtab.create disassembly subroutines
+
+  let cfg {disassembly} =
+    Disasm_expert.Recursive.global_cfg disassembly
+
+  let disassembly {disassembly=d} = d
+  let subroutines {subroutines=s} = s
+
+  let set_length set =
+    Sexp.Atom (string_of_int @@ Set.length set)
+
+  let inspect {disassembly; subroutines} = Sexp.List [
+      List [
+        Atom ":number-of-basic-blocks";
+        set_length (Dis.blocks disassembly);
+      ];
+      List [
+        Atom ":number-of-subroutines";
+        set_length (Sub.entries subroutines);
+      ]
+    ]
+
+  let slot = KB.Class.property Theory.Unit.cls
+      ~package:"bap" "disassembly"
+      ~persistent:(KB.Persistent.of_binable(module struct
+                     type nonrec t = t [@@deriving bin_io]
+                   end)) @@
+    KB.Domain.flat ~empty ~equal "disassembly" ~inspect
 
   module Toplevel = struct
-    let result = Toplevel.var "result"
     let run spec arch ~code ~data file k =
+      let result = Toplevel.var "disassembly-result" in
       Toplevel.put result begin
         with_arch arch code @@ fun () ->
         with_filename spec arch code data file @@ fun () ->
-        k >>= fun k ->
-        disasm k >>= fun g ->
-        symtab k >>| fun s -> g,s,k
+        k
       end;
       Toplevel.get result
   end
@@ -170,12 +198,12 @@ type state = State.t [@@deriving bin_io]
 type t = {
   arch    : arch;
   spec    : Ogre.doc;
-  core    : State.t;
-  disasm  : disasm;
+  state   : State.t;
+  disasm  : disasm Lazy.t;
   memory  : value memmap;
   storage : dict;
-  program : program term;
-  symbols : Symtab.t;
+  program : program term Lazy.t;
+  symbols : Symtab.t Lazy.t;
   passes  : string list;
 } [@@deriving fields]
 
@@ -249,11 +277,13 @@ module Input = struct
     let finish proj = {
       proj with
       storage = Dict.set proj.storage Image.specification spec;
-      program = Term.map sub_t proj.program ~f:(fun sub ->
-          match Term.get_attr sub address with
-          | Some a when Addr.equal a (Image.entry_point img) ->
-            Term.set_attr sub Sub.entry_point ()
-          | _ -> sub)
+      program =
+        Lazy.map proj.program ~f:(fun prog ->
+            Term.map sub_t prog ~f:(fun sub ->
+                match Term.get_attr sub address with
+                | Some a when Addr.equal a (Image.entry_point img) ->
+                  Term.set_attr sub Sub.entry_point ()
+                | _ -> sub))
     } in
     of_image finish filename img
 
@@ -327,8 +357,7 @@ let set_package package = match package with
   | None -> KB.return ()
   | Some pkg -> KB.Symbol.set_package pkg
 
-let state {core} = core
-let package {core={State.package}} = package
+let state {state} = state
 
 let unused_options =
   List.iter ~f:(Option.iter ~f:(fun name ->
@@ -361,20 +390,33 @@ let create
     Signal.send Info.got_data data;
     Signal.send Info.got_code code;
     Signal.send Info.got_spec spec;
-    let init = match state with
-      | Some state -> State.{state with package}
-      | None -> State.empty ?package arch in
-    let state =
-      let open KB.Syntax in
-      set_package package >>= fun () ->
-      Memmap.to_sequence code |> KB.Seq.fold ~init ~f:(fun k (mem,_) ->
-          State.update k mem) in
-    let cfg,symbols,core = State.Toplevel.run spec arch ~code ~data file state in
+    let run k =
+      State.Toplevel.run spec arch ~code ~data file k in
+    let state = match state with
+      | Some state -> state
+      | None ->
+        let compute_state =
+          let open KB.Syntax in
+          set_package package >>= fun () ->
+          Theory.Unit.for_file file >>= fun unit ->
+          KB.collect State.slot unit >>= fun state ->
+          if KB.Domain.is_empty (KB.Slot.domain State.slot) state
+          then
+            Memmap.to_sequence code |>
+            KB.Seq.fold ~init:State.empty ~f:(fun k (mem,_) ->
+                State.disassemble k mem) >>=
+            State.partition >>= fun state ->
+            KB.provide State.slot unit state >>| fun () ->
+            state
+          else !!state in
+        run compute_state in
+    let cfg = lazy (run @@ State.cfg state) in
+    let symbols = lazy (run @@ State.symbols state) in
     Result.return @@ finish {
-      core;
+      state;
       spec;
-      disasm = Disasm.create cfg;
-      program = Program.lift symbols;
+      disasm = Lazy.(cfg >>| Disasm.create);
+      program = Lazy.(symbols >>| Program.lift) ;
       symbols;
       arch; memory=union_memory code data;
       storage = Dict.set Dict.empty filename file;
@@ -391,15 +433,20 @@ let create
 
 let specification = spec
 
+let symbols {symbols} = Lazy.force symbols
+let disasm {disasm} = Lazy.force disasm
+let program {program} = Lazy.force program
+
+let with_symbols p x = {p with symbols = lazy x}
+let with_program p x = {p with program = lazy x}
+let map_program p ~f = {p with program = Lazy.map p.program ~f}
+
+let with_memory = Field.fset Fields.memory
+let with_storage = Field.fset Fields.storage
+
 let restore_state _ =
   failwith "Project.restore_state: this function should no be used.
     Please use the Toplevel module to save/restore the state."
-
-let with_memory = Field.fset Fields.memory
-let with_symbols = Field.fset Fields.symbols
-let with_program = Field.fset Fields.program
-
-let with_storage = Field.fset Fields.storage
 
 let set t tag x =
   with_storage t @@
@@ -444,12 +491,12 @@ let substitute project mem tag value : t =
         | None -> None) in
   let find_section = find_tag Image.section in
   let find_symbol mem =
-    Symtab.owners project.symbols (Memory.min_addr mem) |>
+    Symtab.owners (symbols project) (Memory.min_addr mem) |>
     List.hd |>
     Option.map ~f:(fun (name,entry,_) ->
         Block.memory entry, name) in
   let find_block mem =
-    Symtab.dominators project.symbols mem |>
+    Symtab.dominators (symbols project) mem |>
     List.find_map ~f:(fun (_,_,cfg) ->
         Seq.find_map (Cfg.nodes cfg) ~f:(fun block ->
             if Addr.(Block.addr block = Memory.min_addr mem)
@@ -602,21 +649,50 @@ end
 let passes () = DList.to_list passes
 let find_pass = Pass.find
 
-module Collator = struct
+module Registry(T : T)(I : T) = struct
   open Bap_knowledge
-
   type info = {
     name : Knowledge.Name.t;
     desc : string option;
+    extra : I.t;
   }
 
+  let registry : (Knowledge.name, string option * T.t * I.t) Hashtbl.t =
+    Hashtbl.create (module Knowledge.Name)
+
+  let register ?desc ?package name extra entity =
+    let name = Knowledge.Name.create ?package name in
+    if Hashtbl.mem registry name then
+      invalid_argf "An element with name %s is already registered \
+                    please choose a unique name"
+        (Knowledge.Name.show name) ();
+    Hashtbl.add_exn registry name (desc,entity,extra)
+
+  let find ?package name =
+    let name = Knowledge.Name.read ?package name in
+    match Hashtbl.find registry name with
+    | Some (_,x,_) -> Some x
+    | None -> None
+
+  let registered () =
+    Hashtbl.to_alist registry |>
+    List.map ~f:(fun (name,(desc,_,extra)) -> {name; desc; extra})
+
+  let name {name} = name
+  let desc = function
+    | {desc=None} -> "not provided"
+    | {desc=Some txt} -> txt
+  let extra {extra} = extra
+end
+
+module Collator = struct
   type t = Collator : {
       prepare : project -> 's;
       collate : int -> 's -> project -> 's;
       summary : 's -> unit;
     } -> t
 
-  let registry = Hashtbl.create (module Knowledge.Name)
+  include Registry(struct type nonrec t = t end)(Unit)
 
   let apply (Collator {prepare; collate; summary}) projects =
     match Seq.split_n projects 1 with
@@ -626,31 +702,224 @@ module Collator = struct
     | _ -> ()
 
   let register ?desc ?package name ~prepare ~collate ~summary =
-    let name = Knowledge.Name.create ?package name in
-    if Hashtbl.mem registry name then
-      invalid_argf "A collator with name %s is already registered \
-                    please choose another unique name"
-        (Knowledge.Name.show name) ();
-    Hashtbl.add_exn registry name (desc,Collator {
-        prepare;
-        collate;
-        summary;
-      })
+    register ?desc ?package name () @@ Collator {
+      prepare;
+      collate;
+      summary;
+    }
+end
 
-  let find ?package name =
-    let name = Knowledge.Name.read ?package name in
-    match Hashtbl.find registry name with
-    | Some (_,x) -> Some x
-    | None -> None
+module Analysis = struct
+  open Bap_knowledge
+  open Bap_core_theory
+  open Knowledge.Syntax
 
-  let registered () =
-    Hashtbl.to_alist registry |>
-    List.map ~f:(fun (name,(desc,_)) -> {name; desc})
+  type ctxt = {
+    rule : string;
+    pos : int;
+    parsed : string list;
+    inputs : string list;
+  }
 
-  let name {name} = name
-  let desc = function
-    | {desc=None} -> "not provided"
-    | {desc=Some txt} -> txt
+  type 'a arg = {
+    parse : ctxt -> ('a * ctxt) knowledge;
+    desc : string;
+    rule : string;
+  }
+
+  type ('a,'r) args = {
+    run : 'a -> 'r arg;
+    grammar : string list;
+  }
+
+  type problem =
+    | No_input
+    | Bad_syntax of string
+    | Trailing_input
+
+  type parse_error = {
+    ctxt : ctxt;
+    problem : problem
+  }
+
+  type Knowledge.conflict += Fail of parse_error
+
+
+  let fail ctxt problem =
+    Knowledge.fail (Fail {ctxt; problem})
+
+  let string_of_problem = function
+    | No_input -> "expects an argument"
+    | Bad_syntax msg -> msg
+    | Trailing_input -> "too many arguments"
+
+  let string_of_parse_error {ctxt; problem} =
+    sprintf "Syntax error: when parsing rule %s of argument %d - %s"
+      ctxt.rule (ctxt.pos+1) (string_of_problem problem)
+
+  let () = Knowledge.Conflict.register_printer @@ function
+    | Fail err -> Some (string_of_parse_error err)
+    | _ -> None
+
+  let required parse ctxt =
+    match ctxt.inputs with
+    | [] -> fail ctxt No_input
+    | x :: xs ->
+      let fail x = fail ctxt (Bad_syntax x) in
+      parse ~fail x >>| fun r -> r,{
+          ctxt with pos = ctxt.pos + 1;
+                    parsed = x :: ctxt.parsed;
+                    inputs = xs;
+        }
+
+  let argument ?(desc="No description") ~parse rule = {
+    parse=(required parse); rule; desc;
+  }
+
+  let optional arg = {
+    rule = sprintf "[%s]" arg.rule;
+    desc = arg.desc;
+    parse = fun ctxt -> match ctxt.inputs with
+      | [] -> KB.return (None,ctxt)
+      | _ -> arg.parse ctxt >>| fun (x,ctxt) -> Some x,ctxt
+  }
+
+  let pull_keyword kw inputs =
+    let rec loop searched = function
+      | [] -> None
+      | [k] when String.equal k kw && List.is_empty searched ->
+        Some []
+      | k :: x :: xs when String.equal k kw ->
+        Some (x :: List.rev_append searched xs)
+      | x :: xs -> loop (x::searched) xs in
+    loop [] inputs
+
+  let filter_flag kw inputs =
+    let rec loop searched = function
+      | [] -> None
+      | k :: xs when String.equal k kw ->
+        Some (List.rev_append searched xs)
+      | x :: xs -> loop (x::searched) xs in
+    loop [] inputs
+
+  let keyword key arg = {
+    rule = sprintf "[:%s %s]" key arg.rule;
+    desc = "an argument prefixed by the keyword";
+    parse = fun ctxt ->
+      match pull_keyword (":"^key) ctxt.inputs with
+      | None -> KB.return (None,ctxt)
+      | Some inputs -> arg.parse {ctxt with inputs} >>|
+        fun (x,ctxt) -> Some x,ctxt
+  }
+
+  let flag key = {
+    rule = sprintf "[:%s]" key;
+    desc = "an optional flag";
+    parse = fun ctxt ->
+      match filter_flag (":"^key) ctxt.inputs with
+      | None -> KB.return (false,ctxt)
+      | Some inputs -> KB.return (true, {ctxt with inputs})
+  }
+
+  let apply_until_exhausted ctxt arg =
+    let rec loop rs ctxt = match ctxt.inputs with
+      | [] -> KB.return (List.rev rs,ctxt)
+      | _ -> arg.parse ctxt >>= fun (r,ctxt) ->
+        loop (r::rs) ctxt in
+    loop [] ctxt
+
+  let rest arg = {
+    rule = sprintf "[%s] ..." arg.rule;
+    desc = arg.desc;
+    parse = fun ctxt -> apply_until_exhausted ctxt arg
+  }
+
+  let empty = {
+    rule = "";
+    desc = "no arguments are expected";
+    parse = fun ctxt -> match ctxt.inputs with
+      | [] -> KB.return ((),ctxt)
+      | _ -> fail ctxt Trailing_input
+  }
+
+
+  let parse_string ~fail:_ x = !!x
+
+  let string = argument "<string>"
+      ~parse:parse_string
+      ~desc:"a sequence of characters without whitespaces"
+
+  let parse_object cls ~fail:_ x = KB.Object.read cls x
+
+  let object_of cls =
+    argument "<label>"
+      ~parse:(parse_object cls)
+      ~desc:(sprintf "an object of the %s" name)
+
+  let program = object_of Theory.Program.cls
+  let unit = object_of Theory.Unit.cls
+
+  let parse_bitvec ~fail str =
+    try !!(Bitvec.of_string str)
+    with Invalid_argument msg ->
+      fail msg
+
+  let bitvec = argument "<bitvec>"
+      ~parse:parse_bitvec
+      ~desc:"a bitvector of arbitrary length"
+
+  module Arg = struct
+    type 'a t = 'a arg
+    let map arg ~f = {
+      arg with
+      parse = fun ctxt ->
+        arg.parse {ctxt with rule = arg.rule} >>| fun (x,ctxt) ->
+        f x,ctxt
+    }
+
+    let apply ({parse=f} as lhs) ({parse=x} as rhs) = {
+      rule = lhs.rule ^ " " ^ rhs.rule;
+      desc = "";
+      parse = fun ctxt ->
+        f {ctxt with rule = lhs.rule} >>= fun (f,ctxt) ->
+        x {ctxt with rule = rhs.rule} >>| fun (x,ctxt) ->
+        f x,ctxt
+    }
+  end
+
+  let ($) t arg = {
+    grammar = arg.rule :: t.grammar;
+    run = fun f -> Arg.apply (t.run f) arg
+  }
+  let args a = {
+    grammar = [a.rule];
+    run = fun f -> Arg.map ~f a
+  }
+  let apply ~f args = args.run f
+
+  let run inputs args code =
+    let ctxt = {rule = ""; pos=0; parsed=[]; inputs} in
+    (apply args ~f:code).parse ctxt >>= fun (f,_ctxt) ->
+    f
+
+  type t = string list -> unit knowledge
+  include Registry(struct type nonrec t = t end)(struct
+      type t = string list
+    end)
+
+  let register ?desc ?package name args analysis =
+    let code inputs = run inputs args analysis in
+    register ?desc ?package name (List.rev args.grammar) code
+
+  let apply f xs = f xs
+
+  let grammar = extra
+
+  module Grammar = struct
+    type t = string list
+    let to_string = String.concat ~sep:" "
+  end
+  type grammar = Grammar.t
 end
 
 module type S = sig

--- a/lib/bap_core_theory/bap_core_theory_effect.ml
+++ b/lib/bap_core_theory/bap_core_theory_effect.ml
@@ -8,11 +8,13 @@ type cls = Effects
 let package = "core-theory"
 
 module Sort = struct
-  type effects = Top | Set of Set.M(String).t
+  type effects = Top | Set of Set.M(KB.Name).t
   type +'a t = effects
   type data = Data
   type ctrl = Ctrl
-  let single eff = Set (Set.singleton (module String) eff)
+  let single eff =
+    let eff = KB.Name.create ~package:"effect" eff in
+    Set (Set.singleton (module KB.Name) eff)
   let make name = single name
   let define name = make name
 
@@ -25,7 +27,7 @@ module Sort = struct
   let refine name other : 'a t = make name && other
 
   let top = Top
-  let bot = Set (Set.empty (module String))
+  let bot = Set (Set.empty (module KB.Name))
 
   let union xs = List.reduce xs ~f:both |> function
     | Some x -> x

--- a/lib/bap_disasm/bap_disasm_calls.ml
+++ b/lib/bap_disasm/bap_disasm_calls.ml
@@ -201,5 +201,4 @@ let equal s1 s2 =
   Set.equal s1.entries s2.entries &&
   Solution.equal ~equal:Parent.equal s1.parents s2.parents
 
-
 let domain = KB.Domain.flat ~empty ~equal "callgraph"

--- a/lib/bap_disasm/bap_disasm_driver.mli
+++ b/lib/bap_disasm/bap_disasm_driver.mli
@@ -10,6 +10,7 @@ type insns
 type jump
 
 val init : state
+val equal : state -> state -> bool
 val scan : mem -> state -> state knowledge
 val merge : state -> state -> state
 

--- a/lib/bap_types/bap_exp.ml
+++ b/lib/bap_types/bap_exp.ml
@@ -102,7 +102,7 @@ module PP = struct
       pr "@[<4>%a@;with [%a, %a]:%a <- %a@]"
         pp mem pp idx pp_edn edn Bap_size.pp s pp exp
     | Ite (ce, te, fe) ->
-      pr "@[<2>if %a@;then %a@;else %a@]" pp ce pp te pp fe
+      pr "@[if %a@;then %a@;else %a@]" pp ce pp te pp fe
     | Extract (hi, lo, exp) ->
       pr "extract:%d:%d[%a]" hi lo pp exp
     | Concat (le, re) as p ->
@@ -116,7 +116,7 @@ module PP = struct
     | BinOp (PLUS,le,(Int x as re)) as p when msb x ->
       pr (pfmt p le ^^ " - " ^^ pfmt p re) pp le Word.pp (Word.neg x)
     | BinOp (op, le, re) as p ->
-      pr (pfmt p le ^^ " %a " ^^ pfmt p re) pp le pp_binop op pp re
+      pr (pfmt p le ^^ "@ %a@ " ^^ pfmt p re) pp le pp_binop op pp re
     | UnOp (op, exp) as p ->
       pr ("%a" ^^ pfmt p exp) pp_unop op pp exp
     | Var var -> Bap_var.pp fmt var
@@ -124,7 +124,7 @@ module PP = struct
     | Cast (ct, n, exp) ->
       pr "%a:%d[%a]" pp_cast ct n pp exp
     | Let (var, def, body) ->
-      pr "let %a = %a in@ %a" Bap_var.pp var pp def pp body
+      pr "@[let %a =@ %a in@ %a@]" Bap_var.pp var pp def pp body
     | Unknown (s, typ) ->
       pr "unknown[%s]:%a" s Bap_type.pp typ
 end

--- a/lib/bap_types/bap_stmt.ml
+++ b/lib/bap_types/bap_stmt.ml
@@ -9,19 +9,19 @@ open Bap_bil
 let rec pp fmt s =
   let open Stmt in match s with
   | Move (var, exp) ->
-    fprintf fmt "@[<v2>%a := %a@]" Bap_var.pp var Bap_exp.pp exp
+    fprintf fmt "@[<2>%a :=@ %a@]" Bap_var.pp var Bap_exp.pp exp
   | Jmp (Exp.Var _ | Exp.Int _ as exp) ->
-    fprintf fmt "jmp %a" Bap_exp.pp exp
-  | Jmp exp -> fprintf fmt "jmp (%a)" Bap_exp.pp exp
-  | Special s -> fprintf fmt "special (%s)" s
+    fprintf fmt "@[<2>jmp@ %a@]" Bap_exp.pp exp
+  | Jmp exp -> fprintf fmt "@[<2>jmp@ (%a)@]" Bap_exp.pp exp
+  | Special s -> fprintf fmt "special@ @[<1>(%s)@]" s
   | While (cond, body) ->
-    fprintf fmt "@[<v0>@[<v2>while (%a) {@;%a@]@;}@]"
+    fprintf fmt "@[<v0>@[<v2>while (@[%a@]) {@;%a@]@;}@]"
       Bap_exp.pp cond pp_list body
   | If (cond, ts, []) ->
-    fprintf fmt "@[<v0>@[<v2>if (%a) {@;%a@]@,}@]"
+    fprintf fmt "@[<v0>@[<v2>if (@[%a@]) {@;%a@]@,}@]"
       Bap_exp.pp cond pp_list ts
   | If (cond, ts, fs) ->
-    fprintf fmt "@[<v0>@[<v2>if (%a) {@;%a@]@,}@;%a@]"
+    fprintf fmt "@[<v0>@[<v2>if (@[%a@]) {@;%a@]@,}@;%a@]"
       Bap_exp.pp cond pp_list ts pp_else fs
   | CpuExn  n -> fprintf fmt "cpuexn (%d)" n
 and pp_list fmt = function
@@ -30,10 +30,10 @@ and pp_list fmt = function
   | x :: xs -> fprintf fmt "%a@;%a" pp x pp_list xs
 and pp_else fmt = function
   | [] -> ()
-  | fs -> fprintf fmt "@[<v0>@[<v2>else {@;%a@]@\n}@]" pp_list fs
+  | fs -> fprintf fmt "@[<v0>@[<v2>else {@;%a@]@;}@]" pp_list fs
 
 let pp_stmts fmt ss =
-  fprintf fmt "@[<v0>@[<v2>{@\n%a@]@\n}@]" pp_list ss
+  fprintf fmt "@[<v0>@[<v2>{@;%a@]@;}@]" pp_list ss
 
 module Stmt = struct
   open Bap_bil.Stmt

--- a/lib/knowledge/bap_knowledge.mli
+++ b/lib/knowledge/bap_knowledge.mli
@@ -137,7 +137,7 @@ module Knowledge : sig
   (** an instance of the persistance type class  *)
   type 'a persistent
 
-  (** the knowledge base state  *)
+  (** the knowledge base state *)
   type state
 
   (** a set of possible conflicts  *)
@@ -240,14 +240,22 @@ module Knowledge : sig
   (** state with no knowledge  *)
   val empty : state
 
-
-
   (** [of_bigstring data] loads state from [data] *)
   val of_bigstring : Bigstring.t -> state
 
 
   (** [to_bigstring state] serializes state into a binary representation.  *)
   val to_bigstring : state -> Bigstring.t
+
+  (** [load path] loads the knowledge base from the file at [path].
+      @since 2.2.0
+  *)
+  val load : string -> state
+
+  (** [save state path] saves the knowledge base to the file at [path].
+      @since 2.2.0
+  *)
+  val save : state -> string -> unit
 
 
   (** prints the state of the knowledge base.  *)

--- a/oasis/analyze
+++ b/oasis/analyze
@@ -1,0 +1,13 @@
+Flag analyze
+  Description: Build the KB analyze command
+  Default: false
+
+Library analyze_plugin
+  Build$: flag(everything) || flag(analyze)
+  Path: plugins/analyze
+  FindlibName: bap-plugin-analyze
+  CompiledObject: best
+  BuildDepends: core_kernel, monads, ppx_jane, linenoise,
+                bap-knowledge, bap-core-theory, bap-main, bap
+  InternalModules: Analyze_main, Analyze_core_commands
+  XMETADescription: implements the analyze command

--- a/oasis/analyze
+++ b/oasis/analyze
@@ -8,6 +8,7 @@ Library analyze_plugin
   FindlibName: bap-plugin-analyze
   CompiledObject: best
   BuildDepends: core_kernel, monads, ppx_jane, linenoise,
-                bap-knowledge, bap-core-theory, bap-main, bap
+                bap-knowledge, bap-core-theory, bap-main, bap,
+                bitvec
   InternalModules: Analyze_main, Analyze_core_commands
   XMETADescription: implements the analyze command

--- a/oasis/x86
+++ b/oasis/x86
@@ -22,7 +22,7 @@ Library x86_plugin
  Path:             plugins/x86
  FindlibName:      bap-plugin-x86
  BuildDepends:     bap, bap-abi, bap-c, bap-x86-cpu, bap-llvm, core_kernel,
-                   ppx_jane, bap-main, bap-future, bap-api
+                   ppx_jane, bap-main, bap-future, bap-api, ogre
  Modules:          X86_backend, X86_prefix
  InternalModules:  X86_abi,
                    X86_btx,

--- a/opam/opam
+++ b/opam/opam
@@ -11,6 +11,7 @@ depends: [
   "base-unix"
   "bitstring"
   "camlzip"
+  "linenoise" {>= "1.1" & < "2.0"}
   "cmdliner" {>= "1.0" & < "2.0"}
   "ppx_jane" {>= "v0.12" & < "v0.13"}
   "core_kernel" {>= "v0.12" & < "v0.13"}

--- a/plugins/analyze/analyze_core_commands.ml
+++ b/plugins/analyze/analyze_core_commands.ml
@@ -1,0 +1,194 @@
+open Core_kernel
+open Bap_main
+open Bap_knowledge
+open Bap_core_theory
+open Bap.Std
+
+open KB.Syntax
+
+include Loggers()
+
+let read_name name =
+  KB.Symbol.package >>| fun package ->
+  KB.Name.to_string (KB.Name.read ~package name)
+
+
+let print_semantics label slots =
+  KB.collect Theory.Program.Semantics.slot label >>= fun sema ->
+  KB.List.map slots ~f:read_name >>| fun slots ->
+  match slots with
+  | [] -> Format.printf "%a@\n" KB.Value.pp sema
+  | slots -> Format.printf "%a@\n" (KB.Value.pp_slots slots) sema
+
+let require prop label has =
+  KB.collect prop label >>= function
+  | None -> KB.return false
+  | Some p -> has p
+
+let belongs_to_unit unit insn =
+  match unit with
+  | None -> KB.return true
+  | Some unit ->
+    require Theory.Label.unit insn @@ fun unit' ->
+    KB.return @@ Theory.Unit.equal unit unit'
+
+let belongs_to_subr subr insn =
+  match subr with
+  | None -> KB.return true
+  | Some subr ->
+    require Theory.Label.addr subr @@ fun subr ->
+    require Theory.Label.unit insn @@ fun unit ->
+    require Theory.Label.addr insn @@ fun insn ->
+    require Theory.Unit.Target.bits unit @@ fun bits ->
+    KB.collect Project.State.slot unit >>| fun state ->
+    let subrs = Project.State.subroutines state in
+    let insn = Word.create insn bits
+    and subr = Word.create subr bits in
+    Disasm.Subroutines.belongs subrs ~entry:subr insn
+
+let find_by_name subrs name =
+  Disasm.Subroutines.entries subrs |>
+  Set.to_sequence |>
+  KB.Seq.find ~f:(fun addr ->
+      let addr = Word.to_bitvec addr in
+      Theory.Label.for_addr addr >>= fun label ->
+      KB.collect Theory.Label.name label >>| function
+      | None -> false
+      | Some name' -> String.equal name name')
+
+let iter_subr entry subrs disasm ~f =
+  Disasm.Driver.explore disasm ~entry ~init:()
+    ~follow:(fun next ->
+        KB.return @@
+        Disasm.Subroutines.belongs subrs ~entry next)
+    ~block:(fun _mem -> Disasm.Driver.execution_order)
+    ~node:(fun insns () -> KB.List.iter insns ~f)
+    ~edge:(fun _ _ _ -> KB.return ())
+
+
+let make_triple unit =
+  KB.collect Theory.Unit.Target.arch   unit >>= fun arch ->
+  KB.collect Theory.Unit.Target.subarch unit >>= fun sub ->
+  KB.collect Theory.Unit.Target.vendor unit >>= fun vendor ->
+  KB.collect Theory.Unit.Target.system unit >>= fun system ->
+  KB.collect Theory.Unit.Target.abi unit >>| fun abi ->
+  let (=?) x default = Option.value x ~default in
+  sprintf "%s%s-%s-%s-%s"
+    (arch =? "unknown") (sub =? "") (vendor =? "none")
+    (system =? "unknown") (abi =? "unknown")
+
+
+let print_unit () =
+  KB.objects Theory.Unit.cls >>=
+  KB.Seq.iter ~f:(fun obj ->
+      KB.Object.repr Theory.Unit.cls obj >>= fun str ->
+      make_triple obj >>| fun triple ->
+      Format.printf "%-40s %s@\n" str triple)
+
+let ensure x yes =
+  x >>= function
+  | true -> yes ()
+  | false -> KB.return ()
+
+let in_package package f = match package with
+  | None -> f ()
+  | Some package -> KB.Symbol.in_package package f
+
+let print_insn ?package slots obj =
+  in_package package @@ fun () ->
+  KB.Object.repr Theory.Program.cls obj >>= fun str ->
+  match slots with
+  | None ->
+    Format.printf "%s@\n" str;
+    KB.return ()
+  | Some slots ->
+    Format.printf "%s@\n" str;
+    print_semantics obj slots
+
+let list_insns unit slots =
+  KB.objects Theory.Program.cls >>=
+  KB.Seq.iter ~f:(fun obj ->
+      ensure (belongs_to_unit unit obj) @@ fun () ->
+      print_insn slots obj)
+
+let print_subr unit name slots =
+  KB.collect Project.State.slot unit >>= fun state ->
+  KB.Symbol.package >>= fun current ->
+  KB.collect Theory.Unit.path unit >>= fun package ->
+  in_package package @@ fun () ->
+  let sub = Project.State.subroutines state
+  and dis = Project.State.disassembly state in
+  find_by_name sub name >>= function
+  | None -> KB.return ()
+  | Some entry ->
+    iter_subr entry sub dis ~f:(print_insn ~package:current slots)
+
+let matches name filter = match filter with
+  | None -> true
+  | Some prefix ->
+    String.is_prefix ~prefix name
+
+let list_subrs unit filter =
+  KB.objects Theory.Program.cls >>=
+  KB.Seq.iter ~f:(fun obj ->
+      belongs_to_unit unit obj >>= function
+      | false -> KB.return ()
+      | true ->
+        KB.collect Theory.Label.is_subroutine obj >>= function
+        | None | Some false -> KB.return ()
+        | Some true ->
+          KB.Object.repr Theory.Program.cls obj >>= fun str ->
+          KB.collect Theory.Label.name obj >>| function
+          | None when Option.is_none filter ->
+            Format.printf "%s: unresolved@\n" str
+          | Some name when matches name filter ->
+            Format.printf "%s: %s\n" str name
+          | _ -> () )
+
+let register () =
+  let open Project.Analysis in
+  let package = "bap" in
+
+  register ~package "instruction"
+    (args program $ rest string) print_semantics
+    ~desc:"Prints the instruction semantics. Prints the semantics of \
+           an instruction with the given label. If no fields are \
+           specified, then prints all properties in the semantics \
+           object. Otherwise, prints only the specified fields.";
+
+  register ~package "instructions"
+    (args @@
+     keyword "unit" unit $
+     keyword "semantics" (rest string)) list_insns
+    ~desc:"Prints all instructions. If :unit is specified then prints \
+           only instructions that belong to that unit. If :semantics \
+           is specified then prints the semantics of each \
+           instruction. The :semantics keyword could be followed by \
+           one or more field names. If no fields are specified, then \
+           all properties of an instruction will be printed, otherwise \
+           only those that are specified will be printed.";
+
+  register ~package "units"
+    (args empty) print_unit
+    ~desc:"Prints all units. Prints all units stored in the knowledge \
+           base." ;
+
+  register ~package "subroutines"
+    (args @@
+     keyword "unit" unit $
+     keyword "matches" string)
+    list_subrs
+    ~desc:"Prints all subroutines. If :unit is specified, then prints \
+           only subroutines of that unit. If :matches is specified, \
+           then prints only subroutines that match the name." ;
+
+  register ~package "subroutine"
+    (args @@ unit $ string $ keyword "semantics" (rest string))
+    print_subr
+    ~desc:"Prints a subroutine. Prints the subroutine in the specified \
+           unit with the given name. If :semantics is specified, then \
+           prints the semantics of each instruction. The :semantics \
+           keyword could be followed by one or more field names. If no \
+           fields are specified, then all properties of an instruction \
+           will be printed, otherwise only those that are specified \
+           will be printed.";

--- a/plugins/analyze/analyze_core_commands.mli
+++ b/plugins/analyze/analyze_core_commands.mli
@@ -1,0 +1,1 @@
+val register : unit -> unit

--- a/plugins/analyze/analyze_main.ml
+++ b/plugins/analyze/analyze_main.ml
@@ -1,0 +1,357 @@
+let doc = {|
+# DESCRIPTION
+
+Analyses the knowledge base. Loads the knowledge base and executes the
+specified commands or run the REPL if no commands or script files were
+specified.
+
+The knowledge base is not saved until the $(b,save) directive is
+issued. The knowledge base itself is optional and can be specified
+using the $(b,--project) parameter, which defaults to $(b,a.proj).
+
+The commands can be entered via the REPL, which features completion
+(hit the $(b,<TAB>) key) and contextual hints. Alternatively, commands
+could be specified via a script file (see $(b,--script)), with one
+command per line, or using the command-line itself, with each command
+delimited with quotes, e.g.,
+
+```
+    bap analyze commands # prints all commands
+    bap analyze --project=test.proj 'subroutines :unit file:echo'
+```
+
+All commands are stored in the history file that persists between
+invocations of bap. The location of the file could be specified with
+the $(b,--history) option, which could also be used to interactively
+create the script files.
+
+# GRAMMAR
+
+The expected input is a list of commands or directives separated with
+the newline characters. The directive $(b,directive) will output the
+list of available directives and corresponding descriptions. The
+$(b,commands) directive will list all available commands, and $(b,help
+<command>) will provide detailed information about $(b,<command>) its
+syntax and semantics.
+
+The syntax rules for commands are described in the
+$(b,Project.Analysis) API documentation but in general it follows the
+common command line syntax, i.e., each command is a sequence of words
+separated by whitespaces, with keyworded arguments prefixed with
+$(b,:) instead of $(b,-) or $(b,--), e.g.,
+
+```
+     subroutines :unit file:echo :matches malloc
+```
+|}
+
+
+open Core_kernel
+open Bap_main
+open Bap_knowledge
+open Bap.Std
+
+include Loggers()
+
+type problem =
+  | Unknown_command of {package : string; name : string}
+  | Conflict of Knowledge.Conflict.t * string * string list
+  | Bad_directive of {dir : string; msg : string}
+  | Sys_error_on_load of exn
+
+type Extension.Error.t += Fail of problem
+
+type ctxt = {
+  path : string;
+  package : string;
+  history : string;
+  quit : bool;
+  commands : Project.Analysis.info Map.M(Knowledge.Name).t;
+  directives : string Map.M(String).t;
+}
+
+
+let collect_commands () =
+  Project.Analysis.registered () |>
+  List.fold ~init:(Map.empty (module Knowledge.Name))
+    ~f:(fun hints info ->
+        let name = Project.Analysis.name info in
+        Map.add_exn hints name info)
+
+
+let initial_ctxt ~history directives path = {
+  path;
+  package = "user";
+  quit = false;
+  commands = collect_commands ();
+  history;
+  directives = List.fold directives
+      ~init:String.Map.empty
+      ~f:(fun dirs (name,_,desc) ->
+          Map.add_exn dirs name desc)
+}
+
+let fail problem = Error (Fail problem)
+
+let break_line str =
+  String.split ~on:' ' str |>
+  List.filter ~f:(fun s -> not (String.is_empty s))
+
+let exec_command ?(package="bap") cmd args =
+  match Project.Analysis.find ~package cmd with
+  | None -> fail (Unknown_command {package; name=cmd})
+  | Some analysis ->
+    let code = Project.Analysis.apply analysis args in
+    match Toplevel.try_exec code with
+    | Ok () -> Ok ()
+    | Error err -> fail (Conflict (err,cmd,args))
+
+let in_package ctxt package =
+  Toplevel.exec @@ Knowledge.Symbol.set_package package;
+  {ctxt with package}
+
+let set_package args ctxt = match args with
+  | [pkg] -> Ok (in_package ctxt pkg)
+  | _ -> fail (Bad_directive {
+      dir = "in-package";
+      msg = "expects exactly one argument";
+    })
+
+
+let save_base args ctxt = match args with
+  | [] | [_] ->
+    let path = Option.value (List.hd args)
+        ~default:ctxt.path in
+    Knowledge.save (Toplevel.current ()) path;
+    Ok ctxt
+  | _ -> fail (Bad_directive {
+      dir = "save";
+      msg = "takes at most one argument";
+    })
+
+let no_args dir f args ctxt = match args with
+  | [] -> f ctxt
+  | _ -> fail (Bad_directive {dir; msg = "doesn't accept arguments"})
+
+let quit = no_args "quit" @@ fun ctxt -> Ok {ctxt with quit = true}
+let clear = no_args "clear" @@ fun ctxt ->
+  LNoise.clear_screen ();
+  Ok ctxt
+
+let short str =
+  let len = min
+      (String.length str)
+      (Option.value (String.index str '.') ~default:40) in
+  String.lowercase @@ String.subo str ~len
+
+let list_commands = no_args "commands" @@ fun ctxt ->
+  Project.Analysis.registered () |>
+  List.iter ~f:(fun analysis ->
+      let name = Project.Analysis.name analysis
+      and desc = short @@ Project.Analysis.desc analysis in
+      Format.printf "%-40s %s@\n%!" (Knowledge.Name.to_string name) desc);
+  Ok ctxt
+
+let help_msg = "\
+Type `commands' for the list of available commands or `directives' \
+for the list of directives. Commands, unlike directives, are properly \
+namespaced (packaged), the name of the currently opened namesapce \
+(package) is displayed in the prompt. Most of the commands accept \
+required or optional arguments. Some arguments are keyworded, i.e., \
+them must be prefixed with the specified keyword, e.g.,
+
+instruction /bin/ls:0x8080 :semantics bil
+
+Type `help <command> ...` for the detailed description of the \
+<command>. If more than one command is specified, then the detailed \
+description will be printed for each.
+"
+
+let help args ctxt = match args with
+  | [] ->
+    Format.printf "@[%a@]" Format.pp_print_text help_msg;
+    Ok ctxt
+  | _ :: _ :: _ ->
+    fail (Bad_directive {
+        dir = "help";
+        msg = "expects zero or one argument";
+      })
+  | [cmd] ->
+    match Map.find ctxt.directives cmd with
+    | Some desc -> Format.printf "%s@\n" desc; Ok ctxt
+    | None ->
+      let name = Knowledge.Name.read ~package:ctxt.package cmd in
+      match Map.find ctxt.commands name with
+      | None -> fail (Bad_directive {
+          dir = "help";
+          msg = sprintf "no such command %s in package %s"
+              cmd ctxt.package;
+        })
+      | Some info ->
+        let grammar = Project.Analysis.grammar info
+        and desc = Project.Analysis.desc info  in
+        Format.printf "SYNOPSIS\n\n%s %s\n\nDESCRIPTION\n@[%a@]\n"
+          cmd (Project.Analysis.Grammar.to_string grammar)
+          Format.pp_print_text desc;
+        Ok ctxt
+
+let list_directives = no_args "directives" @@ fun ctxt ->
+  Map.iteri ctxt.directives ~f:(fun ~key:dir ~data:desc ->
+      Format.printf "%-40s %s@\n%!" dir desc);
+  Ok ctxt
+
+let directives = [
+  "in-package", set_package, "sets the default package";
+  "save", save_base, "saves the knowledge base on disk";
+  "quit", quit, "quits the interactive session";
+  "clear", clear, "clears the screen";
+  "commands", list_commands, "lists known commands";
+  "help", help,  "prints the help message";
+  "directives", list_directives, "lists directives";
+]
+
+let find_directive dir = List.find_map directives ~f:(fun (s,f,_) ->
+    if String.equal s dir then (Some f) else None)
+
+let dispatch str ctxt = match break_line str with
+  | [] -> Ok ctxt
+  | cmd :: args -> match find_directive cmd with
+    | Some dir -> dir args ctxt
+    | None ->
+      match exec_command ~package:ctxt.package cmd args with
+      | Ok () -> Ok ctxt
+      | Error err -> Error err
+
+let report_error err =
+  Format.eprintf "%a@\n%!" Extension.Error.pp err
+
+let load_history filename =
+  if Sys.file_exists filename
+  then match LNoise.history_load ~filename with
+    | Ok () -> ()
+    | Error msg ->
+      Format.eprintf "Failed to load the history file: %s@\n%!" msg
+
+let remember ctxt input =
+  match LNoise.history_add input with
+  | Error msg -> warning "failed to remember the input: %s" msg
+  | Ok () ->
+    match LNoise.history_save ~filename:ctxt.history with
+    | Ok () -> ()
+    | Error msg -> warning "failed to write history: %s" msg
+
+let complete ctxt prefix completions =
+  let matches = String.is_prefix ~prefix in
+  List.iter directives ~f:(fun (name,_,_) ->
+      if matches name
+      then LNoise.add_completion completions name);
+  Project.Analysis.registered () |>
+  List.iter ~f:(fun info ->
+      let name = Project.Analysis.name info in
+      let pkg = Knowledge.Name.package name in
+      let short = Knowledge.Name.unqualified name in
+      let full = Knowledge.Name.to_string name in
+      if pkg = ctxt.package && matches short
+      then LNoise.add_completion completions short
+      else if matches full || matches short
+      then LNoise.add_completion completions full)
+
+
+let hint {package; commands} prefix =
+  match break_line prefix with
+  | [] -> None
+  | cmd :: args ->
+    let inputed = List.length args in
+    let cmd = Knowledge.Name.read ~package cmd in
+    match Map.find commands cmd with
+    | None -> None
+    | Some info ->
+      let grammar = break_line @@
+        Project.Analysis.Grammar.to_string @@
+        Project.Analysis.grammar info in
+      match List.drop grammar inputed with
+      | [] | [""] -> None
+      | xs ->
+        Option.return (" " ^ String.concat ~sep:" " xs,
+                       LNoise.Yellow,
+                       false)
+
+let rec interactive_loop ctxt =
+  Format.printf "%!";
+  LNoise.set_completion_callback (complete ctxt);
+  LNoise.set_hints_callback (hint ctxt);
+  match LNoise.linenoise (ctxt.package ^ "> ") with
+  | exception Sys.Break -> interactive_loop ctxt
+  | None -> Ok ()
+  | Some input ->
+    remember ctxt input;
+    match dispatch input ctxt with
+    | Error err -> report_error err; interactive_loop ctxt
+    | Ok {quit=true} -> Ok ()
+    | Ok ctxt -> interactive_loop ctxt
+
+let load_script = function
+  | None -> Ok []
+  | Some path ->
+    try Ok (In_channel.read_lines path)
+    with exn -> fail (Sys_error_on_load exn)
+
+
+let dispatch_commands commands ctxt =
+  let open Result.Monad_infix in
+  List.fold commands ~init:(Ok ctxt) ~f:(fun ctxt cmd ->
+      ctxt >>= dispatch cmd)
+
+let run_non_interactive commands script ctxt =
+  let open Result.Monad_infix in
+  dispatch_commands commands ctxt >>= fun ctxt ->
+  load_script script >>= fun commands ->
+  dispatch_commands commands ctxt
+
+let string_of_problem = function
+  | Unknown_command {package; name} ->
+    sprintf "Can't find a command %S in the package %S" name package
+  | Conflict (err,cmd,_) ->
+    sprintf "Command %s failed with %s" cmd
+      (Knowledge.Conflict.to_string err)
+  | Bad_directive {msg} -> sprintf "Error: %s" msg
+  | Sys_error_on_load exn ->
+    sprintf "Failed to load a script: %s" (Exn.to_string exn)
+
+
+let () =
+  let open Extension in
+  let open Extension.Command in
+  let knowledge = parameter
+      Type.("knowledge-base" %: string =? "a.proj")
+      "project" ~aliases:["k"]
+      ~doc:"The path to a knowledge base." in
+  let commands = arguments Extension.Type.("command" %: string)
+      ~doc:"The command to execute." in
+  let script = parameter Type.("path" %: some file) "script"
+      ~aliases:["s"]
+      ~doc:"The path to a script file with commands." in
+  let history =
+    let history_location =
+      match Sys.getenv_opt "HOME" with
+      | None | Some "" -> ".bap_history"
+      | Some home -> Filename.concat home ".bap_history" in
+    parameter Type.("path" %: file =? history_location) "history"
+      ~aliases:["H"] in
+  declare "analyze" ~doc (args $knowledge $commands $script $history) @@
+  fun base commands script history _ctxt ->
+  Analyze_core_commands.register ();
+  if Sys.file_exists base
+  then Toplevel.set @@ Knowledge.load base;
+  let ctxt = in_package (initial_ctxt history directives base) "bap" in
+  match commands,script with
+  | [], None ->
+    load_history history;
+    interactive_loop ctxt
+  | _ -> match run_non_interactive commands script ctxt with
+    | Ok _ -> Ok ()
+    | Error err -> Error err
+
+let () = Extension.Error.register_printer @@ function
+  | Fail problem -> Some (string_of_problem problem)
+  | _ -> None

--- a/plugins/api/api_main.ml
+++ b/plugins/api/api_main.ml
@@ -250,9 +250,8 @@ let main paths proj =
     error "api wasn't applied: %a" Error.pp e;
     exit 1
   | Ok mappers ->
-    let prog = Project.program proj in
-    List.fold mappers ~init:prog ~f:(fun prog map -> map#run prog) |>
-    Project.with_program proj
+    Project.map_program proj ~f:(fun prog ->
+        List.fold mappers ~init:prog ~f:(fun prog map -> map#run prog))
 
 let list_of_paths paths =
   List.iter ~f:(fun p -> Format.printf "%s\n" (Api_path.to_string p)) paths

--- a/plugins/callsites/callsites_main.ml
+++ b/plugins/callsites/callsites_main.ml
@@ -83,9 +83,7 @@ let fill_calls program =
   Term.map sub_t program ~f:(insert_defs program)
 
 
-let main proj =
-  let prog = Project.program proj in
-  Project.with_program proj (fill_calls prog)
+let main = Project.map_program ~f:fill_calls
 
 let () =
   Config.manpage [

--- a/plugins/demangle/demangle_main.ml
+++ b/plugins/demangle/demangle_main.ml
@@ -6,11 +6,9 @@ open Bap_plugins.Std
 include Self()
 
 
-let apply demangler proj =
-  let prog = Project.program proj in
-  Term.map sub_t prog ~f:(fun sub ->
-      Sub.with_name sub (Demangler.run demangler (Sub.name sub))) |>
-  Project.with_program proj
+let apply demangler =
+  Project.map_program ~f:(Term.map sub_t ~f:(fun sub ->
+      Sub.with_name sub (Demangler.run demangler (Sub.name sub))))
 
 let find_demangler name =
   Demanglers.available () |>

--- a/plugins/glibc_runtime/glibc_runtime_main.ml
+++ b/plugins/glibc_runtime/glibc_runtime_main.ml
@@ -130,8 +130,7 @@ let main ctxt proj =
   if Extension.Configuration.get ctxt enable ||
      is_glibc proj
   then
-    Project.with_program proj @@
-    fix_glibc_runtime (Project.program proj)
+    Project.map_program proj ~f:fix_glibc_runtime
   else proj
 
 let () = Extension.declare ~doc ~provides:["abi"] @@ fun ctxt ->

--- a/plugins/map_terms/map_terms_main.ml
+++ b/plugins/map_terms/map_terms_main.ml
@@ -120,15 +120,14 @@ let () =
   Map_terms_features.init ();
   Ok ()
 
-let main patts file proj =
+let main patts file =
   let patts = match file with
     | None -> patts
     | Some file -> match Scheme.parse_file file with
       | Ok ps -> patts @ ps
       | Error err -> raise (Parse_error err) in
   let marker = new marker patts in
-  Project.with_program proj @@
-  marker#run (Project.program proj)
+  Project.map_program ~f:marker#run
 
 module Cmdline = struct
 

--- a/plugins/mips/mips_abi.ml
+++ b/plugins/mips/mips_abi.ml
@@ -108,9 +108,8 @@ let set_abi proj m =
   C.Abi.register A.name abi;
   let api = C.Abi.create_api_processor A.size abi in
   Bap_api.process api;
-  let prog = Project.program proj in
-  let prog = demangle strip_leading_dot prog in
-  Project.set (Project.with_program proj prog) Bap_abi.name A.name
+  let proj = Project.map_program proj ~f:(demangle strip_leading_dot) in
+  Project.set proj Bap_abi.name A.name
 
 let main proj = match Project.arch proj with
   | `mips ->

--- a/plugins/optimization/optimization_main.ml
+++ b/plugins/optimization/optimization_main.ml
@@ -155,19 +155,18 @@ let digest_of_sub sub level =
 let run level proj =
   let arch = Project.arch proj in
   let can_touch = is_optimization_allowed (is_flag arch) level in
-  let prog = Project.program proj in
-  let free = free_vars prog in
-  Project.with_program proj @@
-  Term.map sub_t prog ~f:(fun sub ->
-      let digest = digest_of_sub sub level in
-      match O.Cache.load digest with
-      | Some data -> O.apply sub data
-      | None ->
-        let data = process_sub free can_touch sub in
-        let sub = O.update sub data in
-        let data = O.find_unreachable sub data in
-        O.Cache.save digest data;
-        O.remove_dead_code sub data)
+  Project.map_program proj ~f:(fun prog ->
+      let free = free_vars prog in
+      Term.map sub_t prog ~f:(fun sub ->
+          let digest = digest_of_sub sub level in
+          match O.Cache.load digest with
+          | Some data -> O.apply sub data
+          | None ->
+            let data = process_sub free can_touch sub in
+            let sub = O.update sub data in
+            let data = O.find_unreachable sub data in
+            O.Cache.save digest data;
+            O.remove_dead_code sub data))
 
 let () =
   Config.manpage [

--- a/plugins/powerpc/powerpc_abi.ml
+++ b/plugins/powerpc/powerpc_abi.ml
@@ -83,8 +83,7 @@ let main proj = match Project.arch proj with
     C.Abi.register Abi32.name abi;
     let api = C.Abi.create_api_processor Abi32.size abi in
     Bap_api.process api;
-    let prog = Project.program proj in
-    Project.set (Project.with_program proj prog) Bap_abi.name Abi32.name
+    Project.set proj Bap_abi.name Abi32.name
   | _ -> proj
 
 let setup () = Bap_abi.register_pass main

--- a/plugins/primus_propagate_taint/primus_propagate_taint_main.ml
+++ b/plugins/primus_propagate_taint/primus_propagate_taint_main.ml
@@ -184,10 +184,7 @@ module Marker(Machine : Primus.Machine.S) = struct
 
   let mark _ =
     Machine.Local.get mapper >>= fun s ->
-    Machine.update (fun proj ->
-        Project.program proj |>
-        mark_terms s |>
-        Project.with_program proj)
+    Machine.update (Project.map_program ~f:(mark_terms s))
 
   let init () =
     Primus.Interpreter.leave_blk >>> mark

--- a/plugins/propagate_taint/propagate_taint_main.ml
+++ b/plugins/propagate_taint/propagate_taint_main.ml
@@ -194,8 +194,7 @@ let main args proj =
   then eprintf "@.Coverage: %a@." State.pp_coverage state;
 
   let marker = new marker (State.taints state) in
-  Project.program proj |> marker#run |>
-  Project.with_program proj
+  Project.map_program proj ~f:marker#run
 
 module Cmdline = struct
 

--- a/plugins/resolve_indirects/resolve_indirects_main.ml
+++ b/plugins/resolve_indirects/resolve_indirects_main.ml
@@ -17,13 +17,12 @@ let resolver memory = object
     | _ -> exp
 end
 
-let main proj = 
-  let prog = Project.program proj in
-  let memory = Project.memory proj in
-  Term.map sub_t prog ~f:(fun sub -> 
-      Term.map blk_t sub ~f:(fun blk -> 
-          Blk.map_exp blk ~f:(Exp.map (resolver memory)))) |>
-  Project.with_program proj
+let main =
+  Project.map_program ~f:(fun prog ->
+      let memory = Project.memory proj in
+      Term.map sub_t prog ~f:(fun sub ->
+          Term.map blk_t sub ~f:(fun blk ->
+              Blk.map_exp blk ~f:(Exp.map (resolver memory)))))
 
 let () =
   Project.register_pass ~name:"resolve-indirects" main

--- a/plugins/ssa/ssa_main.ml
+++ b/plugins/ssa/ssa_main.ml
@@ -1,11 +1,9 @@
 open Bap.Std
 include Self()
 
-let main proj =
-  Project.with_program proj @@
-  Term.map sub_t (Project.program proj) ~f:Sub.ssa;;
+let main = Project.map_program ~f:(Term.map sub_t ~f:Sub.ssa)
 
-
+;;
 Config.manpage [
   `S "SYNOPSIS";
   `Pre "

--- a/plugins/stub_resolver/stub_resolver_main.ml
+++ b/plugins/stub_resolver/stub_resolver_main.ml
@@ -336,8 +336,7 @@ let update prog =
           | _ -> jmp
   end)#run prog
 
-let main proj =
-  Project.with_program proj (update @@ Project.program proj)
+let main = Project.map_program ~f:update
 
 let () = Extension.declare ~doc @@ fun ctxt ->
   Bap_abi.register_pass main;

--- a/plugins/taint/taint_main.ml
+++ b/plugins/taint/taint_main.ml
@@ -107,10 +107,7 @@ module Marker = struct
 end
 
 
-let mark regs ptrs proj =
-  Project.program proj |>
-  Marker.run ~regs ~ptrs |>
-  Project.with_program proj
+let mark regs ptrs = Project.map_program ~f:(Marker.run ~regs ~ptrs)
 
 let main regs ptrs = match regs,ptrs with
   | [],[] -> ()

--- a/plugins/trivial_condition_form/trivial_condition_form_main.ml
+++ b/plugins/trivial_condition_form/trivial_condition_form_main.ml
@@ -35,7 +35,7 @@ module TCF = struct
 
   let prog = Term.map sub_t ~f:sub
 
-  let proj p = Project.with_program p @@ prog @@ Project.program p
+  let proj = Project.map_program ~f:prog
 end
 
 

--- a/plugins/warn_unused/warn_unused_main.ml
+++ b/plugins/warn_unused/warn_unused_main.ml
@@ -72,14 +72,10 @@ let print unchecked proj =
   (printer unchecked)#run prog ()
 
 let mark unchecked proj =
-  Project.program proj |>
-  (marker unchecked)#run |>
-  Project.with_program proj
+  Project.map_program proj ~f:(marker unchecked)#run
 
 let taint proj =
-  Project.program proj |>
-  taint |>
-  Project.with_program proj
+  Project.map_program proj taint
 
 let run pass proj =
   let prog = Project.program proj in


### PR DESCRIPTION
This PR brings a few improvements to BAP that are summarized in the
following demo:

[![asciicast](https://asciinema.org/a/358996.svg)](https://asciinema.org/a/358996)

Important highlights of the PR:

- a REPL for querying and modifying the knowledge base
- a portable and efficient representation of the knowledge base

REPL
----

The REPL is using lineoise and features completion (hit TAB),
context-dependent hints (prints what the grammar expects as you
type) and is, of course, extensible, i.e., it is possible to implement
your own commands and call them from the REPL. The script mode as well
as direct input of the commands from the command-line is also
supported.

Efficient KB Representation
---------------------------

The KB representation is more efficient (more than x2 improvement in
space) and is portable across different versions of bap (and the
representation is itself versioned).

To enable such speed up we changed the representation of the
Knowledge.Name into an interned form using a hash function with low
probability of collisions. Much like the polymorphic variants in
OCaml except that we use 63 bits instead of 31. Of course, hash
collisions are captured and properly reported.

This also slightly improved performance and memory footprint of bap in
general as names were used everywhere in BAP, in variables, in sorts,
etc.

Although the representation is using bin_prot it is designed to enable
interaction with other languages as well as extensibility. Each
property is stored as `<ID> <LEN> <PAYLOAD>` where `<ID>` is the name
of the property (interned), `<LEN>` is the length of the payload (so
that it can be skipped if it is not supported by the parser), and
<PAYLOAD> is the string of bytes in the format specific to the
property serializer (which itself may include a version tag).

Optimized Loading And Storing
-----------------------------

Both loading and storing of the cache is now made via memory
mapping (that means that the knowledge base should be a regular
file). Since all the information is now stored in the knowledge base,
just loading it is enough to get the project, which makes loading the
project x20 or x25 faster than it was before. This affects both
loading from the cache and loading from the specified knowledge base.

Interaction With The Cache
--------------------------

The cache as before, along with other data, stores a knowledge base per each
file, indexed by the digest of the input file and all parameters that
affect the disassembly. The only thing that changed is that now the
result of disassembly is also stored in the knowledge base (previously
it was stored as a separate file). When no project is specified (or the
project file doesn't exist) the file is loaded from the cache. This
enables fast extraction of the file's KB from the cache, e.g.,

```
bap /bin/ls --project ls.proj --update
```

will load `/bin/ls` from the cache and immediately store it in the
`ls.proj`, provided that `ls.proj` didn't exist.

Lazy Project
------------

The project data structure includes a lot of fat data representation,
such as whole program CFG, Symtab that includes a CFG per each
function, and the program data structure. This information takes a lot
of space both on disk and in RAM and was computed even if it was never
used. Moreover, it is easily computable from KB, which uses a much
more efficient representation. To address this we made the
abovementioned data structures lazy, i.e., if you don't use the
program IR then it will not be computed. This saves space and time a
lot.

New API
-------

The following API were added:
- [Project.State] that represents the disassembled binary;
- [Project.Analysis] for writing your own KB analyses.

Minor Tweaks
------------

Tweaks the pretty-printing representation of the knowledge, BIR, and
BIL. It is now much more readable, concise, and properly indented.

Bug Fixes
---------

Fixes #1216
Fixes #1169
Fixes #1168