### PR TITLE
removes the testsuite submodule

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,8 +15,6 @@ jobs:
      steps:
          - name: Checkout code
            uses: actions/checkout@v2
-           with:
-             submodules: recursive
 
          - name: Install OCaml
            uses: avsm/setup-ocaml@v1

--- a/.github/workflows/build-dev-repo.yml
+++ b/.github/workflows/build-dev-repo.yml
@@ -27,8 +27,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          submodules: recursive
 
       - name: Use OCaml ${{ matrix.ocaml-version }}
         uses: avsm/setup-ocaml@v1

--- a/.github/workflows/nightly-testing.yml
+++ b/.github/workflows/nightly-testing.yml
@@ -50,7 +50,6 @@ jobs:
         - name: Checkout the Tests
           uses: actions/checkout@v2
           with:
-            submodules: true
             repository: BinaryAnalysisPlatform/bap
 
         - name: Install Extra System Dependencies

--- a/.github/workflows/weekly-regress.yml
+++ b/.github/workflows/weekly-regress.yml
@@ -39,7 +39,6 @@ jobs:
         - name: Checkout the Tests
           uses: actions/checkout@v2
           with:
-            submodules: true
             repository: BinaryAnalysisPlatform/bap
             ref: v2.1.0
 

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ _oasis
 bap_main_config.ml
 tools/postinstall.ml
 OMakefile
+/testsuite/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "testsuite"]
-	path = testsuite
-	url = https://github.com/BinaryAnalysisPlatform/bap-testsuite

--- a/Makefile
+++ b/Makefile
@@ -51,12 +51,13 @@ distclean:
 test: build
 	$(SETUP) -test $(BAPTESTFLAGS)
 
-check:
-	if [ -d .git ]; then git submodule init; git submodule update; 	fi
+testsuite:
+	git clone https://github.com/BinaryAnalysisPlatform/bap-testsuite.git testsuite
+
+check: testsuite
 	make -C testsuite
 
-veri:
-	if [ -d .git ]; then git submodule init; git submodule update; 	fi
+veri: testsuite
 	make -C testsuite veri
 
 .PHONY: indent check-style status-clean


### PR DESCRIPTION
The main reason is that opam recursively initializes submodules when
it installs bap from sources and given that our testsuite has a few
binaries along with the traces it sums up to 5Gb of space, which leads
to the out-of-disk-space errors when we build from docker. The easiest
solution would be to remove the testsuite from the main repo. Moreover,
having it as a submodule doesn't really help and is mostly a
nuisance.

The proposed solution is to just clone the testsuite (potentially we
can select a branch or a commit) in the test scripts. This is
basically the same as what is git doing for submodules but now it will
be under our control.