### PR TITLE
fixes the implementation of strncasecmp and strcmp models

### DIFF
--- a/plugins/primus_lisp/lisp/atoi.lisp
+++ b/plugins/primus_lisp/lisp/atoi.lisp
@@ -22,6 +22,14 @@
 (defmacro make-converter (type s)
   (cast type (read-ascii-word s)))
 
-(defun atoi  (s) (make-converter int s))
-(defun atol  (s) (make-converter long s))
-(defun atoll (s) (make-converter long-long s))
+(defun atoi  (s)
+  (declare (external "atoi"))
+  (make-converter int s))
+
+(defun atol  (s)
+  (declare (external "atol"))
+  (make-converter long s))
+
+(defun atoll (s)
+  (declare (external "atoll"))
+  (make-converter long-long s))

--- a/plugins/primus_lisp/lisp/posix.lisp
+++ b/plugins/primus_lisp/lisp/posix.lisp
@@ -2,3 +2,4 @@
 (require stdio)
 (require string)
 (require errno)
+(require ascii)

--- a/plugins/primus_lisp/lisp/string.lisp
+++ b/plugins/primus_lisp/lisp/string.lisp
@@ -1,6 +1,7 @@
 (require types)
 (require pointers)
 (require memory)
+(require ascii)
 
 (defun strlen (p)
   (declare (external "strlen"))
@@ -140,20 +141,25 @@
   (memcmp s1 s2 (min (strlen/with-null s1)
                      (strlen/with-null s2))))
 
-(defun strncasecmp (p1 p2 n)
-  (declare (external "strncasecmp"))
+(defun memcasecmp (p1 p2 n)
   (let ((res 0) (i 0))
     (while (and (< i n) (not res))
       (set res (compare
-                (tolower (memory-read p1))
-                (tolower (memory-read p2))))
+                (ascii-to-lower (cast int (memory-read p1)))
+                (ascii-to-lower (cast int (memory-read p2)))))
       (incr p1 p2 i))
     res))
 
-(defun strcasecmp (p1 p2)
+(defun strncasecmp (p1 p2 n)
   (declare (external "strncasecmp"))
-  (strncasecmp p1 p2 (min (strlen p1)
-                          (strlen p2))))
+  (memcasecmp p1 p2 (min n
+                         (strlen/with-null p1)
+                         (strlen/with-null p2))))
+
+(defun strcasecmp (p1 p2)
+  (declare (external "strcasecmp"))
+  (strncasecmp p1 p2 (min (strlen/with-null p1)
+                          (strlen/with-null p2))))
 
 
 (defmacro find-substring (compare hay needle)


### PR DESCRIPTION
Also publishes the ascii module and ato* functions, apparently, these features weren't included in the posix feature.

Thanks, @dtpeters for reporting this.