### PR TITLE
removes section and other symbols in ELF

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,7 +36,11 @@ jobs:
                opam install omake
 
          - name: Configure BAP
-           run: opam exec -- ./configure-omake
+           run: |
+               opam exec -- ./configure-omake \
+                 --enable-tests \
+                 --with-llvm-version=9 \
+                 --with-llvm-config=llvm-config-9
 
          - name: Build BAP
            run: opam exec -- make

--- a/configure-omake
+++ b/configure-omake
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-rm -f _oasis
-rm -f setup.log.om
+rm -f _oasis setup.log.om setup.data _oasis_setup.om
 mv oasis/benchmarks oasis/benchmarks.backup
 mv oasis/piqi-printers oasis/piqi-printers.backup
 mv oasis/common oasis/common.backup

--- a/configure-omake
+++ b/configure-omake
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 rm -f _oasis
+rm -f setup.log.om
 mv oasis/benchmarks oasis/benchmarks.backup
 mv oasis/piqi-printers oasis/piqi-printers.backup
 mv oasis/common oasis/common.backup
@@ -17,10 +18,32 @@ sed -i 's/.*Build$.*//' _oasis
 sed -i 's/.*CCOpt:.*//' _oasis
 sed -i 's/.*CCLib:.*//' _oasis
 
+FST=true
+
+
+for i in "$@"; do
+  if $FST; then
+    set --
+    FST=false
+  fi
+
+  case $i in
+    --*=*)
+      ARG=${i%%=*}
+      VAL=${i##*=}
+      set -- "$@" "$ARG" "$VAL"
+      ;;
+    *)
+      set -- "$@" "$i"
+      ;;
+  esac
+done
+
+
 # call setup twice so that it can capture the AB deps
 for pass in `seq 2`; do
     oasis setup
     ocamlfind ocamlopt unix.cmxa setup.ml -o setup.exe
     rm setup.cmx setup.cmi setup.o
-    ./setup.exe -configure --prefix $(opam config var prefix) --enable-tests
+    ./setup.exe -configure --prefix $(opam config var prefix) "$@"
 done

--- a/lib/bap_llvm/OMakefile
+++ b/lib/bap_llvm/OMakefile
@@ -3,10 +3,14 @@
 # for more documentation.
 
 CFLAGS += -O2
-CXXFLAGS += -O2 -std=c++11 -fPIC -I$(ROOT)/lib/bap_disasm -I/usr/lib/llvm-6.0/include -std=c++0x -fuse-ld=gold -Wl,--no-keep-files-mapped -Wl,--no-map-whole-files -fPIC -fvisibility-inlines-hidden -Werror=date-time -std=c++11 -Wall -W -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -pedantic -Wno-long-long -Wno-maybe-uninitialized -Wdelete-non-virtual-dtor -Wno-comment -ffunction-sections -fdata-sections -O2 -DNDEBUG  -fno-exceptions -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+CXXFLAGS += -O2 -std=c++11 -fPIC -I$(ROOT)/lib/bap_disasm
 
-OCAMLMKLIBFLAGS += -L/usr/lib/llvm-6.0/lib -lLLVM-6.0 -dllpath /usr/lib/llvm-6.0/lib -lstdc++  -lz -lrt -ldl -ltinfo -lpthread -lm -lcurses
-
+# pull the llvm configuration
+CXXFLAGS += $(split $(oasis_llvm_cxxflags))
+OCAMLMKLIBFLAGS += \
+	$(split $(oasis_llvm_libs)) \
+	$(split $(oasis_llvm_ldflags)) \
+	-lcurses -lstdc++
 
 include _oasis_hier.om
 

--- a/lib/bap_llvm/llvm_elf_loader.hpp
+++ b/lib/bap_llvm/llvm_elf_loader.hpp
@@ -202,12 +202,16 @@ void emit_relocations(const ELFObjectFile<T> &obj, ogre_doc &s) {
         for (auto rel : sec.relocations()) {
             auto sym = rel.getSymbol();
             if (sym != prim::end_symbols(obj)) {
-                uint64_t raddr = prim::relocation_offset(rel);
-                if (auto addr = prim::symbol_address(*sym))
-                    if (*addr) s.entry("llvm:relocation") << raddr << *addr;
-                if (auto name = prim::symbol_name(*sym))
-                    if (!name->empty())
-                        s.entry("llvm:name-reference") << raddr << *name;
+                auto typ = prim::symbol_type(*sym);
+                if (typ && (*typ == SymbolRef::ST_Function ||
+                            *typ == SymbolRef::ST_Unknown)) {
+                    uint64_t raddr = prim::relocation_offset(rel);
+                    if (auto addr = prim::symbol_address(*sym))
+                        if (*addr) s.entry("llvm:relocation") << raddr << *addr;
+                    if (auto name = prim::symbol_name(*sym))
+                        if (!name->empty())
+                            s.entry("llvm:name-reference") << raddr << *name;
+                }
             }
         }
     }

--- a/opam/opam
+++ b/opam/opam
@@ -308,7 +308,6 @@ depexts: [
     "llvm-9-dev"
     "time"
     "clang"
-    "llvm"
     "m4"
     "dejagnu"
   ] {os-distribution = "ubuntu"}


### PR DESCRIPTION
Apparently, we were running our tests on LLVM 6, not LLVM 9 as we used to believe. This PR switches to LLVM 9 for running tests and fixes a bug that was not present in LLVM 6 and below (it could be that it appears before 9 though). The problem was in the emission of section symbols from the `eh_frame` section, which apparently should represent call frames, so it is not obvious to me why they are tagged as STT_SECTION that is mapped to LLVM's ST_Debug. It is unclear what those symbols encode,  but is quite obvious that llvm misinterprets them as at the end of the day we have a bunch of symbols named `.text` that hides the real symbols. This PR prevents the emission of such symbols, as well as other symbols, such as file, object, and abi-specific symbols, as we don't really know the interpretation of their fields. 

This PR also removes the LLVM 6 dependency from our CI file as well as makes changing the llvm version more straightforward when the omake backend is used, e.g.,

```
./configure-omake --with-llvm-version=9 --with-llvm-config=llvm-config-9
```

Yes, it is awkward but you have to specify both the version and llvm-config path. 