### PR TITLE
switches to Fowler-Noll-Vo hash algorithm for hashing names

### DIFF
--- a/lib/knowledge/bap_knowledge.mli
+++ b/lib/knowledge/bap_knowledge.mli
@@ -1278,6 +1278,11 @@ module Knowledge : sig
     (** string is a persistent data type.  *)
     val string : string persistent
 
+    (** names are persistent.
+
+        @since 2.2.0 *)
+    val name : name persistent
+
     (** [list t] derives persistence for a list.  *)
     val list : 'a persistent -> 'a list persistent
 
@@ -1350,7 +1355,6 @@ module Knowledge : sig
         ["user"] package.
     *)
     val create : ?package:string -> string -> t
-
 
     (** [read ?package input] reads a full name from input.
 


### PR DESCRIPTION
The previous algorithm had a very bad collision rate, especially for
small strings. The new one is much better and is tested on large
dictionaries (of English words and large password databases,
with no collisions found) and is guaranteed not to collide on small strings,
which were tested exhaustively.

Warning: the change of the hash function will break the knowledge base
format so do `bap --cache-clean` after the update.