### PR TITLE
fixes a trivial typo in the symbolic fread implementation

### DIFF
--- a/plugins/primus_symbolic_executor/lisp/symbolic-stdio.lisp
+++ b/plugins/primus_symbolic_executor/lisp/symbolic-stdio.lisp
@@ -62,7 +62,7 @@
 
 (defun fread (ptr size n stream)
   (declare (external "fread"))
-  (let ((r (read (fileno stream) buf (* n size))))
+  (let ((r (read (fileno stream) ptr (* n size))))
     (if (< r 0) r
       (/ r size))))
 


### PR DESCRIPTION
what is non-trivial is why this bug wasn't detected by the type
checker, which is tracked in #1223.