### PR TITLE
overhauls the target/architecture abstraction (3/n)

### DIFF
--- a/lib/bap_core_theory/bap_core_theory.mli
+++ b/lib/bap_core_theory/bap_core_theory.mli
@@ -1255,6 +1255,12 @@ module Theory : sig
     *)
     val get : ?package:string -> string -> t
 
+    (** [read ?package name] is a synonym for [get ?package name].
+
+        Introduces for the consistency with the [Enum.S] interface.
+    *)
+    val read : ?package:string -> string -> t
+
     (** [declared ()] is the list of declared targets.
         The order is unspecified, see also {!families}. The list
         doesn't include the [unknown] target. *)
@@ -1694,6 +1700,9 @@ module Theory : sig
 
       (** the hash value of the enum  *)
       val hash : t -> int
+
+      (** [members ()] the list of all members of the enumeration type. *)
+      val members : unit -> t list
     end
 
     (** Creates a new enumerated type.  *)

--- a/lib/bap_core_theory/bap_core_theory_target.ml
+++ b/lib/bap_core_theory/bap_core_theory_target.ml
@@ -35,6 +35,7 @@ module Enum = struct
     val domain : t KB.domain
     val persistent : t KB.persistent
     val hash : t -> int
+    val members : unit -> t list
   end
 
   module Make() = struct
@@ -61,6 +62,7 @@ module Enum = struct
     let unknown = Name.of_string ":unknown"
     let is_unknown = Name.equal unknown
     let hash = Name.hash
+    let members () = Hash_set.to_list elements
     include Base.Comparable.Make(Name)
     include (Name : Stringable.S with type t := t)
     include (Name : Pretty_printer.S with type t := t)
@@ -202,6 +204,8 @@ let get ?package name =
   if not (Hashtbl.mem targets name)
   then invalid_argf "Unknown target %s" (Name.to_string name) ();
   name
+
+let read = get
 
 let info name = match Hashtbl.find targets name with
   | None -> unknown

--- a/lib/bap_core_theory/bap_core_theory_target.mli
+++ b/lib/bap_core_theory/bap_core_theory_target.mli
@@ -31,6 +31,7 @@ val declare :
   string -> t
 
 val get : ?package:string -> string -> t
+val read : ?package:string -> string -> t
 val lookup : ?package:string -> string -> t option
 val unknown : t
 val is_unknown : t -> bool
@@ -76,6 +77,7 @@ module Enum : sig
     val domain : t KB.domain
     val persistent : t KB.persistent
     val hash : t -> int
+    val members : unit -> t list
   end
 
   module Make() : S

--- a/lib/bap_image/bap_memory.ml
+++ b/lib/bap_image/bap_memory.ml
@@ -461,3 +461,16 @@ let slot = KB.Class.property ~package:"bap"
     Theory.Program.cls "mem" domain
     ~public:true
     ~desc:"a memory region occupied by the program"
+
+let () =
+  let open KB.Syntax in
+  KB.promise Theory.Label.addr @@ fun label ->
+  KB.collect slot label >>|? fun mem ->
+  Some (Addr.to_bitvec (min_addr mem))
+
+let () =
+  let open KB.Rule in
+  declare ~package:"bap" "addr-of-mem" |>
+  require slot |>
+  provide Theory.Label.addr |>
+  comment "addr of the first byte"

--- a/lib/bap_systemz/bap_systemz_target.ml
+++ b/lib/bap_systemz/bap_systemz_target.ml
@@ -1,0 +1,40 @@
+open Core_kernel
+open Bap_core_theory
+
+let package = "bap"
+
+type r64 and r32 and r16 and r8
+
+type 'a bitv = 'a Theory.Bitv.t Theory.Value.sort
+
+let r64 : r64 bitv = Theory.Bitv.define 64
+let r32 : r32 bitv = Theory.Bitv.define 32
+let r16 : r16 bitv = Theory.Bitv.define 16
+let r8  : r8  bitv = Theory.Bitv.define 8
+let bool = Theory.Bool.t
+
+let reg t n = Theory.Var.define t n
+
+let array ?(index=string_of_int) t pref size =
+  List.init size ~f:(fun i -> reg t (pref ^ index i))
+
+let untyped = List.map ~f:Theory.Var.forget
+let (@<) xs ys = untyped xs @ untyped ys
+
+let mems = Theory.Mem.define r64 r8
+
+let gpr = array r64 "R" 16
+let fpr = array r64 "F" 16
+let mem = reg mems "mem"
+
+let vars = gpr @< fpr @< [mem]
+
+let parent = Theory.Target.declare ~package "systemz"
+
+let z9 = Theory.Target.declare ~package "systemz9" ~parent
+    ~bits:64
+    ~code:mem
+    ~data:mem
+    ~vars
+
+let llvm_encoding = Theory.Language.declare ~package "llvm-systemz"

--- a/lib/bap_systemz/bap_systemz_target.mli
+++ b/lib/bap_systemz/bap_systemz_target.mli
@@ -1,0 +1,21 @@
+open Bap_core_theory
+
+
+type r64 and r32 and r16 and r8
+
+type 'a bitv = 'a Theory.Bitv.t Theory.Value.sort
+
+val r64 : r64 bitv
+val r32 : r32 bitv
+val r16 : r16 bitv
+val r8  : r8 bitv
+
+val mem : (r64, r8) Theory.Mem.t Theory.var
+val gpr : r64 Theory.Bitv.t Theory.var list
+val fpr : r64 Theory.Bitv.t Theory.var list
+
+val parent : Theory.Target.t
+
+val z9 : Theory.Target.t
+
+val llvm_encoding : Theory.Language.t

--- a/lib/bap_types/bap_arch.ml
+++ b/lib/bap_types/bap_arch.ml
@@ -75,6 +75,7 @@ module T = struct
   let persistent = KB.Persistent.of_binable (module struct
       type t = arch [@@deriving bin_io]
     end)
+
   let slot = KB.Class.property ~package:"bap"
       Theory.Program.cls "arch" domain
       ~persistent

--- a/lib/bap_types/bap_ir.ml
+++ b/lib/bap_types/bap_ir.ml
@@ -115,7 +115,7 @@ module Tid = struct
     then intern str
     else match str.[0] with
       | '%' -> parse @@ sprintf "#<%s 0x%s>"
-          (KB.Name.show (KB.Class.name Theory.Program.Semantics.cls))
+          (KB.Name.show (KB.Class.name Theory.Semantics.cls))
           (String.subo ~pos:1 str)
       | '@' -> intern (String.subo ~pos:1 str)
       | _ -> intern str
@@ -1251,7 +1251,7 @@ module Term = struct
     end)
 
   let slot = Knowledge.Class.property
-      Theory.Program.Semantics.cls "bir" domain
+      Theory.Semantics.cls "bir" domain
       ~package ~persistent
       ~public:true
       ~desc:"BIL semantics in a graphical IR"

--- a/lib/bap_types/bap_ir.mli
+++ b/lib/bap_types/bap_ir.mli
@@ -69,7 +69,7 @@ end
 module Term : sig
   type 'a t = 'a term
 
-  val slot : (Theory.Program.Semantics.cls, blk term list) KB.slot
+  val slot : (Theory.Semantics.cls, blk term list) KB.slot
 
   val clone : 'a t -> 'a t
   val same : 'a t -> 'a t -> bool

--- a/lib/bap_types/bap_stmt.ml
+++ b/lib/bap_types/bap_stmt.ml
@@ -110,6 +110,6 @@ let persistent = Knowledge.Persistent.of_binable (module struct
   end)
 
 let slot = Knowledge.Class.property ~package:"bap"
-    ~persistent Theory.Program.Semantics.cls "bil" domain
+    ~persistent Theory.Semantics.cls "bil" domain
     ~public:true
     ~desc:"semantics of statements in BIL"

--- a/lib/bap_types/bap_stmt.mli
+++ b/lib/bap_types/bap_stmt.mli
@@ -26,6 +26,6 @@ end
 module Stmts_pp : Printable.S with type t = stmt list
 module Stmts_data : Data.S with type t = stmt list
 
-val slot : (Theory.Program.Semantics.cls, stmt list) Knowledge.slot
+val slot : (Theory.Semantics.cls, stmt list) Knowledge.slot
 val domain : stmt list Knowledge.domain
 val persistent : stmt list Knowledge.persistent

--- a/lib/x86_cpu/x86_target.ml
+++ b/lib/x86_cpu/x86_target.ml
@@ -186,7 +186,7 @@ let i686 = Theory.Target.declare ~package "i686"
 let amd64 = Theory.Target.declare ~package "amd64"
     ~parent:i686
     ~nicknames:["x64"; "x86_64"; "x86-64"; ]
-    ~bits:32
+    ~bits:64
     ~data:M64.data
     ~code:M64.data
     ~vars:M64.vars

--- a/oasis/mc
+++ b/oasis/mc
@@ -9,7 +9,8 @@ Library mc_plugin
   CompiledObject:  best
   Modules:         Mc_main
   BuildDepends:    core_kernel, bap-main, bap, regular, bap-plugins,
-                   bap-core-theory, bap-knowledge, ppx_jane, bitvec
+                   bap-core-theory, bap-knowledge, ppx_jane, bitvec,
+                   ogre
   XMETAExtraLines: tags="command, disassemble"
 
 

--- a/oasis/systemz
+++ b/oasis/systemz
@@ -1,0 +1,22 @@
+Flag systemz
+ Description: Build Systemz lifter
+ Default: false
+
+Library "bap-systemz"
+ Build$:           flag(everything) || flag(systemz)
+ XMETADescription: common definitions for Systemz targets
+ Path: lib/bap_systemz
+ BuildDepends: core_kernel, bap-knowledge, bap-core-theory
+ FindlibName: bap-systemz
+ Modules: Bap_systemz_target
+
+Library systemz_plugin
+  XMETADescription: provide Systemz lifter
+  Path:             plugins/systemz
+  Build$:           flag(everything) || flag(systemz)
+  BuildDepends:     core_kernel, ppx_jane, ogre,
+                    bap-core-theory, bap-knowledge, bap-main,
+                    bap, bap-systemz
+  FindlibName:      bap-plugin-systemz
+  InternalModules:  Systemz_main, Systemz_lifter
+  XMETAExtraLines:  tags="systemz, lifter, z9"

--- a/plugins/bil/bil_lifter.ml
+++ b/plugins/bil/bil_lifter.ml
@@ -479,7 +479,8 @@ let provide_lifter ~enable_intrinsics ~with_fp () =
     Knowledge.collect Memory.slot obj >>? fun mem ->
     Knowledge.collect Disasm_expert.Basic.Insn.slot obj >>? fun insn ->
     match lift ~enable_intrinsics arch mem insn with
-    | Error _ ->
+    | Error err ->
+      info "BIL: the BIL lifter failed with %a" Error.pp err;
       Knowledge.return (Insn.of_basic insn)
     | Ok bil ->
       Bil_semantics.context >>= fun ctxt ->

--- a/plugins/systemz/.merlin
+++ b/plugins/systemz/.merlin
@@ -1,0 +1,2 @@
+B ../../lib/bap_systemz
+REC

--- a/plugins/systemz/systemz_lifter.ml
+++ b/plugins/systemz/systemz_lifter.ml
@@ -1,0 +1,148 @@
+open Core_kernel
+open Bap_core_theory
+open Bap.Std
+
+open KB.Syntax
+include Bap_main.Loggers()
+
+module Target = Bap_systemz_target
+module MC = Disasm_expert.Basic
+
+let make_regs regs =
+  let regs =
+    List.mapi regs ~f:(fun i r -> (i,r)) |>
+    Map.of_alist_exn (module Int) in
+  Map.find_exn regs
+
+let gpr = make_regs Target.gpr
+let regnum s = Scanf.sscanf s "R%d" ident
+
+(** [require_gpr insn n f] parses the machine instruction operands and
+    requires that the [n]th register should be a GPR register and if
+    it is, calls the action [f] with the variable that corresponds the register
+*)
+let require_gpr insn pos f =
+  match (MC.Insn.ops insn).(pos) with
+  | Op.Reg r -> f (gpr (regnum (Reg.name r)))
+  | _ -> KB.return Insn.empty
+
+(* The Theory of Systemz machines.
+
+   For each target system we build a theory as a functor that takes
+   the Core theory and extends it with operations specific to that
+   target.
+*)
+module Systemz(CT : Theory.Core) = struct
+  open Target
+
+  (* We commonly start with a set of helpers, which also comprise the
+     theory of our target. For example, [seq] extends the [seq x y] to
+     [seq [x y ... z]], which makes it easier to write other
+     functions...  *)
+  let rec seq = function
+    | [] -> CT.perform Theory.Effect.Sort.bot
+    | [x] -> x
+    | x :: xs -> CT.seq x @@ seq xs
+
+  (* ... for each sort of effects we will build a corresponding
+     constructor. This one handles a sequence of data effects and
+     packs them into a basic block that has the required type of [unit
+     eff].  *)
+  let data xs =
+    KB.Object.create Theory.Program.cls >>= fun lbl ->
+    CT.blk lbl (seq xs) (seq [])
+
+  let (@) = CT.append r64
+
+
+  (* finally, we can build the semantics of our LR instruction, we use
+     our parser function [parse_gpr] to parse operands to GPR
+     registers, and build the denotation as a data effect, which
+     assigns the lower part of the destination register a value of the
+     lower part of the source register.  This function relies on
+     operations taken from the [CT] structure, namely [set] for
+     assignment, [var] for reading the value of a variable, [high] and
+     [low] for extracting parts of the register, and [@] that is
+     defined above as an infix version of the [append] operation
+     specialized for 64-bit registers.  *)
+  let lr insn =
+    require_gpr insn 0 @@ fun rd ->
+    require_gpr insn 1 @@ fun rs ->
+    data CT.[
+        set rd (high r32 (var rd) @ low r32 (var rs))
+      ]
+end
+
+
+(* The lifter provides the instruction semantics and has type
+   [Theory.program KB.obj -> unit Theory.eff], or, the same
+   type but using [Bap.Std] abbreviations,
+   [tid -> insn knowledge].
+
+   The only input parameter is a label that denotes a program
+   location, aka a knowledge base object of type
+   core-theory:program. The label is like a generalized address - it
+   uniquely identifies a program location, even across modules.
+
+   To build the semantics the lifter can access various properties of
+   the instruction. Accessing a property might trigger computations
+   that associated with this property, e.g., the instruction will be
+   disassembled if it wasn't yet. It is even possible to access the
+   semantics property of the instruction (the property that the lifter
+   is supposed to compute). Thus, the lifter could be a co-recursive
+   function with other lifters (itself included, of course).
+
+   The list of properties of that class  can be obtained using the
+   following command: `bap list classes -f core-theory:program`.
+
+   The return type [unit Theory.eff] is the denotation of effects that
+   the instruction performs. The ['a Theory.eff] type is an
+   abbreviation for ['a Theory.effect], which, in turn, is an
+   abbreviation to the knowledge base value of class
+   [Theory.Effect.cls], therefore the fully de-abbreviated type of the
+   return type is:
+
+   [(Theory.Effect.cls, unit Theory.Effect.sort) KB.cls KB.value knowledge]
+
+   The set of sorts that parameterize the class denote what kinds of
+   effects the instruction can have. With the [Effect.top] effect,
+   which is denoted with the [unit] type, being the sort of all sorts
+   of effects that an instruction can possibly have. In other words,
+   the return type of the lifter expects an object that can denote any
+   effect.
+
+   To build the denotations of effects the lifter function is using
+   a theory object, which is created using [Theory.instance] and
+   [Theory.require] functions. The theory is a structure that
+   includes a lot of functions that comprise the [Theory.Core]
+   signature. This functions can be seen as smart constructors that
+   build denotations.
+
+   In our example, we will build a denotation for only one instrucion,
+   `LR` (for load register) that loads (moves) a value from one
+   register to another.
+
+   Our simple framework matches on the opcode name and calls corresponding
+   function, which expects the decoded machine instruction as its
+   input and produces the effect denotation.
+
+
+*)
+let lifter label : unit Theory.eff =
+  KB.collect MC.Insn.slot label >>= function
+  | None -> KB.return Insn.empty
+  | Some insn ->
+    Theory.instance () >>= Theory.require >>= fun (module Core) ->
+    let module Systemz = Systemz(Core) in
+    let open Systemz in
+    insn |> match MC.Insn.name insn with
+    | "LR" -> lr
+    | code ->
+      info "unsupported opcode: %s" code;
+      fun _ -> KB.return Insn.empty
+
+
+
+(* a lifter is a promise to provide the instruction semantics.*)
+let load () =
+  KB.promise Theory.Semantics.slot lifter

--- a/plugins/systemz/systemz_lifter.mli
+++ b/plugins/systemz/systemz_lifter.mli
@@ -1,0 +1,1 @@
+val load : unit -> unit

--- a/plugins/systemz/systemz_main.ml
+++ b/plugins/systemz/systemz_main.ml
@@ -1,0 +1,87 @@
+open Bap_main
+open Bap.Std
+open Bap_core_theory
+open KB.Syntax
+module CT = Theory
+
+include Bap_main.Loggers()
+
+module Target = Bap_systemz_target
+module Dis = Disasm_expert.Basic
+
+(* to enable backward compatiblity with Arch.t
+   we map all systemz targets to `systemz  *)
+let map_arch () =
+  KB.promise Arch.unit_slot @@ fun unit ->
+  KB.collect Theory.Unit.target unit >>| fun t ->
+  if Theory.Target.belongs Target.parent t
+  then `systemz
+  else `unknown
+
+(* the same target may have different encodings
+   or share encodings with other targets, in addition,
+   the encoding may differ per each instruction and even
+   be context-dependent, therefore target and encodings
+   are separate properties of different classes. In our
+   case, everything is trivial.
+*)
+let provide_decoding () =
+  KB.promise CT.Label.encoding @@ fun label ->
+  CT.Label.target label >>| fun t ->
+  if CT.Target.belongs Target.parent t
+  then Target.llvm_encoding
+  else CT.Language.unknown
+
+
+(* following the dependency injection principal, we have to provide
+   the disassembler instance for our encoding.
+
+   The _target parameter may further refine the target system, which
+   could be reflected in the disassembler parameters. Not used in our
+   case.*)
+let enable_llvm () =
+  Dis.register Target.llvm_encoding @@ fun _target ->
+  Dis.create ~backend:"llvm" "systemz"
+
+(* The file loader parses the file and provides its specification
+   in the OGRE format. Our task is to analyze the specification and
+   figure out if it is systemz (and if yes, then what version). For
+   starters, we just assume that the loader will say "systemz" in
+   the arch field.
+*)
+let enable_loader () =
+  let request_arch doc =
+    let open Ogre.Syntax in
+    match Ogre.eval (Ogre.request Image.Scheme.arch) doc with
+    | Error _ -> assert false (* nothing could go wrong here! *)
+    | Ok arch -> arch in
+  KB.promise CT.Unit.target @@ fun unit ->
+  KB.collect Image.Spec.slot unit >>| request_arch >>| function
+  | Some "systemz" -> Target.z9
+  | _ -> CT.Target.unknown
+
+
+(* the main function registers all our providers right now,
+   we may later add some command line options whose values
+   will be avaialble via the _ctxt parameter, which is now
+   unused. *)
+let main _ctxt =
+  enable_llvm ();
+  enable_loader ();
+  provide_decoding ();
+  map_arch ();
+  Systemz_lifter.load ();
+  Ok ()
+
+(* semantic tags that describe what our plugin is providing,
+   setting them is important not only for introspection but
+   for the proper function of the cache subsystem.
+*)
+let provides = [
+  "systemz";
+  "lifter";
+]
+
+(* finally, let's register our extension and call the main function  *)
+let () = Bap_main.Extension.declare main
+    ~provides

--- a/src/bap_frontend.ml
+++ b/src/bap_frontend.ml
@@ -117,6 +117,7 @@ type entity = [
   | `Agents
   | `Rules
   | `Collators
+  | `Targets
 ]
 
 let entities : (string, entity) List.Assoc.t = [
@@ -133,6 +134,7 @@ let entities : (string, entity) List.Assoc.t = [
   "agents", `Agents;
   "rules", `Rules;
   "collators", `Collators;
+  "targets", `Targets;
 ]
 
 let entity_name = function
@@ -148,6 +150,7 @@ let entity_name = function
   | `Agents -> "agents"
   | `Rules -> "rules"
   | `Collators -> "collators"
+  | `Targets -> "targets"
 
 let entity_desc : (entity * string) list = [
   `Entities, "prints this message";
@@ -294,6 +297,17 @@ let () =
         then Format.printf "  %-24s @[<hov>%a@]@\n" name
             Format.pp_print_text desc);
     Ok ()
+  | `Targets ->
+    let open Bap_core_theory in
+    Theory.Target.families () |> List.iter ~f:(function
+        | parent :: members ->
+          Format.printf "  %s:@\n" (Theory.Target.to_string parent);
+          List.iter members ~f:(fun m ->
+              Format.printf "   - %s@\n"
+                (Theory.Target.to_string m))
+        | _ -> ());
+    Ok ()
+
 
 let () =
   let _unused : (module unit) = (module Bap.Std) in


### PR DESCRIPTION
In this episode, we liberate `bap mc` and `bap objdump` from the bonds
of the `Arch.t` representation. We also add the systemz lifter for
demonstration purposes. Of course, the lifter is minimal and far from
being usable, but that serves well its didactic purposes.

The interface of the `bap mc` command is preserved but is extended
with a few more command-line options that provide a great deal of
flexibility. Not only it is now possible to specify the target and
encoding, but it is now possible to pass options directly to the
backend, which is useful for disassembling targets that are not yet
known to BAP. Below is an excerpt from the bap-mc man page
(see bap mc --help)

```
       SETTING ARCHITECHTURE

       The target architecture is controlled by several groups of options that
       can not be used together:

       - arch;
       - target and encoding;
       - triple, backend, cpu, bits, and order.

       The arch option provides the least control but is easiest to use. It
       relies on the dependency-injection mechanism and lets the target
       support packages (plugins that implement support for the given
       architecture) do their best to guess the target and encoding that
       matches the provided name. Use the common names for the architecture
       and it should work. You can use the bits and order options to give more
       hints to the target support packages. They default to 32 and little
       correspondingly.

       The target and encoding provides precise control over the selection of
       the target and the encoding that is used to represent machine
       instructions. The encoding field can be omitted and will be deduced
       from the target. Use  bap list targets and  bap list encodings to get
       the list of supported targets and encodings respectivly.

       Finally, the triple, backend, cpu,... group of options provides the
       full control over the disassembler backend and bypasses the
       dependency-injection mechanism to pass the specified options directly
       to the corresponding backends. This enables disassembling of targets
       and encodings that are not yet supported by BAP. The meanings of the
       options totally depend on the selected backend and they are passed as
       is to the corresponding arguments of the Disasm_expert.Basic.create
       function. The bits and order defaults to 32 and little corresondingly
       and are used to specify the number of bits in the target's addresses
       and the order of bytes in the word. This group of options is useful
       during the implementation and debugging of new targets and thus is
       reserved for experts. Note, when this group is used the semantics of
       the instructions will not be provided as it commonly requires the
       target specification.
```