### PR TITLE
upgrades bap to LLVM 11

### DIFF
--- a/lib/bap_llvm/llvm_disasm.cpp
+++ b/lib/bap_llvm/llvm_disasm.cpp
@@ -506,7 +506,7 @@ private:
 
     void init_prefixes() {
         for (std::size_t i = 0; i < ins_info->getNumOpcodes(); i++) {
-            if (ends_with(ins_info->getName(i), "_PREFIX")) {
+            if (ends_with(std::string(ins_info->getName(i)), "_PREFIX")) {
                 prefixes.push_back(i);
             }
         }


### PR DESCRIPTION
There were a few breaking changes so we have stick with if/else
macros. Mostly the the COFF loader is affected.

Note, I was using llvm-11 from the http://apt.llvm.org/bionic/ source
repository, which could be broken as it is missing libraries for
static linking, so in order to use this pre-built binaries you have to
use the dynamic linking mode, e.g.,
```
./configure-omake --with-llvm-version=11 \
                  --with-llvm-config=llvm-config-11
                  --disable-llvm-static
```

I hope this will go away with an official (ubuntu) build of llvm.