### PR TITLE
enables poorman submodules for the testsuite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,7 @@ testsuite:
 	git clone https://github.com/BinaryAnalysisPlatform/bap-testsuite.git testsuite
 
 check: testsuite
-	make -C testsuite
-
-veri: testsuite
-	make -C testsuite veri
+	make REVISION=7f51548cc3e -C testsuite
 
 .PHONY: indent check-style status-clean
 


### PR DESCRIPTION
Since we had to reliquish the power of true submodules in #1218 (to
prevent opam from recursively checkout all submodules, including
pre-recorded traces, on each package installation) we were no longer
able to upgrade the testsuite in a preparation for an upcomming PR
without breaking the existing tests. In other words, we need
submodules back.

This PR restores them, but instead of relying on true submodules we
just record the revision in the Makefile and take care of checking out
this revision. Most of the work (not much) is done in the testsuite
repo (i.e., checking the revision out).

The idea is that when we need to extend/change the testsuite for some
PR to the bap repository (e.g., we added a new feature that we would
like to test), we create a branch in bap-testsuite with that change
and reference its SHA in the PR'ed (to the bap repository) Makefile.
Once changes are accepted the corresponding branch to the testsuite
repository could also be merged (preserving commit shas) et
voila. Basically, the same as with submodules but instead of creating
a commit that changes submodule we just need to change the Makefile.