### PR TITLE
fixes Machine.Observation.watch function and publishes fork/switch

### DIFF
--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -352,6 +352,19 @@ module Std : sig
       val finished : unit observation
       [@@deprecated "[since 2020-03] use System.fini or Machine.kill instead"]
 
+      (** [fork (parent,child)] occurs when the machine [parent] forks a
+          new clone [child]. The computation continues in the [child]
+          machine.
+
+          @since 2.2.0 *)
+      val fork : (id * id) observation
+
+      (** [switch (was,now)] occurs when computation switches from
+          the machine [was] to the machine [now].
+
+          @since 2.2.0 *)
+      val switch : (id * id) observation
+
       (** [exn_raised exn] occurs every time an abnormal control flow
           is initiated *)
       val exn_raised : exn observation

--- a/lib/bap_primus/bap_primus_machine.mli
+++ b/lib/bap_primus/bap_primus_machine.mli
@@ -17,3 +17,5 @@ val exn_raised : exn observation
 val kill : id observation
 val start : string observation
 val stop : string observation
+val fork : (id * id) observation
+val switch : (id * id) observation

--- a/lib/bap_primus/bap_primus_observation.ml
+++ b/lib/bap_primus/bap_primus_observation.ml
@@ -30,17 +30,18 @@ type 'a mstream = {
 
 let providers : (string,provider) Hashtbl.t = Hashtbl.create (module String)
 
+
 let provider ?desc ?package name =
   let data,newdata = Stream.create () in
   let triggers,newtrigger = Stream.create () in
   let name = Name.create ?package name in
   let info = Info.create ?desc name in
-  let key = Univ_map.Key.create ~name:("watch-"^Name.show name) ident in
+  let key = Univ_map.Key.create ~name:(Name.show name) ident in
   {info; newdata; data; triggers; newtrigger; observers=0; key}
 
 let update_provider provider ~f =
   Hashtbl.update providers provider ~f:(function
-      | None -> failwith "bug: unregistered provider"
+      | None -> failwithf "bug: unregistered provider: %s" provider ()
       | Some p -> f p)
 
 let register_observer =


### PR DESCRIPTION
The names of providers and observations diverged, which resulted in a
bug. Fixes #1232.

This PR also publishes `Machine.fork` (aka `machine-fork`) and
`Machine.switch` (aka `machine-switch`) observations due to the users
requests.

Thanks @bgz25 for reporting the issue.