### PR TITLE
adds binding operators to the monads library

### DIFF
--- a/lib/monads/monads_monad.ml
+++ b/lib/monads/monads_monad.ml
@@ -82,6 +82,17 @@ module Monad = struct
       include Lift.Syntax
       let (>=>) g f = Fn.compose f g [@@inline]
     end
+
+    module Let = struct
+      let (let*) = (>>=)
+      let (let+) = (>>|)
+      let (and+) x y =
+        x >>= fun x ->
+        y >>| fun y ->
+        (x,y)
+      let (and*) = (and+)
+    end
+
     open Syntax
 
     module Pair = struct
@@ -252,6 +263,7 @@ module Monad = struct
     let sequence = List.sequence
     let rec forever t = bind t (fun _ -> forever t)
     include Syntax
+    include Let
   end
 
   module Make(M : B) : S with type 'a t := 'a M.t =
@@ -433,6 +445,17 @@ module Ident
     let (!$$$$$) = ident
   end
 
+  module Let = struct
+    open Syntax
+    let (let*) = (>>=)
+    let (let+) = (>>|)
+    let (and+) x y =
+      x >>= fun x ->
+      y >>| fun y ->
+      (x,y)
+    let (and*) = (and+)
+  end
+
   module Let_syntax = struct
     include Syntax
     let return = ident
@@ -457,6 +480,7 @@ module Ident
   module Monad_infix = Syntax
   include Let_syntax.Let_syntax
   include Syntax
+  include Let
 end
 
 module OptionT = struct

--- a/lib/monads/monads_types.ml
+++ b/lib/monads/monads_types.ml
@@ -218,6 +218,24 @@ module Monad = struct
       val (!$$$$$) : ('a -> 'b -> 'c -> 'd -> 'e -> 'f) ->
         (('a,'s) t -> ('b,'s) t -> ('c,'s) t -> ('d,'s) t -> ('e,'s) t -> ('f,'s) t)
     end
+
+    module Let = struct
+      module type S = sig
+        type 'a t
+        val (let*) : 'a t -> ('a -> 'b t) -> 'b t
+        val (and*) : 'a t -> 'b t -> ('a * 'b) t
+        val (let+) : 'a t -> ('a -> 'b) -> 'b t
+        val (and+) : 'a t -> 'b t -> ('a * 'b) t
+      end
+
+      module type S2 = sig
+        type ('a,'e) t
+        val (let*) : ('a,'e) t -> ('a -> ('b,'e) t) -> ('b,'e) t
+        val (and*) : ('a,'e) t -> ('b,'e) t -> ('a * 'b, 'e) t
+        val (let+) : ('a,'e) t -> ('a -> 'b) -> ('b,'e) t
+        val (and+) : ('a,'e) t -> ('b,'e) t -> ('a * 'b, 'e) t
+      end
+    end
   end
 
   module type S = sig
@@ -271,7 +289,9 @@ module Monad = struct
 
 
     include Syntax.S with type 'a t := 'a t
+    include Syntax.Let.S with type 'a t := 'a t
     include Monad.S with type 'a t := 'a t
+    module Let : Syntax.Let.S with type 'a t := 'a t
     module Syntax : Syntax.S with type 'a t := 'a t
   end
 
@@ -330,7 +350,9 @@ module Monad = struct
 
 
     include Syntax.S2 with type ('a,'e) t := ('a,'e) t
+    include Syntax.Let.S2 with type ('a,'e) t := ('a,'e) t
     include Monad.S2 with type ('a,'e) t := ('a,'e) t
+    module Let : Syntax.Let.S2 with type ('a,'e) t := ('a,'e) t
     module Syntax : Syntax.S2 with type ('a,'e) t := ('a,'e) t
   end
 end


### PR DESCRIPTION
Instead of extending the `Syntax` module of the `Monad.S` and
`Monad.S2` interface, which will break the interfaces, we add a new
module `Let` which includes binding operators for Monadic and
applicative interfaces (`let*`/`and*` and `let+`/`and+`
correspondingly).

That means that in order to be able to use the monadic operators for
the monad `Example` we need to open either `Example` or `Example.Let`
first, so we can write

```
open Example.Let

let example x y =
  let* r = compute x in
  let+ s = compute y in
  r + s
```

instead of the old style with `fun`,

```
open Example.Syntax

let example x y =
  compute x >>= fun r ->
  compute y >>| fun s ->
  r + s
```

Parallel binding is provided via the `(and*)` and `(and+)` operators,
so it is possible to write

```
open Example.Let

let example x y =
  let* r = compute x in
  and* s = compute y in
  Example.return (r + s)
```