### PR TITLE
fixes warnings introduced with #1116

### DIFF
--- a/lib/bap_c/bap_c_type.ml
+++ b/lib/bap_c/bap_c_type.ml
@@ -79,7 +79,7 @@ type 'a qualifier = 'a Qualifier.t [@@deriving bin_io, compare, sexp]
 module Attr = struct
   type t = {
     name : string;
-    args : string sexp_list;
+    args : string list [@sexp.list];
   } [@@deriving bin_io, compare, sexp]
 end
 
@@ -90,7 +90,7 @@ module Spec = struct
   type ('a,'b) t = {
     qualifier : 'a;
     t : 'b;
-    attrs : attr sexp_list;
+    attrs : attr list [@sexp.list];
   } [@@deriving bin_io, compare, sexp]
 
 end

--- a/lib/bap_plugins/bap_plugins.ml
+++ b/lib/bap_plugins/bap_plugins.ml
@@ -17,10 +17,12 @@ module Plugin = struct
   type t = {
     path : string;
     name : string;
-    bundle : bundle sexp_opaque;
-    loaded : unit future sexp_opaque;
-    finish : unit promise sexp_opaque;
-  } [@@deriving fields, sexp_of]
+    bundle : bundle;
+    loaded : unit future;
+    finish : unit promise;
+  } [@@deriving fields]
+
+  let sexp_of_t {path} = sexp_of_string path
 
   type system_event = [
     | `Opening  of string

--- a/lib/bitvec_binprot/bitvec_binprot.ml
+++ b/lib/bitvec_binprot/bitvec_binprot.ml
@@ -7,5 +7,5 @@ module Functions = Bin_prot.Utils.Make_binable(struct
     type t = Bitvec.t
     let to_binable = Bitvec.to_binary
     let of_binable = Bitvec.of_binary
-  end)
+  end) [@@warning "-D"]
 include Functions

--- a/lib/regular/regular_bytes.ml
+++ b/lib/regular/regular_bytes.ml
@@ -8,6 +8,7 @@ module Binable = Bin_prot.Utils.Make_binable(struct
     let to_binable = Std_bytes.unsafe_to_string
     let of_binable = Std_bytes.of_string
   end)
+[@@warning "-D"]
 
 module Stringable = struct
   type t = Std_bytes.t

--- a/lib/regular/regular_seq.ml
+++ b/lib/regular/regular_seq.ml
@@ -40,7 +40,7 @@ module Binable = Bin_prot.Utils.Make_binable1(struct
     type 'a t = 'a Sequence.t
     let to_binable = Sequence.to_list
     let of_binable = Sequence.of_list
-  end)
+  end)[@@warning "-D"]
 
 include Binable
 let compare_seq = compare


### PR DESCRIPTION
We missed some deprecation warnings in #1116. Most of them are dealing
with `sexp_*` types, which are easy to deal.

Another class of warnings is the deprecation of `Binprot.Of_binable`
due to introduction of uuid-identifiers witnessing the binary
representation. The idea is good and not novel to BAP, we always had
have those uuids. However, right now we're resolving this issue by
hushing the warning and we plan to address it in the nearest future,
in the next release.