### PR TITLE
initializes the default policy in primus taint analyzers

### DIFF
--- a/plugins/primus_systems/systems/core.asd
+++ b/plugins/primus_systems/systems/core.asd
@@ -61,13 +61,17 @@
                 No policy is specified"
   :depends-on (bap:promiscuous-executor)
   :components (bap:taint-primitives
-               bap:taint-signals))
+               bap:taint-signals
+               bap:propagate-taint-by-computation
+               bap:propagate-taint-exact))
 
 (defsystem bap:taint-analyzer
   :description "Uses promiscuous-executor for taint analysis.
-                Propagates taint by computation."
+                The default taint propagation policy is selected
+                using the --primus-taint-select-default-policy
+                option (defaults to propagate-by-computation)"
   :depends-on (bap:base-taint-analyzer)
-  :components (bap:propagate-taint-by-computation))
+  :components (bap:select-default-taint-policy))
 
 
 (defsystem bap:reflective-taint-analyzer
@@ -82,7 +86,7 @@
   :description "Uses promiscuous-executor for taint analysis.
                 Propagates taint exactly."
   :depends-on (bap:base-taint-analyzer)
-  :components (bap:propagate-taint-exact))
+  :components (bap:select-propagate-taint-exact-policy))
 
 
 (defsystem bap:constant-tracker


### PR DESCRIPTION
Fixes #1144. We add three more components for policy selection. One
that selects the policy selected by the user via the command-line and
another two per each policy that we support. The base-taint-analyzer
system is leaving the policy selection unspecified. The taint-analyzer
system selects the policy based on the command-line parameter and teh
exact-taint-analyzer is relying on the exact taint propagation.