### PR TITLE
fixes improper compartmentalization of project computations

### DIFF
--- a/lib/bap/bap_project.ml
+++ b/lib/bap/bap_project.ml
@@ -398,13 +398,13 @@ let create
     Signal.send Info.got_code code;
     Signal.send Info.got_spec spec;
     let run k =
+      let k = KB.(set_package package >>= fun () -> k) in
       State.Toplevel.run spec target ~code ~memory file k in
     let state = match state with
       | Some state -> state
       | None ->
         let compute_state =
           let open KB.Syntax in
-          set_package package >>= fun () ->
           Theory.Unit.for_file file >>= fun unit ->
           KB.collect State.slot unit >>= fun state ->
           if KB.Domain.is_empty (KB.Slot.domain State.slot) state


### PR DESCRIPTION
This PR fixes a bug reported by @jtpaash (with a nicely reproducible
demo). The bug was introduced when we switched to lazy computations so
that now symtab and program data structures computations were delayed
and could be run in a different state than the disassembly. The main
culprit was that those computations were forgetting to properly open
the current package to be able to access the objects of the currently
disassembled program (they were instead picking those objects from the
lastly disassembled program). Fortunately the fix is obvious and
simple.