### PR TITLE
fixes bapbuild by removing no longer necessary predicates

### DIFF
--- a/lib/bap_build/bap_build.ml
+++ b/lib/bap_build/bap_build.ml
@@ -12,8 +12,6 @@ module Plugin_rules = struct
 
   let default_packages = ["bap"; "core_kernel"; "ppx_bap"]
   let default_predicates = [
-    "custom_ppx";
-    "ppxlib";
   ]
 
   let default_tags = [


### PR DESCRIPTION
Apparently those predicates are no longer needed and are mishandled by
ppx_bap. Probably we should also inherit some META-magic from
ppx_jane.

Note, with these predicates `type nonrec t = t [@@deriving]` no longer
works.