### PR TITLE
enables intermachine communication

### DIFF
--- a/lib/bap_primus/bap_primus_env.ml
+++ b/lib/bap_primus/bap_primus_env.ml
@@ -121,6 +121,10 @@ module Make(Machine : Machine) = struct
           Machine.Observation.make on_generated (var,x) >>| fun () ->
           x
 
+  let is_set var =
+    Machine.Local.get state >>| fun t ->
+    Map.mem t.values var
+
   let has var =
     Machine.Local.get state >>| fun t ->
     Map.mem t.values var || Map.mem t.random var

--- a/lib/bap_primus/bap_primus_env.mli
+++ b/lib/bap_primus/bap_primus_env.mli
@@ -14,4 +14,5 @@ module Make(Machine : Machine) : sig
   val del : var -> unit Machine.t
   val has : var -> bool Machine.t
   val all : var seq Machine.t
+  val is_set : var -> bool Machine.t
 end

--- a/lib/bap_primus/bap_primus_types.ml
+++ b/lib/bap_primus/bap_primus_types.ml
@@ -70,8 +70,15 @@ module type Machine = sig
                                      (exit_status * project) m effect
   module Local  : State with type 'a m := 'a t
                          and type 'a t := 'a state
+
   module Global : State with type 'a m := 'a t
                          and type 'a t := 'a state
+
+  module Other : sig
+    val get : id -> 'a state -> 'a t
+    val put : id -> 'a state -> 'a -> unit t
+    val update : id -> 'a state -> f:('a -> 'a) -> unit t
+  end
 
   val raise : exn -> 'a t
   val catch : 'a t -> (exn -> 'a t) -> 'a t


### PR DESCRIPTION
This PR adds a new interface, `Machine.Other`, that enables access to
the local state of other machines. It is possible both to pry into
others local state and even change it. So is it carefuly.

This PR is a step towards the solution of the #1076 issue. More will
come.