### PR TITLE
propagates stub resolver results to program term attributes

### DIFF
--- a/plugins/stub_resolver/stub_resolver.mli
+++ b/plugins/stub_resolver/stub_resolver.mli
@@ -3,6 +3,12 @@ open Bap.Std
 open Bap_core_theory
 open Bap_knowledge
 
+type t
+
 (** [run prog] - returns the mapping from
     stubs to implementations *)
-val run : program term -> tid Tid.Map.t
+val run : program term -> t
+
+val stubs : t -> Set.M(Tid).t
+
+val links : t -> tid Map.M(Tid).t

--- a/plugins/stub_resolver/stub_resolver_tests.ml
+++ b/plugins/stub_resolver/stub_resolver_tests.ml
@@ -121,7 +121,7 @@ let run name symbols expected should_fail _ctxt =
           Map.add_exn tids
             (tid_for_name_exn prog stub)
             (tid_for_name_exn prog impl)) in
-  let pairs = Stub_resolver.run prog in
+  let pairs = Stub_resolver.(links@@run prog) in
   let equal = Map.equal Tid.equal expected pairs in
   assert_bool name (equal || should_fail)
 


### PR DESCRIPTION
The stub resolver wasn't setting the Sub.stub attribute for
subroutines resolved as stubs. Now it is done as a part of the abi
pass that relinks stubs to their implementations.