### PR TITLE
protects symbolic executor from segfaults when setting memory inputs

### DIFF
--- a/plugins/primus_symbolic_executor/primus_symbolic_executor_main.ml
+++ b/plugins/primus_symbolic_executor/primus_symbolic_executor_main.ml
@@ -94,7 +94,7 @@ end = struct
         let name = Primus.Memory.Descriptor.name bank in
         Machine.Global.get memories >>= fun memories ->
         match Map.find memories name with
-        | None -> Machine.return ()
+        | None -> allocate bank addr addr
         | Some {lower; upper} -> allocate bank lower upper
 
     let set input value = match input with


### PR DESCRIPTION
Do not fail when memory location wasn't explicitly set as symbolic but
just register it on the fly.