### PR TITLE
adds the testing repository to several actions

### DIFF
--- a/.github/workflows/build-from-opam.yml
+++ b/.github/workflows/build-from-opam.yml
@@ -24,6 +24,7 @@ jobs:
 
         - name: Add the testing Repository
           run: opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
+
         - name: Install system dependencies
           run: opam depext -u bap
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: release
 on:
   schedule:
     - cron: '0 0 * * SAT' # every Saturday
+  workflow_dispatch:
 
 jobs:
   build:
@@ -22,6 +23,8 @@ jobs:
            with:
              ocaml-version: 4.11.1+flambda
 
+        - name: Add the testing Repository
+          run: opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
          - name: Build deb packages
            run: ./tools/release.sh ${{ env.VERSION }}
 


### PR DESCRIPTION
Since we're depending on the master version of the ppx_bap package,
which is only available in our testing repository.

Also enables on-demand build for the release action.