### PR TITLE
updates bapdoc to the latest changes in core_kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build: setup.ml
 
 .PHONY: doc
 doc:
-	@ocamlbuild -pkgs bap,bap-plugins,core_kernel tools/bapdoc.native
+	@ocamlbuild -pkgs bap,bap-plugins,core_kernel,core_kernel.caml_unix tools/bapdoc.native
 	make -C doc
 
 all:

--- a/tools/bapdoc.ml
+++ b/tools/bapdoc.ml
@@ -4,7 +4,7 @@ open Core_kernel
 open Poly
 open Bap_plugins.Std
 
-
+module Unix = Caml_unix
 module Filename = Caml.Filename
 
 let libraries = [


### PR DESCRIPTION
re-enables back the hidden Unix module