### PR TITLE
updates bapdoc to the latest changes in core_kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build: setup.ml
 
 .PHONY: doc
 doc:
-	@ocamlbuild -pkgs bap,bap-plugins,core_kernel tools/bapdoc.native
+	@ocamlbuild -pkgs bap,bap-plugins,core_kernel,core_kernel.caml_unix tools/bapdoc.native
 	make -C doc
 
 all:

--- a/tools/bapdoc.ml
+++ b/tools/bapdoc.ml
@@ -4,7 +4,7 @@ open Core_kernel
 open Poly
 open Bap_plugins.Std
 
-
+module Unix = Caml_unix
 module Filename = Caml.Filename
 
 let libraries = [


### PR DESCRIPTION
re-enables back the hidden Unix module

That PR still doesn't fix the documentation building process, as we are failing with a stack overflow error. Trying to build with the master branch of odoc also didn't give any positive results. See https://github.com/ocaml/odoc/issues/539 for more information on the issue.