### PR TITLE
adds bap-references and uses them in plugins to access relocations

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -44,6 +44,7 @@ B lib/bap
 B lib/bap_main
 B lib/bap_recipe
 B lib/bap_relation
+B lib/bap_references
 B lib/bap_abi
 B lib/bap_api
 B lib/bitvec

--- a/lib/bap_references/bap_references.ml
+++ b/lib/bap_references/bap_references.ml
@@ -1,0 +1,100 @@
+open Bap_knowledge
+open Core_kernel
+open Bap.Std
+open Bap_core_theory
+
+
+open Image.Scheme
+open Ogre.Syntax
+
+module Bitvec = struct
+  include Bitvec
+  include Bitvec_sexp.Functions
+end
+
+
+module Refs = Map.Make(Bitvec)
+
+type ref =
+  | Addr of Bitvec.t
+  | Name of string
+[@@deriving compare, sexp, equal]
+
+type value = Ref of ref | Bad [@@deriving compare, sexp, equal]
+type t = value Refs.t [@@deriving sexp_of, equal]
+
+
+let empty = Refs.empty
+
+let slot = KB.Class.property Theory.Unit.cls "refs"
+    ~package:"bap"
+    ~public:true
+    ~desc:"external references" @@
+  KB.Domain.flat ~empty "refs"
+    ~inspect:sexp_of_t
+    ~equal
+
+let chop_version s =
+  match String.lfindi s ~f:(fun _ -> Char.equal '@') with
+  | None | Some 0 -> s
+  | Some len -> String.subo ~len s
+
+
+let arch =
+  let open Ogre.Syntax in
+  Ogre.request Image.Scheme.arch >>| function
+  | None -> `unknown
+  | Some arch -> match Arch.of_string arch with
+    | None -> `unknown
+    | Some arch -> arch
+
+let width = Ogre.(arch >>| Arch.addr_size >>| Size.in_bits)
+
+let collect init merge map src =
+  width >>| Bitvec.modulus >>= fun m ->
+  Ogre.collect Ogre.Query.(select (from src)) >>|
+  Seq.fold ~init ~f:(fun exts (addr, value) ->
+      Map.update exts Bitvec.(int64 addr mod m) ~f:(function
+          | None -> map m value
+          | Some value' -> merge m value' value))
+
+let name _ x = Ref (Name (chop_version x))
+and addr m x = Ref (Addr Bitvec.(int64 x mod m))
+
+let merge_name m x y =
+  let y = name m y in
+  match x with
+  | Bad -> Bad
+  | Ref (Addr _) as y -> y
+  | Ref (Name _) as x ->
+    if compare_value x y = 0 then y else Bad
+
+let merge_addr m x y =
+  let y = addr m y in
+  match x with
+  | Bad -> Bad
+  | Ref (Addr _) as x when compare_value x y <> 0 -> Bad
+  | _ -> y
+
+let extract =
+  collect empty merge_name name external_reference >>= fun names ->
+  collect names merge_addr addr relocation
+
+let create doc = match Ogre.eval extract doc with
+  | Ok exts -> exts
+  | Error _ -> empty
+
+let lookup exts addr = match Map.find exts addr with
+  | Some Bad -> None
+  | Some Ref x -> Some x
+  | None -> None
+
+let provide_from_spec () =
+  let open KB.Rule in
+  declare ~package:"bap" "refs-of-spec" |>
+  require Image.Spec.slot |>
+  provide slot |>
+  comment "extracts external references from the specification";
+  let open KB.Syntax in
+  KB.promise slot @@ fun unit ->
+  KB.collect Image.Spec.slot unit >>| create

--- a/lib/bap_references/bap_references.mli
+++ b/lib/bap_references/bap_references.mli
@@ -1,0 +1,14 @@
+open Bap_core_theory
+
+type t
+
+type ref =
+  | Addr of Bitvec.t
+  | Name of string
+[@@deriving compare, sexp, equal]
+
+val slot : (Theory.Unit.cls, t) KB.slot
+
+val lookup : t -> Bitvec.t -> ref option
+
+val provide_from_spec : unit -> unit

--- a/oasis/bil
+++ b/oasis/bil
@@ -8,6 +8,7 @@ Library bil_plugin
   Build$:           flag(everything) || flag(bil)
   FindlibName:      bap-plugin-bil
   BuildDepends:     bap, bap-core-theory, bap-knowledge, core_kernel,
-                    ppx_bap, bap-future, monads, bitvec, bitvec-order, ogre, bap-main
+                    ppx_bap, bap-future, monads, bitvec, bitvec-order, ogre,
+                    bap-main, bap-references
   XMETAExtraLines:  tags="bil,analysis,semantics"
   InternalModules:  Bil_main, Bil_lifter, Bil_semantics, Bil_ir, Bil_float

--- a/oasis/references
+++ b/oasis/references
@@ -1,0 +1,11 @@
+Flag references
+  Description: Build the references library
+  Default: false
+
+Library bap_references
+  Build$:       flag(everything) || flag(references)
+  Path:         lib/bap_references
+  FindlibName:  bap-references
+  BuildDepends: core_kernel, bap, bap-core-theory, bap-knowledge,
+                bitvec, bitvec-sexp, ogre, ppx_bap
+  Modules:      Bap_references

--- a/oasis/relocatable
+++ b/oasis/relocatable
@@ -10,5 +10,5 @@ Library relocatable_plugin
   InternalModules: Rel_symbolizer
   BuildDepends:    bap, ogre, bap-knowledge, core_kernel, monads,
                    bitvec, bitvec-order, bitvec-sexp, bap-core-theory, ppx_bap,
-                   bap-main, bap-arm, bap-powerpc, bap-x86-cpu
+                   bap-main, bap-arm, bap-powerpc, bap-x86-cpu, bap-references
   XMETAExtraLines: tags="brancher, loader, ogre"


### PR DESCRIPTION
We were using the futures interface to acccess relocation information
stored in the ogre specification. That doesn't play nice with multiple
projects (well, at least in the way that it was implemented). Since the
references are already computed and stored in the knowledge base in
the relocatable plugin we can reuse them also in the BIL plugin. We
just need to make this library public.

Really fixes #1216 (the previous fix didn't really work)

TODO
- [ ] add documentation to bap-references
- [ ] add library to opam-repository