### PR TITLE
fixes nightly tests

### DIFF
--- a/.github/workflows/nightly-testing.yml
+++ b/.github/workflows/nightly-testing.yml
@@ -38,12 +38,15 @@ jobs:
         - name: Install System Dependencies
           run: opam depext -u bap
 
+        - name: Install radare2 Dependencies
+          run: opam depext -u bap-radare2
+
         - name: Cleanup the Caches
           if: matrix.os == 'ubuntu-latest'
           run: sudo apt clean --yes
 
         - name: Build and Install BAP
-          run: opam install bap
+          run: opam install bap bap-radare2
 
         - name: Checkout the Tests
           uses: actions/checkout@v2


### PR DESCRIPTION
The tests are requiring the presence of radare (for the sole purpose
of disabling radare), therefore they were failing since when we excluded
bap-radare2 from the default distribution of bap. The solution is
simple just install bap-radare. As a nice side-effect we will also
test that radare2 is properly installed.