### PR TITLE
fixes PE/COFF sections

### DIFF
--- a/.github/workflows/build-dev-repo.yml
+++ b/.github/workflows/build-dev-repo.yml
@@ -42,6 +42,8 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           rm -rf /usr/local/bin/2to3
+          brew unlink gcc@8
+          brew unlink gcc@9
           brew update
           brew upgrade
           echo 'LLVM_CONFIG=/usr/local/opt/llvm@9/bin/llvm-config' >> $GITHUB_ENV

--- a/.github/workflows/nightly-testing.yml
+++ b/.github/workflows/nightly-testing.yml
@@ -30,6 +30,8 @@ jobs:
           if: matrix.os == 'macos-latest'
           run: |
             rm -rf /usr/local/bin/2to3
+            brew unlink gcc@8
+            brew unlink gcc@9
             brew update
             brew upgrade
             echo 'LLVM_CONFIG=/usr/local/opt/llvm@9/bin/llvm-config' >> $GITHUB_ENV

--- a/lib/bap_llvm/bap_llvm_loader.ml
+++ b/lib/bap_llvm/bap_llvm_loader.ml
@@ -280,16 +280,17 @@ let provide_coff_segmentation = [
   foreach_by_name Ogre.Query.(from
                                 LLVM.section_entry
                               $ LLVM.coff_virtual_section_header
-                              $ LLVM.section_flags
-                              $ LLVM.code_entry) @@
-  fun (name, _, size, start) (_,addr,vsize) (_,(r,w,x)) (_,off,_) ->
+                              $ LLVM.section_flags) @@
+  fun (name, _, size, start) (_,addr,vsize) (_,(r,w,x)) ->
   let addr = Int64.(addr + bias) in [
     Ogre.provide segment addr vsize r w x;
     Ogre.provide mapped addr size start;
-    Ogre.provide code_region addr vsize off;
     Ogre.provide section addr vsize;
     Ogre.provide named_region addr vsize name;
-  ]
+  ] @ provide_if x [
+      Ogre.provide code_region addr vsize start;
+    ]
+
 ]
 
 let overload file_type info =

--- a/lib/bap_llvm/llvm_coff_loader.hpp
+++ b/lib/bap_llvm/llvm_coff_loader.hpp
@@ -35,10 +35,13 @@ void emit_section(const coff_section &sec, uint64_t base, bool is_rel, ogre_doc 
     uint64_t vsize = is_rel ? sec.SizeOfRawData : sec.VirtualSize;
     uint64_t fsize = sec.SizeOfRawData;
     uint64_t off = sec.PointerToRawData;
-    s.entry("llvm:section-entry") << sec.Name << vaddr << fsize << off;
-    s.entry("llvm:coff-virtual-section-header") << sec.Name << vaddr << vsize;
-    s.entry("llvm:section-flags") << sec.Name << r << w << x;
-    if (x) s.entry("llvm:code-entry") << sec.Name << off << fsize;
+    if (!is_rel || x) { // hush non-executable sections for object files, as they
+                        // all have the same address
+        s.entry("llvm:section-entry") << sec.Name << vaddr << fsize << off;
+        s.entry("llvm:coff-virtual-section-header") << sec.Name << vaddr << vsize;
+        s.entry("llvm:section-flags") << sec.Name << r << w << x;
+        if (x) s.entry("llvm:code-entry") << sec.Name << off << fsize;
+    }
 }
 
 error_or<uint64_t> symbol_file_offset(const coff_obj &obj, const SymbolRef &sym);


### PR DESCRIPTION
We were missing non-executable sections in coff files. Thanks to
@TodAmon and @ReversingWithMe for noticing this.