### PR TITLE
adds the `--target` parameter to disassemble and compare commands

### DIFF
--- a/lib/bap/bap_project.ml
+++ b/lib/bap/bap_project.ml
@@ -226,7 +226,7 @@ module Input = struct
     | LT | EQ -> target'
     | GT -> target
     | NC -> invalid_argf "the derived target %s is incompatible \
-                          with the target specified by the user - %s"
+                          with the user-specified target %s."
               (Theory.Target.to_string target')
               (Theory.Target.to_string target) ()
 


### PR DESCRIPTION
The target command-line parameter specializes (refines) the target
architecture of the disassembled binary, in order to specify abi,
fabi, and other target-specific parameters.

If the specified target is less specific than the binarie's target
then it will be ignored, if it is incompatible then an error will
occur.

Example, `arm-linux-gnueabi-echo` binary from `testsuite/bin` is a
binary built for bap:armv5+le, so we can refine it by adding an
application profile and floating-points (see `bap list targets` for
the full list of targets),

```
$ bap bin/arm-linux-gnueabi-echo --target=armv7-a+fp+le
```

At the same time if we will try to specify `amd64` or even an arm
but that is not derived from `armv5+le`, we will get an error, e.g.,

```
$ bap bin/arm-linux-gnueabi-echo --target=armv7-a+fp+eb
Failed to build the project: the derived target bap:armv5+le is incompatible
with the user-specified target bap:armv7-a+fp+eb.
```