### PR TITLE
enables writing program semantics (lifting) in Primus Lisp

### DIFF
--- a/lib/bap_core_theory/bap_core_theory_target.ml
+++ b/lib/bap_core_theory/bap_core_theory_target.ml
@@ -184,15 +184,17 @@ let declare
   t
 
 let lookup ?package name =
-  let name = Self.read ?package name in
-  if Hashtbl.mem targets name then Some name
-  else None
+  try Some (Self.read ?package name)
+  with _exn -> None
 
 let get ?package name =
-  let name = Self.read ?package name in
-  if not (Hashtbl.mem targets name)
-  then invalid_argf "Unknown target %s" (Self.to_string name) ();
-  name
+  match lookup ?package name with
+  | None ->
+    invalid_argf
+      "Unknown target %s. \
+       Use `bap list targets' for the list of targets"
+      name ();
+  | Some t -> t
 
 let read = get
 

--- a/lib/bap_primus/bap_primus_lisp_attribute.mli
+++ b/lib/bap_primus/bap_primus_lisp_attribute.mli
@@ -8,26 +8,41 @@
 *)
 
 open Bap_primus_lisp_types
+open Bap_core_theory
 
 type 'a t
-
 type set
 
 type error = ..
 exception Unknown_attr of string * tree
-exception Bad_syntax of error * tree list
+exception Failure of error * tree list
 
-(** registers a new attribute. An attribute is a monoind that is
-    parsed from a sexp and added to existing attribute of the same
-    kind.*)
-val register :
-  name:string ->
-  add:('a -> 'a -> 'a) ->
-  parse:(tree list -> 'a) -> 'a t
+val declare :
+  ?desc:string ->
+  ?package:string ->
+  domain:'a KB.domain ->
+  parse:(tree list -> 'a) ->
+  string -> 'a t
+
 
 val parse : set -> tree -> set
 
 module Set : sig
-  val get : set -> 'a t -> 'a option
-  val empty : set
+  include KB.Value.S with type t := set
+  val get : 'a t -> set -> 'a
+  val slot : (Theory.program, set) KB.slot
+end
+
+module Parse : sig
+  type nonrec tree = tree
+  type nonrec error = error = ..
+  type error += Expect_atom | Expect_list
+
+  val atom : tree -> string option
+  val list : tree -> tree list option
+  val tree :
+    atom:(string -> 'a) ->
+    list:(tree list -> 'a) ->
+    tree -> 'a
+  val fail : error -> tree list -> _
 end

--- a/lib/bap_primus/bap_primus_lisp_attributes.mli
+++ b/lib/bap_primus/bap_primus_lisp_attributes.mli
@@ -4,12 +4,12 @@ open Bap_primus_lisp_types
 module Attribute = Bap_primus_lisp_attribute
 
 module External : sig
-  val t : string list Attribute.t
+  val t : String.Set.t Attribute.t
 end
 
 module Variables : sig
-  val global : var list Attribute.t
-  val static : var list Attribute.t
+  val global : Set.M(Bap_primus_lisp_var).t Attribute.t
+  val static : Set.M(Bap_primus_lisp_var).t Attribute.t
 end
 
 module Advice : sig

--- a/lib/bap_primus/bap_primus_lisp_context.mli
+++ b/lib/bap_primus/bap_primus_lisp_context.mli
@@ -235,6 +235,7 @@
 *)
 
 open Core_kernel
+open Bap_core_theory
 open Bap.Std
 
 module Attribute = Bap_primus_lisp_attribute
@@ -251,40 +252,8 @@ val create : (string * string list) list -> t
 
 val empty : t
 
-
-
-(** [cx <= cx'] is true if [cx] is same as [cx'] or if [cx] is more
-    specific. Where a context [c] is the same as context [c'] if [c]
-    is as specific as [c'], i.e., no more, no less.
-
-    This is a partial order relation, i.e., it is possible that both
-    contexts are neither same, nor one is less than of another, nor
-    vice verse.
-
-    Examples:
-
-    {v
-
-    ((arch arm v7)) <= ((arch arm)) => true
-    ((arch arm v7) (compiler gcc)) <= ((arch arm)) => false
-    v}
-*)
+val order : t -> t -> KB.Order.partial
 val (<=) : t -> t -> bool
-
-
-(** Partial ordering between context classes.
-
-    We define thepartial order in terms of how generic is a
-    definition.
-
-*)
-type porder =
-  | Less     (** less generic:     c1 <= c2  && not(c2 <= c1) *)
-  | Same     (** exactly the same: c1 <= c2  &&   c2 <= c1  *)
-  | Equiv    (** not comparable :  not(c1 <= c2) && not(c2 <= c1) *)
-  | More     (** more generic :  not(c1 <= c2) &&   c2 <= c1  *)
-
-val compare : t -> t -> porder
 val pp : Format.formatter -> t -> unit
 
 val merge : t -> t -> t

--- a/lib/bap_primus/bap_primus_lisp_parse.ml
+++ b/lib/bap_primus/bap_primus_lisp_parse.ml
@@ -239,7 +239,7 @@ module Parse = struct
 
   let parse_declaration attrs tree =
     try Attribute.parse attrs tree
-    with Attribute.Bad_syntax (err,trees) ->
+    with Attribute.Failure (err,trees) ->
       raise (Attribute_parse_error (err,trees,tree))
 
   let parse_declarations attrs =
@@ -284,11 +284,9 @@ module Parse = struct
     | _ -> false
 
   let constrained prog attrs =
-    match Attribute.Set.get attrs Context.t with
-    | None -> prog
-    | Some constraints ->
-      Program.with_context prog @@
-      Context.merge (Program.context prog) constraints
+    Program.with_context prog @@
+    Context.merge (Program.context prog) @@
+    Attribute.Set.get Context.t attrs
 
   let defun ?docs ?(attrs=[]) name p body prog gattrs tree =
     let attrs = parse_declarations gattrs attrs in

--- a/lib/bap_primus/bap_primus_lisp_program.ml
+++ b/lib/bap_primus/bap_primus_lisp_program.ml
@@ -1057,10 +1057,10 @@ module Typing = struct
 
   let applicable global =
     List.filter ~f:(fun def ->
-        match Lisp.Attribute.Set.get
-                (Def.attributes def) Lisp.Context.t with
-        | None -> true
-        | Some def_ctxt -> Lisp.Context.(global <= def_ctxt))
+        let def_ctxt =
+          Lisp.Attribute.Set.get Lisp.Context.t
+            (Def.attributes def) in
+        Lisp.Context.(def_ctxt <= global))
 
   let find_signal (sigs : Def.signal Def.t list) name =
     List.find sigs ~f:(fun s -> String.equal (Def.name s) name)
@@ -1118,6 +1118,15 @@ module Typing = struct
       program = empty;
       gamma = Gamma.empty;
     }
+
+    let program env = env.program
+
+    let equal x y = equal x.program y.program
+    let merge x y = {
+      program = merge x.program y.program;
+      gamma = Gamma.merge x.gamma y.gamma;
+    }
+
 
     let infer ?(externals=[]) vars program =
       let program = Reindex.program program in

--- a/lib/bap_primus/bap_primus_lisp_program.mli
+++ b/lib/bap_primus/bap_primus_lisp_program.mli
@@ -36,7 +36,10 @@ module Type : sig
   type env
   type error
   val empty : env
+  val equal : env -> env -> bool
+  val merge : env -> env -> env
   val infer : ?externals:(string * signature) list -> Var.t seq -> program -> env
+  val program : env -> program
   val check : Var.t seq -> program -> error list
   val errors : env -> error list
   val pp_error : Format.formatter -> error -> unit

--- a/lib/bap_primus/bap_primus_lisp_semantics.ml
+++ b/lib/bap_primus/bap_primus_lisp_semantics.ml
@@ -1,29 +1,46 @@
 open Core_kernel
 open Bap.Std
 open Bap_core_theory
+open Monads.Std
 
 open Bap_primus_lisp_types
+open Bap_primus_lisp_attributes
 
+module Attribute = Bap_primus_lisp_attribute
 module Program = Bap_primus_lisp_program
+module Source = Bap_primus_lisp_source
 module Resolve = Bap_primus_lisp_resolve
 module Def = Bap_primus_lisp_def
-module Check = Bap_primus_lisp_type.Check
+module Type = Bap_primus_lisp_type
 module Key = Bap_primus_lisp_program.Items
 
-open KB.Syntax
-open KB.Let
+module Meta = struct
+  module State = struct
+    type t = {
+      binds : unit Theory.Value.t Map.M(Theory.Var.Top).t;
+      arith : (module Bitvec.S);
+      scope : unit Theory.var list Map.M(Theory.Var.Top).t;
+    }
+  end
+  include Monad.State.T1(State)(KB)
+  include Monad.State.Make(State)(KB)
+end
 
-
-type words
+open Meta.Syntax
+open Meta.Let
 
 type value = unit Theory.Value.t
 type effect = unit Theory.Effect.t
 
-type KB.Conflict.t += Unresolved_definition of Resolve.resolution
+type KB.Conflict.t += Unresolved_definition of string
 
-let language = Theory.Language.declare ~package:"bap" "primus-lisp"
+let package = "bap"
+let language = Theory.Language.declare ~package "primus-lisp"
 
-let program = KB.Class.property Theory.Source.cls "primus-lisp-program" @@
+let program =
+  KB.Class.property Theory.Source.cls "primus-lisp-program"
+    ~public:true
+    ~package @@
   KB.Domain.flat "lisp-program"
     ~empty:Program.empty
     ~equal:Program.equal
@@ -32,35 +49,96 @@ let program = KB.Class.property Theory.Source.cls "primus-lisp-program" @@
         let r = Format.asprintf "%a" Program.pp p in
         Sexp.Atom r)
 
+let typed = KB.Class.property Theory.Source.cls "typed-program"
+    ~package @@
+  KB.Domain.flat "typed-lisp-program"
+    ~empty:Program.Type.empty
+    ~equal:Program.Type.equal
+    ~join:(fun x y -> Ok (Program.Type.merge x y))
 
-let lookup prog item name = match Resolve.semantics prog item name () with
+let fail s = Meta.lift (KB.fail s)
+
+let unresolved problem =
+  let msg = Format.asprintf "%a" Resolve.pp_resolution problem in
+  fail (Unresolved_definition msg)
+
+let resolve prog item name =
+  match Resolve.semantics prog item name () with
   | None -> !!None
-  | Some (Error problem) ->
-    KB.fail (Unresolved_definition problem)
+  | Some (Error problem) -> unresolved problem
   | Some (Ok (fn,_)) -> !!(Some fn)
 
-module Primitive = struct
-  type t = {
-    name : string;
-    args : Theory.Value.Top.t list;
-  } [@@deriving compare, equal, sexp]
-  let name p = p.name
-  let args p = p.args
+let check_arg _ _ = true
 
-  let slot = KB.Class.property Theory.Program.cls "lisp-primitive" @@
-    KB.Domain.optional "lisp-primitive"
-      ~equal
-      ~inspect:sexp_of_t
+let is_external def =
+  not @@ Set.is_empty (Attribute.Set.get External.t (Def.attributes def))
 
-  let eval name args =
-    KB.Object.scoped Theory.Program.cls @@ fun obj ->
-    KB.provide slot obj (Some {name;args}) >>= fun () ->
-    KB.collect Theory.Semantics.slot obj
+type info = {
+  types : (Theory.Target.t -> Type.signature);
+  docs : string;
+}
+
+let library = Hashtbl.create (module String)
+
+module Property = struct
+  let name = KB.Class.property Theory.Program.cls ~package "lisp-name" @@
+    KB.Domain.optional "lisp-name"
+      ~equal:String.equal
+      ~inspect:sexp_of_string
+
+  type args = Theory.Value.Top.t list [@@deriving equal, sexp]
+
+
+  type KB.conflict += Unequal_arity
+
+  let args = KB.Class.property Theory.Program.cls ~package "lisp-args" @@
+    KB.Domain.optional "lisp-args"
+      ~equal:equal_args
+      ~inspect:sexp_of_args
+      ~join:(fun xs ys ->
+          List.map2 xs ys ~f:(KB.Domain.join Theory.Value.Top.domain) |>
+          function
+          | Ok rs -> Result.all rs
+          | Unequal_lengths -> Error Unequal_arity)
 end
 
-let primitive = Primitive.slot
+let definition =
+  KB.Class.property Theory.Program.cls "lisp-definition"
+    ~package
+    ~public:true
+    ~persistent:(KB.Persistent.of_binable (module struct
+                   type t = Theory.Label.t option [@@deriving bin_io]
+                 end)) @@
+  KB.Domain.optional "label"
+    ~equal:Theory.Label.equal
+    ~inspect:Theory.Label.sexp_of_t
 
-type primitive = Primitive.t
+
+let primitive defn name args =
+  let open KB.Syntax in
+  KB.Object.scoped Theory.Program.cls @@ fun obj ->
+  KB.sequence [
+    KB.provide Property.name obj (Some name);
+    KB.provide definition obj (Some defn);
+    KB.provide Property.args obj (Some args);
+  ] >>= fun () ->
+  KB.collect Theory.Semantics.slot obj
+
+let declare
+    ?(types=fun _ -> Type.{
+        args = [];
+        rest = Some any;
+        ret = any;
+      })
+    ?(docs="undocumented") name =
+  if Hashtbl.mem library name
+  then invalid_argf "A primitive `%s' already exists, please \
+                     choose a different name for your primitive" name ();
+  Hashtbl.add_exn library name {
+    docs;
+    types
+  }
+
 
 let sort = Theory.Value.sort
 let size x = Theory.Bitv.size (sort x)
@@ -71,7 +149,6 @@ let forget = Theory.Value.forget
 let create eff res =
   KB.Value.put Theory.Semantics.value eff (forget res)
 
-let res = KB.Value.get Theory.Semantics.value
 
 let symbol =
   KB.Class.property Theory.Value.cls "lisp-symbol" @@
@@ -79,39 +156,180 @@ let symbol =
     ~equal:String.equal
     ~inspect:(fun x -> Sexp.Atom x)
 
-let static =
-  KB.Class.property Theory.Value.cls "static-value" @@
+
+let static_slot =
+  KB.Class.property Theory.Value.cls "static-value"
+    ~package
+    ~public:true
+    ~persistent:(KB.Persistent.of_binable (module struct
+                   type t = Bitvec_binprot.t option [@@deriving bin_io]
+                 end)) @@
   KB.Domain.optional "bitvec"
     ~equal:Bitvec.equal
     ~inspect:(fun x -> Sexp.Atom (Bitvec.to_string x))
 
+
+
+let update_value r f =
+  let v = KB.Value.get Theory.Semantics.value r in
+  KB.Value.put Theory.Semantics.value r (f v)
+
+let set_static r x = update_value r @@ fun v ->
+  KB.Value.put static_slot v (Some x)
+
+let symsort = Bap_primus_value.Index.key_width
+let res = KB.Value.get Theory.Semantics.value
+let bits = Theory.Bitv.define
+let static x =
+  KB.Value.get static_slot (res x)
+
+let (!) = KB.(!!)
+
+let empty = Theory.Effect.empty Theory.Effect.Sort.bot
+
+let sym str =
+  let v = update_value empty @@ fun v ->
+    KB.Value.put symbol v (Some str) in
+  match str with
+  | "nil" -> Meta.return@@set_static v Bitvec.zero
+  | name ->
+    Meta.lift @@
+    KB.Symbol.intern name Theory.Value.cls >>|
+    KB.Object.id >>| Int63.to_int64 >>|
+    Bitvec.M64.int64 >>|
+    set_static v
+
+let is_machine_var t v =
+  Set.mem (Theory.Target.vars t) (Theory.Var.forget v)
+
+let machine_var_by_name t name =
+  Set.find (Theory.Target.vars t) ~f:(fun v ->
+      String.equal (Theory.Var.name v) name)
+
+let make_var ?t:constr target name  =
+  let word = Theory.Target.bits target in
+  match machine_var_by_name target name with
+  | Some v -> v
+  | None ->
+    let t = Option.value constr ~default:word in
+    Theory.Var.forget@@Theory.Var.define (bits t) name
+
+let lookup_parameter prog v =
+  let name = Theory.Var.name v in
+  Program.get prog Key.para |>
+  List.find ~f:(fun p ->
+      String.equal (Def.name p) name) |> function
+  | None -> None
+  | Some p -> Some (Def.Para.default p)
+
+let is_parameter prog v = Option.is_some (lookup_parameter prog v)
+
+module Env = struct
+  open Meta.State
+
+  let lookup v =
+    let v = Theory.Var.forget v in
+    Meta.get () >>| fun {binds} ->
+    Map.find binds v
+
+
+  let set v x =
+    Meta.update @@ fun s -> {
+      s with binds = Map.set s.binds
+                 (Theory.Var.forget v) x
+    }
+
+  let del v =
+    Meta.update @@ fun s -> {
+      s with binds = Map.remove s.binds (Theory.Var.forget v)
+    }
+
+  let is_bound v = lookup v >>| Option.is_some
+
+  let var word {data={exp=n; typ=t}} =
+    let s = match t with
+      | Any | Name _ -> word
+      | Symbol -> symsort
+      | Type m -> m in
+    Theory.Var.forget@@Theory.Var.define (bits s) n
+
+  let set_args ws bs = Meta.update @@ fun s -> {
+      s with binds = List.fold bs ~init:s.binds ~f:(fun s (v,x) ->
+      Map.set s (var ws v) x)
+    }
+
+  let del_args ws bs = Meta.update @@ fun s -> {
+      s with binds = List.fold bs ~init:s.binds ~f:(fun s (v,_) ->
+      Map.remove s (var ws v))
+    }
+end
+
+module Scope = struct
+  let forget = Theory.Var.forget
+
+  let push orig =
+    let orig = forget orig in
+    Meta.lift@@Theory.Var.fresh (Theory.Var.sort orig) >>= fun v ->
+    Meta.update  (fun s -> {
+          s with scope = Map.update s.scope orig ~f:(function
+        | None -> [v]
+        | Some vs -> v::vs)
+        }) >>| fun () ->
+    v
+
+  let lookup orig =
+    let+ {scope} = Meta.get () in
+    match Map.find scope orig with
+    | None | Some [] -> None
+    | Some (x :: _) -> Some x
+
+  let pop orig =
+    Meta.update @@ fun s -> {
+      s with scope = Map.change s.scope (forget orig) ~f:(function
+        | None | Some [] | Some [_] -> None
+        | Some (_::xs) -> Some xs)
+    }
+
+  let clear =
+    let* s = Meta.get () in
+    let+ () = Meta.put {
+        s with scope = Map.empty (module Theory.Var.Top)
+      } in
+    s.scope
+
+  let restore scope = Meta.update @@ fun s -> {
+      s with scope
+    }
+
+
+end
+
 module Prelude(CT : Theory.Core) = struct
-  let bits = Theory.Bitv.define
-  let label = KB.Object.create Theory.Program.cls
+  let label = Meta.lift (KB.Object.create Theory.Program.cls)
 
   let rec seq = function
-    | [] -> CT.perform Theory.Effect.Sort.bot
+    | [] -> Meta.lift@@CT.perform Theory.Effect.Sort.bot
     | [x] -> x
-    | x :: xs -> CT.seq x @@ seq xs
+    | x :: xs ->
+      let* xs = seq xs in
+      let* x = x in
+      Meta.lift@@CT.seq (KB.return x) (KB.return xs)
 
-  let skip = seq []
-  let pass = seq []
+  let skip = CT.perform Theory.Effect.Sort.bot
+  let pass = CT.perform Theory.Effect.Sort.bot
 
   let pure res =
-    label >>= fun lbl ->
-    res >>= fun res ->
-    CT.blk lbl (seq []) (seq []) >>| fun eff ->
-    create eff res
+    res >>| fun res ->
+    create empty res
 
   let bigint x m =
     let s = bits m in
     let m = Bitvec.modulus m in
     let x = Bitvec.(bigint x mod m) in
-    CT.int s x
+    pure @@ Meta.lift (CT.int s x) >>| fun r ->
+    set_static r x
 
-  let zero = bigint Z.zero 1
-
-  let (:=) = CT.set
+  let (:=) v x = Meta.lift@@CT.set v x
 
   let full eff res =
     seq eff >>= fun eff ->
@@ -120,20 +338,26 @@ module Prelude(CT : Theory.Core) = struct
 
   let data xs =
     label >>= fun lbl ->
-    CT.blk lbl (seq xs) (seq [])
+    let* data = seq xs in
+    Meta.lift@@CT.blk lbl !data skip
 
   let ctrl xs =
     label >>= fun lbl ->
-    CT.blk lbl (seq []) (seq xs)
+    let* ctrl = seq xs in
+    Meta.lift@@CT.blk lbl pass !ctrl
 
-  let blk lbl xs =
-    seq [CT.blk lbl pass skip; seq xs]
+  let blk lbl xs = seq [
+      Meta.lift@@CT.blk lbl pass skip;
+      seq xs;
+    ]
 
   let cast s x =
-    CT.cast (bits s) CT.b0 !!x
+    Meta.lift@@CT.cast (bits s) CT.b0 !x
 
-  let undefined =
-    full [CT.perform lisp_machine] zero
+  let nil = !!(Theory.Value.empty Theory.Bool.t)
+  let undefined = full [] nil
+  let purify eff =
+    full [] !!(res eff)
 
   let unified x y f =
     Theory.Value.Match.(begin
@@ -147,29 +371,12 @@ module Prelude(CT : Theory.Core) = struct
         undefined
       end)
 
-
-  let nil = pure @@ zero
-
-  let var n m =
-    CT.var@@Theory.Var.define (bits m) n
-
-
-  let symsort = Bap_primus_value.Index.key_width
-
-
-  let sym name =
-    KB.return @@
-    KB.Value.put symbol (Theory.Value.empty (bits symsort)) (Some name)
-
-  let undefined =
-    full [CT.perform lisp_machine] zero
-
   let coerce_bits s x f =
     let open Theory.Value.Match in
     let| () = can Theory.Bitv.refine x @@ fun x ->
-      CT.cast s CT.b0 !!x >>= f in
+      Meta.lift@@CT.cast s CT.b0 !x >>= f in
     let| () = can Theory.Bool.refine x @@ fun cnd ->
-      CT.ite !!cnd
+      Meta.lift@@CT.ite !cnd
         (CT.int s Bitvec.one)
         (CT.int s Bitvec.zero) >>= fun x ->
       f x in
@@ -179,103 +386,172 @@ module Prelude(CT : Theory.Core) = struct
     let open Theory.Value.Match in
     let| () = can Theory.Bool.refine x f in
     let| () = can Theory.Bitv.refine x @@ fun x ->
-      CT.non_zero !!x >>= fun x -> f x in
+      Meta.lift@@CT.non_zero !x >>= fun x -> f x in
     undefined
 
-  let reify prog target name =
+  let is_static eff = Option.is_some (static eff)
+
+  let assign ?(local=false) target v eff =
+    let v = Theory.Var.forget v in
+    match static eff with
+    | Some _ when local || not (is_machine_var target v) ->
+      Env.set v (res eff) >>= fun () ->
+      purify eff
+    | _ ->
+      Env.del v >>= fun () ->
+      full [!!eff; data [v := !(res eff)]] !!(res eff)
+
+  let reify ppf prog defn target name args =
     let word = Theory.Target.bits target in
-    let rec eval : ast -> unit Theory.eff = function
-      | {data=Int {data={exp=x; typ=Type m}}} -> pure@@bigint x m
-      | {data=Int {data={exp=x; typ=Any}}} -> pure@@bigint x word
-      | {data=Var {data={exp=n; typ=Type m}}} -> pure@@var n m
-      | {data=Var {data={exp=n; typ=Any}}} -> pure@@var n word
-      | {data=Sym {data=s}} -> pure@@sym s
+    let var ?t n = make_var ?t target n in
+    let rec eval : ast -> unit Theory.Effect.t Meta.t = function
+      | {data=Int {data={exp=x; typ=Type m}}} -> bigint x m
+      | {data=Int {data={exp=x}}} -> bigint x word
+      | {data=Var {data={exp=n; typ=Type t}}} -> lookup@@var ~t n
+      | {data=Var {data={exp=n}}} -> lookup@@var n
+      | {data=Sym {data=s}} -> sym s
       | {data=Ite (cnd,yes,nay)} -> ite cnd yes nay
-      | {data=Let ({data={exp=n; typ=Type t}},x,y)} -> let_ n t x y
-      | {data=Let ({data={exp=n; typ=Any}},x,y)} -> let_ n word x y
+      | {data=Let ({data={exp=n; typ=Type t}},x,y)} -> let_ ~t n x y
+      | {data=Let ({data={exp=n}},x,y)} -> let_ n x y
       | {data=App (Dynamic name,args)} -> app name args
       | {data=Seq xs} -> seq_ xs
-      | {data=Set ({data={exp=n; typ=Type t}},x)} -> set_ n t x
-      | {data=Set ({data={exp=n; typ=Any}},x)} -> set_ n word x
+      | {data=Set ({data={exp=n; typ=Type t}},x)} -> set_ (var ~t n) x
+      | {data=Set ({data={exp=n}},x)} -> set_ (var n) x
       | {data=Rep (cnd,body)} -> rep cnd body
+      | {data=Msg (fmt,args)} -> msg fmt args
       | _ -> undefined
     and ite cnd yes nay =
       let* cnd = eval cnd in
-      let* yes = eval yes in
-      let* nay = eval nay in
-      coerce_bool (res cnd) @@ fun cres ->
-      Theory.Var.fresh Theory.Bool.t >>= fun c ->
-      full [
-        !!cnd;
-        data [c := !!cres];
-        CT.branch (CT.var c) !!yes !!nay;
-      ] @@
-      CT.ite (CT.var c) !!(res yes) !!(res nay)
+      match static cnd with
+      | Some cnd ->
+        if Bitvec.(equal cnd zero)
+        then eval nay
+        else eval yes
+      | None ->
+        coerce_bool (res cnd) @@ fun cres ->
+        Meta.lift@@Theory.Var.fresh Theory.Bool.t >>= fun c ->
+        let* yes = eval yes in
+        let* nay = eval nay in
+        full [
+          !!cnd;
+          data [c := !cres];
+          Meta.lift@@CT.branch (CT.var c) !yes !nay;
+        ] @@
+        Meta.lift@@CT.ite (CT.var c) !(res yes) !(res nay)
     and rep cnd body =
-      let* cnd = eval cnd in
-      let* body = eval body in
-      let* head = label and* loop = label and* tail = label in
-      coerce_bool (res cnd) @@ fun cres ->
-      full [
-        blk head [ctrl [CT.goto tail]];
-        blk loop [!!body];
-        blk tail [!!cnd; ctrl [
-            CT.branch !!cres (CT.goto head) skip
-          ]]
-      ] !!cres
+      let* r = eval cnd in
+      match static r with
+      | Some x ->
+        if Bitvec.(equal x zero)
+        then !!r
+        else
+          eval body >>= fun _ ->
+          rep cnd body
+      | None ->
+        let* body = eval body in
+        let* head = label and* loop = label and* tail = label in
+        coerce_bool (res r) @@ fun cres ->
+        full [
+          blk head [ctrl [Meta.lift@@CT.goto tail]];
+          blk loop [!!body];
+          blk tail [!!r; ctrl [
+              Meta.lift@@CT.branch !cres (CT.goto head) skip
+            ]]
+        ] !!cres
+    and call ?(toplevel=false) name xs =
+      match Resolve.defun check_arg prog Key.func name xs with
+      | None ->
+        if toplevel then !!Insn.empty
+        else Meta.lift@@primitive defn name xs
+      | Some (Ok (fn,_)) when is_external fn ->
+        sym (Def.name fn) >>= fun dst ->
+        Meta.lift@@primitive defn "invoke-subroutine" (res dst::xs)
+      | Some (Ok (fn,bs)) ->
+        Env.set_args word bs >>= fun () ->
+        Scope.clear >>= fun scope ->
+        eval (Def.Func.body fn) >>= fun eff ->
+        Scope.restore scope >>= fun () ->
+        Env.del_args word bs >>= fun () ->
+        !!eff
+      | Some (Error problem) -> unresolved problem
     and app name xs =
       map xs >>= fun (aeff,xs) ->
-      Primitive.eval name (List.map ~f:forget xs) >>= fun peff ->
-      if KB.Domain.is_empty Theory.Semantics.domain peff
-      then
-        let* dst = Theory.Label.for_name name in
-        let* eff = args name xs in
-        full [
-          !!aeff;
-          !!eff;
-          ctrl [CT.goto dst]
-        ] !!(res eff)
-      else
-        full [!!aeff; !!peff] !!(res peff)
+      call name xs >>= fun peff ->
+      full [!!aeff; !!peff] !!(res peff)
     and map args =
       seq [] >>= fun eff ->
-      KB.List.fold args ~init:(eff,[]) ~f:(fun (eff,args) arg ->
+      Meta.List.fold args ~init:(eff,[]) ~f:(fun (eff,args) arg ->
           let* eff' = eval arg in
           let+ eff = seq [!!eff; !!eff'] in
           (eff,forget (res eff')::args)) >>| fun (eff,args) ->
       eff, List.rev args
     and seq_ xs =
-      nil >>= fun init ->
-      KB.List.fold ~init xs ~f:(fun eff x  ->
+      pure nil >>= fun init ->
+      Meta.List.fold ~init xs ~f:(fun eff x  ->
           let* eff' = eval x in
           full [!!eff; !!eff'] !!(res eff'))
-    and set_ n t x =
+    and msg fmt args =
+      map args >>= fun (aeff,args) ->
+      List.iter fmt ~f:(function
+          | Lit s -> Format.printf "%s" s
+          | Pos n -> match List.nth args n with
+            | None -> failwithf "bad positional %d" n ()
+            | Some v -> match KB.Value.get static_slot v with
+              | Some v -> Format.printf "%a" Bitvec.pp v
+              | None -> Format.printf "@[<hv>%a@]" KB.Value.pp v);
+      Format.fprintf ppf "@\n";
+      !!aeff
+    and lookup v =
+      Scope.lookup v >>= function
+      | Some v -> lookup v
+      | None ->
+        Env.lookup v >>= function
+        | Some v -> pure !!v
+        | None -> match lookup_parameter prog v with
+          | None -> pure@@Meta.lift@@CT.var v
+          | Some def ->
+            let* eff = eval def in
+            assign target v eff
+    and set_ v x =
       let* eff = eval x in
-      let v = Theory.Var.define (bits t) n in
-      coerce_bits (bits t) (res eff) @@ fun reff ->
-      full [!!eff; data [v := !!reff]] !!reff
-    and let_ v t x b =
-      let* x = eval x in
-      let* b = eval b in
-      let v = Theory.Var.define (bits t) v in
-      coerce_bits (bits t) (res x) @@ fun rx ->
-      cast t rx >>= fun rx ->
-      full [
-        !!x;
-        data [v := !!rx];
-        !!b;
-      ] !!(res b)
-    and args name xs =
-      sym name >>= fun x ->
-      Primitive.eval "invoke-subroutine" (forget x::xs) in
-    lookup prog Key.func name >>= function
-    | Some fn -> eval (Def.Func.body fn)
-    | None -> !!Insn.empty
+      Scope.lookup v >>= function
+      | Some v ->
+        assign target ~local:true v eff
+      | None ->
+        assign target v eff
+    and let_ ?(t=word) v x b =
+      let* xeff = eval x in
+      let orig = Theory.Var.define (bits t) v in
+      if is_parameter prog orig
+      then
+        Env.set orig (res xeff) >>= fun () ->
+        let* beff = eval b in
+        Env.del orig >>= fun () ->
+        full [!!beff] !!(res beff)
+      else
+        Scope.push orig >>= fun v ->
+        let* aeff = assign ~local:true target v xeff in
+        let* beff = eval b in
+        Scope.pop orig >>= fun () ->
+        full [
+          !!aeff;
+          !!beff;
+        ] !!(res beff) in
+    match args with
+    | Some args -> call ~toplevel:true name args
+    | None ->
+      resolve prog Key.func name >>= function
+      | Some fn ->
+        eval (Def.Func.body fn)
+      | None -> !!Insn.empty
 end
 
 module Unit = struct
+  open KB.Syntax
+  open KB.Let
+
   let slot = KB.Class.property Theory.Unit.cls "lisp-unit"
-      ~package:"bap"
+      ~package
       ~public:true @@ KB.Domain.optional "unit-name"
       ~inspect:sexp_of_string
       ~equal:equal_string
@@ -295,11 +571,39 @@ module Unit = struct
   let language = language
 end
 
+type KB.conflict += Illtyped_program of Program.Type.error list
 
-let provide () =
+let obtain_typed_program unit =
+  let open KB.Syntax in
+  KB.collect Theory.Unit.source unit >>= fun src ->
+  KB.collect Theory.Unit.target unit >>= fun target ->
+  let prog = KB.Value.get typed src in
+  match Program.Type.(equal empty prog) with
+  | false -> !!prog
+  | true ->
+    let prog = KB.Value.get program src in
+    let vars = Theory.Target.vars target |>
+               Set.to_sequence |>
+               Seq.map ~f:Var.reify in
+    let externals = Hashtbl.to_alist library |>
+                    List.Assoc.map ~f:(fun {types} ->
+                        types target) in
+    let tprog = Program.Type.infer ~externals vars prog in
+    match Program.Type.errors tprog with
+    | [] ->
+      let src = KB.Value.put typed src tprog in
+      KB.provide Theory.Unit.source unit src >>| fun () ->
+      tprog
+    | errs -> KB.fail (Illtyped_program errs)
+
+
+
+let provide_semantics ?(stdout=Format.std_formatter) () =
+  let open KB.Syntax in
   KB.Rule.(begin
       declare "primus-lisp-semantics" |>
-      require Theory.Label.name |>
+      require Property.name |>
+      require Property.args |>
       require Theory.Label.unit |>
       require Theory.Unit.source |>
       require Theory.Unit.target |>
@@ -307,21 +611,66 @@ let provide () =
       provide Theory.Semantics.slot |>
       comment "reifies Primus Lisp definitions"
     end);
+  let (>>=?) x f = x >>= function
+    | None -> !!Insn.empty
+    | Some x -> f x in
   KB.promise Theory.Semantics.slot @@ fun obj ->
-  KB.collect Theory.Label.unit obj >>= function
-  | None -> !!Insn.empty
-  | Some unit ->
-    Unit.is_lisp unit >>= function
-    | false -> !!Insn.empty
-    | true ->
-      KB.collect Theory.Label.name obj >>= function
-      | None -> !!Insn.empty
-      | Some name ->
-        KB.collect Theory.Unit.source unit >>= fun src ->
-        KB.collect Theory.Unit.target unit >>= fun target ->
-        let prog = KB.Value.get program src in
-        Theory.instance () >>= Theory.require >>= fun (module Core) ->
-        let open Prelude(Core) in
-        reify prog target name
+  KB.collect Theory.Label.unit obj >>=? fun unit ->
+  KB.collect Property.name obj >>=? fun name ->
+  KB.collect Property.args obj >>= fun args ->
+  obtain_typed_program unit >>= fun typed ->
+  KB.collect Theory.Unit.target unit >>= fun target ->
+  let prog = Program.Type.program typed in
+  let bits = Theory.Target.bits target in
+  let module Arith = Bitvec.Make(struct
+      let modulus = Bitvec.modulus bits
+    end) in
+  let meta = Meta.State.{
+      binds = Map.empty (module Theory.Var.Top);
+      scope = Map.empty (module Theory.Var.Top);
+      arith = (module Arith);
+    } in
+  Theory.instance () >>= Theory.require >>= fun (module Core) ->
+  let open Prelude(Core) in
+  Meta.run (reify stdout prog obj target name args) meta >>| fun (res,_) ->
+  res
 
-let enable () = provide ()
+let provide_attributes () =
+  let open KB.Syntax in
+  let empty = Attribute.Set.empty in
+  let (>>=?) x f = x >>= function
+    | None -> !!empty
+    | Some x -> f x in
+  KB.promise Attribute.Set.slot @@ fun this ->
+  KB.collect Theory.Label.unit this >>=? fun unit ->
+  KB.collect Property.name this >>=? fun name ->
+  obtain_typed_program unit >>|
+  Program.Type.program >>= fun prog ->
+  match Resolve.semantics prog Key.func name () with
+  | None -> !!empty
+  | Some (Error problem) ->
+    let msg = Format.asprintf "%a" Resolve.pp_resolution problem in
+    KB.fail (Unresolved_definition msg)
+  | Some (Ok (fn,_)) ->
+    !!(Def.attributes fn)
+
+let enable ?stdout () =
+  provide_semantics ?stdout ();
+  provide_attributes ()
+
+let static = static_slot
+
+let () = KB.Conflict.register_printer @@ function
+  | Unresolved_definition s -> Some s
+  | Property.Unequal_arity ->
+    Some "The number of arguments is different"
+  | Illtyped_program errs ->
+    let open Format in
+    let msg = asprintf "%a"
+        (pp_print_list
+           ~pp_sep:pp_print_newline
+           Program.Type.pp_error) errs in
+    Some msg
+  | _ -> None
+
+include Property

--- a/lib/bap_primus/bap_primus_lisp_semantics.mli
+++ b/lib/bap_primus/bap_primus_lisp_semantics.mli
@@ -4,19 +4,21 @@ open Bap_primus_lisp_types
 open Bap_primus_lisp_program
 
 
-type primitive
-
-module Primitive : sig
-  type t = primitive
-  val name : t -> string
-  val args : t -> unit Theory.Value.t list
-end
+type KB.conflict += Unresolved_definition of string
+type KB.conflict += Illtyped_program of Type.error list
 
 val program : (Theory.Source.cls, program) KB.slot
-val primitive : (Theory.program, primitive option) KB.slot
+val definition : (Theory.program, Theory.Label.t option) KB.slot
+val name : (Theory.program, string option) KB.slot
+val args : (Theory.program, unit Theory.Value.t list option) KB.slot
 val symbol : (Theory.Value.cls, String.t option) KB.slot
 val static : (Theory.Value.cls, Bitvec.t option) KB.slot
-val enable : unit -> unit
+val enable : ?stdout:Format.formatter -> unit -> unit
+
+val declare :
+  ?types:(Theory.Target.t -> Bap_primus_lisp_type.signature) ->
+  ?docs:string ->
+  string -> unit
 
 module Unit : sig
   val create : ?name:string -> Theory.Target.t -> Theory.Unit.t KB.t

--- a/oasis/primus
+++ b/oasis/primus
@@ -10,8 +10,8 @@ Library bap_primus
   CompiledObject: best
   BuildDepends: bap, bap-abi, bap-c, uuidm, bap-future, parsexp, bap-strings,
                 core_kernel, regular, monads, graphlib, bap-knowledge,
-                bap-core-theory, zarith, bitvec, zarith, ppx_bap
-
+                bap-core-theory, zarith, bitvec, zarith, ppx_bap,
+                bitvec-binprot
   Modules: Bap_primus
   InternalModules:
            Bap_primus_env,

--- a/oasis/primus-lisp
+++ b/oasis/primus-lisp
@@ -16,6 +16,7 @@ Library primus_lisp_library_plugin
                    Primus_lisp_semantic_primitives,
                    Primus_lisp_ieee754,
                    Primus_lisp_io,
+                   Primus_lisp_show,
                    Primus_lisp_run
   XMETADescription: install and load Primus lisp libraries
   DataFiles:        lisp/*.lisp ($primus_lisp_library_path)

--- a/plugins/bil/bil_semantics.ml
+++ b/plugins/bil/bil_semantics.ml
@@ -488,6 +488,11 @@ module Basic : Theory.Basic = struct
         ctrl @@ match name with
         | Some name -> [Bil.(encode call name)]
         | None -> [Bil.special (Format.asprintf "(goto %a)" Tid.pp lbl)]
+
+
+  let fbits x =
+    x >>= fun x ->
+    unk @@ Theory.Float.bits (sort x)
 end
 
 module Core : Theory.Core = struct

--- a/plugins/primus_lisp/lisp/init.lisp
+++ b/plugins/primus_lisp/lisp/init.lisp
@@ -48,7 +48,7 @@
   (let ((key k))
     (case/dispatch key x xs)))
 
-(defun non-zero (x)
+(defmacro non-zero (x)
   "(non-zero X) is true if X is not zero"
   (not (is-zero x)))
 
@@ -56,11 +56,11 @@
   "(+= X Y) assigns a sum of X and Y to variable X"
   (set x (+ x y)))
 
-(defun -1 (x)
+(defmacro -1 (x)
   "(-1 X) returns the predecessor of X"
   (- x 1))
 
-(defun +1 (x)
+(defmacro +1 (x)
   "(+1 x) returns the successor of X"
   (+ x 1))
 
@@ -92,6 +92,11 @@
    form is 0:1"
   (let ((r x)) (if r r (or xs))))
 (defmacro or (x) x)
+
+(defmacro set$ (s x)
+  "(set$ s x) set the value of the symbol s to x, returns x.
+   Like set but without implicit quotation."
+  (set-symbol-value s x))
 
 (defmacro sign (x)
   "returns 1 if X > 0, 0 if X = 0, and -1 if X < 0"

--- a/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
+++ b/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
@@ -4,20 +4,205 @@ open Bap_primus.Std
 open KB.Syntax
 open KB.Let
 
+let export = Primus.Lisp.Type.Spec.[
+    "+", all any @-> any,
+    "(+ X Y ... Z) returns X + Y + ... + Z, performing any necessary \
+     type conversions in the process. If no numbers are supplied, 0 is \
+     returned.";
+
+    "-", all any @-> any,
+    "(- X Y ... Z) returns X - Y - ... - Z, performing any necessary \
+     type conversions in the process. If no numbers are supplied \
+     returns 0. If one number is supplied returns its negation.";
+
+    "neg", one any @-> any,
+    "(neg X) returns the negation of X. Same as (- X).";
+
+    "*", all any @-> any,
+    "(*  X Y ... Z) returns X * Y * ... * Z, performing any necessary \
+     type conversions in the process. If no numbers are supplied, 1 is \
+     returned.";
+
+    "/", all any @-> any,
+    "(/  X Y ... Z) returns X / Y / ... / Z, performing any necessary \
+     type conversions in the process. If no numbers are supplied, 1 is \
+     returned. If one number is provided returns its reciprocal.";
+
+
+    "s/", all any @-> any,
+    "(s/ X Y ... Z) returns signed X / Y / ... / Z, performing any \
+     necessary type conversions in the process. If no numbers are \
+     supplied, 1 is returned. If one number is provided returns its \
+     signed reciprocal.";
+
+    "mod", all any @-> any,
+    "(/ X Y ... Z) returns mod(X,Y) Y mod ... mod Z, performing any \
+     necessary type conversions in the process. Where `X mod Y` is the \
+     remainder of [X / Y]. If no numbers are supplied, 1 is \
+     returned. If one number is provided returns that number.";
+
+    "signed-mod", all any @-> any,
+    "(/ X Y ... Z) returns signed mod(X,Y) Y mod ... mod Z, performing \
+     any necessary type conversions in the process. Where `X mod Y` is \
+     the remainder of [X / Y]. If no numbers are supplied, 1 is \
+     returned. If one number is provided returns that number.";
+
+    "lshift", all any @-> any,
+    "(lshift X Y ... Z) returns X << Y << ... << Z, performing \
+     any necessary type conversions in the process. Where `X << Y` is \
+     logical shift left of X by Y bits. If no numbers are supplied, 1 \
+     is returned. If one number is provided returns that number";
+
+    "rshift", all any @-> any,
+    "(rshift X Y ... Z) returns X >> Y >> ... >> Z, performing \
+     any necessary type conversions in the process. Where `X >> Y` is \
+     logical shift right of X by Y bits. If no numbers are supplied, 1 \
+     is returned. If one number is provided returns that number";
+
+    "arshift", all any @-> any,
+    "(arshift X Y ... Z) returns X ~>> Y ~>> ... ~>> Z, performing \
+     any necessary type conversions in the process. Where `X ~>> Y` is \
+     arithmetic shift right of X by Y bits. If no numbers are supplied, 1 \
+     is returned. If one number is provided returns that number";
+
+    "logand", all any @-> any,
+    "(logand X Y ... Z) returns X land Y land ... land Z, performing \
+     any necessary type conversions in the process. Where `X land Y` is \
+     bitwise (logical) /\ (AND) of X and Y. If no numbers are supplied, 1 \
+     is returned. If one number is provided returns that number";
+
+    "logor", all any @-> any,
+    "(logor X Y ... Z) returns X lor Y lor ... lor Z, performing \
+     any necessary type conversions in the process. Where `X lor Y` is \
+     bitwise (logical) \\/ (OR) of X and Y. If no numbers are supplied, 1 \
+     is returned. If one number is provided returns that number";
+
+    "logxor", all any @-> any,
+    "(loxgor X Y ... Z) returns X lxor Y lxor ... lxor Z, performing \
+     any necessary type conversions in the process. Where `X lor Y` is \
+     bitwise (logical) exclusive \\/ (XOR) of X and Y. If no numbers \
+     are supplied, 1 is returned. If one number is provided returns \
+     that number";
+
+    "=", all any @-> any,
+    "(= X Y ... Z) returns one if all numbers are equal in value.";
+
+    "/=", all any @-> any,
+    "(/= X Y ... Z) returns one if all numbers are distinct.";
+
+    "<", all any @-> any,
+    "(< X Y ... Z) returns one if all numbers are in monotonically \
+     increasing order.";
+
+    ">", all any @-> any,
+    "(> X Y ... Z) returns one if all numbers are in monotonically \
+     decreasing order.";
+
+    "<=", all any @-> any,
+    "(<= X Y ... Z) returns one if all numbers are in monotonically \
+     nondecreasing order.";
+
+    ">=", all any @-> any,
+    "(> X Y ... Z) returns one if all numbers are in monotonically \
+     nonincreasing order.";
+
+    "is-zero", all any @-> any,
+    "(is-zero X Y ... Z) returns one if all numbers are zero.";
+
+    "not", all any @-> any,
+    "(not X Y ... Z) returns one if all numbers are not \
+     true. Equivalent to (is-zero X Y Z)";
+
+    "is-positive", all any @-> any,
+    "(is-zero X Y ... Z) returns one if all numbers are positive.";
+
+    "is-negative", all any @-> any,
+    "(is-zero X Y ... Z) returns one if all numbers are negative.";
+
+    "word-width", all any @-> any,
+    "(word-width X Y ... Z) returns the maximum width of its \
+     arguments. If no arguments provided returns the size of the \
+     machine word.";
+
+    "exec-addr", one int @-> any,
+    "(exec-addr ADDR) transfers control flow to ADDR.";
+
+    "load-byte", one int @-> byte,
+    "(load-byte PTR) loads one byte from the address PTR";
+
+    "load-word", one int @-> int,
+    "(load-word PTR) loads one word from the address PTR";
+
+    "load-bits", tuple [any; int] @-> int,
+    "(load-word SIZE PTR) loads a SIZE-bit long word from the address PTR";
+
+    "load-half", one int @-> int,
+    "(load-half PTR) loads half-word from the address PTR";
+
+    "store-byte", tuple[int; any] @-> any,
+    "(store-byte POS VAL) stores byte VAL at the memory position POS";
+
+    "store-word", tuple[int; any] @-> any,
+    "(store-word POS VAL) stores VAL at the memory position POS";
+
+    "memory-write", tuple [int; byte] @-> int,
+    "(memory-write PTR X) stores X at PTR.";
+
+    "get-program-counter", unit @-> int,
+    "(get-program-counter) returns the address of the current instruction";
+
+    "get-current-program-counter", unit @-> int,
+    "(get-current-program-counter) is an alias to (get-program-counter)";
+
+    "set-symbol-value", tuple [sym; a] @-> a,
+    "(set-symbol-value S X) sets the value of the symbol S to X.
+         Returns X";
+
+    "cast-low", tuple [int; a] @-> b,
+    "(cast-low S X) extracts low S bits from X.";
+
+    "cast-high", tuple [int; a] @-> b,
+    "(cast-high S X) extracts high S bits from X.";
+
+    "cast-signed", tuple [int; a] @-> b,
+    "(cast-signed S X) performs signed extension of X to the size of S bits";
+
+    "cast-unsigned", tuple [int; a] @-> b,
+    "(cast-unsigned S X) performs unsigned extension of X to the size of S bits";
+  ]
+
 type KB.conflict += Illformed of string
 
 let illformed fmt =
   Format.kasprintf (fun msg ->
       KB.fail (Illformed msg)) fmt
 
+let () = KB.Conflict.register_printer (function
+    | Illformed msg-> Some ("illformed lisp program " ^ msg)
+    | _ -> None)
+
+
+let domain = KB.Domain.optional "cst"
+    ~equal:Sexp.equal
+    ~inspect:ident
+
+let eslot = KB.Class.property Theory.Semantics.cls "eff"
+    ~package:"core"
+    ~public:true
+    domain
+
+let pslot = KB.Class.property Theory.Value.cls "val"
+    ~package:"core"
+    ~public:true
+    domain
+
 let nothing = KB.Value.empty Theory.Semantics.cls
-
-
 let size = Theory.Bitv.size
 let forget x = x >>| Theory.Value.forget
-let to_bitv x = Theory.Value.resort Theory.Bitv.refine x
 let empty s = Theory.Value.(forget @@ empty s)
 let fresh = KB.Object.create Theory.Program.cls
+let sort = Theory.Value.sort
+let bits x = size @@ sort x
 
 module Primitives(CT : Theory.Core) = struct
 
@@ -33,59 +218,99 @@ module Primitives(CT : Theory.Core) = struct
   let negone s =
     CT.int s @@ Bitvec.(ones mod modulus (size s))
 
-  let one s = CT.int s @@ Bitvec.one
-  let int s x = CT.int s @@ Bitvec.(int x mod modulus (size s))
 
-
-  let require_one = function
+  let unary = function
     | [x] -> !!x
     | _ -> illformed "requires exactly one argument"
 
-  let require_two xs f = match xs with
+  let binary xs f = match xs with
     | [x; y] -> f x y
     | _ -> illformed "requires exactly two arguments"
 
-  let require_bitv x = match to_bitv x with
+  let ternary xs f = match xs with
+    | [x; y; z] -> f x y z
+    | _ -> illformed "requires exactly three arguments"
+
+  let const x = KB.Value.get Primus.Lisp.Semantics.static x
+  let set_const v x =
+    KB.Value.put Primus.Lisp.Semantics.static v (Some x)
+  let const_int s x = CT.int s x >>| fun v -> set_const v x
+  let int s x = const_int s @@ Bitvec.(int x mod modulus (size s))
+  let true_ = CT.b1 >>| fun v -> set_const v Bitvec.one
+  let false_ = CT.b0 >>| fun v -> set_const v Bitvec.zero
+  let const_bool x = if x then true_ else false_
+
+  let bitv x =
+    match Theory.Value.resort Theory.Bitv.refine x with
     | Some x -> !!x
-    | None -> illformed "requires a bitvector"
+    | None -> match Theory.Value.resort Theory.Bool.refine x with
+      | None -> illformed "defined for bits or bools"
+      | Some b ->
+        let s = Theory.Bitv.define 1 in
+        let b1 = const_int s Bitvec.M1.one
+        and b0 = const_int s Bitvec.M1.zero in
+        match const b with
+        | Some r ->
+          if Bitvec.(equal r zero)
+          then b0
+          else b1
+        | None -> CT.ite !!b b1 b0
 
-  let all_bitv = KB.List.map ~f:require_bitv
 
-  let monoid s f init xs =
-    all_bitv xs >>= function
-    | [] -> forget@@init s
+  let nbitv = KB.List.map ~f:bitv
+
+  type 'a bitv = 'a Theory.Bitv.t Theory.Value.sort
+
+  let monoid s sf df init xs =
+    nbitv xs >>= function
+    | [] -> forget@@const_int s init
     | x :: xs ->
       KB.List.fold ~init:x xs ~f:(fun res x ->
-          CT.cast s CT.b0 !!x >>= fun x ->
-          f !!res !!x) |>
+          match const res, const x with
+          | Some res, Some x ->
+            const_int s@@sf res x
+          | _ ->
+            CT.cast s CT.b0 !!x >>= fun x ->
+            df !!res !!x) |>
       forget
 
   let is_one x = CT.(inv@@is_zero x)
 
-  let rec is_ordered f = function
-    | [] | [_] -> CT.b1
+  let (&&&) x y = match const x, const y with
+    | Some x, Some y ->
+      if Bitvec.(equal x zero || equal y zero)
+      then false_
+      else true_
+    | _ -> CT.and_ !!x !!y
+
+  let rec is_ordered sf df = function
+    | [] | [_] -> true_
     | x :: (y :: _ as rest) ->
-      match to_bitv x, to_bitv y with
+      bitv x >>= fun x ->
+      bitv y >>= fun y ->
+      match const x, const y with
       | Some x, Some y ->
-        f !!x !!y >>= fun r ->
-        is_ordered f rest >>= fun r' ->
+        const_bool@@sf x y >>= fun r ->
+        is_ordered sf df rest >>= fun r' ->
+        r &&& r'
+      | _ ->
+        df !!x !!y >>= fun r ->
+        is_ordered sf df rest >>= fun r' ->
         CT.and_ !!r !!r'
-      | _ -> CT.unk Theory.Bool.t
 
-  let order f xs = forget@@is_ordered f xs
+  let order sf df xs = forget@@is_ordered sf df xs
 
-  let all f xs =
-    CT.b1 >>= fun init ->
+  let all sf df xs =
+    true_ >>= fun init ->
     KB.List.fold ~init xs ~f:(fun r x ->
-        match to_bitv x with
-        | None -> illformed "requires bitvec"
-        | Some x ->
-          CT.and_ !!r (f !!x)) |>
+        bitv x >>= fun x ->
+        let r' = match const x with
+          | Some x -> const_bool (sf x)
+          | None -> df !!x in
+        r' >>= fun r' ->
+        r &&& r') |>
     forget
 
-  let unary f xs =
-    require_one xs >>= require_bitv >>= fun x ->
-    forget@@f !!x
 
   let full eff res =
     res >>= fun res ->
@@ -94,10 +319,10 @@ module Primitives(CT : Theory.Core) = struct
 
   let pure res = full (seq []) res
 
-  let static = pure
   let ctrl eff =
     let* lbl = fresh in
     CT.blk lbl (seq []) eff
+
   let data eff =
     let* lbl = fresh in
     CT.blk lbl eff (seq [])
@@ -115,8 +340,7 @@ module Primitives(CT : Theory.Core) = struct
     CT.(and_ (non_zero x) (inv (is_negative x)))
 
   let word_width s xs =
-    let bits x = size @@ Theory.Value.sort x in
-    all_bitv xs >>= fun xs ->
+    nbitv xs >>= fun xs ->
     List.max_elt xs ~compare:(fun x y ->
         Int.compare (bits x) (bits y)) |>
     Option.value_map ~f:(fun x ->
@@ -125,72 +349,691 @@ module Primitives(CT : Theory.Core) = struct
     forget
 
   let exec_addr xs =
-    require_one xs >>=
-    require_bitv >>= fun dst ->
-    CT.jmp !!dst
+    unary xs >>= bitv >>= fun dst ->
+    match const dst with
+    | None -> CT.jmp !!dst
+    | Some bitv ->
+      Theory.Label.for_addr bitv >>= fun dst ->
+      CT.goto dst
 
-  let memory_read t xs =
-    require_one xs >>=
-    require_bitv >>= fun src ->
-    CT.(load (var (Theory.Target.data t)) !!src) |>
-    forget
+  let load_byte t xs =
+    let mem = CT.var @@ Theory.Target.data t in
+    unary xs >>= bitv >>= fun addr -> forget@@CT.(load mem !!addr)
 
-  let memory_write t xs =
-    require_two xs @@ fun dst data ->
-    require_bitv dst >>= fun dst ->
-    require_bitv data >>= fun data ->
+
+  let is_big_endian t =
+    if Theory.Endianness.equal (Theory.Target.endianness t)
+        Theory.Endianness.eb then CT.b1 else CT.b0
+
+  let to_sort x =
+    bitv x >>| const >>= function
+    | None -> illformed "the sort specification must be static"
+    | Some sz ->
+      if Bitvec.fits_int sz then
+        !!(Theory.Bitv.define (Bitvec.to_int sz))
+      else illformed "cast size must fit into it"
+
+  let load_word t xs =
+    let mem = CT.var @@ Theory.Target.data t in
+    let s = Theory.Bitv.define (Theory.Target.bits t) in
+    let b = is_big_endian t in
+    unary xs >>= bitv >>= fun addr ->
+    forget@@CT.(loadw s b mem !!addr)
+
+  let loadn t xs =
+    let mem = CT.var @@ Theory.Target.data t in
+    binary xs @@ fun sz x ->
+    to_sort sz >>= fun s ->
+    bitv x >>= fun x ->
+    forget@@CT.(loadw s (is_big_endian t) mem !!x)
+
+  let load_bits t xs =
+    let mem = CT.var @@ Theory.Target.data t in
+    binary xs @@ fun sz x ->
+    to_sort sz >>= fun s ->
+    bitv x >>= fun x ->
+    forget@@CT.(loadw s (is_big_endian t) mem !!x)
+
+  let store_byte t xs =
+    binary xs @@ fun dst data ->
+    bitv dst >>= fun dst ->
+    bitv data >>= fun data ->
     let mem = Theory.Target.data t in
     let (:=) = CT.set in
     CT.(mem := store (var mem) !!dst !!data)
 
+  let store_word t xs =
+    binary xs @@ fun dst data ->
+    bitv dst >>= fun dst ->
+    bitv data >>= fun data ->
+    let mem = Theory.Target.data t in
+    let (:=) = CT.set in
+    let b = is_big_endian t in
+    CT.(mem := storew b (var mem) !!dst !!data)
+
+  let rec prefix p = function
+    | [] -> []
+    | x::xs -> (p,x) :: prefix p xs
+
+  let rec combinations = function
+    | [] -> []
+    | x :: xs -> prefix x xs @ combinations xs
+
+
+  let distinct_pair (x,y) =
+    bitv x >>= fun x ->
+    bitv y >>= fun y ->
+    match const x, const y with
+    | Some x, Some y -> const_bool Bitvec.(x <> y)
+    | _ -> CT.neq !!x !!y
+
+  let distinct = function
+    | [] | [_] -> true_
+    | xs ->
+      true_ >>= fun init ->
+      KB.List.fold (combinations xs) ~init ~f:(fun t p ->
+          distinct_pair p >>= fun t' ->
+          t &&& t')
+
+  let neg x =
+    bitv x >>= fun x -> match const x with
+    | None -> forget@@CT.neg !!x
+    | Some v -> forget@@const_int (sort x) v
+
+  let one_op_x op x =
+    bitv x >>= fun x -> match const x with
+    | None -> forget@@CT.(op (int (sort x) Bitvec.one) !!x)
+    | Some v -> forget@@const_int (sort x) v
+
+  let reciprocal = one_op_x CT.div
+  let sreciprocal = one_op_x CT.sdiv
+
+  let get_pc s lbl =
+    KB.collect Primus.Lisp.Semantics.definition lbl >>= function
+    | None -> !!(empty s)
+    | Some lbl -> KB.collect Theory.Label.addr lbl >>= function
+      | None -> !!(empty s)
+      | Some addr -> forget@@const_int s addr
+
+  let get_symbol sym =
+    match KB.Value.get Primus.Lisp.Semantics.symbol sym with
+    | Some sym -> sym
+    | None -> match KB.Value.get pslot sym with
+      | Some (Atom name) -> name ^ ":symbol"
+      | _ -> "#unknown:symbol"
+
+
+  let set_symbol sym x =
+    let sym = get_symbol sym in
+    bitv x >>= fun x ->
+    let s = sort x in
+    let var = Theory.Var.define s sym in
+    CT.set var !!x
+
+  let mk_cast cast xs =
+    binary xs @@ fun sz x ->
+    to_sort sz >>= fun s ->
+    bitv x >>= fun x ->
+    forget@@cast s !!x
+
+  let signed = mk_cast CT.signed
+  let unsigned = mk_cast CT.unsigned
+  let low = mk_cast CT.low
+  let high = mk_cast CT.high
+
   let dispatch lbl name args =
     Theory.Label.target lbl >>= fun t ->
-    let s = Theory.Bitv.define (Theory.Target.bits t) in
-    match name with
-    | "+" -> pure@@monoid s CT.add CT.zero args
-    | "-" -> pure@@monoid s CT.sub CT.zero args
-    | "*" -> pure@@monoid s CT.mul one args
-    | "/" -> pure@@monoid s CT.div one args
-    | "s/" -> pure@@monoid s CT.sdiv one args
-    | "mod" -> pure@@monoid s CT.modulo one args
-    | "signed-mod" -> pure@@monoid s CT.smodulo one args
-    | "lshift" -> pure@@monoid s CT.lshift one args
-    | "rshift" -> pure@@monoid s CT.rshift one args
-    | "arshift" -> pure@@monoid s CT.arshift one args
-    | "logand" -> pure@@monoid s CT.logand negone args
-    | "logor" -> pure@@monoid s CT.logor CT.zero args
-    | "logxor" -> pure@@monoid s CT.logxor CT.zero args
-    | "=" -> pure@@order CT.eq args
-    | "/=" -> pure@@order CT.neq args
-    | "<" -> pure@@order CT.ult args
-    | ">" -> pure@@order CT.ugt args
-    | "<=" -> pure@@order CT.ule args
-    | ">=" -> pure@@order CT.uge args
-    | "is-zero" | "not" -> pure@@all CT.is_zero args
-    | "is-positive" -> pure@@all is_positive args
-    | "is-negative" -> pure@@all is_negative args
-    | "word-width" -> static@@word_width s args
-    | "exec-addr" -> ctrl@@exec_addr args
-    | "memory-read" -> pure@@memory_read t args
-    | "memory-write" -> data@@memory_write t args
+    let bits = Theory.Target.bits t in
+    let module Z = struct
+      include Bitvec.Make(struct
+          let modulus = Bitvec.modulus bits
+        end)
+      let is_zero = Bitvec.equal zero
+      let is_negative = msb
+      let is_positive x =
+        not (is_negative x) && not (is_zero x)
+    end in
+    let s = Theory.Bitv.define bits in
+    match name,args with
+    | "+",_-> pure@@monoid s Z.add CT.add Z.zero args
+    | "-",[x]|"neg",[x] -> pure@@neg x
+    | "-",_-> pure@@monoid s Z.sub CT.sub Z.zero args
+    | "*",_-> pure@@monoid s Z.mul CT.mul Z.one args
+    | "/",[x]-> pure@@reciprocal x
+    | "/",_-> pure@@monoid s Z.div CT.div Z.one args
+    | "s/",[x]-> pure@@sreciprocal x
+    | "s/",_-> pure@@monoid s Z.sdiv CT.sdiv Z.one args
+    | "mod",_-> pure@@monoid s Z.rem CT.modulo Z.one args
+    | "signed-mod",_-> pure@@monoid s Z.srem CT.smodulo Z.one args
+    | "lshift",_-> pure@@monoid s Z.lshift CT.lshift Z.one args
+    | "rshift",_-> pure@@monoid s Z.rshift CT.rshift Z.one args
+    | "arshift",_-> pure@@monoid s Z.arshift CT.arshift Z.one args
+    | "logand",_-> pure@@monoid s Z.logand CT.logand Z.ones args
+    | "logor",_-> pure@@monoid s Z.logor CT.logor Z.zero args
+    | "logxor",_-> pure@@monoid s Z.logxor CT.logxor Z.zero args
+    | "=",_-> pure@@order Bitvec.(=) CT.eq args
+    | "<",_-> pure@@order Bitvec.(<) CT.ult args
+    | ">",_-> pure@@order Bitvec.(>) CT.ugt args
+    | "<=",_-> pure@@order Bitvec.(<=) CT.ule args
+    | ">=",_-> pure@@order Bitvec.(>=) CT.uge args
+    | "/=",_| "distinct",_-> pure@@forget@@distinct args
+    | "is-zero",_| "not",_-> pure@@all Bitvec.(equal zero) CT.is_zero args
+    | "is-positive",_-> pure@@all Z.is_positive is_positive args
+    | "is-negative",_-> pure@@all Z.is_negative is_negative args
+    | "word-width",_-> pure@@word_width s args
+    | "exec-addr",_-> ctrl@@exec_addr args
+    | ("load-byte"|"memory-read"),_-> pure@@load_byte t args
+    | "load-word",_-> pure@@load_word t args
+    | "load-bits",_-> pure@@load_bits t args
+    | ("store-byte"|"memory-write"),_-> data@@store_byte t args
+    | "store-word",_-> data@@store_word t args
+    | "get-program-counter",[]
+    | "get-current-program-counter",[] -> pure@@get_pc s lbl
+    | "set-symbol-value",[sym;x] -> data@@set_symbol sym x
+    | "cast-low",xs -> pure@@low xs
+    | "cast-high",xs -> pure@@high xs
+    | "cast-signed",xs -> pure@@signed xs
+    | "cast-unsigned",xs -> pure@@unsigned xs
     | _ -> !!nothing
 end
 
-module Sema = Primus.Lisp.Semantics
+
+module CST : Theory.Core = struct
+  type t = Sexp.t
+
+
+  let pure s cst = KB.Value.put pslot (Theory.Value.empty s) (Some cst)
+  let eff s cst = KB.Value.put eslot (Theory.Effect.empty s) (Some cst)
+  let data = eff Theory.Effect.Sort.bot
+  let ctrl = eff Theory.Effect.Sort.bot
+  let ret = KB.return
+  let atom s = Sexp.Atom s
+
+  let list = function
+    | [Sexp.Atom op;
+       List ((Atom opx) :: xs);
+       List ((Atom opy) :: ys)]
+      when String.(op = opx && op = opy) ->
+      Sexp.List (Atom op :: List.append xs ys)
+    | [Sexp.Atom op; List ((Atom opx) :: xs); y]
+      when String.(op = opx) ->
+      Sexp.List (Sexp.Atom op :: xs@[y])
+    | [Sexp.Atom op; x; List ((Atom opy) :: ys)]
+      when String.(op = opy) ->
+      Sexp.List (Sexp.Atom op :: x :: ys)
+    | xs -> Sexp.List xs
+
+  let app x xs = list (atom x :: xs)
+
+  let psort = Theory.Value.sort
+  let esort = Theory.Effect.sort
+
+  let (>>->) x f =
+    x >>= fun v ->
+    let s = psort v in
+    f s (KB.Value.get pslot v)
+
+  let (>>|>) x f = x >>-> fun s v -> ret (f s v)
+
+  let (>>->?) x f =
+    x >>= fun v ->
+    let s = psort v in
+    match KB.Value.get pslot v with
+    | None -> ret (Theory.Value.empty s)
+    | Some v -> f s v
+
+
+  let (>>|>?) x f = x >>->? fun s v -> ret (f s v)
+
+  let (>>=>) x f =
+    x >>= fun v ->
+    let s = esort v in
+    f s (KB.Value.get eslot v)
+
+  let (>>=>?) x f =
+    x >>= fun v ->
+    let s = esort v in
+    match KB.Value.get eslot v with
+    | None -> ret (Theory.Effect.empty s)
+    | Some x -> f s x
+
+
+  let empty = Theory.Value.empty
+
+  let unary_s s op x = x >>|> fun _ -> function
+    | None -> empty s
+    | Some v -> pure s @@ app op [v]
+
+  let unary op x = x >>|>? fun s v -> pure s @@ app op [v]
+
+  let monoid_s s op x y =
+    x >>-> fun _ x ->
+    y >>|> fun _ y ->
+    match x, y with
+    | Some x, Some y -> pure s @@ app op [x; y]
+    | _ -> empty s
+
+  let monoid op x y =
+    x >>->? fun s x ->
+    y >>|>? fun _ y ->
+    pure s @@ app op [x; y]
+
+  module Minimal = struct
+    let b0 = ret@@pure Theory.Bool.t (atom "0")
+    let b1 = ret@@pure Theory.Bool.t (atom "1")
+
+    let unk s = ret@@empty s
+
+    let var v =
+      let s = Theory.Var.sort v in
+      ret@@pure s@@atom (Theory.Var.name v)
+
+    let let_ v x y =
+      x >>-> fun _ x ->
+      y >>|> fun s y ->
+      let name = Theory.Var.name v in
+      match x,y with
+      | Some x, Some y ->
+        pure s@@app "let" [atom name; x; y]
+      | _ -> empty s
+
+    let ite c x y =
+      c >>-> fun _ c ->
+      x >>->? fun s x ->
+      y >>|>? fun _ y -> match c with
+      | None -> empty s
+      | Some c -> pure s@@app "ite" [c; x; y]
+
+    let inv = unary "not"
+    let and_ = monoid "logand"
+    let or_ = monoid "logor"
+    let int s x = ret@@pure s@@atom (Bitvec.to_string x)
+    let msb x = unary_s Theory.Bool.t "msb" x
+    let lsb x = unary_s Theory.Bool.t "lsb" x
+    let neg x = unary "-" x
+    let not x = unary "not" x
+    let add x = monoid "+" x
+    let sub x = monoid "-" x
+    let mul x = monoid "*" x
+    let div x = monoid "/" x
+    let sdiv x = monoid "s/" x
+    let modulo x = monoid "mod" x
+    let smodulo x = monoid "signed-mod" x
+    let logand x = monoid "logand" x
+    let logor x = monoid "logor" x
+    let logxor x = monoid "logxor" x
+
+    let genshift name fill x off =
+      fill >>-> fun _ fill ->
+      x >>-> fun s x ->
+      off >>|> fun _ off ->
+      match fill, x, off with
+      | Some fill, Some x, Some off ->
+        pure s @@ app name [fill; x; off]
+      | _ -> empty s
+    let shiftr x = genshift "shiftr" x
+    let shiftl x = genshift "shiftl" x
+    let sle x = monoid_s Theory.Bool.t "s<=" x
+    let ule x = monoid_s Theory.Bool.t "<" x
+
+
+    let cast s fill exp =
+      fill >>-> fun _ fill ->
+      exp >>|> fun s' x ->
+      let ct = sprintf "%d" @@ Theory.Bitv.size s in
+      match fill, x  with
+      | Some fill, Some x ->
+        if Theory.Value.Sort.same s s'
+        then pure s x
+        else
+          pure s@@list [
+            atom "cast";
+            atom ct;
+            fill;
+            x
+          ]
+      | _ -> empty s
+
+    let concat s xs =
+      List.map xs ~f:(fun x -> x >>|> fun _ -> ident) |>
+      KB.List.all >>| Option.all >>| function
+      | None -> empty s
+      | Some xs -> pure s @@ app "concat" xs
+
+    let append s x y = monoid_s s "append" x y
+
+    let load m x =
+      m >>-> fun s m ->
+      x >>|> fun _ x ->
+      let s = Theory.Mem.vals s in
+      match m, x with
+      | Some m, Some x -> pure s @@ app "load" [m; x]
+      | _ -> empty s
+
+    let store m p x =
+      m >>-> fun s m ->
+      p >>-> fun _ p ->
+      x >>|> fun _ x ->
+      match m, p, x with
+      | Some m, Some p, Some x ->
+        pure s @@ app "store" [m; p; x]
+      | _ -> empty s
+
+    let nil = Theory.Effect.empty Theory.Effect.Sort.bot
+
+    let perform eff = ret (Theory.Effect.empty eff)
+
+    let set v x = x >>|> fun _ x ->
+      match x with
+      | None -> nil
+      | Some x -> data@@app "set" [
+          atom (Theory.Var.name v);
+          x
+        ]
+
+    let jmp x = x >>|> fun _ x -> match x with
+      | None -> nil
+      | Some x -> ctrl@@app "goto" [x]
+
+    let goto dst =
+      KB.collect Theory.Label.addr dst >>= function
+      | Some dst ->
+        ret@@ctrl@@app "goto" [atom (Bitvec.to_string dst)]
+      | None ->
+        KB.Object.repr Theory.Program.cls dst >>= fun dst ->
+        ret@@ctrl@@app "goto" [atom dst]
+
+    let both s xs ys =
+      match xs,ys with
+      | None,None -> ret nil
+      | Some r,None
+      | None, Some r -> ret@@eff s r
+      | Some xs, Some ys ->
+        ret@@eff s@@list [xs; ys]
+
+    let seq xs ys =
+      xs >>=> fun s xs ->
+      ys >>=> fun _ ys ->
+      both s xs ys
+
+    let blk _ xs ys =
+      xs >>=> fun _ xs ->
+      ys >>=> fun _ ys ->
+      both Theory.Effect.Sort.top xs ys
+
+    let repeat cnd body =
+      cnd >>-> fun _ cnd ->
+      body >>=>? fun s body ->
+      match cnd with
+      | None -> ret@@nil
+      | Some cnd ->
+        ret@@eff s@@app "while" [cnd; body]
+
+    let branch cnd yes nay =
+      cnd >>-> fun _ cnd ->
+      yes >>=>? fun s yes ->
+      nay >>=>? fun _ nay ->
+      match cnd with
+      | None -> ret@@nil
+      | Some cnd ->
+        ret@@eff s@@app "if" [cnd; yes; nay]
+  end
+  include Theory.Basic.Make(Minimal)
+
+  let mk_cast name s x =
+    x >>|> fun s' x -> match x with
+    | None -> empty s
+    | Some x ->
+      if Theory.Value.Sort.same s s'
+      then pure s x
+      else pure s@@app name [
+          atom@@sprintf "%d" (Theory.Bitv.size s);
+          x
+        ]
+
+  let high s = mk_cast "high" s
+  let low s = mk_cast "low" s
+  let signed s = mk_cast "signed" s
+  let unsigned s = mk_cast "unsigned" s
+
+  let extract s lo hi x =
+    lo >>-> fun _ lo ->
+    hi >>-> fun _ hi ->
+    x >>|> fun _ x ->
+    match lo,hi,x with
+    | Some lo, Some hi, Some x ->
+      pure s@@app "extract" [lo; hi; x]
+    | _ -> empty s
+
+  let loadw s dir mem ptr =
+    dir >>-> fun _ dir ->
+    mem >>-> fun _ mem ->
+    ptr >>|> fun _ ptr ->
+    match dir,mem,ptr with
+    | Some dir, Some mem, Some ptr ->
+      pure s@@app "loadw" [
+        atom@@sprintf "%d" (Theory.Bitv.size s);
+        dir;
+        mem;
+        ptr
+      ]
+    | _ -> empty s
+
+  let storew dir mem ptr exp =
+    dir >>-> fun _ dir ->
+    mem >>-> fun s mem ->
+    ptr >>-> fun _ ptr ->
+    exp >>|> fun _ exp ->
+    match Option.all [dir; mem; ptr; exp] with
+    | Some args -> pure s@@app "storew" args
+    | _ -> empty s
+
+  let mk_shift name x m =
+    x >>->? fun s x ->
+    m >>|> fun _ -> function
+    | None -> empty s
+    | Some m -> pure s@@app name [x; m]
+
+  let arshift x = mk_shift "arshift" x
+  let rshift x = mk_shift "rshift" x
+  let lshift x = mk_shift "lshift" x
+  let eq x = monoid_s Theory.Bool.t "=" x
+  let neq x = monoid_s Theory.Bool.t "/=" x
+  let slt x = monoid_s Theory.Bool.t "s<" x
+  let ult x = monoid_s Theory.Bool.t "<" x
+  let sgt x = monoid_s Theory.Bool.t "s>" x
+  let ugt x = monoid_s Theory.Bool.t ">" x
+  let sge x = monoid_s Theory.Bool.t "s>=" x
+  let uge x = monoid_s Theory.Bool.t ">=" x
+
+  let asort s =
+    atom@@Format.asprintf "%a" Theory.Value.Sort.pp (Theory.Value.Sort.forget s)
+
+
+  let wellknown = Theory.IEEE754.[
+      binary16,  ":b16";
+      binary32,  ":b32";
+      binary64,  ":b64";
+      binary80,  ":b80";
+      binary128, ":b128";
+      decimal32, ":d32";
+      decimal64, ":d64";
+      decimal128, ":d128";
+    ]
+
+  let format s =
+    let s = Theory.Value.Sort.forget s in
+    match Theory.Float.(refine s) with
+    | None -> asort s
+    | Some s ->
+      List.find_map wellknown ~f:(fun (par,name) ->
+          let s' = Theory.IEEE754.Sort.define par in
+          if Theory.Value.Sort.same s s'
+          then Some (atom name)
+          else None) |> function
+      | Some s -> s
+      | None -> asort s
+
+
+
+  let float s x =
+    x >>|> fun _ x -> match x with
+    | None -> empty s
+    | Some x -> pure s@@app "float" [format s; x]
+
+  let fbits x =
+    x >>|> fun s x ->
+    let s = Theory.Float.bits s in
+    match x with
+    | None -> empty s
+    | Some x -> pure s@@app "fbits" [x]
+
+  let is_finite x = unary_s Theory.Bool.t "is-finite" x
+  let is_nan x = unary_s Theory.Bool.t "is-nan" x
+  let is_inf x = unary_s Theory.Bool.t "is-inf" x
+  let is_fzero x = unary_s Theory.Bool.t "is-fzero" x
+  let is_fpos x = unary_s Theory.Bool.t "is-fpos" x
+  let is_fneg x = unary_s Theory.Bool.t "is-fneg" x
+
+  let rmode s = ret@@pure Theory.Rmode.t @@ atom s
+  let rne = rmode ":rne"
+  let rna = rmode ":rna"
+  let rtp = rmode ":rtp"
+  let rtn = rmode ":rtn"
+  let rtz = rmode ":rtz"
+  let requal = eq
+
+  let mk_fcast name s m x =
+    m >>-> fun _ m ->
+    x >>|> fun _ x ->
+    match m,x with
+    | Some m, Some x -> pure s@@app name [m;x]
+    | _ -> empty s
+
+  let cast_float s = mk_fcast "cast-float" s
+  let cast_sfloat s = mk_fcast "cast-sfloat" s
+  let cast_int s = mk_fcast "cast-int" s
+  let cast_sint s = mk_fcast "cast-sint" s
+
+  let fneg x = unary "fneg" x
+  let fabs x = unary "fabs" x
+
+  let monoid_f name m x y =
+    x >>->? fun s x ->
+    y >>->? fun _ y ->
+    m >>|> fun _ m ->
+    match m with
+    | None -> empty s
+    | Some m -> pure s@@app name [m; x; y]
+
+  let unary_f name m x =
+    x >>->? fun s x ->
+    m >>|> fun _ m ->
+    match m with
+    | None -> empty s
+    | Some m -> pure s@@app name [m; x]
+
+  let ternary_f name m x y z =
+    x >>->? fun s x ->
+    y >>->? fun _ y ->
+    z >>->? fun _ z ->
+    m >>|> fun _ m ->
+    match m with
+    | None -> empty s
+    | Some m -> pure s@@app name [m; x; y; z]
+
+  let binary_fi name m f x =
+    f >>->? fun s f ->
+    m >>-> fun _ m ->
+    x >>|> fun _ x ->
+    match m,x with
+    | Some m, Some x -> pure s@@app name [m; f; x]
+    | _ -> empty s
+
+
+  let fadd m = monoid_f "+." m
+  let fsub m = monoid_f "-." m
+  let fmul m = monoid_f "*." m
+  let fdiv m = monoid_f "/." m
+  let fmodulo m = monoid_f "mod." m
+  let fsqrt m = unary_f "fsqrt" m
+  let fround m = unary_f "fround" m
+  let fmad m = ternary_f "fmad" m
+  let fsucc x = unary "fsucc" x
+  let fpred x = unary "fpred" x
+  let forder x = monoid_s Theory.Bool.t "forder" x
+
+  let fconvert s m x =
+    m >>-> fun _ m ->
+    x >>|> fun _ x ->
+    match m,x with
+    | Some m, Some x -> pure s@@app "fconvert" [
+        format s; m; x
+      ]
+    | _ -> empty s
+
+  let pow m = monoid_f "pow" m
+  let hypot m = monoid_f "hypot" m
+
+  let rsqrt m = unary_f "rsqrt" m
+  let exp m = unary_f "exp" m
+  let expm1 m = unary_f "expm1" m
+  let exp2 m = unary_f "exp2" m
+  let exp2m1 m = unary_f "exp2m1" m
+  let exp10 m = unary_f "exp10" m
+  let exp10m1 m = unary_f "exp10m1" m
+  let log m = unary_f "log" m
+  let log2 m = unary_f "log2" m
+  let log10 m = unary_f "log10" m
+  let logp1 m = unary_f "logp1" m
+  let log2p1 m = unary_f "log2p1" m
+  let log10p1 m = unary_f "log10p1" m
+  let sin m = unary_f "sin" m
+  let cos m = unary_f "cos" m
+  let tan m = unary_f "tan" m
+  let sinpi m = unary_f "sinpi" m
+  let cospi m = unary_f "cospi" m
+  let atanpi m = unary_f "atanpi" m
+  let atan2pi m = monoid_f "atan2pi" m
+  let asin m = unary_f "asin" m
+  let acos m = unary_f "acos" m
+  let atan m = unary_f "atan" m
+  let atan2 m = monoid_f "atan2" m
+  let sinh m = unary_f "sinh" m
+  let cosh m = unary_f "cosh" m
+  let tanh m = unary_f "tanh" m
+  let asinh m = unary_f "asinh" m
+  let acosh m = unary_f "acosh" m
+  let atanh m = unary_f "atanh" m
+
+  let compound m = binary_fi "compound" m
+  let rootn m = binary_fi "rootn" m
+  let pown m = binary_fi "pown" m
+end
+
+module Lisp = Primus.Lisp.Semantics
 
 let provide () =
   KB.Rule.(begin
       declare "primus-lisp-core-primitives" |>
-      require Sema.primitive   |>
+      require Lisp.name |>
+      require Lisp.args |>
       provide Theory.Semantics.slot |>
       comment "implements semantics for the core primitives"
     end);
+  List.iter export ~f:(fun (name,types,docs) ->
+      Primus.Lisp.Semantics.declare ~types ~docs name);
+  let (let*?) x f = x >>= function
+    | None -> !!nothing
+    | Some x -> f x in
   KB.promise Theory.Semantics.slot @@ fun obj ->
-  KB.collect Sema.primitive obj >>= function
-  | None -> !!nothing
-  | Some p ->
-    Theory.instance () >>= Theory.require >>= fun (module CT) ->
-    let module P = Primitives(CT) in
-    let name = Sema.Primitive.name p
-    and args = Sema.Primitive.args p in
-    P.dispatch obj name args
+  let*? name = KB.collect Lisp.name obj in
+  let*? args = KB.collect Lisp.args obj in
+  Theory.instance () >>= Theory.require >>= fun (module CT) ->
+  let module P = Primitives(CT) in
+  P.dispatch obj name args
+
+let enable_extraction () =
+  Theory.declare ~provides:["extraction"; "primus-lisp"; "lisp"]
+    ~package:"bap"
+    ~name:"primus-lisp" (KB.return (module CST : Theory.Core))

--- a/plugins/primus_lisp/primus_lisp_semantic_primitives.mli
+++ b/plugins/primus_lisp/primus_lisp_semantic_primitives.mli
@@ -1,1 +1,2 @@
 val provide : unit -> unit
+val enable_extraction : unit -> unit

--- a/plugins/primus_lisp/primus_lisp_show.ml
+++ b/plugins/primus_lisp/primus_lisp_show.ml
@@ -1,0 +1,107 @@
+let doc = "Shows the static semantics of Primus Lisp definitions.
+
+# DESCRIPTION
+
+Accepts a list of definition names and prints their static
+reifications (semantics). To load a specific program (feature) use
+the default mechanism ($(b,--primus-lisp-load)).
+
+
+# EXAMPLE
+
+Assuming that the following Lisp program
+
+```
+(defun foo ()
+  (set R0 (/= 1 2 3 4)))
+```
+
+is stored in the file $(b,demo.lisp) that is located in the current
+folder, use the following parameters to print the reification,
+
+
+```
+bap show foo --primus-lisp-load=demo -tarmv5+le
+```
+
+Notice, that the target specification is necessary when a definition
+is not closed, i.e., when it references global variables (registers).
+
+To print only specific slot of the value, use $(b,--slot) (short
+version $(b,o)), e.g., the following will print only the BIL representation,
+
+```
+bap show foo --primus-lisp-load=demo -tarmv5+le -obap:bil
+```
+
+"
+
+open Core_kernel
+open Bap_core_theory
+open Bap_main
+open Bap.Std
+open Extension.Syntax
+open KB.Syntax
+
+open Bap_primus.Std
+
+type error = Conflict of KB.Conflict.t
+
+type Extension.Error.t += Failed of error
+
+let fail err = Error (Failed err)
+
+module Spec = struct
+  open Extension
+  open Command
+
+  let bitvec = Type.define Bitvec.zero
+      ~parse:Bitvec.of_string
+      ~print:Bitvec.to_string
+
+  let target = Type.define Theory.Target.unknown
+      ~print:Theory.Target.to_string
+      ~parse:(Theory.Target.get ~package:"bap")
+
+  let names = Command.arguments Type.string
+  let target = Command.parameter target "target"
+      ~aliases:["t"; "arch"]
+  let slots = Command.parameters Type.(list string) "slots"
+      ~aliases:["s"; "o"]
+  let addr = Command.parameter Type.(some bitvec) "address"
+      ~aliases:["a"]
+  let t = args $ target $ names $ slots $ addr
+end
+
+
+let show target slots addr name =
+  let pp = match List.concat slots with
+    | [] -> KB.Value.pp
+    | ss -> KB.Value.pp_slots ss in
+  Toplevel.try_exec @@ begin
+    Primus.Lisp.Unit.create target >>= fun unit ->
+    KB.Object.scoped Theory.Program.cls @@ fun obj ->
+    KB.sequence [
+      KB.provide Theory.Label.unit obj (Some unit);
+      KB.provide Theory.Label.addr obj addr;
+      KB.provide Primus.Lisp.Semantics.name obj (Some name);
+    ] >>= fun () ->
+    KB.collect Theory.Semantics.slot obj >>| fun sema ->
+    Format.eprintf "%s:@ %a@." name pp sema
+  end
+
+let () = Extension.Command.declare ~doc "show-lisp" Spec.t @@
+  fun target names slots addr _ctxt ->
+  List.map names ~f:(show target slots addr) |>
+  Result.all_unit |>
+  Result.map_error ~f:(fun err ->
+      Failed (Conflict err))
+
+let string_of_error = function
+  | Conflict err ->
+    Format.asprintf "Failed to reify the program: %a"
+      KB.Conflict.pp err
+
+let () = Extension.Error.register_printer @@ function
+  | Failed err -> Some (string_of_error err)
+  | _ -> None


### PR DESCRIPTION
Introduction
============

It is now possible to specify program semantics, including
semantics of instructions (aka lifters) and even semantics of the
whole programs in Primus Lisp.

Essentially Primus Lisp programs could be compiled into program
values, i.e., core theory terms. The main motivation for this work was
writing lifters and stubs in Primus Lisp, which significantly reduces
the effort wrt writing a lifter directly in OCaml. For example, it
took me less than a day to write a RISCV lifter in Primus Lisp (the PR
is upcoming).

The feature is seamlessly integrated with the knowledge base that
makes it available not only for the new architectures but for
extending the lifters for existing architectures. Whenever a semantics
of a basic instruction is requested, a corresponding Lisp definition
(which has name that matches the opcode name prefixed with the opcode
encoding and the corresponding number of arguments) is sought and if
found its is reified into a Core Theory term.

The Primus Lisp language itself underwent a few deep changes and is now a
meta language for writing programs that write programs. Its Lisp
nature makes it an ideal choice for writing lifters thanks to
mono-iconic representation of the host and target languages. The
Primus Lisp meta compiler is an interpreter that partially evaluates
Primus Lisp programs until no further refinements are possible. This
results in a very-specialized minimal code. To illustrate this, let's
consider the following example (assuming that it is stored in the
`demo.lisp` file that is located in the current folder),

```lisp
(defun example1 ()
  (set R0 (/= 1 2 3)))
```

Since the value of `(/= 1 2 3)` is statically known we reify it into
an efficient representation,

```
$ bap show example1 --primus-lisp-load=demo -tarmv5+le -obap:bil
example1:
"{
   R0 := 1
 }"
```

We still produce an assignment because the target is `armv5+le`, which
tells us that `R0` is a register. Let's consider an example where we
can't compute the input statically,
```lisp
(defun example2 ()
  (set R0 (/= R1 1 2 3)))
```

which is refied into,
```
$ bap show example2 --primus-lisp-load=demo -tarmv5+le -obap:bil
example2:
"{
   R0 := R1 <> 1 & R1 <> 2 & R1 <> 3
 }"
```

The meta-compiler supports partial computations for all forms, so it
is possible to use `let` forms (with lexical and dynamic scoping) and
define helper functions and macros, e.g.,

```
(defun example3 ()
  (let ((x (average 1 2 3)))
    (set R0 (+ (average 10 R1 30) x))))

(defun average (x y z)
  (/ (+ x y z) 3))
```

will be reified to
```
$ bap show example3 --primus-lisp-load=demo -tarmv5+le -obap:bil
example3:
"{
   R0 := (R1 + 0x28) / 3 + 2
 }"
```

Such mono-iconic representation is possible because the value of a
Primus Lisp expression is no longer a word, but a program term, which
is represented as the knowledge base value of class
`Theory.Effect.cls`. This value is also known in `Bap.Std` as
`Insn.t`, coincidentally the type of a value that is expected to be
provided by lifters.