### PR TITLE
hushes the BIL lifter when there is no BIL

### DIFF
--- a/plugins/bil/bil_lifter.ml
+++ b/plugins/bil/bil_lifter.ml
@@ -318,8 +318,10 @@ let provide_basic () =
   KB.collect Disasm_expert.Basic.Insn.slot obj >>= function
   | None -> !!Theory.Semantics.empty
   | Some insn ->
-    KB.collect Bil.code obj >>| fun bil ->
-    Insn.of_basic ~bil insn
+    KB.Object.repr Theory.Program.cls obj >>= fun lbl ->
+    KB.collect Bil.code obj >>| function
+    | [] -> Theory.Semantics.empty
+    | bil -> Insn.of_basic ~bil insn
 
 let provide_lifter ~with_fp () =
   info "providing a lifter for all BIL lifters";


### PR DESCRIPTION
This is a quick fix that prevents the BIL lifter from interpreting an
absence of BIL as an absence of effects. The root of the problem is
that we chose `[]` as the empty value for the BIL domain, which is
easy to confuse with an absence of effects (or representable in BIL
effects).

We can't change the domain, as it will break the interface, but a
better solution might be changing the domain of the Bil.code slot that
was introduced recently and is not yet in the stable API. Meantime,
the current solution will be the hotfix.