### PR TITLE
prunes empty segments

### DIFF
--- a/plugins/primus_loader/primus_loader_basic.ml
+++ b/plugins/primus_loader/primus_loader_basic.ml
@@ -87,6 +87,7 @@ module Make(Param : Param)(Machine : Primus.Machine.S)  = struct
     | Ok segs ->
       Machine.Seq.fold ~init:null segs
         ~f:(fun endp {Image.Scheme.addr; size; info=(_,w,x)} ->
+            assert Int64.(size <> 0L);
             make_word addr >>= fun lower ->
             make_word Int64.(size-1L) >>= fun diff ->
             let upper = Word.(lower + diff) in


### PR DESCRIPTION
Filters out empty segments from the specification. An empty segment
breaks, in particular, the Primus loader which treats it as a segment
that covers all addresses (an appropriate assert is added to make it
easier to discover such issues in the future).

Thanks @anwarmamat for reporting the issue.