### PR TITLE
fixes recipes search paths

### DIFF
--- a/lib/bap_main/bap_main.ml
+++ b/lib/bap_main/bap_main.ml
@@ -1223,7 +1223,9 @@ let enable_logging = function
 let load_recipe recipe =
   let paths = [
     Stdlib.Filename.current_dir_name;
-    Extension.Configuration.datadir] in
+    Extension.Configuration.datadir;
+    Extension.Configuration.sysdatadir;
+  ] in
   match Bap_recipe.load ~paths recipe with
   | Ok r ->
     Stdlib.at_exit (fun () -> Bap_recipe.close r);

--- a/plugins/recipe_command/recipe_command_main.ml
+++ b/plugins/recipe_command/recipe_command_main.ml
@@ -102,7 +102,8 @@ type Extension.Error.t += Recipe_error of Recipe.error
 
 let recipe_paths = [
   Filename.current_dir_name;
-  Extension.Configuration.datadir
+  Extension.Configuration.datadir;
+  Extension.Configuration.sysdatadir;
 ]
 
 let cleanup ~keep r =


### PR DESCRIPTION
Includes the system-wide share prefix in the search path so that now it is searched in three locations (in that order): the current working directory, user-specific share folder (commonly ~/.local/share/bap) and system-specific (usually `$(opam config var prefix)/share/bap`).