### PR TITLE
Update bap.mli for auto-documentation

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -5512,6 +5512,7 @@ module Std : sig
 
     (** [entry_point addr] is an address from which a kernel should start *)
     val entry_point : t -> addr
+    
     (** [filename image] a name of file from which an image was
         loaded (if any) *)
     val filename : t -> string option

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -5512,7 +5512,7 @@ module Std : sig
 
     (** [entry_point addr] is an address from which a kernel should start *)
     val entry_point : t -> addr
-    
+
     (** [filename image] a name of file from which an image was
         loaded (if any) *)
     val filename : t -> string option


### PR DESCRIPTION
Added a newline so that the auto-documentation will correctly format the `var entry_point` entry correctly.