### PR TITLE
adds namepspaces (packages) to Primus Lisp

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -49,6 +49,7 @@ B lib/bap_api
 B lib/bitvec
 B lib/bitvec_order
 B lib/bitvec_sexp
+B lib/bitvec_binprot
 B lib/bap_bundle
 B lib/bap_c
 B lib/bap_config

--- a/lib/bap/bap_project.ml
+++ b/lib/bap/bap_project.ml
@@ -360,7 +360,6 @@ let pp_disasm_error ppf = function
     fprintf ppf "<%s>: %a"
       (Disasm_expert.Basic.Insn.asm insn) Error.pp err
 
-
 let set_package package = match package with
   | None -> KB.return ()
   | Some pkg -> KB.Symbol.set_package pkg

--- a/lib/bap_core_theory/bap_core_theory.mli
+++ b/lib/bap_core_theory/bap_core_theory.mli
@@ -1949,6 +1949,25 @@ module Theory : sig
 
       (** the reserved register with undefined behavior.  *)
       val reserved : t
+
+
+      (** {3 Calling Conventions} *)
+
+      (** the register is used to pass function arguments  *)
+      val function_argument : t
+
+      (** the register is used to return values from functions  *)
+      val function_return : t
+
+
+      (** the register is volatile and should be preserved by the caller  *)
+      val caller_saved : t
+
+
+      (** the register is preserved across calls and must be
+          preserved by the callee.   *)
+      val callee_saved : t
+
     end
 
     include KB.Enum.S with type t := t

--- a/lib/bap_core_theory/bap_core_theory.mli
+++ b/lib/bap_core_theory/bap_core_theory.mli
@@ -1155,6 +1155,12 @@ module Theory : sig
     val scoped : 'a Value.sort -> ('a t -> 'b pure) -> 'b pure
 
 
+    (** [printf "%a" Theory.Var.pp v] pretty-prints the identifier
+        of the variable [v].
+
+        @since 2.3.0  *)
+    val pp : Format.formatter -> 'a t -> unit
+
     (** Variable identifiers.  *)
     module Ident : sig
       type t = ident [@@deriving bin_io, compare, sexp]
@@ -1850,6 +1856,17 @@ module Theory : sig
           and arithmetic operations of a computation unit).
       *)
       val special : t
+
+
+
+      (** the pseudo-register.
+
+          The pseudo-registers do not correspond to a real physical or
+          logical register in the instruction set but rather an alias
+          or a hard-wired register, such as constant zero or an
+          instruction register or a program counter.
+      *)
+      val pseudo : t
 
       (** the register is used by the integer arithmetic unit
 

--- a/lib/bap_core_theory/bap_core_theory_target.ml
+++ b/lib/bap_core_theory/bap_core_theory_target.ml
@@ -46,6 +46,10 @@ module Role = struct
     let sign_flag = declare ~package "sign-flag"
     let overflow_flag = declare ~package "overflow-flag"
     let parity_flag = declare ~package "parity-flag"
+    let function_argument = declare ~package "function-argument"
+    let function_return = declare ~package "function-return"
+    let caller_saved = declare ~package "caller-saved"
+    let callee_saved = declare ~package "callee-saved"
   end
 end
 

--- a/lib/bap_core_theory/bap_core_theory_target.ml
+++ b/lib/bap_core_theory/bap_core_theory_target.ml
@@ -27,6 +27,7 @@ module Role = struct
   module Register = struct
     let general = declare ~package "general"
     let special = declare ~package "special"
+    let pseudo = declare ~package "pseudo"
     let integer = declare ~package "integer"
     let floating = declare ~package "floating"
     let vector = declare ~package "vector"

--- a/lib/bap_core_theory/bap_core_theory_target.mli
+++ b/lib/bap_core_theory/bap_core_theory_target.mli
@@ -100,6 +100,10 @@ module Role : sig
     val parity_flag : t
     val hardware : t
     val reserved : t
+    val function_argument : t
+    val function_return : t
+    val caller_saved : t
+    val callee_saved : t
   end
 
   include KB.Enum.S with type t := t

--- a/lib/bap_core_theory/bap_core_theory_target.mli
+++ b/lib/bap_core_theory/bap_core_theory_target.mli
@@ -81,6 +81,7 @@ module Role : sig
   module Register : sig
     val general : t
     val special : t
+    val pseudo : t
     val integer : t
     val floating : t
     val vector : t

--- a/lib/bap_core_theory/bap_core_theory_var.ml
+++ b/lib/bap_core_theory/bap_core_theory_var.ml
@@ -67,6 +67,7 @@ let pp_ident ppf ident = match ident with
   | Var {num; ver} ->
     Format.fprintf ppf "#%a%a" Int63.pp num pp_ver ver
 
+let pp ppf (_,v) = Format.fprintf ppf "%a" pp_ident v
 let name (_,v) = Format.asprintf "%a" pp_ident v
 let ident (_,v) = v
 let sort (s,_) = s

--- a/lib/bap_core_theory/bap_core_theory_var.mli
+++ b/lib/bap_core_theory/bap_core_theory_var.mli
@@ -24,6 +24,7 @@ val is_virtual : 'a t -> bool
 val is_mutable : 'a t -> bool
 val fresh : 'a sort -> 'a t knowledge
 val scoped : 'a sort -> ('a t -> 'b pure) -> 'b pure
+val pp : Format.formatter -> 'a t -> unit
 
 module Ident : sig
   type t = ident [@@deriving bin_io, compare, sexp]

--- a/lib/bap_image/bap_memory.ml
+++ b/lib/bap_image/bap_memory.ml
@@ -447,10 +447,11 @@ include Printable.Make(struct
 let hexdump t = Format.asprintf "%a" pp_hex t
 
 
-let domain = KB.Domain.optional ~inspect:sexp_of_t "mem"
+let domain = KB.Domain.optional "mem"
     ~equal:(fun x y ->
         Addr.equal x.addr y.addr &&
         Int.equal x.size y.size)
+    ~inspect:(fun x -> Sexp.Atom (String.strip (to_string x)))
 
 let slot = KB.Class.property ~package:"bap"
     Theory.Program.cls "mem" domain

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -3658,7 +3658,7 @@ ident ::= ?any atom that is not recognized as a <word>?
         val definition : (Theory.program, Theory.Label.t option) KB.slot
 
         (** the name of a lisp program *)
-        val name : (Theory.program, string option) KB.slot
+        val name : (Theory.program, KB.Name.t option) KB.slot
 
         (** the arguments of a lisp program   *)
         val args : (Theory.program, unit Theory.Value.t list option) KB.slot

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -3349,8 +3349,12 @@ attribute ::=
   | (static <ident> ...)
   | (advice <cmethod> <ident> ...)
   | (<ident> ?ident-specific-format?)
+  | (visibility <visibility>)
+  | <ident>
 
 cmethod ::= :before | :after
+
+visibility ::= :public | :private
 
 docstring ::= <text>
 
@@ -3926,7 +3930,7 @@ ident ::= ?any atom that is not recognized as a <word>?
       (* dedocumented due to deprecation *)
       module Primitive : sig
         type 'a t
-        val create : ?docs:string -> string -> (value list -> 'a) -> 'a t
+        val create : ?docs:string -> ?package:string -> string -> (value list -> 'a) -> 'a t
       end [@@deprecated "[since 2018-03] use [Closure]"]
 
       (* undocumented since it is deprecated *)
@@ -3986,8 +3990,11 @@ ident ::= ?any atom that is not recognized as a <word>?
               end
             ]}
         *)
-        val define : ?types:Type.signature ->
-          ?docs:string -> string -> closure -> unit Machine.t
+        val define :
+          ?types:Type.signature ->
+          ?docs:string ->
+          ?package:string ->
+          string -> closure -> unit Machine.t
 
 
         (** [signal ?params ?docs obs proj] defines a new signal.

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -253,8 +253,20 @@ module Std : sig
       module Provider : sig
         type t = provider
 
-        (** unique name of a provider *)
+        (** the string representation of the provider name.
+
+            The [name t] is the textual representation of
+            [fullname t] except that names in the package
+            ["primus"] are printed unqualifed and all other
+            names are qualified.
+        *)
         val name : t -> string
+
+        (** the name of a provider.
+
+            @since 2.3.0
+        *)
+        val fullname : t -> KB.Name.t
 
         (** a total number of observers that subscribed to this provider  *)
         val observers : t -> int
@@ -2819,7 +2831,8 @@ module Std : sig
         - [core] - the core of the Primus Lisp language;
         - [primus] - the Primus Lisp runtime;
         - [program] - the binary program runtime;
-        - [target] - the target CPU environment.
+        - [target] - the target CPU environment;
+        - [posix] - the definitions of the posix runtime.
 
         In addition to these packages, each target (architecture)
         known to bap (see [bap list targets]) forms a package that
@@ -2830,10 +2843,9 @@ module Std : sig
         with the other option is to use the [target] package in which
         CPU registers of the currently analyzed binary are added.
 
-        Another important packages to consider is [posix] that
-        contains definitions of the [posix] runtime, e.g.,
-        [posix:malloc] and there is also a special [external] package
-        where all externally visible definitions are put.
+        Another important packages to consider is the [external] package
+        where all externally visible definitions are put, see more
+        about it in the [external] attribute description.
 
         {3 Name Visibility}
 

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -3742,7 +3742,8 @@ ident ::= ?any atom that is not recognized as a <word>?
         *)
         val declare :
           ?types:Type.signature ->
-          ?docs:string -> string -> unit
+          ?docs:string ->
+          ?package:string -> string -> unit
       end
 
 

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -3851,7 +3851,7 @@ ident ::= ?any atom that is not recognized as a <word>?
           ?desc:string ->
           ?package:string ->
           domain:'a KB.domain ->
-          parse:(Parse.tree list -> 'a) ->
+          parse:(package:string -> Parse.tree list -> 'a) ->
           string -> 'a t
 
 

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -2644,8 +2644,8 @@ module Std : sig
         {2 Overview}
 
         Primus Lisp is a dialect of Lisp, that can be used to interact
-        with a native program. Primus Lisp is close to Common Lisp and
-        to the Emacs Lisp dialect.
+        with a native program. Primus Lisp is close to the Common Lisp and
+        Emacs Lisp dialects.
 
         Primus Lips is a low-level language that doesn't provide many
         abstractions, as it tries to be as close to the machine
@@ -2659,25 +2659,28 @@ module Std : sig
 
         Primus Lisp is primarily used for the following tasks:
         - writing function summaries (aka stubs);
+        - writing insturction semantics (aka lifters);
+        - stubbing missing hardware;
         - setting up program environment;
         - exploring and observing program behavior.
 
+        A Primus Lisp program is a set of files with each file
+        consisting of:
 
-        A Primus Lisp program is a file, that can contain the
-        following entities:
         - feature requests;
+        - package definitions;
         - declarations;
         - constants
         - substitutions;
-        - methods;
         - macros;
-        - functions;
+        - methods;
+        - functions.
 
         The entities may be specified in any order, however the above
         order constitutes a good programming practice.
 
-        Each file provides (implements) a feature, that has the same
-        name as the name of the file without an extension and
+        Each file provides (implements) a {i feature} that has the same
+        name as the name of the file without an extension and parent
         directories. Thus the namespace of features is flat. A feature
         is usually a function, macro definition, or any other
         definition, or a collection of definition, gathered under the
@@ -2689,22 +2692,44 @@ module Std : sig
         implementation of all functions specified in the POSIX
         standard (not all at the time of writing).
 
-        A collection of files is called a library.  To use features
-        provided by another file, the file should be requested with
-        the [(require <ident>)] form, where [<ident>] is the name of
-        the feature. A file with the requested name is searched in the
-        library, and loaded, making all its definitions available in
-        the lexical scope, that follows the [require] form. If a
-        feature is already provided, then nothing
-        happens. Dependencies should not contain cycles.
+        A collection of directories with lisp files is called a
+        library. A feature (a lisp file) is loaded using the
+        [(require <feature>)] form, where [<feature>] is the name
+        of the feature. E.g., to load the [posix.lisp] file, use
+        [(require posix)]. The loaded feature may, in turn load
+        other features.
 
-        Top-level declarations specify attributes that are shared by
-        all definitions in a file. For example, a declaration
+        When all required features are loaded the Primus Lisp program
+        is formed, which is a set of mutually recursive
+        definitions. In Primus Lisp the same name can have multiple
+        definitions and features may be mutually recursive, e.g.,
+        [foo] may [(require bar)] and [bar] may [(require foo)]. The
+        order in which features are loaded is not important.
+
+        All definitions in Primus Lisp (since 2.3.0) are packaged in
+        namespaces. A namespace (called {i package} in Primus Lisp) is
+        a collection of definitions. A package can {i use} other packages,
+        in that case all public definitions from the used package are
+        copied to the destination package. The order in which packages
+        are defined is irrelevant, e.g., it possible to use a package
+        before it is defined as well as extend the set of used
+        packages several times. It is even possible to form cycles in
+        the use-package relation, e.g., a package [foo] may use
+        package [bar] and [bar] can use [foo]. In that case
+        definitions made in [foo] are always copied to [bar] and
+        definitions made in [bar] are copied to [foo], which
+        effectively maintains equality between [foo] and [bar] as
+        one is always a copy of another.
+
+        Names visibility as well as other attributes of definitions
+        are controled with {i declarations}. The top-level
+        declarations specify attributes that are shared by all
+        definitions in a feature (file). For example, a declaration
 
         {v (declare (context (arch armv7)) v}
 
-        makes all definitions visible only in the context of the ARMv7
-        architecture.
+        makes all definitions {i applicable} (existent) only in the
+        context of the ARMv7 architecture.
 
         Constants and substitutions are primitive abstractions that
         give names to code fragments. Macros are program
@@ -2713,10 +2738,113 @@ module Std : sig
         with the context declarations. Finally, a function can be
         advised with another function using the [advice-add] function.
 
+        {2 Package System}
 
-        {2 Type system}
+        The Primus Lisp package system enables name clashes-free
+        environment in the presence of mutually recursive definition
+        of the whole program with type class-based names
+        overloading. An important feature of the package system is
+        independence on the order of package definitions and
+        inclusions and tolerance to cycles in package dependencies.
 
-        Primus Lips has a gradual type system.  A type defines all
+        Despite that the package system prevents name clashes in a
+        such complex environment it is easy to understand. A package
+        is just a dictionary of definitions, where a defintion is a
+        function, macros, variable, primitive, etc. The namespace of
+        each package is flat, i.e., all definitions have simple
+        unqualified names, e.g., [malloc], [foo], [*bar*]. The
+        namespace of the packages names is also flat, e.g., [posix],
+        [core], [primus]. To access a definition [<def>] in a package
+        [<pkg>] use [<pkg>:<foo>], e.g., [posix:malloc],
+        [core:*bar*]. When a name is missing a package designator,
+        e.g., [foo] the parser automatically adds the name of the
+        {i current} package. The current package defaults to [user] and
+        is set with the [in-package] form, e.g., [(in-package posix)]
+        sets the current package to [posix] and all unqualified names
+        read after it and until the end of the file (or another
+        [in-package] stanza) will be qualified with the [posix]
+        package. Therefore, it is important to understand that every
+        identifier in Primus Lisp, be it a variable, a function or a
+        macro name, a symbol, and so on, is having a package, even
+        though most of the time it left implicit and we commonly use
+        unqualified names.
+
+        The [(use-package foo)] makes all definitions from the package
+        [foo] available in the current package. Since Primus Lisp
+        enables multiple definitions of the same name, no special
+        considerations to prevent shadowing and the definitions are
+        simply added to the current package. It also doesn't matter
+        whether the [use-package] stanza occurs before, in between, or
+        after the definitions of [foo] are loaded as well as it
+        doesn't matter whether it occurs with respect to the
+        defintions of the current package. The mental model is that
+        [(use-package foo)] establishes a relation {i uses} between
+        the current package and the package [foo] and all definitions
+        from [foo] are copied to the current package no matter whether
+        they were lexically made before or after this relation was
+        discovered. Since the definitions from [foo] are now in the
+        current package, they are also copied to all packages that use
+        the current package and so on, in the transitive closure of
+        the uses relation.
+
+        The [use-package] stanza is pretty low-level and it is better
+        to use [defpackage] to define a package, ideally, once. The
+        [defpackage] form takes the name of the package and a list of
+        packages that it uses as well as the documentation that
+        describes the package purpose. E.g.,
+        {v
+          (defpackage riscv
+            (:use target program)
+            (:documentation "general riscv instruction semantics"))
+        v}
+
+        In the example above we specified that the [riscv] package
+        imports definitions from the [target] and [program] packages.
+
+        In Primus Lisp it is not required that the package should be
+        defined before it is used but it is still a good idea to
+        define the package beforehand and, ideally, keep the
+        definition in a single place. With that said, it is possible
+        to have multiple definitions (or no definitios) of a package
+        spread across multiple files. Therefore, it is possible to
+        extend the set of packages that some package uses with all
+        pitfalls and perils. We highly advice to refrain from touching
+        the use-list of packages that you do not control.
+
+        Primus Lisp comes with a set of predefined packages and all of
+        them are used by the [user] package, which is the default
+        package (so their definitions could be used unqualified by
+        default):
+
+        - [core] - the core of the Primus Lisp language;
+        - [primus] - the Primus Lisp runtime;
+        - [program] - the binary program runtime;
+        - [target] - the target CPU environment.
+
+        In addition to these packages, each target (architecture)
+        known to bap (see [bap list targets]) forms a package that
+        is prefilled with the registers of that target, e.g.,
+        [i86:SP], [amd64:RSP], and so on (the target package name is
+        formed from the unqualified name of the target name
+        itself). This gives an additional way to refer to registers,
+        with the other option is to use the [target] package in which
+        CPU registers of the currently analyzed binary are added.
+
+        Another important packages to consider is [posix] that
+        contains definitions of the [posix] runtime, e.g.,
+        [posix:malloc] and there is also a special [external] package
+        where all externally visible definitions are put.
+
+        {3 Name Visibility}
+
+        By default all names defined in a package are public and are
+        exported to all packages that use this package. It is,
+        possible to control the visibility of a name using the
+        visibility attribute. See attributes below for more information.
+
+        {2 Type System}
+
+        Primus Lisp has a gradual type system.  A type defines all
         possible values of an expression. In Primus Lisp, expression
         values can be only scalar, i.e., machine words of different
         widths. The width is always specified in the number of
@@ -3205,22 +3333,114 @@ module Std : sig
         definition is considered only if its context is a subtype of
         the current type context.
 
-        {2 Advice mechanism}
+        {2 Attributes}
+
+        Each Primus Lisp definition has a set of attributes that
+        defines its various properties. The set of attributes is
+        extensible and language users can define their own and
+        attach arbitrary meaning to them. In that sense attributes is
+        the language extension mechanism. There is, however, a set of
+        core attributes that have predefined meaning and that are
+        described above.
+
+        Attributes are declared using the [declare] stanza, e.g.,
+        [(declare (context (target riscv)))]. Attributes can be
+        defined on the top level, in that case, they will be attached
+        to each definition in this feature, alternatively, the can
+        be attached to a definition, e.g.,
+
+        {v
+         (defun malloc (n)
+           "allocates a memory region of size N"
+           (declare (external "malloc"))
+           ...)
+        v}
+
+        The set of attributes of a definition is the union of
+        attributes attached to it and global to the feature
+        attributes.
+
+        {3 The external attribute}
+
+        This attributes instructs the Primus Lisp program loader that
+        the definition has external linkage and must be linked instead
+        of the corresponding definition in the binary program. E.g.,
+        adding [(external "malloc")] will link the current definition
+        instead of the [malloc] function defined in the binary.
+
+        When the program is linked, the linker will scan all
+        definitions and for each definition that has
+        [(external <n1> <n2> ...)] will be copied to the [external]
+        package under names [<n1>], [<n2>], and so on. Next, when the
+        binary program is linked, for each function in the binary the
+        linker will search the [external] package for the matching
+        definition.
+
+        Note, is is possible to use directly the [external] package to
+        make your definitions externally available.
+
+
+        {3 The context attribute}
+
+        This attribute defines the context in which the definition is
+        applicable. See the {!Context} chapter for more details on it.
+
+        {3 Name Visibility}
+
+        The [visibility] attribute controls whether the definition
+        will be exported to the packages that use the package where it
+        is defined. There are two kinds of visibilities - [:public]
+        and [:private]. By default, all definitions have the [:public]
+        visibility. To make a definition private (so that it won't be
+        accessible in other packages even if they use your package)
+        add the visibility declaration to it, e.g.,
+        {v
+          (defun conditional-jump (cmp off)
+            (declare (visibility :private))
+            (let ((pc (get-program-counter)))
+              (when cmp
+                (exec-addr (+ pc off)))))
+        v}
+
+        It is also possible to make all definitions in a feature
+        private by default using a global visibility declaration,
+        e.g.,
+
+        {v
+        (declare (visibility :private))
+        v}
+
+        and make some definitions public by adding corresponding
+        public declarations.
+
+        {3 Global and Static definitions}
+
+        The [global] and [static] definitions create variables (with,
+        correspondingly public and private visibility), e.g.,
+
+        [(global errno-location)]
+
+        Creates an [errno-location] variable in the Primus Lisp
+        runtime state. The names are read in the current package
+        namespace.
+
+
+        {3 Advice mechanism}
 
         Primus Lisp also provides a mechanism for non-intrusive
-        extending existing function definitions. An existing
-        definition maybe advised with another definition. A piece of
+        extending existing Primus Lisp function definitions.
+        A definition maybe advised with another definition. A piece of
         advice maybe added to a function that will be called either
         before or after the evaluation of an advised function, e.g.,
 
         {v
           (defun memory-written (a x)
-            (declare (advice :before memory-write))
+            (declare (advice :before core:memory-write))
             (msg "write $x to $a"))
         v}
 
         This definition not only defines a new function called
-        [memory-written], but also proclaims it as advice function to
+        [memory-written], but also proclaims it as an advice function to
         the [memory-write] function that should before it is called.
 
         If an advisor is attached before the advised function then
@@ -3238,6 +3458,10 @@ module Std : sig
         override the result of the advised function. If there are
         several advisors attached after the same function, then they
         will be called in an unspecified order.
+
+        All names in the [advice] declaration are parsed with the
+        current package set to [external] to enable seamless advising
+        of the function stubs.
 
 
         {2 Signaling Mechanims}
@@ -3348,8 +3572,8 @@ attribute ::=
   | (global <ident> ...)
   | (static <ident> ...)
   | (advice <cmethod> <ident> ...)
-  | (<ident> ?ident-specific-format?)
   | (visibility <visibility>)
+  | (<ident> ?ident-specific-format?)
   | <ident>
 
 cmethod ::= :before | :after
@@ -3370,8 +3594,16 @@ int   ::= ?decimal-octal-hex-or-bin format?
 
 size  ::= ?decimal?
 
-ident ::= ?any atom that is not recognized as a <word>?
-        v}
+ident ::= <package>:<name>
+
+name ::= text
+
+package ::= text
+
+text ::= ?any atom that is not recognized as a <word>?
+
+
+    v}
     *)
     module Lisp : sig
 

--- a/lib/bap_primus/bap_primus_lisp.ml
+++ b/lib/bap_primus/bap_primus_lisp.ml
@@ -731,7 +731,7 @@ module Make(Machine : Machine) = struct
     let name = Lisp.Def.name def in
     let args,ret,tid,addr = find_sub (Project.program proj) name in
     let name = KB.Name.create ~package:"external" name in
-    Lisp.Resolve.defun Lisp.Check.arg
+    Lisp.Resolve.extern Lisp.Check.arg
       program
       Lisp.Program.Items.func name args |> function
     | None ->

--- a/lib/bap_primus/bap_primus_lisp.ml
+++ b/lib/bap_primus/bap_primus_lisp.ml
@@ -90,7 +90,7 @@ let merge_advisors x y = {
 
 let add_advisor cmethod advisor advices advised =
   let advisor = make_advisors cmethod advisor in
-  Map.update advices (KB.Name.read advised) ~f:(function
+  Map.update advices advised ~f:(function
       | None -> advisor
       | Some other -> merge_advisors other advisor)
 

--- a/lib/bap_primus/bap_primus_lisp.ml
+++ b/lib/bap_primus/bap_primus_lisp.ml
@@ -97,14 +97,16 @@ let add_advisor cmethod advisor advices advised =
 
 let collect_advisors prog =
   Lisp.Program.fold prog func ~f:(fun ~package def init ->
-      let adv =
-        Attribute.Set.get Advice.t (Lisp.Def.attributes def) in
-      let advisor =
-        KB.Name.create ~package (Lisp.Def.name def) in
-      List.fold Advice.[After; Before] ~init
-        ~f:(fun init cmethod ->
-            let targets = Advice.targets adv cmethod in
-            Set.fold targets ~init ~f:(add_advisor cmethod advisor)))
+      if Lisp.Program.is_applicable prog def then
+        let adv =
+          Attribute.Set.get Advice.t (Lisp.Def.attributes def) in
+        let advisor =
+          KB.Name.create ~package (Lisp.Def.name def) in
+        List.fold Advice.[After; Before] ~init
+          ~f:(fun init cmethod ->
+              let targets = Advice.targets adv cmethod in
+              Set.fold targets ~init ~f:(add_advisor cmethod advisor))
+      else init)
     ~init:(Map.empty (module KB.Name))
 
 module Errors(Machine : Machine) = struct

--- a/lib/bap_primus/bap_primus_lisp.ml
+++ b/lib/bap_primus/bap_primus_lisp.ml
@@ -359,7 +359,7 @@ module Interpreter(Machine : Machine) = struct
       width >>= fun width ->
       let bv = Bitvec.(bigint v mod modulus width) in
       Eval.const (Word.create bv width) in
-    let sym v = Value.Symbol.to_value (show v.data) in
+    let sym v = Value.Symbol.to_value (KB.Name.unqualified v.data) in
     let var width places v = match Map.find places v.data.exp with
       | None -> var_of_lisp_var width v
       | Some v -> v in

--- a/lib/bap_primus/bap_primus_lisp.ml
+++ b/lib/bap_primus/bap_primus_lisp.ml
@@ -691,10 +691,12 @@ module Make(Machine : Machine) = struct
       Set.union vars @@
       Var.Set.of_list @@
       List.map ~f:(var_of_lisp_var default_width) vars' in
-    Lisp.Program.get s.program Lisp.Program.Items.func |>
-    List.fold ~init:Var.Set.empty  ~f:(fun vars def ->
-        add Variables.global def vars |>
-        add Variables.static def) |>
+    Lisp.Program.fold s.program func
+      ~init:Var.Set.empty
+      ~f:(fun ~package:_ defs init ->
+          List.fold defs ~init ~f:(fun vars def ->
+              add Variables.global def vars |>
+              add Variables.static def)) |>
     Set.to_sequence
 
 

--- a/lib/bap_primus/bap_primus_lisp.ml
+++ b/lib/bap_primus/bap_primus_lisp.ml
@@ -555,13 +555,12 @@ module Make(Machine : Machine) = struct
     let run =
       Machine.get () >>= fun proj ->
       Machine.Local.get state >>= fun s ->
-      Env.all >>= fun vars ->
       let t = Project.target proj in
       let externals =
         signatures_of_subs (Project.program proj) |>
-        List.map ~f:(fun (n,s) -> KB.Name.read n,s t) in
+        List.map ~f:(fun (n,s) -> n,s t) in
       let typeenv =
-        Lisp.Program.Type.infer ~externals vars s.program in
+        Lisp.Program.Type.infer ~externals s.program in
       Lisp.Program.Type.errors typeenv |>
       Machine.List.iter ~f:(fun s ->
           Machine.Observation.make Type.notify_error s) >>= fun () ->

--- a/lib/bap_primus/bap_primus_lisp.mli
+++ b/lib/bap_primus/bap_primus_lisp.mli
@@ -93,7 +93,7 @@ type closure = (module Closure)
 
 module Primitive : sig
   type 'a t
-  val create : ?docs:string -> string -> (value list -> 'a) -> 'a t
+  val create : ?docs:string -> ?package:string -> string -> (value list -> 'a) -> 'a t
 end
 
 val message : message observation
@@ -119,7 +119,8 @@ module Make (Machine : Machine) : sig
 
   val types : Type.env Machine.t
 
-  val define : ?types:Type.signature -> ?docs:string -> string -> closure -> unit Machine.t
+  val define : ?types:Type.signature -> ?docs:string ->
+    ?package:string -> string -> closure -> unit Machine.t
 
   val signal :
     ?params:[< Type.parameters] ->

--- a/lib/bap_primus/bap_primus_lisp.mli
+++ b/lib/bap_primus/bap_primus_lisp.mli
@@ -146,7 +146,7 @@ module Semantics : sig
 
   val program : (Theory.Source.cls, program) KB.slot
   val definition : (Theory.program, Theory.Label.t option) KB.slot
-  val name : (Theory.program, string option) KB.slot
+  val name : (Theory.program, KB.Name.t option) KB.slot
   val args : (Theory.program, unit Theory.Value.t list option) KB.slot
   val symbol : (Theory.Value.cls, String.t option) KB.slot
   val static : (Theory.Value.cls, Bitvec.t option) KB.slot

--- a/lib/bap_primus/bap_primus_lisp.mli
+++ b/lib/bap_primus/bap_primus_lisp.mli
@@ -184,7 +184,7 @@ module Attribute : sig
     ?desc:string ->
     ?package:string ->
     domain:'a KB.domain ->
-    parse:(Parse.tree list -> 'a) ->
+    parse:(package:string -> Parse.tree list -> 'a) ->
     string -> 'a t
 
   module Set : sig

--- a/lib/bap_primus/bap_primus_lisp.mli
+++ b/lib/bap_primus/bap_primus_lisp.mli
@@ -153,7 +153,7 @@ module Semantics : sig
   val enable : ?stdout:Format.formatter -> unit -> unit
   val declare :
     ?types:Type.signature ->
-    ?docs:string -> string -> unit
+    ?docs:string -> ?package:string -> string -> unit
 
 end
 

--- a/lib/bap_primus/bap_primus_lisp_attribute.ml
+++ b/lib/bap_primus/bap_primus_lisp_attribute.ml
@@ -94,7 +94,7 @@ module Set = struct
   let get {slot} = KB.Value.get slot
   module Self = (val KB.Value.derive cls)
 
-  let slot = KB.Class.property Theory.Program.cls "primus-attrs" Self.domain
+  let slot = KB.Class.property Theory.Program.cls "attributes" Self.domain
       ~public:true
       ~package:"primus"
       ~persistent:(KB.Persistent.of_binable (module Self))

--- a/lib/bap_primus/bap_primus_lisp_attribute.ml
+++ b/lib/bap_primus/bap_primus_lisp_attribute.ml
@@ -82,9 +82,13 @@ let parse s attrs name values = match Hashtbl.find parsers name with
 
 let parse attrs = function
   | {data=List ({data=Atom name} as s :: values)} ->
-    let name = Name.read ~package:"primus" name in
+    let name = Name.read ~package:"core" name in
     parse s attrs name values
-  | s -> Parse.(fail Expect_list) [s]
+  | {data=Atom name} as s ->
+    let name = Name.read ~package:"core" name in
+    parse s attrs name []
+  | _ -> attrs
+
 
 module Set = struct
   let get {slot} = KB.Value.get slot
@@ -92,7 +96,7 @@ module Set = struct
 
   let slot = KB.Class.property Theory.Program.cls "primus-attrs" Self.domain
       ~public:true
-      ~package:"bap"
+      ~package:"primus"
       ~persistent:(KB.Persistent.of_binable (module Self))
 
   include Self

--- a/lib/bap_primus/bap_primus_lisp_attribute.ml
+++ b/lib/bap_primus/bap_primus_lisp_attribute.ml
@@ -87,7 +87,7 @@ let parse ~package attrs = function
   | {data=Atom name} as s ->
     let name = Name.read ~package:"core" name in
     parse package s attrs name []
-  | _ -> attrs
+  | s -> Parse.(fail Expect_list) [s]
 
 
 module Set = struct

--- a/lib/bap_primus/bap_primus_lisp_attribute.mli
+++ b/lib/bap_primus/bap_primus_lisp_attribute.mli
@@ -21,11 +21,11 @@ val declare :
   ?desc:string ->
   ?package:string ->
   domain:'a KB.domain ->
-  parse:(tree list -> 'a) ->
+  parse:(package:string -> tree list -> 'a) ->
   string -> 'a t
 
 
-val parse : set -> tree -> set
+val parse : package:string -> set -> tree -> set
 
 module Set : sig
   include KB.Value.S with type t := set

--- a/lib/bap_primus/bap_primus_lisp_attributes.ml
+++ b/lib/bap_primus/bap_primus_lisp_attributes.ml
@@ -100,8 +100,8 @@ module Visibility = struct
       ~package ~domain ~parse
 
   let is_public = function
-    | []  | Public :: _ -> true
-    | _ -> false
+    | Private :: _ -> false
+    | _ -> true
 
 end
 

--- a/lib/bap_primus/bap_primus_lisp_attributes.ml
+++ b/lib/bap_primus/bap_primus_lisp_attributes.ml
@@ -147,33 +147,33 @@ module Advice = struct
     | Some targets -> targets
 
 
-  let parse_target package = function
-    | {data=Atom x} -> KB.Name.read ~package x
+  let parse_target = function
+    | {data=Atom x} -> KB.Name.read ~package:"external" x
     | s -> fail Expect_atom [s]
 
-  let parse_targets package met ss = match ss with
+  let parse_targets met ss = match ss with
     | [] -> fail No_targets ss
     | ss ->
       List.fold ss ~init:{methods=Methods.empty} ~f:(fun {methods} t -> {
             methods = Map.update methods met ~f:(function
                 | None -> Set.singleton (module KB.Name)
-                            (parse_target package t)
-                | Some ts -> Set.add ts (parse_target package t))
+                            (parse_target t)
+                | Some ts -> Set.add ts (parse_target t))
           })
 
-  let parse ~package trees = match trees with
+  let parse ~package:_ trees = match trees with
     | [] -> fail Empty trees
     | {data=List _} as s :: _  ->  fail Bad_syntax [s]
     | {data=Atom s} as lit :: ss ->
       if String.is_empty s then fail (Unknown_method s) [lit];
       match s with
-      | ":before" -> parse_targets package Before ss
-      | ":after" -> parse_targets package After ss
+      | ":before" -> parse_targets Before ss
+      | ":after" -> parse_targets After ss
       | _ when Char.(s.[0] = ':') -> fail (Unknown_method s) [lit]
-      | _ -> parse_targets package Before trees
+      | _ -> parse_targets Before trees
 
   let t = Attribute.declare "advice"
-      ~package:"primus"
+      ~package
       ~domain
       ~parse
 end

--- a/lib/bap_primus/bap_primus_lisp_attributes.mli
+++ b/lib/bap_primus/bap_primus_lisp_attributes.mli
@@ -1,4 +1,5 @@
 open Core_kernel
+open Bap_core_theory
 open Bap_primus_lisp_types
 
 module Attribute = Bap_primus_lisp_attribute
@@ -16,7 +17,7 @@ module Advice : sig
   type cmethod = Before | After
   type t
   val t : t Attribute.t
-  val targets : t -> cmethod -> String.Set.t
+  val targets : t -> cmethod -> Set.M(KB.Name).t
 end
 
 module Visibility : sig

--- a/lib/bap_primus/bap_primus_lisp_attributes.mli
+++ b/lib/bap_primus/bap_primus_lisp_attributes.mli
@@ -18,3 +18,8 @@ module Advice : sig
   val t : t Attribute.t
   val targets : t -> cmethod -> String.Set.t
 end
+
+module Visibility : sig
+  type t
+  val is_public : t -> bool
+end

--- a/lib/bap_primus/bap_primus_lisp_attributes.mli
+++ b/lib/bap_primus/bap_primus_lisp_attributes.mli
@@ -22,5 +22,6 @@ end
 
 module Visibility : sig
   type t
+  val t : t Attribute.t
   val is_public : t -> bool
 end

--- a/lib/bap_primus/bap_primus_lisp_context.ml
+++ b/lib/bap_primus/bap_primus_lisp_context.ml
@@ -35,7 +35,7 @@ let of_project proj =
   let t = Project.target proj in
   let targets =
     t :: Theory.Target.parents t |>
-    List.map ~f:Theory.Target.to_string in
+    List.map ~f:(fun t -> KB.Name.unqualified @@ Theory.Target.name t) in
   Name.Map.of_alist_exn [
     "arch", features @@ [
       Arch.to_string (Project.arch proj);

--- a/lib/bap_primus/bap_primus_lisp_context.ml
+++ b/lib/bap_primus/bap_primus_lisp_context.ml
@@ -107,7 +107,7 @@ let push cs name vs =
       | Some vs' -> Set.union vs vs')
 
 
-let parse : tree list -> t =
+let parse ~package:_ : tree list -> t =
   List.fold ~init:Name.Map.empty ~f:(fun cs tree ->
       let (name,vs) = context_of_tree tree in
       push cs name vs)

--- a/lib/bap_primus/bap_primus_lisp_context.ml
+++ b/lib/bap_primus/bap_primus_lisp_context.ml
@@ -171,6 +171,6 @@ let domain = KB.Domain.define "context"
     ~empty ~order ~join
 
 let t = Attribute.declare "context"
-    ~package:"primus"
+    ~package:"core"
     ~domain
     ~parse

--- a/lib/bap_primus/bap_primus_lisp_def.ml
+++ b/lib/bap_primus/bap_primus_lisp_def.ml
@@ -42,7 +42,7 @@ type const = {
   value : string;
 }
 
-type place = Bap.Std.var
+type place = Theory.Var.Top.t
 
 type semafun = Theory.Label.t -> Theory.Value.Top.t list -> Theory.Semantics.t KB.t
 
@@ -265,7 +265,7 @@ module Place = struct
         docs = "";
         attrs = Attribute.Set.empty;
       };
-      code = var;
+      code = Theory.Var.forget var;
     };
     id = Id.null;
     eq = Eq.null;

--- a/lib/bap_primus/bap_primus_lisp_def.ml
+++ b/lib/bap_primus/bap_primus_lisp_def.ml
@@ -44,6 +44,13 @@ type const = {
 
 type place = Bap.Std.var
 
+type semafun = Theory.Label.t -> Theory.Value.Top.t list -> Theory.Semantics.t KB.t
+
+type sema = {
+  apply : semafun;
+  types : Type.signature;
+}
+
 type para = {
   default : ast;
 }
@@ -106,6 +113,25 @@ end
 
 module Meth = Func
 
+module Sema = struct
+  type body = semafun
+
+  let create ?(docs="") ~types name apply : sema t = {
+    data = {
+      meta = {
+        name = KB.Name.show name;
+        docs;
+        attrs=Attribute.Set.empty};
+      code = {apply; types};
+    };
+    id = Source.Id.null;
+    eq = Source.Eq.null;
+  }
+
+  let types : sema t -> Type.signature = fun {data={code}} -> code.types
+  let apply {data={code}} = code.apply
+end
+
 module Signal = struct
   type nonrec t = signal t
 
@@ -123,6 +149,7 @@ module Signal = struct
 
   let signature {data={code}} = code
 end
+
 
 
 module Para =  struct

--- a/lib/bap_primus/bap_primus_lisp_def.ml
+++ b/lib/bap_primus/bap_primus_lisp_def.ml
@@ -42,6 +42,8 @@ type const = {
   value : string;
 }
 
+type place = Bap.Std.var
+
 type para = {
   default : ast;
 }
@@ -228,6 +230,22 @@ module Primitive = struct
 end
 
 
+module Place = struct
+  let create ?package name var = {
+    data = {
+      meta = {
+        name = KB.Name.show@@KB.Name.read ?package name;
+        docs = "";
+        attrs = Attribute.Set.empty;
+      };
+      code = var;
+    };
+    id = Id.null;
+    eq = Eq.null;
+  }
+
+  let location p = p.data.code
+end
 
 module type Primitives = functor (Machine : Machine) ->  sig
   val defs : unit -> value Machine.t Primitive.t list

--- a/lib/bap_primus/bap_primus_lisp_def.ml
+++ b/lib/bap_primus/bap_primus_lisp_def.ml
@@ -16,7 +16,7 @@ module Type = Bap_primus_lisp_type
 type attrs = Attribute.set
 
 type meta = {
-  name : KB.Name.t;
+  name : string;
   docs : string;
   attrs : attrs;
 } [@@deriving fields]
@@ -64,7 +64,7 @@ type prim = {
 
 type 'a spec = {meta : meta; code : 'a}
 type 'a t = 'a spec indexed
-type 'a def = ?docs:string -> ?attrs:attrs -> KB.Name.t -> 'a
+type 'a def = ?docs:string -> ?attrs:attrs -> string -> 'a
 
 let name {data={meta}} = name meta
 let docs {data={meta}} = docs meta
@@ -78,13 +78,11 @@ let create data tree = {
   eq = tree.eq;
 }
 
-let import package def : 'a t =
-  let name = KB.Name.create ~package @@
-    KB.Name.unqualified (name def) in {
-    def with data = {
-      def.data with meta = {def.data.meta with name}
-    }
+let rename def name : 'a t = {
+  def with data = {
+    def.data with meta = {def.data.meta with name}
   }
+}
 
 
 
@@ -216,7 +214,7 @@ module Primitive = struct
   let create ?(docs="") ?package name code = {
     data = {
       meta = {
-        name = KB.Name.read ?package name;
+        name = KB.Name.show@@KB.Name.read ?package name;
         docs;
         attrs = Attribute.Set.empty
       };
@@ -247,7 +245,7 @@ module Closure = struct
   let create ?types ?(docs="") ?(package="core") name lambda = {
     data = {
       meta = {
-        name = KB.Name.read ~package name;
+        name = KB.Name.show@@KB.Name.read ~package name;
         docs;
         attrs=Attribute.Set.empty};
       code = {

--- a/lib/bap_primus/bap_primus_lisp_def.mli
+++ b/lib/bap_primus/bap_primus_lisp_def.mli
@@ -25,12 +25,12 @@ type signal
 
 type attrs = Attribute.set
 
-val name : 'a t -> KB.Name.t
-val import : string -> 'a t -> 'a t
+val name : 'a t -> string
+val rename : 'a t -> string -> 'a t
 val docs : 'a t -> string
 val attributes : 'a t -> attrs
 
-type 'a def = ?docs:string -> ?attrs:attrs -> KB.Name.t -> 'a
+type 'a def = ?docs:string -> ?attrs:attrs -> string -> 'a
 
 module Func : sig
   val create : (var list -> ast -> tree -> func t) def
@@ -92,7 +92,7 @@ module Closure : sig
 end
 
 module Signal : sig
-  val create : ?docs:string -> types:Type.signature -> KB.Name.t -> signal t
+  val create : ?docs:string -> types:Type.signature -> string -> signal t
   val signature : signal t -> Type.signature
 end
 

--- a/lib/bap_primus/bap_primus_lisp_def.mli
+++ b/lib/bap_primus/bap_primus_lisp_def.mli
@@ -25,11 +25,12 @@ type signal
 
 type attrs = Attribute.set
 
-val name : 'a t -> string
+val name : 'a t -> KB.Name.t
+val import : string -> 'a t -> 'a t
 val docs : 'a t -> string
 val attributes : 'a t -> attrs
 
-type 'a def = ?docs:string -> ?attrs:attrs -> string -> 'a
+type 'a def = ?docs:string -> ?attrs:attrs -> KB.Name.t -> 'a
 
 module Func : sig
   val create : (var list -> ast -> tree -> func t) def
@@ -78,19 +79,20 @@ end
 
 module Primitive : sig
   type nonrec 'a t = 'a primitive t
-  val create : ?docs:string -> string -> (value list -> 'a) -> 'a t
+  val create : ?docs:string -> ?package:string -> string -> (value list -> 'a) -> 'a t
   val body : 'a t -> (value list -> 'a)
 end
 
 module Closure : sig
   val of_primitive : 'a Primitive.t -> closure -> prim t
-  val create : ?types:Type.signature -> ?docs:string -> string -> closure -> prim t
+  val create : ?types:Type.signature -> ?docs:string -> ?package:string
+    -> string -> closure -> prim t
   val signature : prim t -> Type.signature option
   val body : prim t -> closure
 end
 
 module Signal : sig
-  val create : ?docs:string -> types:Type.signature -> string -> signal t
+  val create : ?docs:string -> types:Type.signature -> KB.Name.t -> signal t
   val signature : signal t -> Type.signature
 end
 

--- a/lib/bap_primus/bap_primus_lisp_def.mli
+++ b/lib/bap_primus/bap_primus_lisp_def.mli
@@ -12,6 +12,7 @@ end
 
 type 'a spec
 type 'a t = 'a spec indexed
+type sema
 type func
 type meth
 type macro
@@ -32,6 +33,16 @@ val docs : 'a t -> string
 val attributes : 'a t -> attrs
 
 type 'a def = ?docs:string -> ?attrs:attrs -> string -> 'a
+
+
+module Sema : sig
+  type body = Theory.Label.t -> Theory.Value.Top.t list -> Theory.Semantics.t KB.t
+  val create : ?docs:string -> types:Type.signature ->
+    KB.Name.t -> body ->
+    sema t
+  val apply : sema t -> body
+  val types : sema t -> Type.signature
+end
 
 module Func : sig
   val create : (var list -> ast -> tree -> func t) def

--- a/lib/bap_primus/bap_primus_lisp_def.mli
+++ b/lib/bap_primus/bap_primus_lisp_def.mli
@@ -85,8 +85,8 @@ module Const : sig
 end
 
 module Place : sig
-  val create : ?package:string -> string -> Bap.Std.Var.t -> place t
-  val location : place t -> Bap.Std.Var.t
+  val create : ?package:string -> string -> _ Theory.Var.t -> place t
+  val location : place t -> Theory.Var.Top.t
 end
 
 module Subst : sig

--- a/lib/bap_primus/bap_primus_lisp_def.mli
+++ b/lib/bap_primus/bap_primus_lisp_def.mli
@@ -17,6 +17,7 @@ type meth
 type macro
 type subst
 type const
+type place
 type prim
 type closure = (module Closure)
 type 'a primitive
@@ -70,6 +71,11 @@ end
 module Const : sig
   val create : (value:string -> tree -> const t) def
   val value : const t -> tree
+end
+
+module Place : sig
+  val create : ?package:string -> string -> Bap.Std.Var.t -> place t
+  val location : place t -> Bap.Std.Var.t
 end
 
 module Subst : sig

--- a/lib/bap_primus/bap_primus_lisp_parse.ml
+++ b/lib/bap_primus/bap_primus_lisp_parse.ml
@@ -498,6 +498,11 @@ module Parse = struct
         {data=Atom "in-package"};
         {data=Atom package}]} ->
       Program.with_package state package
+    | {data = List ({data=Atom "defpackage"} ::
+                    {data=Atom name} :: elts)} ->
+      defpackage name state elts
+    | {data = List ({data=Atom "use-package"} :: elts)} ->
+      use_package state elts
     | {data=List [
         {data=Atom "defconstant"};
         {data=Atom name};

--- a/lib/bap_primus/bap_primus_lisp_parse.ml
+++ b/lib/bap_primus/bap_primus_lisp_parse.ml
@@ -1,6 +1,7 @@
 open Core_kernel
 open Bap.Std
 open Format
+open Bap_core_theory
 
 open Bap_primus_lisp_types
 
@@ -14,7 +15,7 @@ module Resolve = Bap_primus_lisp_resolve
 module Program = Bap_primus_lisp_program
 module Type = Bap_primus_lisp_type
 
-type defkind = Func | Macro | Const | Subst | Meth | Para
+type defkind = Func | Macro | Const | Subst | Meth | Para | Inpkg | Defpkg
 
 type format_error =
   | Expect_digit
@@ -36,7 +37,7 @@ type parse_error =
   | Bad_ascii
   | Bad_hex
   | Unknown_subst_syntax
-  | Unresolved of defkind * string * Resolve.resolution
+  | Unresolved of defkind * KB.Name.t * Resolve.resolution
 
 
 exception Parse_error of parse_error * tree list
@@ -90,6 +91,7 @@ module Parse = struct
     List.concat_map cs ~f:(function
         | {data=List _} as cs -> [cs]
         | {data=Atom x} as atom ->
+          let x = KB.Name.read ~package:(Program.package prog) x in
           match Resolve.subst prog subst x () with
           | None -> [atom]
           | Some (Error s) -> fail (Unresolved (Subst,x,s)) atom
@@ -97,12 +99,12 @@ module Parse = struct
             Def.Subst.body d |> List.map ~f:(fun tree ->
                 {tree with id = atom.id}))
 
-  let let_var : tree -> var = function
+  let let_var prog : tree -> var = function
     | {data=List _} as s -> fail Bad_let_binding s
-    | {data=Atom x; id; eq} as s -> match Var.read id eq x with
+    | {data=Atom x; id; eq} as s ->
+      match Var.read ~package:(Program.package prog) id eq x with
       | Error e -> fail (Bad_var_literal e) s
       | Ok var -> var
-
 
   let fmt prog fmt tree =
     let fmt = unqoute fmt in
@@ -144,6 +146,8 @@ module Parse = struct
 
 
   let parse prog tree =
+    let package = Program.package prog in
+    let qualify = KB.Name.read ~package in
     let rec exp : tree -> ast = fun tree ->
       let cons data : ast = {data; id=tree.id; eq=tree.eq} in
 
@@ -156,7 +160,7 @@ module Parse = struct
           List.fold_right bs ~init:(seq e es) ~f:(fun b e ->
               match b with
               | {data=List [v; x]; id; eq} ->
-                {data=Let (let_var v,exp x,e); id; eq}
+                {data=Let (let_var prog v,exp x,e); id; eq}
               | s -> fail Bad_let_binding s)
         | _ -> bad_form "let" tree in
 
@@ -170,7 +174,7 @@ module Parse = struct
         | _ -> bad_form "msg" tree in
 
       let set = function
-        | [v; e] -> cons (Set (let_var v, exp e))
+        | [v; e] -> cons (Set (let_var prog v, exp e))
         | _ -> bad_form "set" tree in
 
       let prog_ es = cons (Seq (exps es)) in
@@ -189,7 +193,8 @@ module Parse = struct
         "error", error;
       ] in
 
-      let macro op args = match Resolve.macro prog macro op args with
+      let macro op args =
+        match Resolve.macro prog macro op args with
         | None -> cons (App (Dynamic op, exps args))
         | Some (Ok (macro,bs)) -> exp (Def.Macro.apply macro bs)
         | Some (Error err) -> fail (Unresolved (Macro,op,err)) tree in
@@ -199,12 +204,13 @@ module Parse = struct
         | {data=List _} as s :: _  -> fail Bad_app s
         | {data=Atom op} :: exps ->
           match List.Assoc.find ~equal:String.equal forms op with
-          | None -> macro op (expand prog exps)
+          | None -> macro (qualify op) (expand prog exps)
           | Some form -> form exps in
 
       let sym ({id;eq;data=r} as s)  =
-        if is_symbol r then cons (Sym { s with data = symbol s.data})
-        else match Var.read id eq r with
+        if is_symbol r
+        then cons (Sym { s with data = qualify@@symbol s.data})
+        else match Var.read ~package id eq r with
           | Error e -> fail (Bad_var_literal e) tree
           | Ok v -> cons (Var v) in
 
@@ -215,8 +221,10 @@ module Parse = struct
 
       let start : tree -> ast = function
         | {data=List xs} -> list xs
-        | {data=Atom x} as t -> match Resolve.const prog const x () with
-          | None -> lit {t with data=x}
+        | {data=Atom ux} as t ->
+          let x = KB.Name.read ~package ux in
+          match Resolve.const prog const x () with
+          | None -> lit {t with data=ux}
           | Some Error err -> fail (Unresolved (Const,x,err)) t
           | Some (Ok (const,())) -> exp (Def.Const.value const) in
       start tree
@@ -224,8 +232,8 @@ module Parse = struct
     and exps : tree list -> ast list = fun xs -> List.map xs ~f:exp in
     exp tree
 
-  let params = function
-    | {data=List vars} -> List.map ~f:let_var vars
+  let params prog = function
+    | {data=List vars} -> List.map ~f:(let_var prog) vars
     | s -> fail Bad_param_list s
 
   let atom = function
@@ -288,9 +296,14 @@ module Parse = struct
     Context.merge (Program.context prog) @@
     Attribute.Set.get Context.t attrs
 
+  let qualify prog = KB.Name.read ~package:(Program.package prog)
+
+
   let defun ?docs ?(attrs=[]) name p body prog gattrs tree =
     let attrs = parse_declarations gattrs attrs in
     let es = List.map ~f:(parse (constrained prog attrs)) body in
+    let name = qualify prog name in
+    let params = params prog in
     Program.add prog func @@ Def.Func.create ?docs ~attrs name (params p) {
       data = Seq es;
       id = tree.id;
@@ -300,6 +313,8 @@ module Parse = struct
   let defmethod ?docs ?(attrs=[]) name p body prog gattrs tree =
     let attrs = parse_declarations gattrs attrs in
     let es = List.map ~f:(parse (constrained prog attrs)) body in
+    let name = qualify prog name in
+    let params = params prog in
     Program.add prog meth @@ Def.Meth.create ?docs ~attrs name (params p) {
       data = Seq es;
       id = tree.id;
@@ -307,6 +322,7 @@ module Parse = struct
     } tree
 
   let defmacro ?docs ?(attrs=[]) name ps body prog gattrs tree =
+    let name = qualify prog name in
     Program.add prog macro @@
     Def.Macro.create ?docs
       ~attrs:(parse_declarations gattrs attrs) name
@@ -314,12 +330,14 @@ module Parse = struct
       body tree
 
   let defparameter ?docs ?(attrs=[]) name body prog gattrs tree =
+    let name = qualify prog name in
     let attrs = parse_declarations gattrs attrs in
     Program.add prog para @@
     Def.Para.create ?docs
       ~attrs name (parse (constrained prog attrs) body) tree
 
   let defsubst ?docs ?(attrs=[]) name body prog gattrs tree =
+    let name = qualify prog name in
     let syntax = match body with
       | s :: _ when is_keyarg s -> Some s
       | _ -> None in
@@ -329,9 +347,22 @@ module Parse = struct
       (reader syntax body) tree
 
   let defconst ?docs ?(attrs=[]) name body prog gattrs tree =
+    let name = qualify prog name in
     Program.add prog const @@
     Def.Const.create ?docs
       ~attrs:(parse_declarations gattrs attrs) name ~value:body tree
+
+
+  let use_package ?package prog packages =
+    List.map packages ~f:atom |>
+    List.fold ~init:prog ~f:(fun prog from ->
+        Program.use_package ?package from prog)
+
+  let defpackage name prog trees =
+    List.fold ~init:prog trees ~f:(fun prog -> function
+        | {data=List ({data=Atom ":use"} :: packages)} ->
+          use_package ~package:name prog packages
+        | s -> fail (Bad_def Defpkg) s)
 
   let toplevels = String.Set.of_list [
       "declare";
@@ -342,6 +373,9 @@ module Parse = struct
       "defun";
       "defmethod";
       "require";
+      "in-package";
+      "defpackage";
+      "use-package";
     ]
 
   let declaration gattrs s = match s with
@@ -354,6 +388,15 @@ module Parse = struct
 
 
   let stmt gattrs state s = match s with
+    | {data = List ({data=Atom "defpackage"} ::
+                    {data=Atom name} :: elts)} ->
+      defpackage name state elts
+    | {data = List ({data=Atom "use-package"} :: elts)} ->
+      use_package state elts
+    | {data = List [
+        {data=Atom "in-package"};
+        {data=Atom package}]} ->
+      Program.with_package state package
     | {data = List (
         {data=Atom "defun"} ::
         {data=Atom name} ::
@@ -453,6 +496,15 @@ module Parse = struct
 
 
   let meta gattrs state s = match s with
+    | {data = List [
+        {data=Atom "in-package"};
+        {data=Atom package}]} ->
+      Program.with_package state package
+    | {data = List ({data=Atom "defpackage"} ::
+                    {data=Atom name} :: elts)} ->
+      defpackage name state elts
+    | {data = List ({data=Atom "use-package"} :: elts)} ->
+      use_package state elts
     | {data=List [
         {data=Atom "defconstant"};
         {data=Atom name};
@@ -547,8 +599,10 @@ module Parse = struct
     let init = Program.with_context Program.empty constraints in
     let init = Program.with_sources init source in
     let state = Source.fold source ~init ~f:(fun _ trees state ->
+        let state = Program.reset_package state in
         List.fold trees ~init:state ~f:(meta (declarations trees))) in
     Source.fold source ~init:state ~f:(fun _ trees state ->
+        let state = Program.reset_package state in
         List.fold trees ~init:state ~f:(stmt (declarations trees)))
 end
 
@@ -655,6 +709,8 @@ let string_of_defkind = function
   | Macro -> "macro"
   | Const -> "constant"
   | Subst -> "substitution"
+  | Inpkg -> "in-package"
+  | Defpkg -> "defpackage"
 
 
 let string_of_def_syntax = function
@@ -664,6 +720,8 @@ let string_of_def_syntax = function
   | Macro -> "(defmacro <ident> (<ident> ...) [<docstring>] [<declarations>] <exp>)"
   | Const -> "(defconstant <ident> [<docstring>] [<declarations>] <atom>)"
   | Subst -> "(defsubst <ident> [<docstring>] [<declarations>] [:<syntax>] <atom> ...)"
+  | Inpkg -> "(in-package <ident>)"
+  | Defpkg -> "(defpackage <ident> (:use <package-list>) (:documentation <docstring>))"
 
 let pp_parse_error ppf err = match err with
   | Bad_var_literal e ->
@@ -691,11 +749,12 @@ let pp_parse_error ppf err = match err with
   | Unknown_subst_syntax ->
     fprintf ppf "unknown substitution syntax"
   | Unresolved (k,n,r) ->
-    fprintf ppf "unable to resolve %s `%s', because %a"
-      (string_of_defkind k) n Resolve.pp_resolution r
+    fprintf ppf "unable to resolve %s `%a', because %a"
+      (string_of_defkind k) KB.Name.pp n Resolve.pp_resolution r
   | Bad_def def ->
     fprintf ppf "bad %s definition, expect %s"
       (string_of_defkind def) (string_of_def_syntax def)
+
 
 let pp_request ppf req = match req with
   | Cmdline ->

--- a/lib/bap_primus/bap_primus_lisp_parse.ml
+++ b/lib/bap_primus/bap_primus_lisp_parse.ml
@@ -307,10 +307,11 @@ module Parse = struct
       eq = tree.eq;
     } tree
 
-  let defmethod ?docs ?(attrs=[]) name p body prog gattrs tree =
+  let defmethod ?docs ?(attrs=[]) name' p body prog gattrs tree =
     let attrs = parse_declarations prog gattrs attrs in
     let es = List.map ~f:(parse (constrained prog attrs)) body in
     let params = params prog in
+    let name = KB.Name.show@@KB.Name.read ~package:"primus" name' in
     Program.add prog meth @@ Def.Meth.create ?docs ~attrs name (params p) {
       data = Seq es;
       id = tree.id;

--- a/lib/bap_primus/bap_primus_lisp_parse.ml
+++ b/lib/bap_primus/bap_primus_lisp_parse.ml
@@ -296,13 +296,9 @@ module Parse = struct
     Context.merge (Program.context prog) @@
     Attribute.Set.get Context.t attrs
 
-  let qualify prog = KB.Name.read ~package:(Program.package prog)
-
-
   let defun ?docs ?(attrs=[]) name p body prog gattrs tree =
     let attrs = parse_declarations gattrs attrs in
     let es = List.map ~f:(parse (constrained prog attrs)) body in
-    let name = qualify prog name in
     let params = params prog in
     Program.add prog func @@ Def.Func.create ?docs ~attrs name (params p) {
       data = Seq es;
@@ -313,7 +309,6 @@ module Parse = struct
   let defmethod ?docs ?(attrs=[]) name p body prog gattrs tree =
     let attrs = parse_declarations gattrs attrs in
     let es = List.map ~f:(parse (constrained prog attrs)) body in
-    let name = qualify prog name in
     let params = params prog in
     Program.add prog meth @@ Def.Meth.create ?docs ~attrs name (params p) {
       data = Seq es;
@@ -322,7 +317,6 @@ module Parse = struct
     } tree
 
   let defmacro ?docs ?(attrs=[]) name ps body prog gattrs tree =
-    let name = qualify prog name in
     Program.add prog macro @@
     Def.Macro.create ?docs
       ~attrs:(parse_declarations gattrs attrs) name
@@ -330,14 +324,12 @@ module Parse = struct
       body tree
 
   let defparameter ?docs ?(attrs=[]) name body prog gattrs tree =
-    let name = qualify prog name in
     let attrs = parse_declarations gattrs attrs in
     Program.add prog para @@
     Def.Para.create ?docs
       ~attrs name (parse (constrained prog attrs) body) tree
 
   let defsubst ?docs ?(attrs=[]) name body prog gattrs tree =
-    let name = qualify prog name in
     let syntax = match body with
       | s :: _ when is_keyarg s -> Some s
       | _ -> None in
@@ -347,7 +339,6 @@ module Parse = struct
       (reader syntax body) tree
 
   let defconst ?docs ?(attrs=[]) name body prog gattrs tree =
-    let name = qualify prog name in
     Program.add prog const @@
     Def.Const.create ?docs
       ~attrs:(parse_declarations gattrs attrs) name ~value:body tree
@@ -356,7 +347,7 @@ module Parse = struct
   let use_package ?package prog packages =
     List.map packages ~f:atom |>
     List.fold ~init:prog ~f:(fun prog from ->
-        Program.use_package ?package from prog)
+        Program.use_package prog ?target:package from)
 
   let defpackage name prog trees =
     List.fold ~init:prog trees ~f:(fun prog -> function

--- a/lib/bap_primus/bap_primus_lisp_parse.ml
+++ b/lib/bap_primus/bap_primus_lisp_parse.ml
@@ -491,11 +491,6 @@ module Parse = struct
         {data=Atom "in-package"};
         {data=Atom package}]} ->
       Program.with_package state package
-    | {data = List ({data=Atom "defpackage"} ::
-                    {data=Atom name} :: elts)} ->
-      defpackage name state elts
-    | {data = List ({data=Atom "use-package"} :: elts)} ->
-      use_package state elts
     | {data=List [
         {data=Atom "defconstant"};
         {data=Atom name};

--- a/lib/bap_primus/bap_primus_lisp_program.ml
+++ b/lib/bap_primus/bap_primus_lisp_program.ml
@@ -73,15 +73,22 @@ let fold_library library ~init ~f =
   Map.fold library ~init ~f:(fun ~key:package ~data init ->
       f ~package data init)
 
+let (++) xs ys : _ Def.t list =
+  let add (ids,defs) def =
+    if Set.mem ids def.id then ids,defs
+    else Set.add ids def.id, def::defs in
+  let init = Set.empty (module Id),[] in
+  snd@@List.fold ys ~f:add ~init:(List.fold ~init xs ~f:add)
+
 let merge_packages p1 p2 = {
-  codes = p1.codes @ p2.codes;
-  defs = p1.defs @ p2.defs;
-  mets = p1.mets @ p2.mets;
-  pars = p1.pars @ p2.pars;
-  sigs = p1.sigs @ p2.sigs;
-  macros = p1.macros @ p2.macros;
-  substs = p1.substs @ p2.substs;
-  consts = p1.consts @ p2.consts;
+  codes = p1.codes ++ p2.codes;
+  defs = p1.defs ++ p2.defs;
+  mets = p1.mets ++ p2.mets;
+  pars = p1.pars ++ p2.pars;
+  sigs = p1.sigs ++ p2.sigs;
+  macros = p1.macros ++ p2.macros;
+  substs = p1.substs ++ p2.substs;
+  consts = p1.consts ++ p2.consts;
 }
 
 let use_package program ?(target=program.package) from = {

--- a/lib/bap_primus/bap_primus_lisp_program.ml
+++ b/lib/bap_primus/bap_primus_lisp_program.ml
@@ -139,9 +139,13 @@ let reexport program =
         ~init:program)
     ~init:program
 
+let merge_sources s1 s2 =
+  if Id.(Source.lastid s1 > Source.lastid s2)
+  then s1 else s2
 
 let merge p1 p2 = reexport {
     p1 with
+    sources = merge_sources p1.sources p2.sources;
     context = Lisp.Context.merge p1.context p2.context;
     library = merge_libraries p1.library p2.library;
     exports = Map.merge_skewed p1.exports p2.exports

--- a/lib/bap_primus/bap_primus_lisp_program.ml
+++ b/lib/bap_primus/bap_primus_lisp_program.ml
@@ -80,7 +80,8 @@ let targets {exports} package = match Map.find exports package with
 let rec transitive_closure program from =
   let init = Set.singleton (module String) from in
   Set.fold (targets program from) ~f:(fun init pack ->
-      Set.union init (transitive_closure program pack))
+      if Set.mem init pack then init
+      else Set.union init (transitive_closure program pack))
     ~init
 
 let fold_library library ~init ~f =

--- a/lib/bap_primus/bap_primus_lisp_program.ml
+++ b/lib/bap_primus/bap_primus_lisp_program.ml
@@ -213,6 +213,13 @@ let add_to_package (fld : 'a item) x p =
       Id.equal x.id d.id) then p
   else Field.fset fld p (x :: Field.get fld p)
 
+
+let is_applicable {context=global} def =
+  let def_ctxt =
+    Lisp.Attribute.Set.get Lisp.Context.t
+      (Def.attributes def) in
+  Lisp.Context.(def_ctxt <= global)
+
 let add prog fld elt =
   let name = KB.Name.read ~package:prog.package (Def.name elt) in
   let parent = KB.Name.package name in
@@ -241,8 +248,6 @@ let fold {library} fld ~init ~f =
           f ~package def x))
 
 let in_package package p f = f {p with package}
-
-
 
 let with_context p context = {p with context}
 let with_sources p sources = {p with sources}

--- a/lib/bap_primus/bap_primus_lisp_program.ml
+++ b/lib/bap_primus/bap_primus_lisp_program.ml
@@ -205,7 +205,8 @@ let get p (fld : 'a item) =
 
 let fold {library} fld ~init ~f =
   Map.fold library ~init ~f:(fun ~key:package ~data x ->
-      f ~package (Field.get fld data) x)
+      List.fold ~init:x (Field.get fld data) ~f:(fun x def ->
+          f ~package def x))
 
 let in_package package p f = f {p with package}
 
@@ -1290,14 +1291,12 @@ module Typing = struct
       ~init:empty_names
 
   let add_places prog vars =
-    fold prog Items.place ~f:(fun ~package places vars ->
-        List.fold places ~f:(fun vars place ->
-            let name = KB.Name.read ~package (Def.name place) in
-            let var = Def.Place.location place in
-            match Var.typ var with
-            | Type.Imm n -> Map.set vars name n
-            | _ -> vars)
-          ~init:vars)
+    fold prog Items.place ~f:(fun ~package place vars ->
+        let name = KB.Name.read ~package (Def.name place) in
+        let var = Def.Place.location place in
+        match Var.typ var with
+        | Type.Imm n -> Map.set vars name n
+        | _ -> vars)
       ~init:vars
 
   let infer externals vars (p : program) :  Gamma.t =

--- a/lib/bap_primus/bap_primus_lisp_program.mli
+++ b/lib/bap_primus/bap_primus_lisp_program.mli
@@ -37,6 +37,7 @@ module Items : sig
   val func  : Def.func  item
   val meth  : Def.meth  item
   val para  : Def.para item
+  val semantics : Def.sema item
   val primitive : Def.prim item
   val signal : Def.signal item
 end
@@ -47,7 +48,7 @@ module Type : sig
   val empty : env
   val equal : env -> env -> bool
   val merge : env -> env -> env
-  val infer : ?externals:(KB.Name.t * signature) list -> Var.t seq -> program -> env
+  val infer : ?externals:(string * signature) list -> program -> env
   val program : env -> program
   val check : Var.t seq -> program -> error list
   val errors : env -> error list

--- a/lib/bap_primus/bap_primus_lisp_program.mli
+++ b/lib/bap_primus/bap_primus_lisp_program.mli
@@ -15,6 +15,8 @@ val equal : t -> t -> bool
 val merge : t -> t -> t
 val add : t -> 'a item -> 'a Def.t -> t
 val get : t -> 'a item -> 'a Def.t list
+val fold : t -> 'a item -> init:'s ->
+  f:(package:string -> 'a Def.t list -> 's -> 's) -> 's
 val context : t -> Context.t
 val sources : t -> Source.t
 val package : t -> string
@@ -22,8 +24,9 @@ val with_sources : t -> Source.t -> t
 val with_context : t -> Context.t -> t
 val with_package : t -> string -> t
 val reset_package : t -> t
-val use_package : ?package:string -> string -> t -> t
-val finish_imports : t -> t
+val use_package : t -> ?target:string -> string -> t
+val in_package : string -> t -> (t -> 'a) -> 'a
+
 
 module Items : sig
   val macro : Def.macro item
@@ -42,7 +45,7 @@ module Type : sig
   val empty : env
   val equal : env -> env -> bool
   val merge : env -> env -> env
-  val infer : ?externals:(string * signature) list -> Var.t seq -> program -> env
+  val infer : ?externals:(KB.Name.t * signature) list -> Var.t seq -> program -> env
   val program : env -> program
   val check : Var.t seq -> program -> error list
   val errors : env -> error list

--- a/lib/bap_primus/bap_primus_lisp_program.mli
+++ b/lib/bap_primus/bap_primus_lisp_program.mli
@@ -11,6 +11,7 @@ type program = t
 type 'a item
 
 val empty : t
+val is_empty : t -> bool
 val equal : t -> t -> bool
 val merge : t -> t -> t
 val add : t -> 'a item -> 'a Def.t -> t

--- a/lib/bap_primus/bap_primus_lisp_program.mli
+++ b/lib/bap_primus/bap_primus_lisp_program.mli
@@ -17,9 +17,13 @@ val add : t -> 'a item -> 'a Def.t -> t
 val get : t -> 'a item -> 'a Def.t list
 val context : t -> Context.t
 val sources : t -> Source.t
+val package : t -> string
 val with_sources : t -> Source.t -> t
 val with_context : t -> Context.t -> t
-
+val with_package : t -> string -> t
+val reset_package : t -> t
+val use_package : ?package:string -> string -> t -> t
+val finish_imports : t -> t
 
 module Items : sig
   val macro : Def.macro item

--- a/lib/bap_primus/bap_primus_lisp_program.mli
+++ b/lib/bap_primus/bap_primus_lisp_program.mli
@@ -23,11 +23,11 @@ val sources : t -> Source.t
 val package : t -> string
 val with_sources : t -> Source.t -> t
 val with_context : t -> Context.t -> t
+val with_places : ?globals:Var.t seq -> t -> Theory.target -> t
 val with_package : t -> string -> t
 val reset_package : t -> t
 val use_package : t -> ?target:string -> string -> t
 val in_package : string -> t -> (t -> 'a) -> 'a
-
 
 module Items : sig
   val macro : Def.macro item

--- a/lib/bap_primus/bap_primus_lisp_program.mli
+++ b/lib/bap_primus/bap_primus_lisp_program.mli
@@ -17,7 +17,7 @@ val merge : t -> t -> t
 val add : t -> 'a item -> 'a Def.t -> t
 val get : t -> 'a item -> 'a Def.t list
 val fold : t -> 'a item -> init:'s ->
-  f:(package:string -> 'a Def.t list -> 's -> 's) -> 's
+  f:(package:string -> 'a Def.t -> 's -> 's) -> 's
 val context : t -> Context.t
 val sources : t -> Source.t
 val package : t -> string

--- a/lib/bap_primus/bap_primus_lisp_program.mli
+++ b/lib/bap_primus/bap_primus_lisp_program.mli
@@ -23,7 +23,7 @@ val sources : t -> Source.t
 val package : t -> string
 val with_sources : t -> Source.t -> t
 val with_context : t -> Context.t -> t
-val with_places : ?globals:Var.t seq -> t -> Theory.target -> t
+val with_places : ?globals:Theory.Var.Top.t seq -> t -> Theory.target -> t
 val with_package : t -> string -> t
 val reset_package : t -> t
 val use_package : t -> ?target:string -> string -> t

--- a/lib/bap_primus/bap_primus_lisp_program.mli
+++ b/lib/bap_primus/bap_primus_lisp_program.mli
@@ -33,6 +33,7 @@ module Items : sig
   val macro : Def.macro item
   val subst : Def.subst item
   val const : Def.const item
+  val place : Def.place item
   val func  : Def.func  item
   val meth  : Def.meth  item
   val para  : Def.para item

--- a/lib/bap_primus/bap_primus_lisp_program.mli
+++ b/lib/bap_primus/bap_primus_lisp_program.mli
@@ -29,6 +29,8 @@ val reset_package : t -> t
 val use_package : t -> ?target:string -> string -> t
 val in_package : string -> t -> (t -> 'a) -> 'a
 
+val is_applicable : t -> 'a Def.t -> bool
+
 module Items : sig
   val macro : Def.macro item
   val subst : Def.subst item

--- a/lib/bap_primus/bap_primus_lisp_resolve.ml
+++ b/lib/bap_primus/bap_primus_lisp_resolve.ml
@@ -36,9 +36,6 @@ type ('t,'a,'b) many = ('t,'a,('t Def.t * 'b) list) resolver
 type exn += Failed of string * Context.t * resolution
 
 let interns d name = String.equal (Def.name d) name
-let externs def name =
-  let names = Attribute.Set.get External.t (Def.attributes def) in
-  Set.mem names name
 
 (* all definitions with the given name *)
 let stage1 has_name defs name =
@@ -174,7 +171,7 @@ let run choose namespace overload prog item name =
       })
 
 let extern typechecks prog item name args =
-  run one externs (overload_defun typechecks args) prog item name
+  run one interns (overload_defun typechecks args) prog item name
 
 let defun typechecks prog item name args =
   run one interns (overload_defun typechecks args) prog item name

--- a/lib/bap_primus/bap_primus_lisp_resolve.ml
+++ b/lib/bap_primus/bap_primus_lisp_resolve.ml
@@ -35,12 +35,10 @@ type ('t,'a,'b) many = ('t,'a,('t Def.t * 'b) list) resolver
 
 type exn += Failed of string * Context.t * resolution
 
-let interns d name = KB.Name.equal (Def.name d) name
+let interns d name = String.equal (Def.name d) name
 let externs def name =
   let names = Attribute.Set.get External.t (Def.attributes def) in
-  Set.mem names (KB.Name.unqualified name)
-
-
+  Set.mem names name
 
 (* all definitions with the given name *)
 let stage1 has_name defs name =
@@ -153,6 +151,8 @@ let one = function
 let many xs = Some xs
 
 let run choose namespace overload prog item name =
+  Program.in_package (KB.Name.package name) prog @@ fun prog ->
+  let name = KB.Name.unqualified name in
   let ctxts = Program.context prog in
   let defs = Program.get prog item in
   let s1 = stage1 namespace defs name in

--- a/lib/bap_primus/bap_primus_lisp_resolve.ml
+++ b/lib/bap_primus/bap_primus_lisp_resolve.ml
@@ -1,12 +1,12 @@
 open Bap.Std
 open Core_kernel
+open Bap_core_theory
 open Format
 open Bap_primus_lisp_types
 
 module Attribute = Bap_primus_lisp_attribute
 module Context = Bap_primus_lisp_context
 module Def = Bap_primus_lisp_def
-module Value = Bap_primus_value
 module Loc = Bap_primus_lisp_loc
 module Program = Bap_primus_lisp_program
 
@@ -26,7 +26,7 @@ type resolution = {
 
 
 type ('t,'a,'b) resolver =
-  Program.t -> 't Program.item -> string -> 'a ->
+  Program.t -> 't Program.item -> KB.Name.t -> 'a ->
   ('b,resolution) result option
 
 type ('t,'a,'b) one = ('t,'a,'t Def.t * 'b) resolver
@@ -35,10 +35,10 @@ type ('t,'a,'b) many = ('t,'a,('t Def.t * 'b) list) resolver
 
 type exn += Failed of string * Context.t * resolution
 
-let interns d name = String.equal (Def.name d) name
+let interns d name = KB.Name.equal (Def.name d) name
 let externs def name =
   let names = Attribute.Set.get External.t (Def.attributes def) in
-  Set.mem names name
+  Set.mem names (KB.Name.unqualified name)
 
 
 
@@ -188,7 +188,8 @@ let macro prog item name code =
 let primitive prog item name () =
   run one interns overload_primitive prog item name
 
-let semantics = primitive
+let semantics prog item name () =
+  run one interns overload_primitive prog item name
 
 let subst prog item name () =
   run one interns overload_primitive prog item name

--- a/lib/bap_primus/bap_primus_lisp_resolve.mli
+++ b/lib/bap_primus/bap_primus_lisp_resolve.mli
@@ -1,15 +1,14 @@
 open Bap.Std
+open Bap_core_theory
 
 open Bap_primus_lisp_types
-module Context = Bap_primus_lisp_context
 module Def = Bap_primus_lisp_def
 module Program = Bap_primus_lisp_program
-module Value = Bap_primus_value
 
 type resolution
 
 type ('t,'a,'b) resolver =
-  Program.t -> 't Program.item -> string -> 'a ->
+  Program.t -> 't Program.item -> KB.Name.t -> 'a ->
   ('b,resolution) result option
 
 type ('t,'a,'b) one = ('t,'a,'t Def.t * 'b) resolver

--- a/lib/bap_primus/bap_primus_lisp_semantics.ml
+++ b/lib/bap_primus/bap_primus_lisp_semantics.ml
@@ -632,8 +632,11 @@ let provide_semantics ?(stdout=Format.std_formatter) () =
     } in
   Theory.instance () >>= Theory.require >>= fun (module Core) ->
   let open Prelude(Core) in
-  Meta.run (reify stdout prog obj target name args) meta >>| fun (res,_) ->
-  res
+  Meta.run (reify stdout prog obj target name args) meta >>= fun (res,_) ->
+  KB.collect Disasm_expert.Basic.Insn.slot obj >>| function
+  | Some basic when Insn.(res <> empty) ->
+    Insn.with_basic res basic
+  | _ -> res
 
 let provide_attributes () =
   let open KB.Syntax in

--- a/lib/bap_primus/bap_primus_lisp_semantics.ml
+++ b/lib/bap_primus/bap_primus_lisp_semantics.ml
@@ -131,7 +131,7 @@ let declare
         ret = any;
       })
     ?(docs="undocumented") ?package name =
-  let name = KB.Name.read ?package name in
+  let name = KB.Name.create ?package name in
   if Hashtbl.mem library name
   then invalid_argf "A primitive `%s' already exists, please \
                      choose a different name for your primitive"

--- a/lib/bap_primus/bap_primus_lisp_semantics.ml
+++ b/lib/bap_primus/bap_primus_lisp_semantics.ml
@@ -49,6 +49,11 @@ let program =
         let r = Format.asprintf "%a" Program.pp p in
         Sexp.Atom r)
 
+type program = {
+  typed : Program.Type.env;
+  places : Var.t Map.M(KB.Name).t;
+}
+
 let typed = KB.Class.property Theory.Source.cls "typed-program"
     ~package @@
   KB.Domain.flat "typed-lisp-program"
@@ -208,7 +213,7 @@ let machine_var_by_name t name =
   Set.find (Theory.Target.vars t) ~f:(fun v ->
       String.equal (Theory.Var.name v) name)
 
-let make_var ?t:constr target name  =
+let make_var ?t:constr _prog target name  =
   let word = Theory.Target.bits target in
   match machine_var_by_name target (KB.Name.unqualified name) with
   | Some v -> v
@@ -415,7 +420,7 @@ module Prelude(CT : Theory.Core) = struct
 
   let reify ppf prog defn target name args =
     let word = Theory.Target.bits target in
-    let var ?t n = make_var ?t target n in
+    let var ?t n = make_var ?t prog target n in
     let regs roles = Theory.Target.regs target ~roles in
     let consts = regs [Theory.Role.Register.constant] in
     let pseudos = regs [Theory.Role.Register.pseudo] in

--- a/lib/bap_primus/bap_primus_lisp_semantics.mli
+++ b/lib/bap_primus/bap_primus_lisp_semantics.mli
@@ -18,6 +18,7 @@ val enable : ?stdout:Format.formatter -> unit -> unit
 val declare :
   ?types:(Theory.Target.t -> Bap_primus_lisp_type.signature) ->
   ?docs:string ->
+  ?package:string ->
   string -> unit
 
 module Unit : sig

--- a/lib/bap_primus/bap_primus_lisp_semantics.mli
+++ b/lib/bap_primus/bap_primus_lisp_semantics.mli
@@ -9,7 +9,7 @@ type KB.conflict += Illtyped_program of Type.error list
 
 val program : (Theory.Source.cls, program) KB.slot
 val definition : (Theory.program, Theory.Label.t option) KB.slot
-val name : (Theory.program, string option) KB.slot
+val name : (Theory.program, KB.Name.t option) KB.slot
 val args : (Theory.program, unit Theory.Value.t list option) KB.slot
 val symbol : (Theory.Value.cls, String.t option) KB.slot
 val static : (Theory.Value.cls, Bitvec.t option) KB.slot

--- a/lib/bap_primus/bap_primus_lisp_types.ml
+++ b/lib/bap_primus/bap_primus_lisp_types.ml
@@ -24,8 +24,8 @@ type typ =
   | Type of int [@@deriving sexp, compare]
 type 'a term = {exp : 'a; typ : typ} [@@deriving compare]
 type word = Z.t term indexed [@@deriving compare]
-type var = string term indexed [@@deriving compare]
-type sym = string indexed [@@deriving compare]
+type var = KB.Name.t term indexed [@@deriving compare]
+type sym = KB.Name.t indexed [@@deriving compare]
 type loc = Loc.t
 
 type error = ..
@@ -55,5 +55,5 @@ and fmt =
   | Lit of string
   | Pos of int
 and binding =
-  | Dynamic of string
+  | Dynamic of KB.Name.t
   | Static of var list * ast

--- a/lib/bap_primus/bap_primus_lisp_var.ml
+++ b/lib/bap_primus/bap_primus_lisp_var.ml
@@ -35,6 +35,14 @@ let read ?package id eq = function
         let x = KB.Name.read ?package (x ^ ":" ^ sz) in
         Ok {data={exp=x; typ=Any}; id; eq}
 
+let reify ~width {data={exp;typ}} =
+  let open Bap.Std in
+  let exp = KB.Name.show exp in
+  match typ with
+  | Type t -> Var.create exp (Type.Imm t)
+  | _ -> Var.create exp (Type.Imm width)
+
+
 include Comparable.Make_plain(struct
     type t = var [@@deriving compare,sexp_of]
   end)

--- a/lib/bap_primus/bap_primus_lisp_var.ml
+++ b/lib/bap_primus/bap_primus_lisp_var.ml
@@ -39,8 +39,8 @@ let reify ~width {data={exp;typ}} =
   let open Bap.Std in
   let exp = KB.Name.show exp in
   match typ with
-  | Type t -> Var.create exp (Type.Imm t)
-  | _ -> Var.create exp (Type.Imm width)
+  | Type t -> Theory.Var.define (Theory.Bitv.define t) exp
+  | _ -> Theory.Var.define (Theory.Bitv.define width) exp
 
 
 include Comparable.Make_plain(struct

--- a/lib/bap_primus/bap_primus_lisp_var.ml
+++ b/lib/bap_primus/bap_primus_lisp_var.ml
@@ -1,4 +1,5 @@
 open Core_kernel
+open Bap_core_theory
 open Bap.Std
 open Bap_primus_lisp_types
 open Format
@@ -6,31 +7,32 @@ open Format
 module Type = Bap_primus_lisp_type
 
 let to_string = function
-  | {data={exp;typ = Any}} -> exp
-  | {data={exp;typ}} -> asprintf "%s:%a" exp Type.pp typ
+  | {data={exp;typ = Any}} -> KB.Name.to_string exp
+  | {data={exp;typ}} -> asprintf "%a:%a" KB.Name.pp exp Type.pp typ
 
 let sexp_of_var v = Sexp.Atom (to_string v)
 
 type read_error = Empty | Not_a_var | Bad_type | Bad_format
 
-let read id eq = function
+let read ?package id eq = function
   | "" -> Error Empty
   | x when Char.is_digit x.[0] || Char.(x.[0] = '\'') || Char.(x.[0] = '"') ->
     Error Not_a_var
   | x -> match String.split x ~on:':' with
     | [] -> assert false
     | _::_::_::_::_ -> Error Bad_format
-    | [ns;name;sz] -> begin match Type.read sz with
+    | [package;name;sz] -> begin match Type.read sz with
         | None -> Error Bad_type
         | Some typ ->
-          let x = ns ^ ":" ^ name in
+          let x = KB.Name.create ~package name in
           Ok {data={exp=x; typ}; id; eq}
       end
-    | [x] -> Ok {data={exp=x; typ=Any}; id; eq}
+    | [x] -> Ok {data={exp=KB.Name.read ?package x; typ=Any}; id; eq}
     | [x;sz] -> match Type.read sz with
-      | Some typ -> Ok {data={exp=x; typ}; id; eq}
+      | Some typ ->
+        Ok {data={exp=KB.Name.read ?package x; typ}; id; eq}
       | None ->
-        let x = x ^ ":" ^ sz in
+        let x = KB.Name.read ?package (x ^ ":" ^ sz) in
         Ok {data={exp=x; typ=Any}; id; eq}
 
 include Comparable.Make_plain(struct

--- a/lib/bap_primus/bap_primus_lisp_var.mli
+++ b/lib/bap_primus/bap_primus_lisp_var.mli
@@ -9,3 +9,4 @@ val to_string : t -> string
 type read_error = Empty | Not_a_var | Bad_type | Bad_format
 
 val read : ?package:string -> Id.t -> Eq.t -> string -> (t,read_error) result
+val reify : width:int -> t -> Bap.Std.Var.t

--- a/lib/bap_primus/bap_primus_lisp_var.mli
+++ b/lib/bap_primus/bap_primus_lisp_var.mli
@@ -1,4 +1,5 @@
 open Core_kernel
+open Bap_core_theory
 open Bap_primus_lisp_types
 
 type t = var [@@deriving compare, sexp_of]
@@ -9,4 +10,4 @@ val to_string : t -> string
 type read_error = Empty | Not_a_var | Bad_type | Bad_format
 
 val read : ?package:string -> Id.t -> Eq.t -> string -> (t,read_error) result
-val reify : width:int -> t -> Bap.Std.Var.t
+val reify : width:int -> t -> 'a Theory.Bitv.t Theory.Var.t

--- a/lib/bap_primus/bap_primus_lisp_var.mli
+++ b/lib/bap_primus/bap_primus_lisp_var.mli
@@ -8,4 +8,4 @@ val to_string : t -> string
 
 type read_error = Empty | Not_a_var | Bad_type | Bad_format
 
-val read : Id.t -> Eq.t -> string -> (t,read_error) result
+val read : ?package:string -> Id.t -> Eq.t -> string -> (t,read_error) result

--- a/lib/bap_primus/bap_primus_observation.ml
+++ b/lib/bap_primus/bap_primus_observation.ml
@@ -31,10 +31,10 @@ type 'a mstream = {
 let providers : (string,provider) Hashtbl.t = Hashtbl.create (module String)
 
 
-let provider ?desc ?package name =
+let provider ?desc ?(package="primus") name =
   let data,newdata = Stream.create () in
   let triggers,newtrigger = Stream.create () in
-  let name = Name.create ?package name in
+  let name = Name.create ~package name in
   let info = Info.create ?desc name in
   let key = Univ_map.Key.create ~name:(Name.show name) ident in
   {info; newdata; data; triggers; newtrigger; observers=0; key}

--- a/lib/bap_primus/bap_primus_observation.ml
+++ b/lib/bap_primus/bap_primus_observation.ml
@@ -150,7 +150,14 @@ let list () = list_providers () |>
 
 module Provider = struct
   type t = provider
-  let name t = Name.show @@ Info.name t.info
+  let name t =
+    let name = Info.name t.info in
+    let short = Name.unqualified name in
+    match Name.package name with
+    | "primus" -> short
+    | package -> sprintf "%s:%s" package short
+
+  let fullname t = Info.name t.info
   let data t = t.data
   let triggers t = t.triggers
   let observers t = t.observers

--- a/lib/bap_primus/bap_primus_observation.mli
+++ b/lib/bap_primus/bap_primus_observation.mli
@@ -1,4 +1,5 @@
 open Core_kernel
+open Bap_core_theory
 open Bap.Std
 open Bap_future.Std
 open Monads.Std
@@ -45,6 +46,7 @@ val list : unit -> Info.t list
 module Provider : sig
   type t = provider
   val name : t -> string
+  val fullname : t -> KB.Name.t
   val observers : t -> int
   val triggers : t -> unit stream
   val data : t -> Sexp.t stream

--- a/lib/x86_cpu/x86_target.ml
+++ b/lib/x86_cpu/x86_target.ml
@@ -4,10 +4,11 @@ open Bap.Std
 
 let package = "bap"
 
-type r128 and r80 and r64 and r32 and r16 and r8
+type r256 and r128 and r80 and r64 and r32 and r16 and r8
 
 type 'a bitv = 'a Theory.Bitv.t Theory.Value.sort
 
+let r256 : r128 bitv = Theory.Bitv.define 256
 let r128 : r128 bitv = Theory.Bitv.define 128
 let r80 : r80 bitv = Theory.Bitv.define 80
 let r64 : r64 bitv = Theory.Bitv.define 64
@@ -175,18 +176,18 @@ module M64 = struct
 
   let stx = M32.stx
   let mmx = M32.mmx
-  let xmmx = array r128 "XMM" 16
+  let ymmx = array r256 "YMM" 16
 
   let flags = M32.flags
   let mems = Theory.Mem.define r64 r8
   let data = Theory.Var.define mems "mem"
 
-  let vars = main @< index @< segment @< rx @< stx @< mmx @< xmmx @<
+  let vars = main @< index @< segment @< rx @< stx @< mmx @< ymmx @<
              flags @< [data]
 
   let regs =  Theory.Role.Register.[
       [general; integer], main @< index @< segment @< rx;
-      [general; floating], stx @< mmx @< xmmx;
+      [general; floating], stx @< mmx @< ymmx;
       [stack_pointer], untyped [reg r64 "RSP"];
       [frame_pointer], untyped [reg r64 "RBP"];
       [Role.index], untyped index;

--- a/oasis/primus-print
+++ b/oasis/primus-print
@@ -7,7 +7,7 @@ Library primus_print_plugin
   Build$: flag(everything) || flag(primus_print)
   FindlibName: bap-plugin-primus_print
   CompiledObject: best
-  BuildDepends: bap-primus, bare, bap, core_kernel, ppx_bap, bap-future, monads
+  BuildDepends: bap-primus, bare, bap, bap-knowledge, bap-core-theory, core_kernel, ppx_bap, bap-future, monads
   XMETADescription: prints Primus states and observations
   Modules: Primus_print_main
   XMETAExtraLines: tags="primus, printer"

--- a/plugins/primus_lisp/lisp/core.lisp
+++ b/plugins/primus_lisp/lisp/core.lisp
@@ -1,0 +1,3 @@
+(require init)
+(require pointers)
+(require memory)

--- a/plugins/primus_lisp/lisp/core.lisp
+++ b/plugins/primus_lisp/lisp/core.lisp
@@ -1,3 +1,5 @@
+;; defines the core of the Primus Lisp language
+;; required automatically by the primus-lisp program loader
 (require init)
 (require pointers)
 (require memory)

--- a/plugins/primus_lisp/lisp/init.lisp
+++ b/plugins/primus_lisp/lisp/init.lisp
@@ -1,4 +1,14 @@
-(defpackage core (:documentation "the core definitions"))
+(defpackage core
+  (:documentation "the core definitions"))
+
+(defpackage primus
+  (:documentation "the runtime state of the Primus Machine")
+  (:use core))
+
+(defpackage user
+  (:documentation "the default user-space package")
+  (:use core primus))
+
 (in-package core)
 
 (defconstant true 1:1  "true is another name for 1:1")

--- a/plugins/primus_lisp/lisp/init.lisp
+++ b/plugins/primus_lisp/lisp/init.lisp
@@ -1,3 +1,5 @@
+(defpackage core)
+(in-package core)
 
 (defconstant true 1:1  "true is another name for 1:1")
 (defconstant false 0:1 "false is another name for 0:1")

--- a/plugins/primus_lisp/lisp/init.lisp
+++ b/plugins/primus_lisp/lisp/init.lisp
@@ -1,4 +1,4 @@
-(defpackage core)
+(defpackage core (:documentation "the core definitions"))
 (in-package core)
 
 (defconstant true 1:1  "true is another name for 1:1")

--- a/plugins/primus_lisp/lisp/init.lisp
+++ b/plugins/primus_lisp/lisp/init.lisp
@@ -5,9 +5,17 @@
   (:documentation "the runtime state of the Primus Machine")
   (:use core))
 
+(defpackage target
+  (:documentation "target-specific definitions (registers, etc)"))
+
+(defpackage program
+  (:documentation "program-specific definitions (program global variables)"))
+
 (defpackage user
   (:documentation "the default user-space package")
-  (:use core primus))
+  (:use core primus target program))
+
+
 
 (in-package core)
 

--- a/plugins/primus_lisp/lisp/init.lisp
+++ b/plugins/primus_lisp/lisp/init.lisp
@@ -11,9 +11,13 @@
 (defpackage program
   (:documentation "program-specific definitions (program global variables)"))
 
+(defpackage posix
+  (:documentation "posix runtime defintions")
+  (:use core primus program target))
+
 (defpackage user
   (:documentation "the default user-space package")
-  (:use core primus target program))
+  (:use core primus target program posix))
 
 
 

--- a/plugins/primus_lisp/lisp/memory.lisp
+++ b/plugins/primus_lisp/lisp/memory.lisp
@@ -1,3 +1,5 @@
+(require init)
+(in-package core)
 ;; functions to access memory
 
 (defun points-to-null (p)

--- a/plugins/primus_lisp/lisp/pointers.lisp
+++ b/plugins/primus_lisp/lisp/pointers.lisp
@@ -1,6 +1,7 @@
+(in-package core)
+
 ;; pointer arithmetic
 
-(require types)
 
 (defmacro ptr+ (t p n)
   "(ptr+ T P N) increments N times the

--- a/plugins/primus_lisp/primus_lisp_io.ml
+++ b/plugins/primus_lisp/primus_lisp_io.ml
@@ -229,10 +229,10 @@ let init redirections =
         let v = Var.create name (Type.imm width) in
         Value.of_int ~width descr >>= Env.set v in
       Machine.sequence [
-        set "*standard-input*" 0;
-        set "*standard-output*" 1;
-        set "*error-output*" 2; (* CL name *)
-        set "*standard-error*" 2; (* conventional name *)
+        set "posix:*standard-input*" 0;
+        set "posix:*standard-output*" 1;
+        set "posix:*error-output*" 2; (* CL name *)
+        set "posix:*standard-error*" 2; (* conventional name *)
       ]
 
     let setup_redirections =

--- a/plugins/primus_lisp/primus_lisp_main.ml
+++ b/plugins/primus_lisp/primus_lisp_main.ml
@@ -311,7 +311,7 @@ module Semantics = struct
       end);
     KB.promise Lisp.Semantics.name @@ fun this ->
     KB.collect Insn.slot this >>|? fun insn ->
-    let name = sprintf "%s:%s" (Insn.encoding insn) (Insn.name insn) in
+    let name = KB.Name.create ~package:(Insn.encoding insn) (Insn.name insn) in
     Some name
 
   let strip_extension = String.chop_suffix ~suffix:".lisp"

--- a/plugins/primus_lisp/primus_lisp_main.ml
+++ b/plugins/primus_lisp/primus_lisp_main.ml
@@ -326,7 +326,7 @@ module Semantics = struct
 
 
   let collect_features sites =
-    List.fold sites ~init:(sites,["user"]) ~f:(fun (paths,fs) site ->
+    List.fold sites ~init:(sites,["core"]) ~f:(fun (paths,fs) site ->
         if Sys.file_exists site
         then if Sys.is_directory site
           then site::paths,include_files fs site
@@ -425,7 +425,7 @@ let () =
       if !!enable_typecheck then
         Project.register_pass' ~deps:["api"] ~autorun:true typecheck;
       let paths = [Filename.current_dir_name] @ !!libs @ library_paths in
-      let features = "user" :: !!features in
+      let features = "core" :: !!features in
       Primus.Components.register_generic ~package:"bap" "lisp-type-checker"
         (module TypeErrorSummary)
         ~desc:"Typechecks program and outputs the summary in the standard output.";

--- a/plugins/primus_lisp/primus_lisp_main.ml
+++ b/plugins/primus_lisp/primus_lisp_main.ml
@@ -326,7 +326,7 @@ module Semantics = struct
 
 
   let collect_features sites =
-    List.fold sites ~init:(sites,["init"]) ~f:(fun (paths,fs) site ->
+    List.fold sites ~init:(sites,["user"]) ~f:(fun (paths,fs) site ->
         if Sys.file_exists site
         then if Sys.is_directory site
           then site::paths,include_files fs site
@@ -425,7 +425,7 @@ let () =
       if !!enable_typecheck then
         Project.register_pass' ~deps:["api"] ~autorun:true typecheck;
       let paths = [Filename.current_dir_name] @ !!libs @ library_paths in
-      let features = "init" :: !!features in
+      let features = "user" :: !!features in
       Primus.Components.register_generic ~package:"bap" "lisp-type-checker"
         (module TypeErrorSummary)
         ~desc:"Typechecks program and outputs the summary in the standard output.";

--- a/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
+++ b/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
@@ -412,8 +412,9 @@ module Primitives(CT : Theory.Core) = struct
     bitv dst >>= fun dst ->
     bitv data >>= fun data ->
     let mem = Theory.Target.data t in
+    let byte = Theory.Mem.vals (Theory.Var.sort mem) in
     let (:=) = CT.set in
-    CT.(mem := store (var mem) !!dst !!data)
+    CT.(mem := store (var mem) !!dst (low byte !!data))
 
   let store_word t xs =
     binary xs @@ fun dst data ->
@@ -488,8 +489,13 @@ module Primitives(CT : Theory.Core) = struct
   let low = mk_cast CT.low
   let high = mk_cast CT.high
 
+  let target lbl =
+    KB.collect Primus.Lisp.Semantics.definition lbl >>= function
+    | None -> Theory.Label.target lbl
+    | Some lbl -> Theory.Label.target lbl
+
   let dispatch lbl name args =
-    Theory.Label.target lbl >>= fun t ->
+    target lbl >>= fun t ->
     let bits = Theory.Target.bits t in
     let module Z = struct
       include Bitvec.Make(struct

--- a/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
+++ b/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
@@ -1048,7 +1048,8 @@ let provide () =
   let*? args = KB.collect Lisp.args obj in
   Theory.instance () >>= Theory.require >>= fun (module CT) ->
   let module P = Primitives(CT) in
-  P.dispatch obj name args
+  P.dispatch obj (KB.Name.unqualified name) args
+
 
 let enable_extraction () =
   Theory.declare ~provides:["extraction"; "primus-lisp"; "lisp"]

--- a/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
+++ b/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
@@ -1035,7 +1035,7 @@ let provide () =
       comment "implements semantics for the core primitives"
     end);
   List.iter export ~f:(fun (name,types,docs) ->
-      Primus.Lisp.Semantics.declare ~types ~docs name);
+      Primus.Lisp.Semantics.declare ~types ~docs ~package:"core" name);
   let (let*?) x f = x >>= function
     | None -> !!nothing
     | Some x -> f x in

--- a/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
+++ b/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
@@ -130,6 +130,10 @@ let export = Primus.Lisp.Type.Spec.[
     "load-byte", one int @-> byte,
     "(load-byte PTR) loads one byte from the address PTR";
 
+    "memory-read", one int @-> byte,
+    "(memory-read PTR) loads one byte from the address PTR \
+     (synonymous to load-byte)";
+
     "load-word", one int @-> int,
     "(load-word PTR) loads one word from the address PTR";
 

--- a/plugins/primus_lisp/primus_lisp_show.ml
+++ b/plugins/primus_lisp/primus_lisp_show.ml
@@ -59,11 +59,16 @@ module Spec = struct
       ~parse:Bitvec.of_string
       ~print:Bitvec.to_string
 
+  let unknown = KB.Name.create ":unknown"
+  let name = Type.define unknown
+      ~parse:KB.Name.read
+      ~print:KB.Name.show
+
   let target = Type.define Theory.Target.unknown
       ~print:Theory.Target.to_string
       ~parse:(Theory.Target.get ~package:"bap")
 
-  let names = Command.arguments Type.string
+  let names = Command.arguments name
   let target = Command.parameter target "target"
       ~aliases:["t"; "arch"]
   let slots = Command.parameters Type.(list string) "slots"
@@ -87,7 +92,7 @@ let show target slots addr name =
       KB.provide Primus.Lisp.Semantics.name obj (Some name);
     ] >>= fun () ->
     KB.collect Theory.Semantics.slot obj >>| fun sema ->
-    Format.eprintf "%s:@ %a@." name pp sema
+    Format.eprintf "%a:@ %a@." KB.Name.pp name pp sema
   end
 
 let () = Extension.Command.declare ~doc "show-lisp" Spec.t @@

--- a/plugins/primus_lisp/site-lisp/ascii.lisp
+++ b/plugins/primus_lisp/site-lisp/ascii.lisp
@@ -1,3 +1,6 @@
+(require posix-init)
+(in-package posix)
+
 (defun ascii-is-special (s)
   "(ascii-special S) is true if S is an ascii special character"
   (< s 32))
@@ -41,7 +44,6 @@
 (defun ascii-to-lower (c)
   (declare (external "tolower"))
   (if (ascii-is-upper c) (logor c 32) c))
-
 
 (defun ascii-to-upper (c)
   (declare (external "toupper"))

--- a/plugins/primus_lisp/site-lisp/ascii.lisp
+++ b/plugins/primus_lisp/site-lisp/ascii.lisp
@@ -1,4 +1,3 @@
-(require posix-init)
 (in-package posix)
 
 (defun ascii-is-special (s)

--- a/plugins/primus_lisp/site-lisp/atoi.lisp
+++ b/plugins/primus_lisp/site-lisp/atoi.lisp
@@ -1,4 +1,3 @@
-(require posix-init)
 (in-package posix)
 (declare (visibility :private))
 

--- a/plugins/primus_lisp/site-lisp/atoi.lisp
+++ b/plugins/primus_lisp/site-lisp/atoi.lisp
@@ -1,3 +1,7 @@
+(require posix-init)
+(in-package posix)
+(declare (visibility :private))
+
 (require types)
 (require ascii)
 
@@ -26,13 +30,13 @@
   (cast type (read-ascii-word s)))
 
 (defun atoi  (s)
-  (declare (external "atoi"))
+  (declare (visibility :public) (external "atoi"))
   (make-converter int s))
 
 (defun atol  (s)
-  (declare (external "atol"))
+  (declare (visibility :public) (external "atol"))
   (make-converter long s))
 
 (defun atoll (s)
-  (declare (external "atoll"))
+  (declare (visibility :public) (external "atoll"))
   (make-converter long-long s))

--- a/plugins/primus_lisp/site-lisp/char.lisp
+++ b/plugins/primus_lisp/site-lisp/char.lisp
@@ -1,0 +1,2 @@
+(require posix-init)
+(in-package posix)

--- a/plugins/primus_lisp/site-lisp/char.lisp
+++ b/plugins/primus_lisp/site-lisp/char.lisp
@@ -1,2 +1,1 @@
-(require posix-init)
 (in-package posix)

--- a/plugins/primus_lisp/site-lisp/errno.lisp
+++ b/plugins/primus_lisp/site-lisp/errno.lisp
@@ -1,3 +1,7 @@
+(require posix-init)
+(in-package posix)
+(declare (visibility :private))
+
 (require posix)
 (require types)
 
@@ -8,5 +12,6 @@
   (+= brk (sizeof int)))
 
 (defun errno-location ()
-  (declare (external "__errno_location"))
+  (declare (visibility :public)
+           (external "__errno_location"))
   errno-location)

--- a/plugins/primus_lisp/site-lisp/errno.lisp
+++ b/plugins/primus_lisp/site-lisp/errno.lisp
@@ -1,4 +1,3 @@
-(require posix-init)
 (in-package posix)
 (declare (visibility :private))
 

--- a/plugins/primus_lisp/site-lisp/getopt.lisp
+++ b/plugins/primus_lisp/site-lisp/getopt.lisp
@@ -1,6 +1,11 @@
+(require posix-init)
 (require type)
 (require array)
 (require strstr)
+
+(in-package posix)
+(declare (visibility :private))
+
 
 (declare (global (optind opterr optopt optarg)))
 
@@ -60,9 +65,10 @@
      (getopt-no-argument argv opts))
    (incr optind)))
 
-
 (defun getopt (argc argv opts)
-  (declare (external "getopt"))
+  (declare
+   (visibility :public)
+   (external "getopt"))
   (when (= 0 optind)
     (set optind 1)
     (set lastidx 0))

--- a/plugins/primus_lisp/site-lisp/getopt.lisp
+++ b/plugins/primus_lisp/site-lisp/getopt.lisp
@@ -1,4 +1,3 @@
-(require posix-init)
 (require type)
 (require array)
 (require strstr)

--- a/plugins/primus_lisp/site-lisp/libc-init.lisp
+++ b/plugins/primus_lisp/site-lisp/libc-init.lisp
@@ -1,6 +1,5 @@
 ;; for the invoke-procedure we need a type of the invoked function
 ;; so, the function must be present in the static representation of a program.
-(require posix-init)
 (in-package posix)
 (declare (visibility :private))
 

--- a/plugins/primus_lisp/site-lisp/libc-init.lisp
+++ b/plugins/primus_lisp/site-lisp/libc-init.lisp
@@ -1,8 +1,8 @@
 ;; for the invoke-procedure we need a type of the invoked function
 ;; so, the function must be present in the static representation of a program.
-
-(require pointers)
-(require memory)
+(require posix-init)
+(in-package posix)
+(declare (visibility :private))
 
 (defun init (main argc argv auxv)
   "GNU libc initialization stub"

--- a/plugins/primus_lisp/site-lisp/libc-init.lisp
+++ b/plugins/primus_lisp/site-lisp/libc-init.lisp
@@ -4,6 +4,7 @@
 (in-package posix)
 (declare (visibility :private))
 
+
 (defun init (main argc argv auxv)
   "GNU libc initialization stub"
   (declare (external "__libc_start_main"))
@@ -19,7 +20,8 @@
 
 
 (defun setup-stack-canary ()
-  (declare (context (abi "sysv")))
+  (declare (context (abi "sysv"))
+           (global program:FS_BASE))
   (set FS_BASE (- brk 0x28))
   (memory-allocate brk (sizeof ptr_t))
   (write-word ptr_t brk 0xDEADBEEFBEAFDEAD)

--- a/plugins/primus_lisp/site-lisp/limit-malloc.lisp
+++ b/plugins/primus_lisp/site-lisp/limit-malloc.lisp
@@ -1,4 +1,5 @@
 ;; up to 4 Mb each chunk, up to 128 Mbytes total
+(in-package posix)
 
 (defmethod init ()
   (set *malloc-max-chunk-size* (* 4 1024 1024))

--- a/plugins/primus_lisp/site-lisp/llvm-x86-64-floats.lisp
+++ b/plugins/primus_lisp/site-lisp/llvm-x86-64-floats.lisp
@@ -1,4 +1,12 @@
-(require posix)
+(defpackage llvm-x86-64
+  (:documentation "x86-64 intrinsics")
+  (:use posix amd64))
+
+(in-package llvm-x86-64)
+
+(declare (context (target amd64))
+         (visibility :private))
+
 (require types)
 
 (defmacro lower-all (r) (set r false))

--- a/plugins/primus_lisp/site-lisp/posix-init.lisp
+++ b/plugins/primus_lisp/site-lisp/posix-init.lisp
@@ -1,0 +1,2 @@
+(require core)
+(defpackage posix (:use core))

--- a/plugins/primus_lisp/site-lisp/posix-init.lisp
+++ b/plugins/primus_lisp/site-lisp/posix-init.lisp
@@ -1,2 +1,2 @@
 (require core)
-(defpackage posix (:use core primus target))
+(defpackage posix (:use core primus program target))

--- a/plugins/primus_lisp/site-lisp/posix-init.lisp
+++ b/plugins/primus_lisp/site-lisp/posix-init.lisp
@@ -1,2 +1,2 @@
 (require core)
-(defpackage posix (:use core))
+(defpackage posix (:use core primus target))

--- a/plugins/primus_lisp/site-lisp/posix-init.lisp
+++ b/plugins/primus_lisp/site-lisp/posix-init.lisp
@@ -1,2 +1,0 @@
-(require core)
-(defpackage posix (:use core primus program target))

--- a/plugins/primus_lisp/site-lisp/primus.lisp
+++ b/plugins/primus_lisp/site-lisp/primus.lisp
@@ -1,0 +1,2 @@
+(require core)
+(defpackage primus (:use core))

--- a/plugins/primus_lisp/site-lisp/primus.lisp
+++ b/plugins/primus_lisp/site-lisp/primus.lisp
@@ -1,2 +1,4 @@
 (require core)
-(defpackage primus (:use core))
+(defpackage primus
+  (:documentation "the runtime state of the Primus Machine")
+  (:use core))

--- a/plugins/primus_lisp/site-lisp/primus.lisp
+++ b/plugins/primus_lisp/site-lisp/primus.lisp
@@ -1,4 +1,0 @@
-(require core)
-(defpackage primus
-  (:documentation "the runtime state of the Primus Machine")
-  (:use core))

--- a/plugins/primus_lisp/site-lisp/simple-memory-allocator.lisp
+++ b/plugins/primus_lisp/site-lisp/simple-memory-allocator.lisp
@@ -1,3 +1,6 @@
+(require posix-init)
+(in-package posix)
+
 (require string)
 (require types)
 
@@ -81,6 +84,7 @@
 
 ;; pre: both old-ptr and new-len are not null
 (defun realloc/update-chunk (old-ptr new-len)
+  (declare (visibility :private))
   (let ((old-len (malloc/get-chunk-size old-ptr)))
     (if (>= old-len new-len) (realloc/shrink-chunk old-ptr new-len)
       (let ((new-ptr (malloc new-len)))
@@ -90,6 +94,7 @@
         new-ptr))))
 
 (defun realloc/as-free (ptr)
+  (declare (visibility :private))
   (free ptr)
   *malloc-zero-sentinel*)
 
@@ -108,16 +113,19 @@
 
 
 (defun malloc-heap-size ()
+  (declare (visibility :private))
   *malloc/total-bytes-allocated*)
 
 
 (defun malloc-will-reach-limit (n)
+  (declare (visibility :private))
   (or (and *malloc-max-chunk-size*
            (> n *malloc-max-chunk-size*))
       (and *malloc-max-arena-size*
            (> (malloc-heap-size) *malloc-max-arena-size*))))
 
 (defun malloc/fill-edges (ptr n)
+  (declare (visibility :private))
   (when *malloc-guard-edges*
     (memset ptr
             *malloc-guard-pattern*
@@ -128,6 +136,7 @@
 
 
 (defun malloc/allocate-arena (len)
+  (declare (visibility :private))
   (set *malloc-arena-start* brk)
   (+= brk len)
   (set *malloc-arena-end* brk)
@@ -141,6 +150,7 @@
                      *malloc-uniform-max-value*)))
 
 (defun malloc/initialize (ptr len)
+  (declare (visibility :private))
   (if *malloc-initialize-memory*
       (memory-allocate ptr len *malloc-initial-value*)
     (when (or *malloc-uniform-min-value*
@@ -150,16 +160,20 @@
                        *malloc-uniform-max-value*))))
 
 (defun malloc/grow-arena-if-needed (len)
+  (declare (visibility :private))
   (let ((free-space (- *malloc-arena-end* *malloc/brk*)))
     (when (> len free-space)
       (malloc/allocate-arena (max *malloc-arena-initial-size* len)))))
 
 (defun realloc/shrink-chunk (ptr len)
+  (declare (visibility :private))
   (malloc/put-chunk-size ptr len)
   ptr)
 
 (defun malloc/put-chunk-size (ptr len)
+  (declare (visibility :private))
   (write-word int ptr len))
 
 (defun malloc/get-chunk-size (ptr)
+  (declare (visibility :private))
   (read-word int (- ptr (sizeof int))))

--- a/plugins/primus_lisp/site-lisp/simple-memory-allocator.lisp
+++ b/plugins/primus_lisp/site-lisp/simple-memory-allocator.lisp
@@ -1,4 +1,3 @@
-(require posix-init)
 (in-package posix)
 
 (require string)

--- a/plugins/primus_lisp/site-lisp/stdio.lisp
+++ b/plugins/primus_lisp/site-lisp/stdio.lisp
@@ -2,6 +2,7 @@
 (require memory)
 (require types)
 
+(in-package posix)
 
 (defun fputc (char stream)
   (declare (external "fputc" "putc"))
@@ -74,12 +75,14 @@
     (or failure written)))
 
 (defun input-item-nth-char (ptr size item desc i)
+  (declare (visibility :private))
   (let ((c (fgetc desc)))
     (if (= c -1) 0
-      (memory-write (+ ptr (* size item) i) (cast char c))
-      1)))
+        (memory-write (+ ptr (* size item) i) (cast char c))
+        1)))
 
 (defun input-item (buf size item fd)
+  (declare (visibility :private))
   (let ((i 0))
     (while (and (< i size)
                 (input-item-nth-char buf size item fd i))
@@ -105,6 +108,7 @@
   (channel-input stream))
 
 (defun terminate-string-and-return-null (ptr)
+  (declare (visibility :private))
   (memory-write ptr 0:8)
   0)
 
@@ -131,6 +135,6 @@
   (declare (external "getchar"))
   (fgetc *standard-input*))
 
-(defmethod machine-kill ()
+(defmethod primus:machine-kill ()
   (channel-flush *standard-output*)
   (channel-flush *standard-error*))

--- a/plugins/primus_lisp/site-lisp/stdlib.lisp
+++ b/plugins/primus_lisp/site-lisp/stdlib.lisp
@@ -4,6 +4,8 @@
 (require simple-memory-allocator)
 (require types)
 
+(in-package posix)
+
 (defun getenv (name)
   "finds a value of an environment variable with the given name"
   (declare (external "getenv"))

--- a/plugins/primus_lisp/site-lisp/string.lisp
+++ b/plugins/primus_lisp/site-lisp/string.lisp
@@ -1,4 +1,3 @@
-(require posix-init)
 (require types)
 (require pointers)
 (require memory)

--- a/plugins/primus_lisp/site-lisp/string.lisp
+++ b/plugins/primus_lisp/site-lisp/string.lisp
@@ -1,7 +1,10 @@
+(require posix-init)
 (require types)
 (require pointers)
 (require memory)
 (require ascii)
+
+(in-package posix)
 
 (defun strlen (p)
   (declare (external "strlen"))
@@ -62,11 +65,12 @@
 
 
 (defmacro find-character (dir p c n)
+  (declare (visibility :private))
   (prog
-   (while (and n (not (points-to char p c)))
-    (decr n)
-    (dir p))
-   (if (points-to char p c) p 0)))
+      (while (and n (not (points-to char p c)))
+        (decr n)
+        (dir p))
+     (if (points-to char p c) p 0)))
 
 (defun memchr (p c n)
   (declare (external "memchr"))
@@ -128,6 +132,7 @@
 (defun strlen/with-null (s)
   "returns a length of the string S
    (including the terminating null character)"
+  (declare (visibility :private))
   (+1 (strlen s)))
 
 (defun strncmp (s1 s2 n)
@@ -163,6 +168,7 @@
 
 
 (defmacro find-substring (compare hay needle)
+  (declare (visibility :private))
   (let ((found 0)
         (n (strlen needle)))
     (while (and (memory-read hay) (not found))

--- a/plugins/primus_lisp/site-lisp/types.lisp
+++ b/plugins/primus_lisp/site-lisp/types.lisp
@@ -1,4 +1,3 @@
-(require posix-init)
 (in-package posix)
 
 (defun model-ilp32 (type)

--- a/plugins/primus_lisp/site-lisp/types.lisp
+++ b/plugins/primus_lisp/site-lisp/types.lisp
@@ -1,3 +1,6 @@
+(require posix-init)
+(in-package posix)
+
 (defun model-ilp32 (type)
   (case type
     'char 8

--- a/plugins/primus_lisp/site-lisp/user.lisp
+++ b/plugins/primus_lisp/site-lisp/user.lisp
@@ -1,3 +1,0 @@
-(require core)
-(require primus)
-(defpackage user (:use core primus target))

--- a/plugins/primus_lisp/site-lisp/user.lisp
+++ b/plugins/primus_lisp/site-lisp/user.lisp
@@ -1,0 +1,3 @@
+(require core)
+(require primus)
+(defpackage user (:use core primus))

--- a/plugins/primus_lisp/site-lisp/user.lisp
+++ b/plugins/primus_lisp/site-lisp/user.lisp
@@ -1,3 +1,3 @@
 (require core)
 (require primus)
-(defpackage user (:use core primus))
+(defpackage user (:use core primus target))

--- a/plugins/primus_loader/primus_loader_basic.ml
+++ b/plugins/primus_loader/primus_loader_basic.ml
@@ -210,8 +210,8 @@ module Make(Param : Param)(Machine : Primus.Machine.S)  = struct
     load_segments () >>= fun e1 ->
     map_segments () >>= fun e2 ->
     let endp = Addr.max e1 e2 in
-    set_word "endp" endp >>= fun () ->
-    set_word "brk"  endp >>= fun () ->
+    set_word "posix:endp" endp >>= fun () ->
+    set_word "posix:brk"  endp >>= fun () ->
     setup_registers () >>= fun () ->
     init_names ()
 end

--- a/plugins/primus_loader/primus_loader_basic.ml
+++ b/plugins/primus_loader/primus_loader_basic.ml
@@ -188,7 +188,7 @@ module Make(Param : Param)(Machine : Primus.Machine.S)  = struct
     fun _argv_frame_ptr ->
     assert Word.(argv_frame_ptr = _argv_frame_ptr);
     save_word endian argc sp >>= fun _ ->
-    set_word "environ" envp_table_ptr
+    set_word "posix:environ" envp_table_ptr
 
 
   let names prog = (object

--- a/plugins/primus_print/primus_print_main.ml
+++ b/plugins/primus_print/primus_print_main.ml
@@ -1,4 +1,5 @@
 open Core_kernel
+open Bap_core_theory
 open Bap.Std
 open Bap_primus.Std
 open Bap_future.Std
@@ -42,7 +43,13 @@ let strip name =
   else name
 
 let has_name name p =
-  String.equal (Primus.Observation.Provider.name p) name
+  let name = KB.Name.read name in
+  let obsname = KB.Name.read @@ Primus.Observation.Provider.name p in
+  if String.(KB.Name.package name = "user")
+  then String.equal
+      (KB.Name.unqualified obsname)
+      (KB.Name.unqualified name)
+  else KB.Name.equal obsname name
 
 let remove_provider name = List.filter ~f:(Fn.non (has_name name))
 

--- a/plugins/primus_print/primus_print_main.ml
+++ b/plugins/primus_print/primus_print_main.ml
@@ -43,13 +43,9 @@ let strip name =
   else name
 
 let has_name name p =
-  let name = KB.Name.read name in
-  let obsname = KB.Name.read @@ Primus.Observation.Provider.name p in
-  if String.(KB.Name.package name = "user")
-  then String.equal
-      (KB.Name.unqualified obsname)
-      (KB.Name.unqualified name)
-  else KB.Name.equal obsname name
+  let name = KB.Name.read ~package:"primus" name in
+  let obsname = Primus.Observation.Provider.fullname p in
+  KB.Name.equal obsname name
 
 let remove_provider name = List.filter ~f:(Fn.non (has_name name))
 

--- a/plugins/primus_symbolic_executor/lisp/symbolic-stdio.lisp
+++ b/plugins/primus_symbolic_executor/lisp/symbolic-stdio.lisp
@@ -1,3 +1,5 @@
+(in-package posix)
+
 (require types)
 
 (declare (static opened-descriptors
@@ -11,6 +13,7 @@
 (defconstant symbolic-stdin minimum-stream-number)
 
 (defun symbolic-open-input (name)
+  (declare (visibility :private))
   (let ((next-desc (+1 opened-descriptors))
         (desc (symbolic-value (symbol-concat name '-desc)
                               (bitwidth int)
@@ -37,12 +40,14 @@
 
 
 (defun symbolic-copy-to-concrete (memory cptr sptr len)
+  (declare (visibility :private))
   (while (> len 0)
     (memory-write (+ cptr len -1)
                   (symbolic-memory-read memory (+ sptr len -1)))
     (decr len)))
 
 (defun symbolic-copy-from-concrete (memory sdst csrc len)
+  (declare (visibility :private))
   (while (> len 0)
     (symbolic-memory-write memory (+ sdst len -1)
                            (memory-read (+ csrc len -1)))
@@ -106,6 +111,7 @@
   (fgetc symbolic-stdin))
 
 (defun init-symbolic-stdin ()
+  (declare (visibility :private))
   (dict-add 'symbolic-open-fpos 0 0)
   (dict-add 'symbolic-open-size 0 *symbolic-initial-file-size*)
   (dict-add 'symbolic-open-data 0
@@ -113,7 +119,6 @@
   (set opened-descriptors 2)
   (dict-add 'symbolic-streams opened-streams 0)
   (set opened-streams minimum-stream-number))
-
 
 (defmethod init ()
   (init-symbolic-stdin))

--- a/plugins/primus_symbolic_executor/lisp/symbolic-stdlib.lisp
+++ b/plugins/primus_symbolic_executor/lisp/symbolic-stdlib.lisp
@@ -1,1 +1,2 @@
+(in-package posix)
 (declare (context (component bap:symbolic-computer)))


### PR DESCRIPTION
This is a big upgrade of the Primus Lisp language that introduces namespaces. We generally follow the Common Lisp style at least syntactically but have a few differences, given that in Primus Lisp the program is a set of mutually recursive definitions and that each name can have more than one definition (under different contexts).

The change is designed to be backward-compatible as much as possible. The existing code doesn't require any modifications as the default package (`user`) imports names from the prebuilt packages so all the same names are available unqualified.

Below is an excerpt from the Primus Lisp documentation, please read for more details on the usage and implementation.


```
        {2 Package System}

        The Primus Lisp package system enables name clashes-free
        environment in the presence of mutually recursive definition
        of the whole program with type class-based names
        overloading. An important feature of the package system is
        independence on the order of package definitions and
        inclusions and tolerance to cycles in package dependencies.

        Despite that the package system prevents name clashes in a
        such complex environment it is easy to understand. A package
        is just a dictionary of definitions, where a defintion is a
        function, macros, variable, primitive, etc. The namespace of
        each package is flat, i.e., all definitions have simple
        unqualified names, e.g., [malloc], [foo], [*bar*]. The
        namespace of the packages names is also flat, e.g., [posix],
        [core], [primus]. To access a definition [<def>] in a package
        [<pkg>] use [<pkg>:<foo>], e.g., [posix:malloc],
        [core:*bar*]. When a name is missing a package designator,
        e.g., [foo] the parser automatically adds the name of the
        {i current} package. The current package defaults to [user] and
        is set with the [in-package] form, e.g., [(in-package posix)]
        sets the current package to [posix] and all unqualified names
        read after it and until the end of the file (or another
        [in-package] stanza) will be qualified with the [posix]
        package. Therefore, it is important to understand that every
        identifier in Primus Lisp, be it a variable, a function or a
        macro name, a symbol, and so on, is having a package, even
        though most of the time it left implicit and we commonly use
        unqualified names.

        The [(use-package foo)] makes all definitions from the package
        [foo] available in the current package. Since Primus Lisp
        enables multiple definitions of the same name, no special
        considerations to prevent shadowing and the definitions are
        simply added to the current package. It also doesn't matter
        whether the [use-package] stanza occurs before, in between, or
        after the definitions of [foo] are loaded as well as it
        doesn't matter whether it occurs with respect to the
        defintions of the current package. The mental model is that
        [(use-package foo)] establishes a relation {i uses} between
        the current package and the package [foo] and all definitions
        from [foo] are copied to the current package no matter whether
        they were lexically made before or after this relation was
        discovered. Since the definitions from [foo] are now in the
        current package, they are also copied to all packages that use
        the current package and so on, in the transitive closure of
        the uses relation.

        The [use-package] stanza is pretty low-level and it is better
        to use [defpackage] to define a package, ideally, once. The
        [defpackage] form takes the name of the package and a list of
        packages that it uses as well as the documentation that
        describes the package purpose. E.g.,
        {v
          (defpackage riscv
            (:use target program)
            (:documentation "general riscv instruction semantics"))
        v}

        In the example above we specified that the [riscv] package
        imports definitions from the [target] and [program] packages.

        In Primus Lisp it is not required that the package should be
        defined before it is used but it is still a good idea to
        define the package beforehand and, ideally, keep the
        definition in a single place. With that said, it is possible
        to have multiple definitions (or no definitios) of a package
        spread across multiple files. Therefore, it is possible to
        extend the set of packages that some package uses with all
        pitfalls and perils. We highly advice to refrain from touching
        the use-list of packages that you do not control.

        Primus Lisp comes with a set of predefined packages and all of
        them are used by the [user] package, which is the default
        package (so their definitions could be used unqualified by
        default):

        - [core] - the core of the Primus Lisp language;
        - [primus] - the Primus Lisp runtime;
        - [program] - the binary program runtime;
        - [target] - the target CPU environment;
        - [posix] - the definitions of the posix runtime.

        In addition to these packages, each target (architecture)
        known to bap (see [bap list targets]) forms a package that
        is prefilled with the registers of that target, e.g.,
        [i86:SP], [amd64:RSP], and so on (the target package name is
        formed from the unqualified name of the target name
        itself). This gives an additional way to refer to registers,
        with the other option is to use the [target] package in which
        CPU registers of the currently analyzed binary are added.

        Another important packages to consider is the [external] package
        where all externally visible definitions are put, see more
        about it in the [external] attribute description.

        {3 Name Visibility}

        By default all names defined in a package are public and are
        exported to all packages that use this package. It is,
        possible to control the visibility of a name using the
        visibility attribute. See attributes below for more information.
```