### PR TITLE
restores output for non-empty instructions

### DIFF
--- a/plugins/mc/mc_main.ml
+++ b/plugins/mc/mc_main.ml
@@ -321,8 +321,13 @@ let new_insn arch mem insn =
 
 let lift arch mem insn =
   match KB.run Theory.Program.cls (new_insn arch mem insn) KB.empty with
-  | Ok (code,_) -> Ok (KB.Value.get Theory.Semantics.slot code)
   | Error conflict -> fail (Inconsistency conflict)
+  | Ok (code,_) ->
+    Result.return @@
+    let sema = KB.Value.get Theory.Semantics.slot code in
+    if Insn.(equal empty sema)
+    then Insn.of_basic insn
+    else sema
 
 let print_insn_size formats mem =
   List.iter formats ~f:(fun _fmt ->


### PR DESCRIPTION
It looks like that #1281 rendered bap useless for unlifted
instructions. Both mc and objdump commads are now outputing
empty objects even without asm or opcodes, which makes it
really hard to write a new lifter.

This PR fixes it on mc and objdump level. I am not sure if we also
need this in the disassembler driver (as in any case the output of
this driver will be incorrect without having full semantics).