### PR TITLE
implements ABI description eDSL

### DIFF
--- a/lib/bap_c/bap_c_abi.ml
+++ b/lib/bap_c/bap_c_abi.ml
@@ -37,13 +37,14 @@ type error = [
   | `Parser_error of string * Error.t
 ] [@@deriving sexp_of]
 
-type param = Bap_c_data.t * exp
+let sexp_of_exp exp = Sexp.Atom (Exp.to_string exp)
+type param = Bap_c_data.t * exp [@@deriving sexp]
 
 type args = {
   return : param option;
   hidden : (Bap_c_type.t * param) list;
   params : param list;
-}
+} [@@deriving sexp]
 
 type t = {
   insert_args : sub term -> attr list -> proto -> args option;
@@ -139,21 +140,24 @@ let create_api_processor size abi : Bap_api.t =
 
     method private apply_args sub attrs t =
       match abi.insert_args sub attrs t with
-      | None -> super#map_sub sub
+      | None ->
+        super#map_sub sub
       | Some {return; hidden; params} ->
         let params = List.mapi params ~f:(fun i a -> i,a) in
-        let args =
-          List.map2_exn params t.Bap_c_type.Proto.args ~f:(fun (i,a) (n,t) ->
-              create_arg i addr_size (arg_intent t) n t a sub) in
-        let ret = match return with
-          | None -> []
-          | Some ret ->
-            let t = t.Bap_c_type.Proto.return in
-            [create_arg 0 addr_size Out "result" t ret sub] in
-        let hid = List.mapi hidden ~f:(fun i (t,a) ->
-            let n = "hidden" ^ if i = 0 then "" else Int.to_string i in
-            create_arg 0 addr_size Both n t a sub) in
-        List.fold (args@hid@ret) ~init:sub ~f:(Term.append arg_t)
+        List.map2 params t.Bap_c_type.Proto.args ~f:(fun (i,a) (n,t) ->
+            create_arg i addr_size (arg_intent t) n t a sub) |>
+        function
+        | Unequal_lengths -> super#map_sub sub
+        | Ok args ->
+          let ret = match return with
+            | None -> []
+            | Some ret ->
+              let t = t.Bap_c_type.Proto.return in
+              [create_arg 0 addr_size Out "result" t ret sub] in
+          let hid = List.mapi hidden ~f:(fun i (t,a) ->
+              let n = "hidden" ^ if i = 0 then "" else Int.to_string i in
+              create_arg 0 addr_size Both n t a sub) in
+          List.fold (args@hid@ret) ~init:sub ~f:(Term.append arg_t)
 
   end in
   let module Api = struct
@@ -193,5 +197,457 @@ module Stack = struct
       then Bil.(var sp - int off)
       else Bil.(var sp + int off) in
     Bil.load ~mem ~addr endian sz
-
 end
+
+
+module Arg = struct
+  open Core_kernel
+  open Bap_core_theory
+  open Bap.Std
+  open Monads.Std
+
+  module C = struct
+    module Size = Bap_c_size
+    module Type = Bap_c_type
+    module Data = Bap_c_data
+  end
+
+  let next_multitude_of ~n x = (x + (n-1)) land (lnot (n-1))
+
+
+
+  module Stack : sig
+    type t
+
+    val create : #C.Size.base -> Theory.Target.t -> t option
+
+    val base : t -> var
+
+
+    (** [slots] returns a list of [(offset,datum,size_in_bits)]
+        slots, where offset is properly aligned.
+    *)
+    val slots : t -> (int * C.Data.t * int) list
+
+    (** [add datum bits] adds [bits] representing [datum] to the
+        next available stack slot. The stack is growing downwards. *)
+    val add : C.Type.t -> C.Data.t -> int -> t -> t
+
+    (** [push datum bits] prepends [bits] representing [datume] to
+        the beginning of the descending stack. *)
+    val push : C.Type.t -> C.Data.t -> int -> t -> t
+
+    (** [skip bits] skips the specified number of bits.   *)
+    val skip : int -> t -> t
+
+    (** [is_empty] is true if no stack slots were allocated.  *)
+    val is_empty : t -> bool
+  end = struct
+    type info = {
+      datum : C.Data.t;
+      ctype : C.Type.t;
+    }
+    type t = {
+      base : Var.t;
+      data  : (info option * int) Map.M(Int).t;
+      align : (info option -> int -> int);
+    }
+
+    let bytes bits = (bits - 1) / 8 + 1
+
+    let create (ruler : #C.Size.base) target =
+      let min_alignment = max
+          (Theory.Target.data_alignment target / 8)
+          (Theory.Target.data_addr_size target / 8) in
+      let align = function
+        | None ->
+          next_multitude_of ~n:min_alignment
+        | Some {ctype} ->
+          let m = Size.in_bytes (ruler#alignment ctype) in
+          next_multitude_of ~n:(max min_alignment m) in
+      match Theory.Target.reg target Theory.Role.Register.stack_pointer with
+      | None -> None
+      | Some sp -> Some {
+          base = Var.reify sp;
+          data = Map.empty (module Int);
+          align;
+        }
+
+    let base stack = stack.base
+
+    let slots stack =
+      Map.to_alist stack.data |>
+      List.filter_map ~f:(fun (off,(info,bits)) ->
+          match info with
+          | None -> None
+          | Some {datum} -> Some (off,datum,bits))
+
+
+    let singleton entry stack =
+      {stack with data = Map.singleton (module Int) 0 entry}
+
+    let append (info,size) stack = match Map.max_elt stack.data with
+      | None -> singleton (info,size) stack
+      | Some (k,(_,s)) ->
+        let k' = stack.align info (k + bytes s) in
+        {stack with data = Map.add_exn stack.data k' (info,size)}
+
+    let add ctype datum size = append (Some {ctype; datum},size)
+    let skip size  = append (None,size)
+
+    let push ctype datum size stack =
+      Map.fold stack.data ~f:(fun ~key:_ ~data stack ->
+          append data stack)
+        ~init:(singleton (Some {ctype; datum},size) stack)
+
+    let is_empty stack = Map.is_empty stack.data
+  end
+
+  module File = struct
+    type t = {
+      args : Var.t Map.M(Int).t;
+      bits : int;
+    }
+
+    let bits self = self.bits
+
+    let pop self = match Map.min_elt self.args with
+      | None -> None
+      | Some (k,x) ->
+        Some ({self with args = Map.remove self.args k},x)
+
+    let popn n self = match Map.split self.args n with
+      | _,None,_ -> None
+      | lt,Some (k,x),rt ->
+        Some ({self with args = Map.add_exn rt k x}, Map.data lt)
+
+    let align n self = match Map.min_elt self.args with
+      | None -> None
+      | Some (k,_) ->
+        let k' = next_multitude_of ~n k in
+        if k = k' then Some (self,())
+        else match Map.split self.args k' with
+          | _,None,_ -> None
+          | _,_,rt when Map.is_empty rt -> None
+          | _,Some (k',x),rt ->
+            Some ({self with args = Map.add_exn rt k' x},())
+
+    let available {args} = Map.length args
+
+    let of_list =
+      List.foldi ~f:(fun pos regs reg -> Map.add_exn regs pos reg)
+        ~init:Int.Map.empty
+
+
+    let create args = {
+      args = of_list args;
+      bits = match args with
+        | [] -> -1
+        | r::_ -> match Var.typ r with
+          | Imm x -> x
+          | _ -> -1
+    }
+
+    let of_roles roles t  =
+      let regs =
+        Theory.Target.regs t ~roles |>
+        Set.to_list |>
+        List.map ~f:Var.reify in
+      create regs
+  end
+
+  type state = {
+    files : File.t Map.M(Int).t;
+    stack : Stack.t option;
+    ruler : C.Size.base;
+    where : [`Return | `Inputs | `Hidden];
+    return : (C.Data.t * Bil.exp) option;
+    inputs : (C.Data.t * Bil.exp) list;
+    hidden :(C.Type.t * (C.Data.t * Bil.exp)) list;
+    target : Theory.Target.t;
+  }
+
+  module Arg = struct
+    module State = struct type t = state end
+    include Monad.State.Make(State)(Monad.Option)
+    include Monad.State.T1(State)(Monad.Option)
+    let reject : unit -> 'a t = fun () -> lift None
+    let catch : 'a t -> (unit -> 'a t) -> 'a t =
+      fun x err ->
+      let* s = get () in
+      match run x s with
+      | None -> err ()
+      | Some (x,s) ->
+        let+ () = put s in
+        x
+  end
+
+  type semantics = unit
+  type arena = int
+  type ctype = C.Type.t
+
+  open Arg.Syntax
+  open Arg.Let
+
+  module Arena = struct
+    let add file =
+      let* s = Arg.get () in
+      let s = {
+        s with files = match Map.max_elt s.files with
+          | None -> Map.singleton (module Int) 0 file
+          | Some (k,_) ->
+            Map.add_exn s.files (k+1) file
+      } in
+      let+ () = Arg.put s in
+      fst (Map.max_elt_exn s.files)
+
+    let create regs = add (File.create (List.map ~f:Var.reify regs))
+    let of_roles roles t = add (File.of_roles roles t)
+
+    let iargs = of_roles Theory.Role.Register.[
+        function_argument;
+        integer;
+      ]
+
+    let irets = of_roles Theory.Role.Register.[
+        function_return;
+        integer;
+      ]
+
+    let fargs = of_roles Theory.Role.Register.[
+        function_argument;
+        floating;
+      ]
+
+    let frets = of_roles Theory.Role.Register.[
+        function_return;
+        floating;
+      ]
+
+
+    let get {files} n = Map.find_exn files n
+
+    let update s n f = match f (get s n) with
+      | None -> Arg.reject ()
+      | Some (arena,res) ->
+        Arg.put {s with files = Map.set s.files n arena} >>= fun () ->
+        Arg.return res
+    let pop s n = update s n File.pop
+    let popn ~n s a = update s a (File.popn n)
+
+  end
+
+  let size s t = match s.ruler#bits t with
+    | None -> Arg.reject ()
+    | Some x -> Arg.return x
+
+  let require cnd = if cnd then Arg.return () else Arg.reject ()
+
+  let push_arg t exp = Arg.update @@ fun s ->
+    match s.where with
+    | `Return -> {
+        s with return = Some (data s.ruler t,exp)
+      }
+    | `Hidden -> {
+        s with hidden = (t, (data s.ruler t, exp)) :: s.hidden
+      }
+    | `Inputs -> {
+        s with inputs = (data s.ruler t, exp) :: s.inputs
+      }
+
+  let register file t =
+    let* s = Arg.get () in
+    let* bits = size s t in
+    let regs = Arena.get s file in
+    require (File.bits regs >= bits) >>= fun () ->
+    let* arg = Arena.pop s file in
+    push_arg t (Bil.var arg)
+
+  let drop file =
+    Arg.get () >>= fun s -> Arena.pop s file >>| fun _ -> ()
+
+  let count file t =
+    let+ s = Arg.get () in
+    let regs = Arena.get s file in
+    let abits = File.bits regs in
+    match s.ruler#bits t with
+    | Some bits when abits > 0 -> Some ((bits - 1) / abits + 1)
+    | _ -> None
+
+  let needs_some f = f >>= function
+    | None -> Arg.reject ()
+    | Some x -> Arg.return x
+
+  let registers ?limit file t =
+    let* s = Arg.get () in
+    let* regs_needed = needs_some @@ count file t in
+    let limit = Option.value limit ~default:regs_needed in
+    require (regs_needed <= limit) >>= fun () ->
+    let* args = Arena.popn ~n:regs_needed s file in
+    let exps = List.map args ~f:Bil.var |>
+               List.reduce_exn ~f:Bil.concat in
+    push_arg t exps
+
+  let align_even file =
+    let* s = Arg.get () in
+    Arena.popn ~n:2 s file >>| ignore
+
+  let switch where = Arg.update @@ fun s -> {s with where}
+  let where = Arg.gets @@ fun s -> s.where
+
+  let with_hidden f =
+    let* was = where in
+    switch `Hidden >>= fun () ->
+    let* x = f () in
+    switch was >>| fun () ->
+    x
+
+  let reference file t =
+    with_hidden @@ fun () ->
+    register file (`Pointer C.Type.Spec.{
+        t;
+        attrs = [];
+        qualifier = C.Type.Qualifier.{
+            const = false;
+            volatile = false;
+            restrict = false;
+          }
+      })
+
+  let update_stack f =
+    let* s = Arg.get () in
+    match s.stack with
+    | None -> Arg.reject ()
+    | Some stack ->
+      Arg.put {s with stack = Some (f stack)}
+
+  let push t =
+    let* s = Arg.get () in
+    let* bits = size s t in
+    update_stack @@ Stack.add t (data s.ruler t) bits
+
+  let memory t =
+    let* s = Arg.get () in
+    let* bits = size s t in
+    update_stack @@ Stack.add t (data s.ruler t) bits
+
+  let skip_memory bits = update_stack @@ Stack.skip bits
+
+  let load t bits sp base =
+    let mem = Var.reify (Theory.Target.data t) in
+    let width = Theory.Target.data_addr_size t in
+    let addr = function
+      | 0 -> Bil.(var sp)
+      | off -> Bil.(var sp + int (Word.of_int ~width off)) in
+    let endianness =
+      if Theory.Endianness.(equal le (Theory.Target.endianness t))
+      then LittleEndian else BigEndian in
+    let load_byte off =
+      Bil.(load ~mem:(var mem) ~addr:(addr off) endianness `r8) in
+    let rec load_bytes bytes loaded off =
+      if loaded < bits then
+        load_bytes (load_byte off :: bytes) (loaded+8) (off+1)
+      else
+        let bytes = match endianness with
+          | LittleEndian -> bytes
+          | BigEndian -> List.rev bytes in
+        Bil.(cast low) bits (List.reduce_exn bytes ~f:Bil.concat) in
+    match Size.of_int_opt bits with
+    | Some r -> Bil.(load ~mem:(var mem) ~addr:(addr base) endianness r)
+    | None -> load_bytes [] 0 base
+
+  let target = Arg.gets @@ fun s -> s.target
+
+  let stack =
+    let* s = Arg.get () in
+    match s.stack with
+    | None -> Arg.reject ()
+    | Some stack -> Arg.return stack
+
+  let split_with_memory file typ =
+    let* s = Arg.get () in
+    let* bits = size s typ in
+    let* reg = Arena.pop s file in
+    let* t = target in
+    let* stack = stack in
+    let regs = Arena.get s file in
+    let base = Stack.base stack in
+    require (Stack.is_empty stack && bits > File.bits regs) >>= fun () ->
+    let mbits = bits - File.bits regs in
+    skip_memory mbits >>= fun () ->
+    push_arg typ @@ Bil.concat (Bil.var reg) (load t mbits base 0)
+
+  let either op1 op2 = Arg.catch op1 (fun _ -> op2)
+
+  let (<|>) = either
+
+  let choice options =
+    match List.reduce ~f:either options with
+    | Some option -> option
+    | None -> Arg.reject ()
+
+  let define ?(return=Arg.return ()) inputs = Arg.sequence [
+      switch `Return;
+      return;
+      switch `Inputs;
+      inputs;
+    ]
+
+  let reify target ruler grammar : args option =
+    let ruler = (ruler :> Bap_c_size.base) in
+    let init = {
+      stack = Stack.create ruler target;
+      ruler;
+      files = Map.empty (module Int);
+      where = `Inputs;
+      return = None;
+      inputs = [];
+      hidden = [];
+      target;
+    } in
+    match Arg.run grammar init with
+    | None -> None
+    | Some ((),{stack;return;inputs;hidden}) ->
+      let memory = match stack with
+        | None -> []
+        | Some stack ->
+          let base = Stack.base stack in
+          Stack.slots stack |>
+          List.map ~f:(fun (off,data,bits) ->
+              data,load target bits base off) in
+      Some {
+        return;
+        params = List.rev_append inputs memory;
+        hidden = List.rev hidden;
+      }
+
+  let unless cnd prog = if not cnd then prog else Arg.return ()
+  let on cnd prog = if cnd then prog else Arg.return ()
+  let guard = require
+  let accept = Arg.return
+  let pure = Arg.return
+  let zero = Arg.reject
+  include Arg
+end
+
+let define target ruler pass =
+  let open Bap_core_theory in
+  let target_name = Theory.Target.name target in
+  let abi_name =
+    let abi = Theory.Target.abi target in
+    if Theory.Abi.(abi = unknown)
+    then Format.asprintf "%a-unknown" KB.Name.pp target_name
+    else Format.asprintf "%a" KB.Name.pp target_name in
+  let abi_processor = {
+    apply_attrs = (fun _ x -> x);
+    insert_args = fun _ attrs proto ->
+      Arg.reify target ruler (pass attrs proto)
+  } in
+  register abi_name abi_processor;
+  Bap_abi.register_pass @@ fun proj ->
+  if Theory.Target.equal (Project.target proj) target
+  then begin
+    Bap_api.process (create_api_processor ruler abi_processor);
+    Project.set proj Bap_abi.name abi_name
+  end
+  else proj

--- a/lib/bap_c/bap_c_abi.mli
+++ b/lib/bap_c/bap_c_abi.mli
@@ -5,7 +5,9 @@
 *)
 
 open Core_kernel
+open Bap_core_theory
 open Bap.Std
+open Monads.Std
 open Bap_c_type
 
 
@@ -97,3 +99,364 @@ module Stack : sig
       [n]'th stack slot *)
   val create : ?growsup:Bool.t -> arch -> int -> exp
 end
+
+
+(** A monadic eDSL for argument passing semantics specification.
+
+    This DSL helps in defining the abi processor's [insert_args]
+    function. The DSL describes the semantics of argument passing that
+    is then reified to the [args] structure. The [DSL] is a choice
+    monad that enables describing the argument passing grammar using
+    backtracing when the chosen strategy doesn't fit. The [reject ()]
+    operator will reject the current computation up until the nearest
+    choice prompt, e.g., in the following example, computations [e1],
+    [e2], and [e3] are rejected and any side-effects that they might
+    had are ignored and, instead the [option2] computation is tried
+    as if the previous sequence had never happend.
+
+    {[
+      choice [
+        sequence [e1; e2; e3; reject ()];
+        option2;
+      ]
+    ]}
+
+    Since the purpose of this DSL is to describe how the passed
+    arguments are read in terms of BIL expressions, the generated
+    specification could be seen as a grammar and the DSL itself as
+    a parser combinator, specialized for describing ABI.
+
+    {2 Example}
+
+    Below we define the semantics of [riscv32] and [riscv64] targets.
+    Both targets have fully specified register files with properly
+    assigned roles and the register order matches with register names
+    ordering, so we can use the simplified Arena creating functions.
+    We have four independent arenas, two for passing in and out integer
+    arguments, and two corresponding arenas for floating-point
+    arguments.
+
+    We start with defining the integer calling convention by first
+    determining how many register are needed to pass an argument.
+    If the size of the argument couldn't be determined we reject the
+    computation. Otherwise, if it fits into one register we try to
+    pass it via a register fallback to memory if there are no
+    registers available. If it requires two registers we first try to
+    pass it as an aligned register pair (with the first part going
+    through the nearest available even register). If we don't have
+    enough aligned registers, we then split it in two parts and pass
+    the first part in a register and the second part in the memory.
+    Finally, if the size is greater than two words we pass it as an
+    implicit reference.
+
+    The floating-point calling convention assumes the presence of the
+    hardware floating-point registers but the specification is general
+    enough to handle the soft floats convention, as any attempt to
+    pass an argument via the hardware floating-point registers will be
+    rejected since the corresponding arena will be empty.
+
+    The convention tries to pass a floating-point argument via the
+    corresponding register file if it fits into a register otherwise
+    it falls back to the integer registers. When an argument fits into
+    the floating-point register we first try passing it through the
+    floating-point file and if it is out of registers we use available
+    integer registers (in riscv with hardware floating-point registers
+    it is possible to pass 16 floating-point arguments all in
+    registers) and finally use the last resort option of using the memory.
+
+    {[
+      module Arg = C.Abi.Arg
+      open Arg.Let
+      open Arg.Syntax
+
+      let is_floating = function
+        | `Basic {C.Type.Spec.t=#C.Type.real} -> true
+        | _ -> false
+
+      let data_model t =
+        let bits = Theory.Target.bits t in
+        new C.Size.base (if bits = 32 then `ILP32 else `LP64)
+
+      let define t =
+        let model = data_model t in
+        C.Abi.define t model @@ fun _ {C.Type.Proto.return=r; args} ->
+        let* iargs = Arg.Arena.iargs t in
+        let* irets = Arg.Arena.irets t in
+        let* fargs = Arg.Arena.fargs t in
+        let* frets = Arg.Arena.frets t in
+
+        (* integer calling convention *)
+        let integer regs t =
+          Arg.count regs t >>= function
+          | None -> Arg.reject ()
+          | Some 1 -> Arg.choice [
+              Arg.register regs t;
+              Arg.memory t;
+            ]
+          | Some 2 -> Arg.choice [
+              Arg.sequence [
+                Arg.align_even regs;
+                Arg.registers ~limit:2 regs t;
+              ];
+              Arg.split_with_memory regs t;
+              Arg.memory t;
+            ]
+          | Some _ -> Arg.reference regs t in
+
+        (* floating-point calling convention *)
+        let float iregs fregs t =
+          Arg.count fregs t >>= function
+          | Some 1 -> Arg.choice [
+              Arg.register fregs t;
+              Arg.register iregs t;
+              Arg.memory t;
+            ]
+          | _ -> integer iregs t in
+
+        let arg iregs fregs r =
+          if is_floating r
+          then float iregs fregs r
+          else integer iregs r in
+
+        Arg.define ?return:(match r with
+            | `Void -> None
+            | r -> Some (arg irets frets r))
+          (Arg.List.iter args ~f:(fun (_,t) ->
+               arg iargs fargs t));
+
+        let () = List.iter ~f:define Bap_risv_target.[riscv32; riscv64]
+
+    ]}
+*)
+module Arg : sig
+  type 'a t
+
+  (** an ordered expendable collection of registers *)
+  type arena
+
+  type semantics
+
+  type ctype = Bap_c_type.t
+
+
+  (** [define ?return args] the toplevel function for defining
+      argument passing semantics.
+
+      The function has two entries, the optional [return] entry
+      describes the semantics of passing of the return value,
+      and the second section describes the semantics of passing the
+      list of arguments.
+
+      The semantics is defined as a sequence of these two rules,
+      with the return rule evaluated first. Therefore, if [return]
+      is rejected the whole semantics will be rejected.
+  *)
+  val define : ?return:unit t -> unit t -> semantics t
+
+  (** [register arena t] passes the argument of type [t] using
+      the next available register in [arena].
+
+      The computation is rejected if no registers are available;
+      if [t] doesn't fit into a register in [arena]; or if size
+      of [t] can't be determined.
+  *)
+  val register : arena -> ctype -> unit t
+
+
+  (** [registers arena t] passes the argument in consecutive
+      registers from [arena].
+
+      Rejects the computation if [arena] doesn't have the necessary
+      number of registers; the number of required registers is greater
+      than [limit]; or if the size of [t] is unknown.
+  *)
+  val registers : ?limit:int -> arena -> ctype -> unit t
+
+
+  (** [align_even arena] ensures that the first available register in
+      [arena] has even number.
+
+      Registers in an arena are enumerated from zero in the order of
+      their appearence in the arena specification. This function
+      removes, when necessary, a register form the arena, so that the
+      next available register has an even number.
+
+      The computation is rejected if there are no more even registers
+      in [arena].
+  *)
+  val align_even : arena -> unit t
+
+  (** [reference arena t] passes the argument of type [t] as a pointer
+      to [t] via the first available register in [arena].
+
+      Rejects the computation if there are no available registers in
+      [arena] or if the target doesn't have a register with the stack
+      pointer role. The size of [t] is not required. *)
+  val reference : arena -> ctype -> unit t
+
+  (** [memory t] passes the argument of type [t] in the next
+      available stack slot.
+
+      Rejects the computation if the size of [t] is not known or
+      if the target doesn't have a register with the stack pointer
+      role.
+
+      The address of the slot is aligned corresponding to the
+      alignment requirements of [t] but no less than the
+      minimal data alignment requirements of the architecture or
+      the natural alignment of the stack pointer.
+
+      Note, passing a number arguments via a descending stack using
+      [memory] will pass the arguments in the right-to-left (RTL aka
+      C) order, i.e., the first passed argument will end up at the
+      bottom (will have the minimal address). Use [push] if you want
+      the left-to-right order.
+
+  *)
+  val memory : ctype -> unit t
+
+
+  (** [split_with_memory arena t] passes the low order part of the
+      value in a register (if available) and the rest in the memory.
+
+      The size of the part that is passed via the registers is equal
+      to the size of the register. The part that is passed via the
+      stack is aligned to the stack boundary.
+
+      Rejects the computation if the size of [t] is not known; if
+      [arena] is empty; or if some other argument is already passed
+      via memory.
+
+  *)
+  val split_with_memory : arena -> ctype -> unit t
+
+
+  (** [push t] pushes the argument of type [t] via stack.
+
+      Rejects the computation if the size of [t] is not known.
+
+      The address of the slot is aligned corresponding to the
+      alignment requirements of [t] but no less than the
+      minimal data alignment requirements of the architecture or
+      the natural alignment of the stack pointer.
+
+      When passing a number of arguments via a descending stack, the
+      last pushed argument will be at the bottom of the stack, i.e.,
+      will have the minimal address. This corresponds to the LTR aka
+      Pascal ordering.
+  *)
+  val push : ctype -> unit t
+
+  (** [count arena t] counts the number of registers need to pass a
+      value of type [t].
+
+      Returns [None] if the size of [t] is not known or if the [arena]
+      size is empty.
+  *)
+  val count : arena -> ctype -> int option t
+
+  (** [either option1 option2] tries to pass using [option1] and
+      if it is rejected uses [option2].
+
+      For example, [either (register x) (memory x)] tries to pass
+      [x] via a register and if it is not possible (either because
+      [x] doesn't fit into a register or there are no registers
+      available) tries to pass it via memory.
+  *)
+  val either : 'a t -> 'a t -> 'a t
+
+
+  (** [choice [o1 o2 ... oN]] tries options in order until the first
+      one that is not rejected.
+  *)
+  val choice : 'a t list -> 'a t
+
+
+  (** [reify t size args] compiles the argument passing specification.
+
+      If the spec is not rejected the returned structure will contain
+      the reification of the argument passing semantics.
+
+  *)
+  val reify : Theory.Target.t -> #Bap_c_size.base -> semantics t -> args option
+
+  include Monad.S with type 'a t := 'a t
+  include Monad.Choice.S with type 'a t := 'a t
+
+
+  (** An ordered collection of registers.
+
+      Arena is an expendable collection of registers that is used to
+      pass arguments. Passing an argument via the register consumes
+      it so it is no longer available in the same computation.
+
+      If a computation that used a register is later rejected then the
+      register is available again (the same as with any other
+      side-effects of a rejected compuation).
+
+      The order of registers in arena, as well as their numbering
+      according to that order, usually matters. Many targets have
+      registers with the alphabetic orders of registers matching
+      their arena orders (with notable exception of x86) that enables
+      the direct usage of the [Theory.Target.regs] function to create
+      arenas.
+  *)
+  module Arena : sig
+
+    (** [create regs] creates an arena from the ordered list of registers.
+
+        All registers must have the same size and the list could be
+        empty. The registers will be used in the order of their
+        appereance in the [regs] list. *)
+    val create : _ Theory.Var.t list -> arena t
+
+    (** [of_roles t roles] creates an arena from registers of the
+        specified roles.
+
+        The registers are ordered in the alphabetic order. The
+        returned arena might be empty. *)
+    val of_roles : Theory.role list -> Theory.Target.t -> arena t
+
+
+    (** [iargs t] the integer argument arena.
+
+        An alias to [of_roles [function_argument; integer]]
+    *)
+    val iargs : Theory.Target.t -> arena t
+
+
+    (** [irets t] the integer return values arena.
+
+        An alias to [of_roles [function_return; integer]]
+    *)
+    val irets : Theory.Target.t -> arena t
+
+    (** [fargs t] the floating-point argument arena.
+
+        An alias to [of_roles [function_argument; floating]]
+    *)
+    val fargs : Theory.Target.t -> arena t
+
+
+    (** [frets t] the floating-point return values arena.
+
+        An alias to [of_roles [function_return; floatin]]
+    *)
+    val frets : Theory.Target.t -> arena t
+  end
+end
+
+
+(** [define target pass] the high-level ABI specification function.
+
+    The function creates an abi processor and registers it using the
+    name obtained from the [target]. The [pass] function is used to
+    define the [insert_args] method (with the [sub] argument
+    ignored).
+
+    The function also registers an ABI pass that checks the project
+    target and if it matches with the passed [target] the function
+    creates and registers the C API processor.
+*)
+val define : Theory.Target.t -> #Bap_c_size.base ->
+  (attr list -> proto -> Arg.semantics Arg.t) -> unit

--- a/lib/bap_c/bap_c_data.ml
+++ b/lib/bap_c/bap_c_data.ml
@@ -49,7 +49,7 @@ type value =
 
 (** abstraction of a С datum.
 
-    The datum is a sequence of bits, that represent a particular C
+    The datum is a sequence of bits that represenst a particular C
     value. We abstract datum as either an immediate value of the given
     size and value lattice, or a sequence of data, or a pointer to a
     datum.*)

--- a/lib/bap_core_theory/bap_core_theory.mli
+++ b/lib/bap_core_theory/bap_core_theory.mli
@@ -1363,6 +1363,8 @@ module Theory : sig
       ?byte:int ->               (** defaults to [8]  *)
       ?data:_ Mem.t Var.t ->     (** defaults to [mem : Mem(bits,byte)] *)
       ?code:_ Mem.t Var.t ->     (** defaults to [mem : Mem(bits,byte)] *)
+      ?data_alignment:int ->     (** defaults to 8 bit *)
+      ?code_alignment:int ->     (** defaults to 8 bit *)
       ?vars:unit Var.t list ->   (** defaults to [[]] *)
       ?regs:(role list * unit Var.t list) list -> (** defaults to [[]] *)
       ?endianness:endianness ->  (** defaults to [Endian.big] *)
@@ -1499,6 +1501,21 @@ module Theory : sig
         The size of the instruction address, which is taken
         from the sort of the keys of the [data] memory variable. *)
     val code_addr_size : t -> int
+
+
+    (** The required data addresses alignment in bits.
+
+        The target [t] requires that all data addresses are
+        multiples of [data_alignment t]-bit words.
+    *)
+    val data_alignment : t -> int
+
+    (** The required code addresses alignment in bits.
+
+        The target [t] requires that all code addresses are
+        multiples of [code_alignment t]-bit words.
+    *)
+    val code_alignment : t -> int
 
     (** [data target] the main memory variable. *)
     val data : t -> (unit,unit) Mem.t Var.t

--- a/lib/bap_core_theory/bap_core_theory.mli
+++ b/lib/bap_core_theory/bap_core_theory.mli
@@ -1547,6 +1547,16 @@ module Theory : sig
     *)
     val reg : ?exclude:role list -> ?unique:bool -> t -> role -> unit Var.t option
 
+
+    (** [var target name] returns a target variable with the given name.
+
+        The variable is searched in all variables and registers
+        provided in target declaration. The search is O(log(N)).
+
+        @since 2.3.0
+    *)
+    val var : t -> string -> unit Var.t option
+
     (** [endianness target] describes the byte order.
 
         Describes how multibyte words are stored in the main memory. *)
@@ -2407,8 +2417,6 @@ module Theory : sig
 
 
     (** [loadw s e m k] loads a word from the memory [m].
-
-
 
         if [e] evaluates to [b1] (big endian case),
         then the term evaluates to [low s (m[k] @ m[k+1] @ ... @ m[k+n] )],

--- a/lib/bap_core_theory/bap_core_theory_target.mli
+++ b/lib/bap_core_theory/bap_core_theory_target.mli
@@ -20,6 +20,8 @@ val declare :
   ?byte:int ->
   ?data:_ Mem.t Var.t ->
   ?code:_ Mem.t Var.t ->
+  ?data_alignment:int ->
+  ?code_alignment:int ->
   ?vars:unit Var.t list ->
   ?regs:(role list * unit Var.t list) list ->
   ?endianness:endianness ->
@@ -51,6 +53,8 @@ val bits : t -> int
 val byte : t -> int
 val data_addr_size : t -> int
 val code_addr_size : t -> int
+val data_alignment : t -> int
+val code_alignment : t -> int
 val data : t -> (unit,unit) Mem.t Var.t
 val code : t -> (unit,unit) Mem.t Var.t
 val vars : t -> Set.M(Var.Top).t

--- a/lib/bap_core_theory/bap_core_theory_target.mli
+++ b/lib/bap_core_theory/bap_core_theory_target.mli
@@ -54,6 +54,7 @@ val code_addr_size : t -> int
 val data : t -> (unit,unit) Mem.t Var.t
 val code : t -> (unit,unit) Mem.t Var.t
 val vars : t -> Set.M(Var.Top).t
+val var : t -> string -> Var.Top.t option
 val regs :
   ?exclude:role list ->
   ?roles:role list ->

--- a/oasis/c
+++ b/oasis/c
@@ -8,7 +8,8 @@ Library bap_c
   Path: lib/bap_c
   FindlibName: bap-c
   CompiledObject: best
-  BuildDepends: bap, bap-api, core_kernel, ppx_bap, monads, regular
+  BuildDepends: bap, bap-abi, bap-api, core_kernel, ppx_bap, monads, regular,
+                bap-core-theory, bap-knowledge
   Modules: Bap_c,
            Bap_c_abi,
            Bap_c_attr,

--- a/plugins/riscv/riscv_main.ml
+++ b/plugins/riscv/riscv_main.ml
@@ -1,4 +1,4 @@
-open Base
+open Core_kernel
 open Bap_main
 open Bap.Std
 open Bap_core_theory
@@ -46,79 +46,65 @@ let enable_loader () =
 module Abi = struct
   open Bap_c.Std
   open Bap.Std
-  open Monads.Std
-  open Monad.Option.Syntax
-  open Monad.Option.Let
 
-  let name = "riscv"            (* is there an official name? *)
-
-  let (.:()) file num = match Set.nth file num with
-    | None -> failwith "a wrong number of registers"
-    | Some v -> Var.reify v
-
-  let (.%()) file num = Bil.var file.:(num)
+  module Arg = C.Abi.Arg
+  open Arg.Let
+  open Arg.Syntax
 
   let is_floating = function
     | `Basic {C.Type.Spec.t=#C.Type.real} -> true
     | _ -> false
 
-  (* even x = x if x is even otherwise x+1 *)
-  let even x = x + x land 1
-
   let data_model t =
     let bits = Theory.Target.bits t in
     new C.Size.base (if bits = 32 then `ILP32 else `LP64)
 
-  let insert_args t _sub _attrs {C.Type.Proto.return; args} =
-    let bits = Theory.Target.bits t in
-    let a = Theory.Target.regs t ~roles:Theory.Role.Register.[
-        integer; function_argument;
-      ] in
-    let fa = Theory.Target.regs t ~roles:Theory.Role.Register.[
-        floating; function_argument;
-      ] in
-    let regs = Set.length a in
-    let mem = Bil.var @@ Var.reify @@ Theory.Target.data t in
-    let* sp = Theory.Target.reg t Theory.Role.Register.stack_pointer >>| Var.reify in
-    let size = data_model t in
-    let stack t n =
-      size#bits t >>= Size.of_int_opt >>| fun sz ->
-      C.Abi.data size t,
-      Bil.load ~mem LittleEndian sz
-        ~addr:Bil.(var sp + int (Word.of_int ~width:bits n)) in
-    let param t n =
-      if n > regs then stack t (n - regs)
-      else
-        size#bits t >>= fun s ->
-        Monad.Option.guard (s <= 2 * bits) >>| fun () ->
-        C.Abi.data size t, match is_floating return,s <= bits with
-        | true,true -> fa.%(n)
-        | true,false -> Bil.concat fa.%(even n) fa.%(even n + 1)
-        | false,true -> a.%(n)
-        | false,false -> Bil.concat a.%(even n) a.%(even n + 1) in
-    let return = param return 0 in
-    let+ (_,params) = Monad.Option.List.fold args
-        ~init:(0,[]) ~f:(fun (used,pars) (_name,arg) ->
-            size#bits arg >>= fun argsz ->
-            param arg used >>| fun par ->
-            let used = if argsz <= bits then used + 1
-              else used + 2 + used land 1 in
-            used,par::pars) in
-    {C.Abi.return; params = List.rev params; hidden=[]}
+  let define t =
+    let model = data_model t in
+    C.Abi.define t model @@ fun _ {C.Type.Proto.return=r; args} ->
+    let* iargs = Arg.Arena.iargs t in
+    let* irets = Arg.Arena.irets t in
+    let* fargs = Arg.Arena.fargs t in
+    let* frets = Arg.Arena.frets t in
 
-  let apply_headers proj =
-    let t = Project.target proj in
-    if Theory.Target.belongs Target.parent t then
-      let abi = C.Abi.{
-          insert_args = insert_args t;
-          apply_attrs = fun _ x -> x;
-        } in
-      C.Abi.register name abi;
-      let size = data_model t in
-      let apply_headers = C.Abi.create_api_processor size abi in
-      Bap_api.process apply_headers;
-      Project.set proj Bap_abi.name name
-    else proj
+    (* integer calling convention *)
+    let integer regs t =
+      Arg.count regs t >>= function
+      | None -> Arg.reject ()
+      | Some 1 -> Arg.choice [
+          Arg.register regs t;
+          Arg.memory t;
+        ]
+      | Some 2 -> Arg.choice [
+          Arg.sequence [
+            Arg.align_even regs;
+            Arg.registers ~limit:2 regs t;
+          ];
+          Arg.split_with_memory regs t;
+          Arg.memory t;
+        ]
+      | Some _ -> Arg.reference regs t in
+
+    (* floating-point calling convention *)
+    let float iregs fregs t =
+      Arg.count fregs t >>= function
+      | Some 1 -> Arg.choice [
+          Arg.register fregs t;
+          Arg.register iregs t;
+          Arg.memory t;
+        ]
+      | _ -> integer iregs t in
+
+    let arg iregs fregs r =
+      if is_floating r
+      then float iregs fregs r
+      else integer iregs r in
+
+    Arg.define ?return:(match r with
+        | `Void -> None
+        | r -> Some (arg irets frets r))
+      (Arg.List.iter args ~f:(fun (_,t) ->
+           arg iargs fargs t));
 end
 
 
@@ -127,7 +113,8 @@ let main _ctxt =
   enable_llvm Target.llvm32 "riscv32";
   enable_loader ();
   provide_decoding ();
-  Bap_abi.register_pass Abi.apply_headers;
+  Abi.define Target.riscv32;
+  Abi.define Target.riscv64;
   Ok ()
 
 let () = Bap_main.Extension.declare main


### PR DESCRIPTION
This PR introduces a powerful but convenient way of describing complex argument passing semantics. Describing even simple facets of argument passing mechanics
it tedious as it requires taking into consideration a lot of factors, such as the availability of registers, their width, the types of the passed data, its alignment requirements and so on. It is extremely hard to write a generic algorithm that will be able to accommodate the large variety of options and be at the same time useful and easy to use. Instead, we decided to pick a parser combinator approach as naturally we want to describe how to parse (or recognize) data that is passed to us by the caller. The proposed DSL is a choice monad (i.e., it has [choice] and [reject] operators that enable backtracking) so that we can try various options in order. For example, the riscv integer calling convention prescribes that double words (words twice as big as the register size) are passed in an aligned (the first register's number should be even) pair of registers, or, if there is only one register, then the first half of the word is passed in the register and the second in the memory, and if no registers is available at all, then it should be passed via stack. This complex rule is easily expressible in our DSL,

```ocaml
Arg.choice [
 Arg.sequence [
   Arg.align_even regs;
   Arg.registers ~limit:2 regs t;
 ];
 Arg.split_with_memory regs t;
 Arg.memory t;
]
```

and the whole calling convention of RISCV (which is non-trivial) is described in several lines of code,

```ocaml
(* integer calling convention *)
let integer regs t =
  Arg.count regs t >>= function
  | None -> Arg.reject ()
  | Some 1 -> Arg.choice [
      Arg.register regs t;
      Arg.memory t;
    ]
  | Some 2 -> Arg.choice [
      Arg.sequence [
        Arg.align_even regs;
        Arg.registers ~limit:2 regs t;
      ];
      Arg.split_with_memory regs t;
      Arg.memory t;
    ]
  | Some _ -> Arg.reference regs t

(* floating-point calling convention *)
let float iregs fregs t =
  Arg.count fregs t >>= function
  | Some 1 -> Arg.choice [
      Arg.register fregs t;
      Arg.register iregs t;
      Arg.memory t;
    ]
  | _ -> integer iregs t
```

The eDSL is written with the considerations of all major calling conventions and ABI but right now we use it only to describe RISCV (and the coming in the next PR aarch64). We have plans to gradually use the new DSL to describe more completely and precisely the semantics of argument passing for the existing architectures (volunteers are welcome, the language is thoroughly documented and comes with examples). One of the best things with eDSL approach is that it is naturally extensible, so that if we need some non-trivial argument-passing operator we can easily extend the language. So if you hit any problems in expressing your ABI using it, don't hesitate to add a new operator or create an issue requesting it.


## Additional Changes

- adds Theory.Target.var function for easy lookup of a register by name, it is necessary for the next PR but lands here because of rebasing conflicts :)

- adds [data_alignment] and [code_alignment] to the target description.