### PR TITLE
adds armv8 (aarch64) lifter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ testsuite:
 	git clone https://github.com/BinaryAnalysisPlatform/bap-testsuite.git testsuite
 
 check: testsuite
-	make REVISION=eaa6b5e -C testsuite
+	make REVISION=3720beda -C testsuite
 
 .PHONY: indent check-style status-clean
 

--- a/lib/arm/arm_target.ml
+++ b/lib/arm/arm_target.ml
@@ -99,6 +99,8 @@ let regs64 = Theory.Role.Register.[
     [general; floating], untyped [fp64];
     [stack_pointer], untyped [sp64];
     [frame_pointer], untyped [fp64];
+    [function_argument], array r64 "X" 8 @< array r64 "Q" 8;
+    [function_return], [reg r64 "X0"] @< [reg r128 "Q0"];
     [constant; zero; pseudo], [zr64] @< [zr32];
     [pseudo], array r32 "W" 31 @< [reg r32 "WSP"];
     [link], untyped [lr64];

--- a/lib/arm/arm_target.ml
+++ b/lib/arm/arm_target.ml
@@ -375,7 +375,7 @@ let enable_arch () =
 
 let llvm_a32 = CT.Language.declare ~package "llvm-A32"
 let llvm_t32 = CT.Language.declare ~package "llvm-T32"
-let llvm_a64 = CT.Language.declare ~package "llvm-A64"
+let llvm_a64 = CT.Language.declare ~package "llvm-aarch64"
 
 module Dis = Disasm_expert.Basic
 

--- a/lib/arm/arm_target.ml
+++ b/lib/arm/arm_target.ml
@@ -76,10 +76,13 @@ let vfp3regs = Theory.Role.Register.[
 
 let vars32_fp = vars32 @ untyped @@ array r64 "D" 16
 
-let gp64 = array r64 "X" 30
+let gp64 = array r64 "X" 29
 let fp64 = array r128 "Q" 32
-let sp64 = [reg r64 "SP"]
-let lr64 = [reg r64 "LR"]
+let fp64 = reg r64 "FP"       (* X29 *)
+let lr64 = reg r64 "LR"       (* X30 *)
+let sp64 = reg r64 "SP"       (* X31 *)
+let zr64 = reg r64 "XZR"
+let zr32 = reg r32 "WZR"
 let mems64 = CT.Mem.define r64 r8
 let data64 = CT.Var.define mems64 "mem"
 let flags64 = [
@@ -89,13 +92,16 @@ let flags64 = [
   reg bool "VF";
 ]
 
-let vars64 = gp64 @< fp64 @< sp64 @< lr64 @< flags64 @< [data64]
+let vars64 = gp64 @< [fp64; sp64; lr64] @< flags64 @< [data64]
 
 let regs64 = Theory.Role.Register.[
-    [general; integer], gp64 @< sp64 @< lr64;
-    [general; floating], untyped fp64;
-    [stack_pointer], untyped sp64;
-    [link], untyped lr64;
+    [general; integer], gp64 @< [fp64; lr64; sp64];
+    [general; floating], untyped [fp64];
+    [stack_pointer], untyped [sp64];
+    [frame_pointer], untyped [fp64];
+    [constant; zero; pseudo], [zr64] @< [zr32];
+    [pseudo], array r32 "W" 31 @< [reg r32 "WSP"];
+    [link], untyped [lr64];
   ] @ status_regs
 
 

--- a/lib/bap/bap_project.ml
+++ b/lib/bap/bap_project.ml
@@ -44,21 +44,17 @@ let with_filename spec target code memory path =
   let width = Theory.Target.code_addr_size target in
   let bias = query spec Image.Scheme.bias |> Option.map
                ~f:(fun x -> Bitvec.(int64 x mod modulus width)) in
-  KB.promising Theory.Label.unit ~promise:(fun label ->
-      KB.collect Theory.Label.addr label >>=? fun addr ->
-      let addr = Word.create addr width in
-      if Memmap.contains code addr then
-        Theory.Unit.for_file path >>= fun unit ->
-        KB.sequence [
-          KB.provide Image.Spec.slot unit spec;
-          KB.provide Theory.Unit.bias unit bias;
-          KB.provide Theory.Unit.target unit target;
-          KB.provide Image.Spec.slot unit spec;
-          KB.provide Theory.Unit.path unit (Some path);
-          KB.provide memory_slot unit memory;
-        ] >>| fun () ->
-        Some unit
-      else KB.return None)
+  KB.promising Theory.Label.unit ~promise:(fun _ ->
+      Theory.Unit.for_file path >>= fun unit ->
+      KB.sequence [
+        KB.provide Image.Spec.slot unit spec;
+        KB.provide Theory.Unit.bias unit bias;
+        KB.provide Theory.Unit.target unit target;
+        KB.provide Image.Spec.slot unit spec;
+        KB.provide Theory.Unit.path unit (Some path);
+        KB.provide memory_slot unit memory;
+      ] >>| fun () ->
+      Some unit)
 
 
 module State = struct

--- a/lib/bap_c/bap_c_abi.ml
+++ b/lib/bap_c/bap_c_abi.ml
@@ -311,6 +311,8 @@ module Arg = struct
 
     let bits self = self.bits
 
+    let deplet self = {self with args = Map.empty (module Int)}
+
     let pop self = match Map.min_elt self.args with
       | None -> None
       | Some (k,x) ->
@@ -434,7 +436,7 @@ module Arg = struct
         Arg.return res
     let pop s n = update s n File.pop
     let popn ~n s a = update s a (File.popn n)
-
+    let deplet s n = update s n @@ fun s -> Some (File.deplet s,())
   end
 
   let size s t = match s.ruler#bits t with
@@ -491,6 +493,10 @@ module Arg = struct
   let align_even file =
     let* s = Arg.get () in
     Arena.popn ~n:2 s file >>| ignore
+
+  let deplet file =
+    let* s = Arg.get () in
+    Arena.deplet s file
 
   let switch where = Arg.update @@ fun s -> {s with where}
   let where = Arg.gets @@ fun s -> s.where

--- a/lib/bap_c/bap_c_abi.mli
+++ b/lib/bap_c/bap_c_abi.mli
@@ -286,6 +286,12 @@ module Arg : sig
   *)
   val align_even : arena -> unit t
 
+  (** [deplet arena] unconditionally consumes all registers in arena.
+
+      The computation is never rejected.
+  *)
+  val deplet : arena -> unit t
+
   (** [reference arena t] passes the argument of type [t] as a pointer
       to [t] via the first available register in [arena].
 

--- a/lib/bap_core_theory/bap_core_theory.mli
+++ b/lib/bap_core_theory/bap_core_theory.mli
@@ -1574,6 +1574,12 @@ module Theory : sig
     *)
     val var : t -> string -> unit Var.t option
 
+
+    (** [has_roles t roles v] is true if [v] has all the [roles] in [t].
+
+        @since 2.3.0 *)
+    val has_roles : t -> role list -> 'a Var.t -> bool
+
     (** [endianness target] describes the byte order.
 
         Describes how multibyte words are stored in the main memory. *)

--- a/lib/bap_core_theory/bap_core_theory_target.ml
+++ b/lib/bap_core_theory/bap_core_theory_target.ml
@@ -252,6 +252,10 @@ let is_included roles info = match roles with
   | Some included ->
     fun var -> List.for_all included ~f:(has_role info.regs var)
 
+let has_roles t roles var =
+  let {regs} = info t and var = Var.forget var in
+  List.for_all roles ~f:(has_role regs var)
+
 let regs ?exclude ?roles t =
   let info = info t in
   let pred = match exclude,roles with

--- a/lib/bap_core_theory/bap_core_theory_target.mli
+++ b/lib/bap_core_theory/bap_core_theory_target.mli
@@ -64,6 +64,7 @@ val regs :
   ?roles:role list ->
   t -> Set.M(Var.Top).t
 val reg : ?exclude:role list -> ?unique:bool -> t -> role -> unit Var.t option
+val has_roles : t -> role list -> _ Var.t -> bool
 val endianness : t -> endianness
 val system : t -> system
 val abi : t -> abi

--- a/lib/bap_mips/bap_mips_target.ml
+++ b/lib/bap_mips/bap_mips_target.ml
@@ -64,6 +64,7 @@ let define ?(parent=parent) bits endianness =
     ~regs:Theory.Role.Register.[
         [general; integer], regs gpr_names;
         [general; floating], untyped fprs;
+        [constant; zero; pseudo], regs ["ZERO"];
         [stack_pointer], regs ["SP"];
         [frame_pointer], regs ["FP"];
         [link], regs ["RA"];

--- a/lib/bap_primus/bap_primus_lisp_semantics.ml
+++ b/lib/bap_primus/bap_primus_lisp_semantics.ml
@@ -33,6 +33,7 @@ type value = unit Theory.Value.t
 type effect = unit Theory.Effect.t
 
 type KB.Conflict.t += Unresolved_definition of string
+                   | User_error of string
 
 let package = "bap"
 let language = Theory.Language.declare ~package "primus-lisp"
@@ -52,7 +53,6 @@ let program =
 type program = {
   prog : Program.t;
   places : unit Theory.var Map.M(KB.Name).t;
-  pseudo_regs : unit Theory.var Map.M(String).t;
   consts : Set.M(Theory.Var.Top).t;
   pseudos : Set.M(Theory.Var.Top).t;
   zeros : Set.M(Theory.Var.Top).t;
@@ -168,6 +168,7 @@ let static_slot =
 
 
 
+
 let update_value r f =
   let v = KB.Value.get Theory.Semantics.value r in
   KB.Value.put Theory.Semantics.value r (f v)
@@ -178,8 +179,6 @@ let set_static r x = update_value r @@ fun v ->
 let symsort = Bap_primus_value.Index.key_width
 let res = KB.Value.get Theory.Semantics.value
 let bits = Theory.Bitv.define
-let static x =
-  KB.Value.get static_slot (res x)
 
 let (!) = KB.(!!)
 
@@ -187,7 +186,8 @@ let empty = Theory.Effect.empty Theory.Effect.Sort.bot
 
 let intern name =
   let open KB.Syntax in
-  KB.Symbol.intern name Theory.Value.cls >>|
+  let name = KB.Name.read name in
+  KB.Symbol.intern (KB.Name.unqualified name) Theory.Value.cls >>|
   KB.Object.id >>| Int63.to_int64 >>|
   Bitvec.M64.int64
 
@@ -208,6 +208,26 @@ let sym str =
     Meta.lift @@
     intern name >>|
     set_static v
+
+
+let static x =
+  KB.Value.get static_slot (res x)
+
+let intern_value x = match KB.Value.get symbol x with
+  | None -> !!x
+  | Some sym ->
+    Meta.lift @@
+    intern sym >>| fun v ->
+    KB.Value.put static_slot x (Some v)
+
+let reify_sym x = match static x with
+  | Some _ -> Meta.return x
+  | None -> match KB.Value.get symbol (res x) with
+    | None -> Meta.return x
+    | Some name ->
+      Meta.lift @@
+      intern name >>|
+      set_static x
 
 let is_machine_var t v =
   Set.mem (Theory.Target.vars t) (Theory.Var.forget v)
@@ -415,14 +435,14 @@ module Prelude(CT : Theory.Core) = struct
 
   let reify ppf program defn target name args =
     let word = Theory.Target.bits target in
-    let {prog; places; pseudo_regs; consts; pseudos; zeros} = program in
+    let {prog; places; consts; zeros} = program in
     let var ?t n = make_var ?t places target n in
     let rec eval : ast -> unit Theory.Effect.t Meta.t = function
       | {data=Int {data={exp=x; typ=Type m}}} -> bigint x m
       | {data=Int {data={exp=x}}} -> bigint x word
       | {data=Var {data={exp=n; typ=Type t}}} -> lookup@@var ~t n
       | {data=Var {data={exp=n}}} -> lookup@@var n
-      | {data=Sym {data=s}} -> sym (KB.Name.show s)
+      | {data=Sym {data=s}} -> sym (KB.Name.unqualified s)
       | {data=Ite (cnd,yes,nay)} -> ite cnd yes nay
       | {data=Let ({data={exp=n; typ=Type t}},x,y)} -> let_ ~t n x y
       | {data=Let ({data={exp=n}},x,y)} -> let_ n x y
@@ -432,6 +452,7 @@ module Prelude(CT : Theory.Core) = struct
       | {data=Set ({data={exp=n}},x)} -> set_ (var n) x
       | {data=Rep (cnd,body)} -> rep cnd body
       | {data=Msg (fmt,args)} -> msg fmt args
+      | {data=Err msg} -> err msg
       | _ -> undefined
     and ite cnd yes nay =
       let* cnd = eval cnd in
@@ -519,6 +540,7 @@ module Prelude(CT : Theory.Core) = struct
               | None -> Format.printf "@[<hv>%a@]" KB.Value.pp v);
       Format.fprintf ppf "@\n";
       !!aeff
+    and err msg = fail (User_error msg)
     and lookup v =
       Scope.lookup v >>= function
       | Some v -> lookup v
@@ -527,27 +549,13 @@ module Prelude(CT : Theory.Core) = struct
         | Some v -> pure !!v
         | None -> match lookup_parameter prog v with
           | Some def -> eval def >>= assign target v
-          | None -> match Map.find pseudo_regs (Theory.Var.name v) with
-            | None -> pure@@Meta.lift@@CT.var v
-            | Some v -> reg v
-    and reg v =
-      if Set.mem zeros v
-      then bigint Z.zero word
-      else Meta.lift@@make_reg v >>= fun v ->
-        prim ~package:"target" "get-register" [v]
-    and arg x =
-      match KB.Value.get symbol x with
-      | None -> !!x
-      | Some sym -> match Map.find pseudo_regs sym with
-        | None -> !!x
-        | Some v -> reg v >>| res
+          | None -> if Set.mem zeros v
+            then bigint Z.zero word
+            else pure@@Meta.lift@@CT.var v
     and set_ v x =
       Scope.lookup v >>= function
       | Some v -> eval x >>= assign target ~local:true v
       | None when Set.mem consts v -> !!empty
-      | None when Set.mem pseudos v ->
-        Meta.lift@@make_reg v >>= fun v ->
-        prim ~package:"target" "set-register" [v]
       | None -> eval x >>= assign target v
     and let_ ?(t=word) v x b =
       let* xeff = eval x in
@@ -568,10 +576,10 @@ module Prelude(CT : Theory.Core) = struct
           !!beff;
         ] !!(res beff)
     and prim ?(package="core") name args =
-      call (KB.Name.read ~package name) args in
-    let desugar args = Meta.List.map args ~f:arg in
+      call (KB.Name.read ~package name) args >>= reify_sym in
     match args with
-    | Some args -> desugar args >>= call ~toplevel:true name
+    | Some args ->
+      call ~toplevel:true name args
     | None ->
       resolve prog Key.func name >>= function
       | Some fn ->
@@ -623,12 +631,6 @@ let link_library target prog =
       Def.Sema.create ~docs ~types name (primitive name))
     ~init:prog
 
-let index_by_name regs =
-  Set.to_sequence regs |>
-  Seq.map ~f:(fun v -> Theory.Var.name v, v) |>
-  Map.of_sequence_exn (module String)
-
-
 let obtain_typed_program unit =
   let open KB.Syntax in
   KB.collect Theory.Unit.source unit >>= fun src ->
@@ -645,20 +647,12 @@ let obtain_typed_program unit =
     let consts = regs [Theory.Role.Register.constant] in
     let pseudos = regs [Theory.Role.Register.pseudo] in
     let zeros = regs [Theory.Role.Register.zero] in
-    let pseudo_regs = index_by_name pseudos in
     let places = Program.fold prog Key.place
         ~f:(fun ~package place places ->
             let name = KB.Name.create ~package (Def.name place) in
             Map.set places name (Def.Place.location place))
         ~init:(Map.empty (module KB.Name)) in
-    let program = {
-      prog;
-      consts;
-      zeros;
-      pseudos;
-      pseudo_regs;
-      places;
-    } in
+    let program = {prog; consts; zeros; pseudos; places} in
     match Program.Type.errors tprog with
     | [] ->
       let src = KB.Value.put typed src (Some program) in
@@ -736,6 +730,7 @@ let () = KB.Conflict.register_printer @@ function
     Option.some @@ sprintf "unresolved defintion %s" s
   | Property.Unequal_arity ->
     Some "The number of arguments is different"
+  | User_error msg -> Some ("error: " ^ msg)
   | Illtyped_program errs ->
     let open Format in
     let msg = asprintf "%a"

--- a/oasis/arm
+++ b/oasis/arm
@@ -38,5 +38,6 @@ Library arm_plugin
   FindlibName:      bap-plugin-arm
   BuildDepends:     bap, bap-abi, bap-arm, bap-c, core_kernel, bap-main, bap-api
   InternalModules:  Arm_main, Arm_gnueabi
+  DataFiles:        semantics/*.lisp ($datadir/bap/primus/semantics)
   XMETADescription: provide ARM lifter
   XMETAExtraLines:  tags="arm, lifter"

--- a/oasis/arm
+++ b/oasis/arm
@@ -36,7 +36,8 @@ Library arm_plugin
   Build$:           flag(everything) || flag(arm)
   Path:             plugins/arm
   FindlibName:      bap-plugin-arm
-  BuildDepends:     bap, bap-abi, bap-arm, bap-c, core_kernel, bap-main, bap-api
+  BuildDepends:     bap, bap-core-theory, bap-abi, bap-arm, bap-c,
+                    core_kernel, bap-main, bap-api, monads
   InternalModules:  Arm_main, Arm_gnueabi
   DataFiles:        semantics/*.lisp ($datadir/bap/primus/semantics)
   XMETADescription: provide ARM lifter

--- a/plugins/arm/arm_gnueabi.ml
+++ b/plugins/arm/arm_gnueabi.ml
@@ -69,81 +69,78 @@ module Aapcs64 = struct
   open Bap_core_theory
   open Bap_c.Std
   open Bap.Std
-  open Monads.Std
-  open Monad.Option.Syntax
-  open Monad.Option.Let
 
-  let name = "aapcs64"            (* is there an official name? *)
+  let name = "aapcs64"
 
-  let (.:()) file num = match Set.nth file num with
-    | None -> failwith "a wrong number of registers"
-    | Some v -> Var.reify v
-
-  let (.%()) file num = Bil.var file.:(num)
+  module Arg = C.Abi.Arg
+  open Arg.Let
+  open Arg.Syntax
 
   let is_floating = function
     | `Basic {C.Type.Spec.t=#C.Type.real} -> true
     | _ -> false
 
-  (* even x = x if x is even otherwise x+1 *)
-  let even x = x + x land 1
-
   let data_model t =
     let bits = Theory.Target.bits t in
     new C.Size.base (if bits = 32 then `ILP32 else `LP64)
 
-  let insert_args t _sub _attrs {C.Type.Proto.return; args} =
-    let bits = Theory.Target.bits t in
-    let a = Theory.Target.regs t ~roles:Theory.Role.Register.[
-        integer; function_argument;
-      ] in
-    let fa = Theory.Target.regs t ~roles:Theory.Role.Register.[
-        floating; function_argument;
-      ] in
-    let regs = Set.length a in
-    let mem = Bil.var @@ Var.reify @@ Theory.Target.data t in
-    let* sp = Theory.Target.reg t Theory.Role.Register.stack_pointer >>| Var.reify in
-    let size = data_model t in
-    let stack t n =
-      size#bits t >>= Size.of_int_opt >>| fun sz ->
-      C.Abi.data size t,
-      Bil.load ~mem LittleEndian sz
-        ~addr:Bil.(var sp + int (Word.of_int ~width:bits n)) in
-    let param t n =
-      if n > regs then stack t (n - regs)
-      else
-        size#bits t >>= fun s ->
-        Monad.Option.guard (s <= 2 * bits) >>| fun () ->
-        C.Abi.data size t, match is_floating return,s <= bits with
-        | true,true -> fa.%(n)
-        | true,false -> Bil.concat fa.%(even n) fa.%(even n + 1)
-        | false,true -> a.%(n)
-        | false,false -> Bil.concat a.%(even n) a.%(even n + 1) in
-    let return = param return 0 in
-    let+ (_,params) = Monad.Option.List.fold args
-        ~init:(0,[]) ~f:(fun (used,pars) (_name,arg) ->
-            size#bits arg >>= fun argsz ->
-            param arg used >>| fun par ->
-            let used = if argsz <= bits then used + 1
-              else used + 2 + used land 1 in
-            used,par::pars) in
-    {C.Abi.return; params = List.rev params; hidden=[]}
+  let define t =
+    let model = data_model t in
+    C.Abi.define t model @@ fun _ {C.Type.Proto.return=r; args} ->
+    let* iargs = Arg.Arena.iargs t in
+    let* irets = Arg.Arena.irets t in
+    let* fargs = Arg.Arena.fargs t in
+    let* frets = Arg.Arena.frets t in
+    let* x8 = Arg.Arena.create [
+        Option.value_exn (Theory.Target.var t "X8")] in
 
-  let apply_headers proj =
-    let t = Project.target proj in
-    if Theory.Target.belongs Arm_target.LE.v8a t then
-      let abi = C.Abi.{
-          insert_args = insert_args t;
-          apply_attrs = fun _ x -> x;
-        } in
-      C.Abi.register name abi;
-      let size = data_model t in
-      let apply_headers = C.Abi.create_api_processor size abi in
-      Bap_api.process apply_headers;
-      Project.set proj Bap_abi.name name
-    else proj
+    (* integer calling convention *)
+    let pass_integer refs regs t =
+      Arg.count regs t >>= function
+      | Some 1 -> Arg.choice [
+          Arg.register regs t;
+          Arg.memory t;
+        ]
+      | Some 2 -> Arg.choice [
+          Arg.sequence [
+            Arg.align_even regs;
+            Arg.registers ~limit:2 regs t;
+          ];
+          Arg.memory t;
+        ]
+      | _ -> Arg.reference refs t in
+
+    (* floating-point calling convention *)
+    let pass_float refs regs t =
+      Arg.count regs t >>= function
+      | None -> Arg.reference refs t
+      | Some _ -> Arg.choice [
+          Arg.registers regs t;
+          Arg.sequence [
+            Arg.deplet regs;
+            Arg.memory t
+          ]
+        ] in
+
+    let arg refs iregs fregs r =
+      if is_floating r
+      then pass_float iregs fregs r
+      else pass_integer refs iregs r in
+
+    Arg.define ?return:(match r with
+        | `Void -> None
+        | r -> Some (arg x8 irets frets r))
+      (Arg.List.iter args ~f:(fun (_,t) ->
+           arg iargs iargs fargs t))
+
+  let install () =
+    List.iter Arm_target.[LE.v8a;EB.v8a] ~f:(fun parent ->
+        Theory.Target.family parent |>
+        List.iter ~f:define)
+
+
 end
 
 let setup () =
   Bap_abi.register_pass main;
-  Bap_abi.register_pass Aapcs64.apply_headers;
+  Aapcs64.install ();

--- a/plugins/arm/arm_gnueabi.ml
+++ b/plugins/arm/arm_gnueabi.ml
@@ -6,7 +6,7 @@ include Self()
 
 let size = object(self)
   inherit C.Size.base `ILP32
-  method! enum s = self#integer `uint
+  method! enum _ = self#integer `uint
 end
 
 
@@ -32,7 +32,7 @@ let retregs = function
 
 let ret : C.Type.t -> 'a = function
   | `Void -> None,[],regs
-  | other as t -> match retregs t with
+  | t -> match retregs t with
     | [],_,rest -> None,[],rest
     | rets,hids,rest ->
       let data = C.Abi.data size t in
@@ -43,7 +43,7 @@ let ret : C.Type.t -> 'a = function
 let args _ _ {C.Type.Proto.return; args=ps} =
   let return,hidden,regs = ret return in
   let _,_,params =
-    List.fold ps ~init:(regs,mems,[]) ~f:(fun (regs,mems,args) (n,t) ->
+    List.fold ps ~init:(regs,mems,[]) ~f:(fun (regs,mems,args) (_,t) ->
         let words = Option.value (size#bits t) ~default:32 / 32 in
         let exps,regs = List.split_n (align regs t) words in
         let rest,mems = Seq.split_n mems (words - List.length exps) in
@@ -65,4 +65,85 @@ let main proj = match Project.arch proj with
     Project.set proj Bap_abi.name "eabi"
   | _ -> proj
 
-let setup () = Bap_abi.register_pass main
+module Aapcs64 = struct
+  open Bap_core_theory
+  open Bap_c.Std
+  open Bap.Std
+  open Monads.Std
+  open Monad.Option.Syntax
+  open Monad.Option.Let
+
+  let name = "aapcs64"            (* is there an official name? *)
+
+  let (.:()) file num = match Set.nth file num with
+    | None -> failwith "a wrong number of registers"
+    | Some v -> Var.reify v
+
+  let (.%()) file num = Bil.var file.:(num)
+
+  let is_floating = function
+    | `Basic {C.Type.Spec.t=#C.Type.real} -> true
+    | _ -> false
+
+  (* even x = x if x is even otherwise x+1 *)
+  let even x = x + x land 1
+
+  let data_model t =
+    let bits = Theory.Target.bits t in
+    new C.Size.base (if bits = 32 then `ILP32 else `LP64)
+
+  let insert_args t _sub _attrs {C.Type.Proto.return; args} =
+    let bits = Theory.Target.bits t in
+    let a = Theory.Target.regs t ~roles:Theory.Role.Register.[
+        integer; function_argument;
+      ] in
+    let fa = Theory.Target.regs t ~roles:Theory.Role.Register.[
+        floating; function_argument;
+      ] in
+    let regs = Set.length a in
+    let mem = Bil.var @@ Var.reify @@ Theory.Target.data t in
+    let* sp = Theory.Target.reg t Theory.Role.Register.stack_pointer >>| Var.reify in
+    let size = data_model t in
+    let stack t n =
+      size#bits t >>= Size.of_int_opt >>| fun sz ->
+      C.Abi.data size t,
+      Bil.load ~mem LittleEndian sz
+        ~addr:Bil.(var sp + int (Word.of_int ~width:bits n)) in
+    let param t n =
+      if n > regs then stack t (n - regs)
+      else
+        size#bits t >>= fun s ->
+        Monad.Option.guard (s <= 2 * bits) >>| fun () ->
+        C.Abi.data size t, match is_floating return,s <= bits with
+        | true,true -> fa.%(n)
+        | true,false -> Bil.concat fa.%(even n) fa.%(even n + 1)
+        | false,true -> a.%(n)
+        | false,false -> Bil.concat a.%(even n) a.%(even n + 1) in
+    let return = param return 0 in
+    let+ (_,params) = Monad.Option.List.fold args
+        ~init:(0,[]) ~f:(fun (used,pars) (_name,arg) ->
+            size#bits arg >>= fun argsz ->
+            param arg used >>| fun par ->
+            let used = if argsz <= bits then used + 1
+              else used + 2 + used land 1 in
+            used,par::pars) in
+    {C.Abi.return; params = List.rev params; hidden=[]}
+
+  let apply_headers proj =
+    let t = Project.target proj in
+    if Theory.Target.belongs Arm_target.LE.v8a t then
+      let abi = C.Abi.{
+          insert_args = insert_args t;
+          apply_attrs = fun _ x -> x;
+        } in
+      C.Abi.register name abi;
+      let size = data_model t in
+      let apply_headers = C.Abi.create_api_processor size abi in
+      Bap_api.process apply_headers;
+      Project.set proj Bap_abi.name name
+    else proj
+end
+
+let setup () =
+  Bap_abi.register_pass main;
+  Bap_abi.register_pass Aapcs64.apply_headers;

--- a/plugins/arm/semantics/aarch64.lisp
+++ b/plugins/arm/semantics/aarch64.lisp
@@ -1,3 +1,5 @@
+(require bits)
+
 (declare (context (target armv8-a+le)))
 (defpackage aarch64 (:use core target))
 (defpackage llvm-aarch64 (:use aarch64))
@@ -11,12 +13,69 @@
   (set$ dst (+ src imm)))
 
 (defun LDRXui (dst reg off)
-  (set$ dst (load-word (+ reg off))))
+  (set$ dst (load-word (+ reg (lshift off 3)))))
+
+(defun LDRSWui (dst reg off)
+  (set$ dst (cast-signed
+             (word-width)
+             (load-word (+ reg (lshift off 2))))))
+
+(defun UBFMXri (xd xr ir is)
+  (let ((rs (word-width)))
+    (if (< is ir)
+        (if (and (/= is (- rs 1)) (= (+ is 1) ir))
+            (set$ xd (lshift xr (- rs ir)))
+            (set$ xd (lshift
+                      (cast-unsigned rs (extract is 0 xr))
+                      (- rs ir))))
+        (if (= is (- rs 1))
+            (set$ xd (rshift xr ir))
+            (set$ xd (cast-unsigned rs (extract is ir xr)))))))
+
+
+(defun ORRXrs (rd rn rm is)
+  (set$ rd (logor rn (lshift rm is))))
+
+(defun setw (rd x)
+  (set$ rd (cast-unsigned (word-width) x)))
 
 (defun ADRP (dst imm)
   (set$ dst (+ (get-program-counter)
                (cast-signed (word-width) (lshift imm 12)))))
 
+(defun ADDWrs (dst r1 v s)
+  (set$ dst (+ r1 (lshift v s))))
+
+(defun ADDWri (dst r1 imm s)
+  (ADDWrs dst r1 imm s))
+
+(defun add-with-carry (rd x y c)
+  (let ((r (+ x y c)))
+    (set NF (msb r))
+    (set VF (overflow r x y))
+    (set ZF (is-zero r))
+    (set CF (carry r x y))
+    (set$ rd r)))
+
+(defun SUBXrx64 (rd rn rm off)
+  (set$ rd (- rn (shifted rm off))))
+
+(defun SUBSXrs (rd rn rm off)
+  (add-with-carry rd rn (lnot (shifted rm off)) 1))
+
+(defun SUBXrs (rd rn rm off)
+  (set$ rd (- rn (shifted rm off))))
+
+(defun ADDXrs (rd rn rm off)
+  (set$ rd (+ rn (shifted rm off))))
+
+(defun shifted (rm off)
+  (let ((typ (extract 7 6 off))
+        (off (extract 5 0 off)))
+    (case typ
+      0b00 (lshift rm off)
+      0b01 (rshift rm off)
+      0b10 (arshift rm off))))
 
 (defun STPXpre (dst t1 t2 _ off)
   (let ((word (/ (word-width) 8))
@@ -25,17 +84,54 @@
     (store-word (+ dst off word) t2)
     (set$ dst (+ dst off))))
 
+(defun LDPXpost (dst r1 r2 base off)
+  (let ((word (/ (word-width) 8))
+        (off (lshift off 3)))
+    (set$ r1 (load-word base))
+    (set$ r2 (load-word (+ base word)))
+    (set$ dst (+ dst off))))
+
+(defun STRXui (src reg off)
+  (let ((off (lshift off 3)))
+    (store-word (+ reg off) src)))
+
+
+(defun relative-jump (off)
+  (exec-addr (+ (get-program-counter) (lshift off 2))))
 
 (defun BL (off)
-  (let ((pc (get-program-counter)))
-    (set LR (+ pc 4))
-    (exec-addr (+ pc (lshift off 2)))))
+  (set LR (+ (get-program-counter) 4))
+  (relative-jump off))
 
+(defun BR (reg)
+  (exec-addr reg))
+
+(defun BLR (reg)
+  (set LR (+ (get-program-counter) 4))
+  (exec-addr reg))
 
 (defun B (off)
-  (let ((pc (get-program-counter)))
-    (exec-addr (+ pc (lshift off 2)))))
+  (relative-jump off))
 
 
 (defun RET (dst)
   (exec-addr dst))
+
+(defun CBZX (reg off)
+  (when (is-zero reg)
+    (relative-jump off)))
+
+(defun Bcc (cnd off)
+  (when (condition-holds cnd)
+    (relative-jump off)))
+
+(defun condition-holds (cnd)
+  (case cnd
+    0b000 ZF
+    0b001 CF
+    0b010 NF
+    0b011 VF
+    0b100 (logand CF (lnot ZF))
+    0b101 (= NF VF)
+    0b110 (logand (= NF VF) (= ZF 0))
+    true))

--- a/plugins/arm/semantics/aarch64.lisp
+++ b/plugins/arm/semantics/aarch64.lisp
@@ -1,0 +1,41 @@
+(declare (context (target armv8-a+le)))
+(defpackage aarch64 (:use core target))
+(defpackage llvm-aarch64 (:use aarch64))
+
+(in-package aarch64)
+
+(defun MOVZXi (dst imm shift)
+  (set$ dst imm))
+
+(defun ADDXri (dst src imm _shift)
+  (set$ dst (+ src imm)))
+
+(defun LDRXui (dst reg off)
+  (set$ dst (load-word (+ reg off))))
+
+(defun ADRP (dst imm)
+  (set$ dst (+ (get-program-counter)
+               (cast-signed (word-width) (lshift imm 12)))))
+
+
+(defun STPXpre (dst t1 t2 _ off)
+  (let ((word (/ (word-width) 8))
+        (off (lshift off 3)))
+    (store-word (+ dst off) t1)
+    (store-word (+ dst off word) t2)
+    (set$ dst (+ dst off))))
+
+
+(defun BL (off)
+  (let ((pc (get-program-counter)))
+    (set LR (+ pc 4))
+    (exec-addr (+ pc (lshift off 2)))))
+
+
+(defun B (off)
+  (let ((pc (get-program-counter)))
+    (exec-addr (+ pc (lshift off 2)))))
+
+
+(defun RET (dst)
+  (exec-addr dst))

--- a/plugins/arm/semantics/aarch64.lisp
+++ b/plugins/arm/semantics/aarch64.lisp
@@ -133,6 +133,12 @@
   (let ((off (lshift off 3)))
     (store-word (+ reg off) src)))
 
+(defun STRXroX (rt rn rm _ shift)
+  (store-word (+ rn (lshift rm (* shift 3))) rt))
+
+(defun LDRXroX (rt rn rm _ shift)
+  (set$ rt (load-word (+ rn (lshift rm (* shift 3))))))
+
 (defun STRWui (src reg off)
   (let ((off (lshift off 2)))
     (store-word (+ reg off) src)))
@@ -165,7 +171,7 @@
   (when (is-zero reg)
     (relative-jump off)))
 
-(defun CBZX (reg off)
+(defun CBZW (reg off)
   (when (is-zero (base-reg reg))
     (relative-jump off)))
 

--- a/plugins/arm/semantics/aarch64.lisp
+++ b/plugins/arm/semantics/aarch64.lisp
@@ -6,8 +6,11 @@
 
 (in-package aarch64)
 
-(defun MOVZXi (dst imm shift)
-  (set$ dst imm))
+(defun MOVZXi (dst imm pos)
+  (set$ dst (lshift imm pos)))
+
+(defun MOVZWi (dst imm pos)
+  (set$ (base-reg dst) (lshift imm pos)))
 
 (defun ADDXri (dst src imm _shift)
   (set$ dst (+ src imm)))
@@ -19,6 +22,11 @@
   (set$ dst (cast-signed
              (word-width)
              (load-word (+ reg (lshift off 2))))))
+
+(defun LDRWui (dst reg off)
+  (set$ (base-reg dst)
+        (cast-unsigned (word-width)
+                       (load-hword (+ reg (lshift off 2))))))
 
 (defun UBFMXri (xd xr ir is)
   (let ((rs (word-width)))
@@ -34,7 +42,7 @@
 
 
 (defun ORRXrs (rd rn rm is)
-  (set$ rd (logor rn (lshift rm is))))
+  (set$ rd (logor rn (shifted rm is))))
 
 (defun setw (rd x)
   (set$ rd (cast-unsigned (word-width) x)))
@@ -70,6 +78,7 @@
   (set$ rd (+ rn (shifted rm off))))
 
 (defun shifted (rm off)
+  (declare (visibility :private))
   (let ((typ (extract 7 6 off))
         (off (extract 5 0 off)))
     (case typ
@@ -135,3 +144,51 @@
     0b101 (= NF VF)
     0b110 (logand (= NF VF) (= ZF 0))
     true))
+
+(defun target:get-register (reg)
+  (case reg
+    'WZR 0:32
+    'XZR 0:64
+    (extract 31 0 (base-reg reg))))
+
+(defun target:set-register (reg val)
+  (case reg
+    'WZR ()
+    'XZR ()
+    (set$ reg (cast-unsigned 64 val))))
+
+(defun base-reg (reg)
+  (case reg
+    'W0  'X0
+    'W1  'X1
+    'W2  'X2
+    'W3  'X3
+    'W4  'X4
+    'W5  'X5
+    'W6  'X6
+    'W7  'X7
+    'W8  'X8
+    'W9  'X9
+    'W10 'X10
+    'W11 'X11
+    'W12 'X12
+    'W13 'X13
+    'W14 'X14
+    'W15 'X15
+    'W16 'X16
+    'W17 'X17
+    'W18 'X18
+    'W19 'X19
+    'W20 'X20
+    'W21 'X21
+    'W22 'X22
+    'W23 'X23
+    'W24 'X24
+    'W25 'X25
+    'W26 'X26
+    'W27 'X27
+    'W28 'X28
+    'W29 'FP
+    'W30 'LR
+    'WSP 'SP
+    (msg "unknown register")))

--- a/plugins/bil/bil_ir.ml
+++ b/plugins/bil/bil_ir.ml
@@ -129,13 +129,18 @@ module IR = struct
   let ctrl cfg = ret cfg
 
   let set v x =
-    x >>= fun x ->
-    fresh >>= fun entry ->
-    fresh >>= fun tid ->
-    data {
-      entry;
-      blks = [{name=entry; jmps=[]; defs=[Def.reify ~tid v x]}]
-    }
+    KB.Object.scoped Theory.Program.cls @@ fun lbl ->
+    Theory.Label.target lbl >>= fun t ->
+    if Theory.Target.has_roles t [Theory.Role.Register.constant] v
+    then !!empty
+    else
+      x >>= fun x ->
+      fresh >>= fun entry ->
+      fresh >>= fun tid ->
+      data {
+        entry;
+        blks = [{name=entry; jmps=[]; defs=[Def.reify ~tid v x]}]
+      }
 
   let goto ?(is_call=false) ?cnd ~tid dst =
     if is_call

--- a/plugins/primus_lisp/primus_lisp_main.ml
+++ b/plugins/primus_lisp/primus_lisp_main.ml
@@ -277,16 +277,18 @@ module Semantics = struct
     let bitv x = Bitvec.(int64 x mod modulus bits) in
     Insn.ops insn |> Array.to_list |>
     List.map ~f:(function
-        | Op.Fmm _ -> CT.unk word
+        | Op.Fmm _ -> CT.unk word >>| Theory.Value.forget
         | Op.Imm x ->
           let x = bitv (Imm.to_int64 x) in
-          CT.int word x >>| fun v ->
+          CT.int word x >>| Theory.Value.forget >>| fun v ->
           KB.Value.put Lisp.Semantics.static v (Some x)
         | Op.Reg v ->
           let name = Reg.name v in
-          CT.var @@ Theory.Var.define word name >>| fun v ->
+          let reg = match Theory.Target.var target name with
+            | None -> Theory.Var.forget @@ Theory.Var.define word name
+            | Some v -> v in
+          CT.var reg >>| fun v ->
           KB.Value.put Lisp.Semantics.symbol v (Some name)) |>
-    List.map ~f:(fun x -> x >>| Theory.Value.forget) |>
     KB.List.all
 
   let translate_ops_to_args () =

--- a/plugins/primus_lisp/semantics/bits.lisp
+++ b/plugins/primus_lisp/semantics/bits.lisp
@@ -1,0 +1,23 @@
+(in-package core)
+
+(defun msb (x)
+  "(msb X) is the most significant bit of X."
+  (select (- (word-width) 1) x))
+
+(defun lsb (x)
+  "(msb X) is the least significant bit of X."
+  (select 0 x))
+
+(defun carry (rd rn rm)
+  "(carry RD RN RM) is true if the sum RD = RN + RM causes
+   the carry out of the msb bit."
+  (logor (logand (msb rn) (msb rm))
+         (logand (msb rm) (lnot (msb rd)))
+         (logand (msb rn) (lnot (msb rd)))))
+
+
+(defun overflow (rd rn rm)
+  "(overflow RD RN RM) is true if the sum RD = RN + RM results
+   in two's complement overflow."
+  (logor (logand (msb rn) (msb rm) (lnot (msb rd)))
+         (logand (lnot (msb rn)) (lnot (msb rm)) (msb rd))))


### PR DESCRIPTION
# Aarch64 lifter (in Primus Lisp)

The [lifter][1] is written in [Primus Lisp][2] and is complete enough to lift and correctly execute our test binaries. The number of lifted instructions is about 50 but it is easy to add new ones (do not forget to contribute them back to us). I am planning on writing a guide on writing lifters in Primus Lisp but before that (and after that as well) I am always ready to help in our Gitter channel (or in Git Discussions).

During the development of the lifter, I have discovered a few shortcomings which were overcome so the pull request includes some other modifications, including qualify of life changes, bug fixes, and other improvements. They are described in detail below.

## Adds `--show-addr` and `--show-memory` to `bap mc` and `bap objdump`

It is much easier to write lifters with them. Essentially, I am just doing

```shell
bap objdump ./exe --show-{memory,bil,insn}
```

and getting a list of instructions for each chunk of memory and lifting all
that miss semantics.

## Removes pseudo-registers special semantics from Primus Lisp lifter

It didn't really work well aside from toy examples, mostly because pseudo-registers were only handled by the Primus Lisp lifter but were left intact by any other semantics provider. This resulted in a situation where pseudo-registers were sometimes handled and sometimes not. This PR moves the responsibility of properly handling pseudo-registers to the semantics itself (i.e., to the core theory instances), which makes perfect sense and immediately enables them for old lifters (e.g., BIL lifter). Therefore, we can now close #1176, there are no more writes or reads from the ZERO register (despite that we didn't touch neither BIL lifter nor MIPS lifter).

## Adds Theory.Target.has_roles

A faster way of checking register roles (rather than getting the set of registers that has the role and then checking for set membership)

resolves #1087 
resolves #1176 

[1]: https://github.com/BinaryAnalysisPlatform/bap/blob/ec1c81d86a183c71822061a1574f08d9f48f8267/plugins/arm/semantics/aarch64.lisp
[2]: https://github.com/BinaryAnalysisPlatform/bap/pull/1277