### PR TITLE
introduces `bap dependencies` command

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -5792,6 +5792,13 @@ module Std : sig
       val format : (string, (string -> 'a) -> 'a) Ogre.attribute
 
 
+      (** [(require library)] defines that the unit requires
+          [library].
+
+          @since 2.3.0 *)
+      val require : (string, (string -> 'a) -> 'a) Ogre.attribute
+
+
       (** (is-little-endian FLAG)] is set for files with words encoded in the
           little-endian order.
 

--- a/lib/bap_image/bap_image.ml
+++ b/lib/bap_image/bap_image.ml
@@ -123,6 +123,7 @@ module Scheme = struct
   let vendor    () = declare "vendor" (scheme name) ident
   let system    () = declare "system" (scheme name) ident
   let format    () = declare "format" (scheme name) ident
+  let require   () = declare "require" (scheme name) ident
   let abi    () = declare "abi" (scheme name) ident
   let bits    () = declare "bits" (scheme size) ident
   let is_little_endian () = declare "is-little-endian" (scheme flag) ident

--- a/lib/bap_image/bap_image.mli
+++ b/lib/bap_image/bap_image.mli
@@ -106,6 +106,7 @@ module Scheme : sig
   val format : (string, (string -> 'a) -> 'a)  Ogre.attribute
   val vendor : (string, (string -> 'a) -> 'a) Ogre.attribute
   val system : (string, (string -> 'a) -> 'a) Ogre.attribute
+  val require : (string, (string -> 'a) -> 'a) Ogre.attribute
   val abi : (string, (string -> 'a) -> 'a) Ogre.attribute
   val bits : (size, (size -> 'a) -> 'a) Ogre.attribute
   val is_little_endian : (bool, (bool -> 'a) -> 'a) Ogre.attribute

--- a/lib/bap_llvm/llvm_coff_loader.hpp
+++ b/lib/bap_llvm/llvm_coff_loader.hpp
@@ -344,6 +344,15 @@ error_or<uint64_t> symbol_file_offset(const coff_obj &obj, const SymbolRef &sym)
         return failure("failed to get the section");
     }
 }
+
+void emit_import_directories(const coff_obj &obj, ogre_doc &s) {
+    for (auto dir : obj.import_directories()) {
+        StringRef name;
+        if (!dir.getName(name))
+            s.entry("require") << name.str();
+    }
+}
+
 } // namespace coff_loader
 
 error_or<std::string> load(ogre_doc &s, const llvm::object::COFFObjectFile &obj, const char* pdb_path) {
@@ -356,6 +365,7 @@ error_or<std::string> load(ogre_doc &s, const llvm::object::COFFObjectFile &obj,
     emit_symbols(obj, s);
     emit_relocations(obj, s);
     emit_exported_symbols(obj, s);
+    emit_import_directories(obj, s);
     if (pdb_path)
         pdb_loader::load(obj, pdb_path, s);
     return s.str();

--- a/lib/bap_llvm/llvm_loader.hpp
+++ b/lib/bap_llvm/llvm_loader.hpp
@@ -18,6 +18,7 @@ static std::string scheme =
     "(declare subarch (name str))\n"
     "(declare system (name str))\n"
     "(declare vendor (name str))\n"
+    "(declare require (name str))\n"
     "(declare llvm:code-entry (name str) (off int) (size int))\n"
     "(declare llvm:base-address (addr int))\n"
     "(declare llvm:entry-point (addr int))\n"
@@ -33,7 +34,8 @@ static std::string scheme =
     "(declare llvm:symbol-entry (name str) (addr int) (size int) (off int) (value int))\n"
     "(declare llvm:elf-virtual-program-header (name str) (addr int) (size int))\n"
     "(declare llvm:coff-virtual-section-header (name str) (addr int) (size int))\n"
-    "(declare llvm:virtual-segment-command (name str) (addr int) (size int))\n";
+    "(declare llvm:virtual-segment-command (name str) (addr int) (size int))\n"
+    "(declare llvm:coff-import-library (name str))\n";
 
 
 namespace loader {

--- a/oasis/dependencies
+++ b/oasis/dependencies
@@ -8,6 +8,6 @@ Library dependencies_plugin
   Path: plugins/dependencies
   FindlibName: bap-plugin-dependencies
   CompiledObject: best
-  BuildDepends: bap, core_kernel, bap-main, ogre
+  BuildDepends: bap, core_kernel, bap-main, ogre, regular, ppx_bap
   InternalModules: Dependencies_main
   XMETAExtraLines: tags="command, dependencies"

--- a/oasis/dependencies
+++ b/oasis/dependencies
@@ -1,0 +1,13 @@
+Flag dependencies
+  Description: Enable the dependencies command
+  Default: false
+
+Library dependencies_plugin
+  Build$: flag(everything) || flag(dependencies)
+  XMETADescription: analyses the binary dependencies
+  Path: plugins/dependencies
+  FindlibName: bap-plugin-dependencies
+  CompiledObject: best
+  BuildDepends: bap, core_kernel, bap-main, ogre
+  InternalModules: Dependencies_main
+  XMETAExtraLines: tags="command, dependencies"

--- a/oasis/specification
+++ b/oasis/specification
@@ -4,7 +4,7 @@ Flag specification
 
 Library specification_plugin
   Build$: flag(everything) || flag(specification)
-  XMETADescription: implements the specification command
+  XMETADescription: prints the specification of the binary (like readelf)
   Path: plugins/specification
   FindlibName: bap-plugin-specification
   CompiledObject: best

--- a/oasis/specification
+++ b/oasis/specification
@@ -8,6 +8,6 @@ Library specification_plugin
   Path: plugins/specification
   FindlibName: bap-plugin-specification
   CompiledObject: best
-  BuildDepends: bap, core_kernel, bap-main, ogre
+  BuildDepends: bap, core_kernel, bap-main, ogre, regular
   InternalModules: Specification_main
   XMETAExtraLines: tags="command, specification"

--- a/plugins/dependencies/dependencies_main.ml
+++ b/plugins/dependencies/dependencies_main.ml
@@ -1,0 +1,101 @@
+open Core_kernel
+open Bap.Std
+open Bap_main
+
+let input = Extension.Command.argument
+    ~doc:"The input file" Extension.Type.("FILE" %: string =? "a.out")
+
+module Loader = struct
+  type t = {
+    libraries : image -> string seq;
+    imports : image -> string seq;
+  }
+end
+
+
+module Unit = struct
+  type t = {
+    name : string;
+    imports : Set.M(String).t;
+    libraries : Set.M(String).t;
+  } [@@deriving bin_io, compare, sexp]
+
+
+end
+
+module Spec = struct
+  open Image.Scheme
+
+  let imports =
+    Ogre.foreach Ogre.Query.(select (from external_reference))
+      ~f:(fun (_, name) -> name)
+
+  let query what image =
+    match Ogre.eval what (Image.spec image) with
+    | Error err ->
+      failwithf "Query failed: %s" (Error.to_string_hum err) ()
+    | Ok r -> r
+end
+
+module Elf = struct
+
+  type dyn = {
+    tag : word;
+    off : word;
+  }
+
+  let section_by_name img name =
+    Image.memory img |>
+    Memmap.to_sequence |>
+    Seq.find_map ~f:(fun (mem,tag) ->
+        match Value.get Image.section tag with
+        | Some n when String.equal n name -> Some mem
+        | _ -> None)
+
+  let dynamic_contents img =
+    match section_by_name img ".dynamic" with
+    | None -> []
+    | Some mem ->
+      let word_size = (Image.addr_size img :> Size.t) in
+      Memory.fold ~word_size mem ~f:(fun data (acc,dyn) ->
+          match dyn with
+          | None -> acc,Some data
+          | Some tag -> {tag;off=data}::acc,None)
+        ~init:([],None) |> function
+      | acc,_ -> List.rev acc
+
+  let read ~strtab pos =
+    let strtab = Memory.to_buffer strtab in
+    let rec loop off =
+      if Char.equal (Bigsubstring.get strtab off) '\x00'
+      then Bigsubstring.sub strtab ~pos ~len:(off-pos)
+      else loop (off+1) in
+    Bigsubstring.to_string @@ loop pos
+
+  let libraries img =
+    match section_by_name img ".dynstr" with
+    | None -> Seq.empty
+    | Some strtab ->
+      Seq.of_list (dynamic_contents img) |>
+      Seq.filter_map ~f:(fun {tag; off} ->
+          match Word.to_int tag, Word.to_int off with
+          | Ok 1, Ok off -> Some (read ~strtab off)
+          | _ -> None)
+
+  let loader = {Loader.libraries; imports = Spec.(query imports)}
+end
+
+let print_plain =
+  Seq.iter ~f:(Format.printf "%s@\n")
+
+let () = Extension.Command.(begin
+    declare "dependencies" (args $input)
+      ~requires:["loader"]
+  end) @@ fun input _ctxt ->
+  match Image.create ~backend:"llvm" input with
+  | Error err ->
+    invalid_argf "failed to parse the file: %s"
+      (Error.to_string_hum err) ()
+  | Ok (img,_warns) ->
+    print_plain @@ Elf.libraries img;
+    Ok ()


### PR DESCRIPTION
The command outputs program dependencies such as libraries and symbols. The information is collected recursively with various output options, including dependency graph, YAML, JSON, and SEXP.

The information includes the list of imported libraries as well as sets of imported and exported symbols. The information could be collected recursively when the `--recursive` option is specified. In a recursive mode, the list of paths where to search for libraries could be specified with the `--library-path` option that accepts a list of paths. It is also possible to use the host ldconfig cache (or specify custom library config) via the `ldconfig` parameter. Information about each individual dependency is cached, so consecutive calls to bap will reuse the available information and terminate quickly.


## EXAMPLES

The default format is YAML, which suits best for human consumption. Additionally it possible to use JSON or SEXP, as well as Graphviz DOT format. The tool is designed to be used together with YAML and JSON query tools, such as [yq][1] and [jq][2], e.g.,


### Getting the list of imported libraries

```
$ bap dependencies /bin/ls | yq e .ls.libraries -
- libc.so.6
- libselinux.so.1
```

### Running recursively

```
$ bap dependencies /bin/ls --recursive
```

### Using `ldconfig` for getting the local (host) library cache

```
$ bap dependencies /bin/ls --recursive --ldconfig
```

### Running in a rooted environment

```
$ bap dependencies /bin/ls --root=/mnt/image --ldconfig='cat libs'
```

Note, in the example above, all paths will be prefixed with the specified `root`,
e.g., `/bin/ls` will be taken from `/mnt/image/bin/ls` and all paths from the
cache (or paths stored in the binary itself, like rpaths or MachO full paths to libraries) will be prefixed as well with `/mnt/image` effectively creating a chrooted environment.


### Building the dependency graph

```
$ bap dependencies `which ping` -ograph | graph-easy --as boxart
                     ┌────────────────┐
                     │ libresolv.so.2 │
                     └────────────────┘
                       ▲
                       │
                       │
┌──────────────┐     ┌───────────────────────────────┐     ┌────────────────┐
│ libidn.so.11 │ ◀── │             ping              │ ──▶ │ libnettle.so.6 │
└──────────────┘     └───────────────────────────────┘     └────────────────┘
                       │                 │
                       │                 │
                       ▼                 ▼
                     ┌────────────────┐┌─────────────┐
                     │   libc.so.6    ││ libcap.so.2 │
                     └────────────────┘└─────────────┘

```
### Getting the transitive closure of the dependency graph

```
$ bap dependencies `which ping` --recursive --ldconfig -ograph | graph-easy --as boxart
                     ┌────────────────┐
                     │ libresolv.so.2 │ ──────────────────────────────────┐
                     └────────────────┘                                   │
                       ▲                                                  │
                       │                                                  │
                       │                                                  │
┌──────────────┐     ┌──────────────────────────┐     ┌────────────────┐  │
│ libidn.so.11 │ ◀── │           ping           │ ──▶ │ libnettle.so.6 │  │
└──────────────┘     └──────────────────────────┘     └────────────────┘  │
  │                    │                 │              │                 │
  │                    │                 │              │                 │
  │                    ▼                 │              │                 │
  │                  ┌────────────────┐  │              │                 │
  │                  │  libcap.so.2   │  │              │                 │
  │                  └────────────────┘  │              │                 │
  │                    │                 │              │                 │
  │                    │                 │              │                 │
  │                    ▼                 ▼              │                 │
  │                  ┌──────────────────────────┐       │                 │
  └────────────────▶ │        libc.so.6         │ ◀─────┘                 │
                     └──────────────────────────┘                         │
                       │                      ▲                           │
                       │                      └───────────────────────────┘
                       ▼
                     ┌────────────────┐
                     │ ld-linux.so.2  │
                     └────────────────┘
```

### Counting the number of imported symbols

```
$ bap dependencies /bin/ls | yq e '.ls.imports | length' -
115
```

### Outputting all imported symbols

```
bap dependencies /bin/ls --recursive --ldconfig | yq ea '.*.imports' -
```

[1]: https://github.com/mikefarah/yq
[2]: https://stedolan.github.io/jq/