### PR TITLE
adds YAML as an alternative output of the specification command

### DIFF
--- a/lib/ogre/ogre.mli
+++ b/lib/ogre/ogre.mli
@@ -559,6 +559,11 @@ module Doc : sig
   (** [pp ppf doc] prints a [doc] in the specified formatter [ppf]  *)
   val pp : Format.formatter -> doc -> unit
 
+  (** [pp_yamp ppf doc] prints doc to [ppf] in the YAML format.
+
+      @since 2.3.0  *)
+  val pp_yaml : Format.formatter -> doc -> unit
+
 
   (** [clear doc] removes all facts from the document.
 

--- a/plugins/specification/specification_main.ml
+++ b/plugins/specification/specification_main.ml
@@ -18,7 +18,18 @@ type Extension.Error.t += Fail of problem
 
 
 let input = Extension.Command.argument
-    ~doc:"The input file" Extension.Type.("FILE" %: string =? "a.out" )
+    ~doc:"The input file"
+    Extension.Type.("FILE" %: string =? "a.out")
+
+let formats = [
+  "sexp", `Sexp;
+  "yaml", `Yaml;
+]
+
+let format = Extension.Command.parameter
+    (Extension.Type.enum formats) "format"
+    ~aliases:["o"]
+    ~doc:"The output format"
 
 let loader =
   Extension.Command.parameter
@@ -34,26 +45,29 @@ let reader = Data.Read.create ()
 let writer = Data.Write.create ()
     ~to_bigstring:(Binable.to_bigstring (module Ogre.Doc))
 
+let print fmt spec =
+  let pp = match fmt with
+    | `Yaml -> Ogre.Doc.pp_yaml
+    | `Sexp -> Ogre.Doc.pp in
+  Format.printf "%a@\n%!" pp spec
+
 let () = Extension.Command.(begin
-    declare "specification" (args $input $loader)
+    declare "specification" (args $format $input $loader)
       ~doc
       ~requires:["loader"]
-  end) @@ fun input loader ctxt ->
+  end) @@ fun format input loader ctxt ->
   let digest = Data.Cache.Digest.create ~namespace:"specification" in
   let digest = Data.Cache.Digest.add digest "%s%s%s"
       input loader (Extension.Configuration.digest ctxt) in
   let cache = Data.Cache.Service.request reader writer in
   match Data.Cache.load cache digest with
-  | Some spec ->
-    Format.printf "%a@\n%!" Ogre.Doc.pp spec;
-    Ok ()
+  | Some spec -> print format spec; Ok ()
   | None -> match Image.find_loader loader with
     | None -> problem (Unknown_loader loader)
     | Some (module Load) -> match Load.from_file input with
       | Ok (Some spec) ->
         Data.Cache.save cache digest spec;
-        Format.printf "%a@\n%!" Ogre.Doc.pp spec;
-        Ok ()
+        print format spec; Ok ()
       | Ok None -> Ok ()
       | Error err -> problem (Loader_error err)
 


### PR DESCRIPTION
Motivation: YAML is both human-readable and machine-readbale and together with yq it is possible to easily construct various queries or translate it to json and other formats.

Also adds a corresponding `Ogre.Doc.pp_yaml` function.