### PR TITLE
fixes Thumb's SBC semantics

### DIFF
--- a/plugins/arm/semantics/thumb.lisp
+++ b/plugins/arm/semantics/thumb.lisp
@@ -53,7 +53,7 @@
   (set$ rd (+ rn rm)))
 
 (defun tSBC (rd _ rn rm _ _)
-  (add-with-carry rd rn (- rm) CF))
+  (add-with-carry rd rn (lnot rm) CF))
 
 (defun tRSB (rd _ rn _ _)
   "rsbs	r3, r2, #0"


### PR DESCRIPTION
We shall do 1-complement negation instead of 2-complement negation.

Thanks @ccasin, @philzook58 for pointing out that the implementation
was incorrect!