### PR TITLE
preserves the encoding name of the instruction

### DIFF
--- a/lib/arm/arm_target.ml
+++ b/lib/arm/arm_target.ml
@@ -382,7 +382,7 @@ let enable_arch () =
 
 
 let llvm_a32 = CT.Language.declare ~package "llvm-armv7"
-let llvm_t32 = CT.Language.declare ~package "llvm-thumbv7"
+let llvm_t32 = CT.Language.declare ~package "llvm-thumb"
 let llvm_a64 = CT.Language.declare ~package "llvm-aarch64"
 
 module Dis = Disasm_expert.Basic

--- a/lib/bap_disasm/bap_disasm_basic.ml
+++ b/lib/bap_disasm/bap_disasm_basic.ml
@@ -561,6 +561,9 @@ let make_name target encoding =
     (Theory.Language.to_string encoding)
     (Theory.Target.to_string target)
 
+let encoding_name encoding =
+  KB.Name.unqualified @@ Theory.Language.name encoding
+
 let register encoding construct =
   if Hashtbl.mem constructors encoding
   then invalid_argf "A disassembler backend for the encoding %s \
@@ -578,10 +581,7 @@ let register encoding construct =
           d.users <- d.users + 1;
           Hashtbl.add_exn disassemblers ~key:name ~data:d
         end;
-        Ok dis)
-
-let encoding_name encoding =
-  KB.Name.unqualified @@ Theory.Language.name encoding
+        Ok {dis with enc = encoding_name encoding})
 
 let lookup target encoding =
   let name = make_name target encoding in
@@ -595,7 +595,7 @@ let lookup target encoding =
     | Some create -> create target
 
 let create ?(debug_level=0) ?(cpu="") ?(attrs="") ?(backend="llvm") triple =
-  let name = sprintf "%s-%s%s" backend triple cpu in
+  let name = String.concat ~sep:"-" [backend; triple; cpu] ^ attrs in
   match Hashtbl.find disassemblers name with
   | Some d ->
     d.users <- d.users + 1;

--- a/plugins/arm/semantics/thumb.lisp
+++ b/plugins/arm/semantics/thumb.lisp
@@ -4,7 +4,7 @@
 (declare (context (target armv4+le)))
 
 (defpackage thumb (:use core target arm))
-(defpackage llvm-thumbv7 (:use thumb))
+(defpackage llvm-thumb (:use thumb))
 
 (in-package thumb)
 


### PR DESCRIPTION
Ensures that the instruction encoding matches with the name of encoding that is used to decode it. Before this fix, the encoding name was sometimes taken from the triple, which enforced us to have the names of encoding that match with the triple. We can now safely peek any encoding name.