### PR TITLE
adds the --show-knowledge option to bap mc

### DIFF
--- a/lib/bap_primus/bap_primus_lisp_semantics.ml
+++ b/lib/bap_primus/bap_primus_lisp_semantics.ml
@@ -46,9 +46,6 @@ let program =
     ~empty:Program.empty
     ~equal:Program.equal
     ~join:(fun x y -> Ok (Program.merge x y))
-    ~inspect:(fun p ->
-        let r = Format.asprintf "%a" Program.pp p in
-        Sexp.Atom r)
 
 type program = {
   prog : Program.t;


### PR DESCRIPTION
This option will dump the final state of the knowledge base. Mostly
useful for debugging and writing lifters.