### PR TITLE
adds `bap primus-lisp-documentation`

### DIFF
--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -3671,7 +3671,7 @@ text ::= ?any atom that is not recognized as a <word>?
         end
 
         module Category : Element
-        module Name     : Element
+        module Name     = Knowledge.Name
         module Descr    : Element
 
 
@@ -3988,6 +3988,13 @@ text ::= ?any atom that is not recognized as a <word>?
           ?types:Type.signature ->
           ?docs:string ->
           ?package:string -> string -> unit
+
+
+        (** [documentation unit] documentation for [unit]'s lisp source.
+
+            Typechecks and loads the unit lisp source and generates
+            its documentation. *)
+        val documentation : Theory.Unit.t -> Doc.index KB.t
       end
 
 

--- a/lib/bap_primus/bap_primus_lisp.mli
+++ b/lib/bap_primus/bap_primus_lisp.mli
@@ -22,7 +22,7 @@ module Doc : sig
   end
 
   module Category : Element
-  module Name     : Element
+  module Name     = KB.Name
   module Descr    : Element
   type index = (Category.t * (Name.t * Descr.t) list) list
 
@@ -155,6 +155,7 @@ module Semantics : sig
     ?types:Type.signature ->
     ?docs:string -> ?package:string -> string -> unit
 
+  val documentation : Theory.Unit.t -> Doc.index KB.t
 end
 
 module Unit : sig

--- a/lib/bap_primus/bap_primus_lisp_parse.ml
+++ b/lib/bap_primus/bap_primus_lisp_parse.ml
@@ -68,7 +68,7 @@ let is_quoted s =
 let is_symbol s =
   String.length s > 1 && Char.(s.[0] = '\'')
 
-let unqoute s =
+let unquote s =
   if is_quoted s
   then String.sub ~pos:1 ~len:(String.length s - 2) s
   else s
@@ -107,7 +107,7 @@ module Parse = struct
       | Ok var -> var
 
   let fmt prog fmt tree =
-    let fmt = unqoute fmt in
+    let fmt = unquote fmt in
     let fail err off =
       let pos =
         Loc.nth_char (loc (Program.sources prog) [tree]) (off+1) in
@@ -355,8 +355,8 @@ module Parse = struct
     List.fold ~init:prog trees ~f:(fun prog -> function
         | {data=List ({data=Atom ":use"} :: packages)} ->
           use_package ~package:name prog packages
-        | {data=List ({data=Atom ":documentation"} :: _)} ->
-          prog
+        | {data=List [{data=Atom ":documentation"}; {data=Atom docs}]} ->
+          Program.update_package_documentation prog name (unquote docs)
         | s -> fail (Bad_def Defpkg) s)
 
   let toplevels = String.Set.of_list [

--- a/lib/bap_primus/bap_primus_lisp_program.mli
+++ b/lib/bap_primus/bap_primus_lisp_program.mli
@@ -28,7 +28,8 @@ val with_package : t -> string -> t
 val reset_package : t -> t
 val use_package : t -> ?target:string -> string -> t
 val in_package : string -> t -> (t -> 'a) -> 'a
-
+val packages : t -> (string * string) list
+val update_package_documentation : t -> string -> string -> t
 val is_applicable : t -> 'a Def.t -> bool
 
 module Items : sig

--- a/lib/bap_primus/bap_primus_lisp_semantics.ml
+++ b/lib/bap_primus/bap_primus_lisp_semantics.ml
@@ -163,9 +163,6 @@ let static_slot =
     ~equal:Bitvec.equal
     ~inspect:(fun x -> Sexp.Atom (Bitvec.to_string x))
 
-
-
-
 let update_value r f =
   let v = KB.Value.get Theory.Semantics.value r in
   KB.Value.put Theory.Semantics.value r (f v)
@@ -647,6 +644,12 @@ let obtain_typed_program unit =
       KB.provide Theory.Unit.source unit src >>| fun () ->
       program
     | errs -> KB.fail (Illtyped_program errs)
+
+
+let typed_program unit =
+  let open KB.Syntax in
+  obtain_typed_program unit >>| fun {prog} -> prog
+
 
 let provide_semantics ?(stdout=Format.std_formatter) () =
   let open KB.Syntax in

--- a/lib/bap_primus/bap_primus_lisp_semantics.mli
+++ b/lib/bap_primus/bap_primus_lisp_semantics.mli
@@ -15,6 +15,8 @@ val symbol : (Theory.Value.cls, String.t option) KB.slot
 val static : (Theory.Value.cls, Bitvec.t option) KB.slot
 val enable : ?stdout:Format.formatter -> unit -> unit
 
+val typed_program : Theory.Unit.t -> program KB.t
+
 val declare :
   ?types:(Theory.Target.t -> Bap_primus_lisp_type.signature) ->
   ?docs:string ->

--- a/lib/knowledge/bap_knowledge.ml
+++ b/lib/knowledge/bap_knowledge.ml
@@ -3071,7 +3071,8 @@ module Knowledge = struct
     module Make() = struct
       type t = Name.t [@@deriving bin_io, sexp]
 
-      let elements = Hash_set.create (module Name)
+      let unknown = Name.of_string ":unknown"
+      let elements = Hash_set.of_list (module Name) [unknown]
       let declare ?package name =
         let name = Name.create ?package name in
         if Hash_set.mem elements name
@@ -3089,7 +3090,6 @@ module Knowledge = struct
         name
 
       let name x = x
-      let unknown = Name.of_string ":unknown"
       let is_unknown = Name.equal unknown
       let hash = Name.hash
       let members () = Hash_set.to_list elements

--- a/oasis/primus-lisp
+++ b/oasis/primus-lisp
@@ -16,7 +16,8 @@ Library primus_lisp_library_plugin
                    Primus_lisp_ieee754,
                    Primus_lisp_io,
                    Primus_lisp_show,
-                   Primus_lisp_run
+                   Primus_lisp_run,
+                   Primus_lisp_documentation
   XMETADescription: install and load Primus lisp libraries
   DataFiles:        lisp/*.lisp ($datadir/bap/primus/lisp),
                     site-lisp/*.lisp ($datadir/bap/primus/site-lisp),

--- a/plugins/primus_lisp/primus_lisp_documentation.ml
+++ b/plugins/primus_lisp/primus_lisp_documentation.ml
@@ -1,0 +1,99 @@
+open Core_kernel
+open Bap_core_theory
+open Bap_main
+open Bap.Std
+open Extension.Syntax
+open KB.Syntax
+
+open Bap_primus.Std
+open Primus.Analysis.Syntax
+open Format
+
+type error = Conflict of KB.Conflict.t
+           | Wrong_target of string
+           | Wrong_system of string
+           | Unexpected_status of Primus.exn
+
+type Extension.Error.t += Failed of error
+
+let fail prob = Error (Failed prob)
+
+let print package index =
+  List.iter index ~f:(fun (cat,elts) ->
+      printf "* %a@\n" Primus.Lisp.Doc.Category.pp cat;
+      List.iter elts ~f:(fun (name,desc) ->
+          if String.equal (KB.Name.package name) package
+          then printf "** ~%s~@\n%a@\n"
+              (KB.Name.unqualified name)
+              Primus.Lisp.Doc.Descr.pp desc))
+
+let string_of_problem = function
+  | Wrong_target s ->
+    sprintf "Unknown target %S, see `bap list targets' \
+             for the list of known targsts" s
+  | Wrong_system s ->
+    sprintf "Unknown system %S, see `bap primus-systems' \
+             for the list of known systems" s
+  | Conflict err ->
+    sprintf "Failed to initialize Primus.@\n%s@."
+      (KB.Conflict.to_string err)
+  | Unexpected_status exn ->
+    sprintf "Failed to initialize Primus.@\n%s@."
+      (Primus.Exn.to_string exn)
+
+let print_dynamic package target system =
+  let proj = Project.empty target in
+  let state = Toplevel.current () in
+  let init =
+    let open Primus.Lisp.Doc.Make(Primus.Analysis) in
+    generate_index >>| print package in
+  match Primus.System.run system proj state ~init with
+  | Ok (Normal,_,_)
+  | Ok (Exn Primus.Interpreter.Halt,_,_) -> Ok ()
+  | Ok (Exn err,_,_) -> fail (Unexpected_status err)
+  | Error problem -> fail (Conflict problem)
+
+let print_static package target =
+  let open KB.Syntax in
+  Result.map_error ~f:(fun prob -> Failed (Conflict prob)) @@
+  Toplevel.try_exec begin
+    KB.Object.create Theory.Unit.cls >>= fun unit ->
+    KB.provide Theory.Unit.target unit target >>= fun () ->
+    Primus.Lisp.Semantics.documentation unit >>| print package
+  end
+
+
+let system = Extension.Command.parameter
+    Extension.Type.(string =? "bap:legacy-main") "system"
+    ~doc:"Print the documentation for the specified system"
+
+let target = Extension.Command.parameter
+    Extension.Type.(string =? ":unknown") "target"
+    ~doc:"Print the documenentation for the specified target"
+
+let semantics = Extension.Command.flag "semantics"
+    ~doc:"Print the documentation for Primus Lisp semantics lifter"
+
+let package = Extension.Command.parameter
+    Extension.Type.(string =? "user") "package"
+    ~doc:"Print the documentation for the specified package."
+
+let spec = Extension.Command.(args $package $semantics $target $system)
+
+let () = Extension.Error.register_printer @@ function
+  | Failed problem -> Some (string_of_problem problem)
+  | _ -> None
+
+let () =
+  Extension.Command.declare "primus-lisp-documentation" spec @@
+  fun package semantics target system _ctxt ->
+  match Theory.Target.lookup ~package:"bap" target with
+  | None -> fail (Wrong_target target)
+  | Some target ->
+    if semantics then print_static package target
+    else
+      let name = KB.Name.read ~package:"bap" system in
+      match Primus.System.Repository.find name with
+      | None -> fail (Wrong_system system)
+      | Some system ->
+        print_dynamic package target system

--- a/plugins/primus_lisp/primus_lisp_documentation.mli
+++ b/plugins/primus_lisp/primus_lisp_documentation.mli
@@ -1,0 +1,3 @@
+open Bap_primus.Std
+
+val print : string -> Primus.Lisp.Doc.index -> unit

--- a/plugins/primus_lisp/primus_lisp_main.ml
+++ b/plugins/primus_lisp/primus_lisp_main.ml
@@ -34,14 +34,6 @@ let load_program paths features project =
     invalid_arg err
 
 module Documentation = struct
-  let pp_index ppf index =
-    List.iter index ~f:(fun (cat,elts) ->
-        fprintf ppf "* %a@\n" Primus.Lisp.Doc.Category.pp cat;
-        List.iter elts ~f:(fun (name,desc) ->
-            fprintf ppf "** ~%a~@\n%a@\n"
-              Primus.Lisp.Doc.Name.pp name
-              Primus.Lisp.Doc.Descr.pp desc))
-
   let print proj =
     let module Machine = struct
       type 'a m = 'a
@@ -51,8 +43,8 @@ module Documentation = struct
     let module Doc = Primus.Lisp.Doc.Make(Machine) in
     let module Main = Primus.Machine.Main(Machine) in
     let print =
-      Doc.generate_index >>| fun index ->
-      printf "%a@\n%!" pp_index index in
+      Doc.generate_index >>|
+      Primus_lisp_documentation.print "user" in
     match Main.run proj print with
     | Normal, _ -> ()
     | Exn e, _ ->


### PR DESCRIPTION
Much like the old `bap --primus-lisp-documentation` this command
prints the Primus Lisp documentation in the .org format. But it
doesn't require a file as it is possible to specify the target using
the `--target` command line option.

Since `primus-lisp-documentation` is a separate command, it is not
necessary to specify a bogus file name and there are more options to
control the output. First of all, it is now possible to specify the
system (using `--system`), so that now it is possible to get the
documentation for symbolic primtives and functions. It is also
possible to set the package name (using `--package`) and request the
documentation for the Primus Lisp Semantics subsystem (with
`--semantics`).

Therefore, to get the documentation for thumb semantics (functions and
primitives), use

```
bap primus-lisp-documentation --semantics --package=thumb
```

The list of packages, along with their documentation is also available
in the `bap primus-lisp-documentation`