### PR TITLE
renames the `core-theory` package to just `core`

### DIFF
--- a/lib/bap/bap_project.ml
+++ b/lib/bap/bap_project.ml
@@ -874,12 +874,12 @@ module Analysis = struct
   let program =
     argument "<label>"
       ~parse:(parse_object Theory.Program.cls)
-      ~desc:(sprintf "an object of the core-theory:program class")
+      ~desc:(sprintf "an object of the core:program class")
 
   let unit =
     argument "<unit>"
       ~parse:(parse_object Theory.Unit.cls)
-      ~desc:(sprintf "an object of the core-theory:unit class")
+      ~desc:(sprintf "an object of the core:unit class")
 
   let parse_bitvec ~fail str =
     try !!(Bitvec.of_string str)

--- a/lib/bap_core_theory/bap_core_theory_IEEE754.ml
+++ b/lib/bap_core_theory/bap_core_theory_IEEE754.ml
@@ -92,7 +92,7 @@ let binary = function
   | k -> binary k
 
 module Sort = struct
-  let ieee754 = Sort.Name.declare ~package:"core-theory" "IEEE754"
+  let ieee754 = Sort.Name.declare ~package:"core" "IEEE754"
   let format {base; w; t=x; k} = Float.Format.define
       Sort.(int base @-> int w @-> int x @-> sym ieee754)
       (Bitv.define k)

--- a/lib/bap_core_theory/bap_core_theory_definition.ml
+++ b/lib/bap_core_theory/bap_core_theory_definition.ml
@@ -33,7 +33,7 @@ type label = program Knowledge.Object.t
 
 type theory_cls
 let theory : (theory_cls,unit) Knowledge.cls =
-  Knowledge.Class.declare ~package:"core-theory" "theory" ()
+  Knowledge.Class.declare ~package:"core" "theory" ()
     ~public:true
     ~desc:"the class of Core Theory instances"
 

--- a/lib/bap_core_theory/bap_core_theory_effect.ml
+++ b/lib/bap_core_theory/bap_core_theory_effect.ml
@@ -5,7 +5,7 @@ module KB = Knowledge
 
 type cls = Effects
 
-let package = "core-theory"
+let package = "core"
 
 module Sort = struct
   type effects = Top | Set of Set.M(KB.Name).t

--- a/lib/bap_core_theory/bap_core_theory_empty.ml
+++ b/lib/bap_core_theory/bap_core_theory_empty.ml
@@ -14,7 +14,7 @@ module Core : Core = struct
 
   let name =
     KB.Symbol.intern "empty" theory
-      ~package:"core-theory"
+      ~package:"core"
       ~public:true
       ~desc:"The empty theory."
 

--- a/lib/bap_core_theory/bap_core_theory_manager.ml
+++ b/lib/bap_core_theory/bap_core_theory_manager.ml
@@ -28,7 +28,7 @@ let features = Set.of_list (module String)
 let names = Set.of_list (module Name)
 
 module Empty = struct
-  let name = Name.create ~package:"core-theory" "empty"
+  let name = Name.create ~package:"core" "empty"
   let requires = ["empty"]
   let provides = [Name.show name]
   module Self = Bap_core_theory_empty.Core
@@ -308,7 +308,7 @@ let domain = Knowledge.Domain.define "theory"
     ~order
 
 let slot = Knowledge.Class.property theory "instance" domain
-    ~package:"core-theory"
+    ~package:"core"
     ~desc:"The theory structure"
 
 
@@ -352,7 +352,7 @@ let theory_for_id id =
   let sym = sprintf "'%s" @@
     List.to_string (Set.to_list id) ~f:Name.show in
   Knowledge.Symbol.intern sym theory
-    ~package:"core-theory-internal"
+    ~package:"core-internal"
 
 let is_instantiated id =
   Knowledge.collect slot id >>| fun t ->

--- a/lib/bap_core_theory/bap_core_theory_program.ml
+++ b/lib/bap_core_theory/bap_core_theory_program.ml
@@ -2,7 +2,7 @@ open Core_kernel
 open Bitvec_order.Comparators
 open Bap_knowledge
 
-let package = "core-theory"
+let package = "core"
 module Value  = Bap_core_theory_value
 module Effect = Bap_core_theory_effect
 module Target = Bap_core_theory_target

--- a/lib/bap_core_theory/bap_core_theory_value.ml
+++ b/lib/bap_core_theory/bap_core_theory_value.ml
@@ -4,7 +4,7 @@ open Caml.Format
 open Bap_knowledge
 module KB = Knowledge
 
-let package = "core-theory"
+let package = "core"
 
 
 module Sort : sig
@@ -57,7 +57,7 @@ end
   let names = Hash_set.create (module KB.Name)
   let short_names = Hashtbl.create (module String)
 
-  let cls = KB.Class.declare ~package:"core-theory" "value" ()
+  let cls = KB.Class.declare ~package:"core" "value" ()
       ~public:true
       ~desc:"the denotation of an expression"
 

--- a/lib/bap_core_theory/bap_core_theory_var.ml
+++ b/lib/bap_core_theory/bap_core_theory_var.ml
@@ -7,7 +7,7 @@ open Knowledge.Syntax
 
 module Value = Knowledge.Value
 
-let package = "core-theory"
+let package = "core"
 
 type const = Const [@@deriving bin_io, compare, sexp]
 type mut = Mut [@@deriving bin_io, compare, sexp]

--- a/plugins/systemz/systemz_lifter.ml
+++ b/plugins/systemz/systemz_lifter.ml
@@ -81,7 +81,7 @@ end
 
    The only input parameter is a label that denotes a program
    location, aka a knowledge base object of type
-   core-theory:program. The label is like a generalized address - it
+   core:program. The label is like a generalized address - it
    uniquely identifies a program location, even across modules.
 
    To build the semantics the lifter can access various properties of
@@ -93,7 +93,7 @@ end
    function with other lifters (itself included, of course).
 
    The list of properties of that class  can be obtained using the
-   following command: `bap list classes -f core-theory:program`.
+   following command: `bap list classes -f core:program`.
 
    The return type [unit Theory.eff] is the denotation of effects that
    the instruction performs. The ['a Theory.eff] type is an


### PR DESCRIPTION
The `theory` part is excessive and only makes it harder to read the
knowledge base. The new name will also make more sense when we will
add more theories.