### PR TITLE
fixes a bug in the method that computes C padding.

### DIFF
--- a/lib/bap_c/bap_c_size.mli
+++ b/lib/bap_c/bap_c_size.mli
@@ -34,11 +34,12 @@ class base :  model -> object
         - if type is void then alignment is 8 bits.*)
     method alignment : t -> size
 
-    (** [padding t off] computes a required padding at given offset
-        that should be inserted before value of type [t] to satisfy
-        the alignment restriction for [t], as determined by the
-        [alignment] method.  *)
+    (* this method was deprecated as
+       1) it has an incorrect type (padding can have any number of bits)
+       2) padding is fully defined by the alignemnt and there is no
+          need to parameterize it. *)
     method padding : t -> bits -> size option
+    [@@deprecated "since [2021-05] this method is ignored"]
 
 
     (** [array spec] if array [spec] is complete, then returns a


### PR DESCRIPTION
For some reason the code assumes that `x mod m` is multitude of
`m` and raises an exception when it doesn't happen (quite often in
fact).

The code is called when a structure size is computed. The main caveat
here is that
1) this method has incorrect type as it constrains the padding size to
be in the set of `8,16,32,64,128,256` but real padding may have any
number of bits (it is their sum that should in this range).
2) this method shouldn't exist at all as the padding is fully defined
by the alignment of the field and there is no need to override it.

Therefore, the solution is to deprecated this method and compute
padding using the alignment information only. The method is no longer
used and any code that overrode it will get a warning.