### PR TITLE
adds support for big-endian arm and thumb architectures

### DIFF
--- a/lib/arm/arm_target.ml
+++ b/lib/arm/arm_target.ml
@@ -388,7 +388,9 @@ let llvm_a64 = CT.Language.declare ~package "llvm-aarch64"
 module Dis = Disasm_expert.Basic
 
 let register ?attrs encoding triple =
-  Dis.register encoding @@ fun _ ->
+  Dis.register encoding @@ fun t ->
+  let triple = if Theory.Endianness.(eb = Theory.Target.endianness t)
+    then triple ^ "eb" else triple in
   Dis.create ?attrs ~backend:"llvm" triple
 
 let symbol_values doc =

--- a/oasis/arm
+++ b/oasis/arm
@@ -37,7 +37,7 @@ Library arm_plugin
   Path:             plugins/arm
   FindlibName:      bap-plugin-arm
   BuildDepends:     bap, bap-core-theory, bap-abi, bap-arm, bap-c,
-                    core_kernel, bap-main, bap-api, monads
+                    core_kernel, bap-main, bap-api, monads, ppx_bap
   InternalModules:  Arm_main, Arm_gnueabi
   DataFiles:        semantics/*.lisp ($datadir/bap/primus/semantics)
   XMETADescription: provide ARM lifter

--- a/plugins/arm/arm_main.ml
+++ b/plugins/arm/arm_main.ml
@@ -16,11 +16,15 @@ let interworking =
     ~doc:"Enable ARM/Thumb interworking. Defaults to (auto),
           i.e., to the automatic detection of interworking"
 
+type arms = [
+  | Arch.arm
+  | Arch.armeb
+] [@@deriving enumerate]
 
 let () = Bap_main.Extension.declare ~doc @@ fun ctxt ->
   let interworking = ctxt-->interworking in
   Arm_target.load ?interworking ();
-  List.iter Arch.all_of_arm ~f:(fun arch ->
+  List.iter all_of_arms ~f:(fun arch ->
       register_target (arch :> arch) (module ARM);
       Arm_gnueabi.setup ());
   Ok ()

--- a/plugins/arm/semantics/arm-bits.lisp
+++ b/plugins/arm/semantics/arm-bits.lisp
@@ -1,5 +1,5 @@
 (defpackage arm (:use core target))
-(declare  (context (target armv4+le)))
+(declare  (context (target arm)))
 
 (in-package arm)
 

--- a/plugins/arm/semantics/thumb.lisp
+++ b/plugins/arm/semantics/thumb.lisp
@@ -1,7 +1,7 @@
 (require bits)
 (require arm-bits)
 
-(declare (context (target armv4+le)))
+(declare (context (target arm)))
 
 (defpackage thumb (:use core target arm))
 (defpackage llvm-thumb (:use thumb))

--- a/plugins/mc/mc_main.ml
+++ b/plugins/mc/mc_main.ml
@@ -90,7 +90,6 @@ type error =
   | Bad_insn of mem * int * int
   | Create_mem of Error.t
   | No_input
-  | Unknown_arch
   | Invalid_base of string
   | Trailing_data of int
   | Inconsistency of KB.conflict
@@ -651,9 +650,6 @@ let string_of_failure = function
       KB.Conflict.pp conflict
   | Bad_user_input -> "Could not parse: malformed input"
   | No_input -> "No input was received"
-  | Unknown_arch ->
-    sprintf "Unknown architecture. Supported architectures:\n%s" @@
-    String.concat ~sep:"\n" @@ List.map Arch.all ~f:Arch.to_string
   | Trailing_data 1 -> "the last byte wasn't disassembled"
   | Trailing_data left ->
     sprintf "%d bytes were left non disassembled" left


### PR DESCRIPTION
The big endian thumb and arm targets are [not supported by LLVM][1]
and while [the fix][2] is available for many years it is still not
reviewed. I tried to [raise the attention][3] to it but with no
success. Since it looks like that they are not going to fix it we need
to fix it on our side. The solution is a little bit hacky but we can
keep it until we switch to Ghidra for disassembling/lifting.

Examples,

```
$ bap mc --arch=thumb --show-insn=asm --show-bil -- 1a 42
tst r2, r3
{
  #1 := R2 & R3
  ZF := #1 = 0
  NF := extract:31:31[#1]
}

$ bap mc --arch=thumb --order=big --show-insn=asm --show-bil -- 42 1a
tst r2, r3
{
  #1 := R2 & R3
  ZF := #1 = 0
  NF := extract:31:31[#1]
}

$ file echo
echo: ELF 32-bit MSB executable, ARM, version 1 (ARM), dynamically
linked, interpreter /lib/ld-uClibc.so.0, for GNU/Linux 2.0.0, stripped

$ bap echo -dasm | grep 8c90 -A4
8c90: <main>
8c90:
8c90: e9 2d 47 f0                                 push {r4, r5, r6, r7, r8, r9, r10, lr}
8c94: e5 9f 33 34                                 ldr r3, [pc, #0x334]
8c98: e1 a0 70 01                                 mov r7, r1
8c9c: e1 a0 60 00                                 mov r6, r0
8ca0: e3 a0 00 06                                 mov r0, #6

$ objdump echo -d | grep 8c90 -A4
00008c90 <main@@Base>:
    8c90:	e92d47f0 	push	{r4, r5, r6, r7, r8, r9, sl, lr}
    8c94:	e59f3334 	ldr	r3, [pc, #820]	; 8fd0 <main@@Base+0x340>
    8c98:	e1a07001 	mov	r7, r1
    8c9c:	e1a06000 	mov	r6, r0
    8ca0:	e3a00006 	mov	r0, #6

$ llvm-objdump echo -d | grep 8c90 -A4 # wrong output
00008c90 <main>:
    8c90: e9 2d 47 f0  	<unknown>
    8c94: e5 9f 33 34  	ldrtlo	r9, [r3], #-4069
    8c98: e1 a0 70 01  	cmneq	r0, r1, ror #1
    8c9c: e1 a0 60 00  	rsbeq	r10, r0, r1, ror #1
    8ca0: e3 a0 00 06  	streq	r10, [r0], -r3, ror #1
```

fixes #1299

[1]: https://bugs.llvm.org/show_bug.cgi?id=38721
[2]: https://reviews.llvm.org/D48811
[3]: https://twitter.com/ivg_t/status/1384932479967055877?s=20