### PR TITLE
switches to FrontC.4.x adds the preprocessing option

### DIFF
--- a/lib/bap_c/bap_c_size.ml
+++ b/lib/bap_c/bap_c_size.ml
@@ -12,7 +12,7 @@ type bits = Int.t
 class base (m : model) = object(self)
   method integer (t : integer) : size =
     match m,t with
-    | _,#char -> `r8
+    | _,(`bool|#char) -> `r8
     | _,#short -> `r16
     | `LP32,#cint -> `r16
     | (`ILP32|`LLP64|`LP64),#cint -> `r32

--- a/lib/bap_c/bap_c_type.ml
+++ b/lib/bap_c/bap_c_type.ml
@@ -37,7 +37,7 @@ type signed =
 [@@deriving bin_io,compare,sexp,enumerate]
 
 type unsigned =
-  [`uchar | `ushort | `uint | `ulong | `ulong_long]
+  [`bool | `uchar | `ushort | `uint | `ulong | `ulong_long]
 [@@deriving bin_io,compare,sexp,enumerate]
 
 type enum =

--- a/oasis/frontc-parser
+++ b/oasis/frontc-parser
@@ -8,6 +8,6 @@ Library frontc_parser_plugin
   Path: plugins/frontc_parser
   FindlibName: bap-plugin-frontc_parser
   CompiledObject: best
-  BuildDepends: bap, bap-c, FrontC, core_kernel, ppx_bap
+  BuildDepends: bap, bap-c, FrontC, core_kernel, ppx_bap, core_kernel.caml_unix
   InternalModules: Frontc_parser_main
   XMETAExtraLines: tags="api,c,parser"

--- a/opam/opam
+++ b/opam/opam
@@ -17,7 +17,7 @@ depends: [
   "core_kernel" {>= "v0.14" & < "v0.15"}
   "ezjsonm"
   "fileutils"
-  "FrontC"
+  "FrontC" {>= "4.1" & < "4.2"}
   "oasis" {build & >= "0.4.10"}
   "ounit" {build}
   "ocamlgraph" {>= "1.8.6"}


### PR DESCRIPTION
Since FrontC.4.x supports new types from C99+ we had to update BAP as
well, both its representation of the C types as well as the parsing
procedure.

We also added an option (disabled by default) to apply
preprocessing (with an ability to specify the path to it) since
FrontC.4.1+ is much more robust and is capable of chewing linux system
headers.

Note, this PR could not be merged until [FrontC.4.1 is merged][1] and
even after a care should be taken to properly reconstraint our
dependencies on FrontC. We might even consider merging this PR after the BAP.2.3.0 release.

[1]: https://github.com/ocaml/opam-repository/pull/18736