### PR TITLE
enables push flag in the publish-docker-image action

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -19,5 +19,6 @@ jobs:
       - name: Publish Ubuntu image to Registry
         uses: docker/build-push-action@v2
         with:
+          push: true
           tags: binaryanalysisplatform/bap:latest
           file: docker/ubuntu/xenial/Dockerfile


### PR DESCRIPTION
The docker images are no longer pushed to dockerhubn after #1312.
First of all, because the secret names were accidentally changed,
and secondly, because the `push` parameter defaults to `false` in
the `v2` version of the action.