### PR TITLE
fixes the ppx_bap version in the dev-repo opam file

### DIFF
--- a/opam/opam
+++ b/opam/opam
@@ -13,7 +13,7 @@ depends: [
   "camlzip"
   "linenoise" {>= "1.1" & < "2.0"}
   "cmdliner" {>= "1.0" & < "2.0"}
-  "ppx_bap"  {= "master"}
+  "ppx_bap" {>= "v0.14" & < "v0.15"}
   "core_kernel" {>= "v0.14" & < "v0.15"}
   "ezjsonm"
   "fileutils"


### PR DESCRIPTION
This file is assuming the presence of the testing snapshot opam
repository, which is not always available. It is also not required to
get ppx_bap from it as it is already for a long time in the upstream
repository.