### PR TITLE
adds armeb abi

### DIFF
--- a/opam/opam
+++ b/opam/opam
@@ -32,11 +32,10 @@ depends: [
   "conf-bap-llvm" {>= "1.1"}
   "parsexp"
   "bap-signatures"
-  "result"
   "z3"
   "conf-radare2"
   "yojson"
-  "result" {= "1.4"}
+  "result"
 ]
 depopts: [
   "conf-ida"

--- a/plugins/arm/arm_gnueabi.ml
+++ b/plugins/arm/arm_gnueabi.ml
@@ -10,55 +10,59 @@ let size = object(self)
 end
 
 
-let nats = Seq.unfold ~init:0 ~f:(fun n -> Some (n,n+1))
-let regs = ARM.CPU.[r0;r1;r2;r3] |> List.map ~f:Bil.var
-let mems = Seq.map nats ~f:(C.Abi.Stack.create `armv7)
+module Define(Arch : sig val name : arch end) = struct
+  let arch = Arch.name
+  let nats = Seq.unfold ~init:0 ~f:(fun n -> Some (n,n+1))
+  let regs = ARM.CPU.[r0;r1;r2;r3] |> List.map ~f:Bil.var
+  let mems = Seq.map nats ~f:(C.Abi.Stack.create arch)
 
-let align ncrn t =
-  if Size.equal (size#alignment t) `r64 then match ncrn with
-    | [_;_;_;_] -> ncrn
-    | [_;r2;r3] -> [r2;r3]
-    | _ -> []
-  else ncrn
+  let align ncrn t =
+    if Size.equal (size#alignment t) `r64 then match ncrn with
+      | [_;_;_;_] -> ncrn
+      | [_;r2;r3] -> [r2;r3]
+      | _ -> []
+    else ncrn
 
-let concat = List.reduce_exn ~f:Bil.concat
+  let concat = List.reduce_exn ~f:Bil.concat
 
-let retregs = function
-  | #C.Type.scalar as t ->
-    List.take regs (Size.in_bytes (size#scalar t) / 4), [], regs
-  | t -> match size#bits (t :> C.Type.t) with
-    | Some sz when sz <= 32 -> List.take regs 1,[],regs
-    | _ -> List.take regs 1, List.take regs 1, List.tl_exn regs
+  let retregs = function
+    | #C.Type.scalar as t ->
+      List.take regs (Size.in_bytes (size#scalar t) / 4), [], regs
+    | t -> match size#bits (t :> C.Type.t) with
+      | Some sz when sz <= 32 -> List.take regs 1,[],regs
+      | _ -> List.take regs 1, List.take regs 1, List.tl_exn regs
 
-let ret : C.Type.t -> 'a = function
-  | `Void -> None,[],regs
-  | t -> match retregs t with
-    | [],_,rest -> None,[],rest
-    | rets,hids,rest ->
-      let data = C.Abi.data size t in
-      Some (data, concat rets),
-      List.map hids ~f:(fun reg -> t,(C.Data.Ptr data, reg)),
-      rest
+  let ret : C.Type.t -> 'a = function
+    | `Void -> None,[],regs
+    | t -> match retregs t with
+      | [],_,rest -> None,[],rest
+      | rets,hids,rest ->
+        let data = C.Abi.data size t in
+        Some (data, concat rets),
+        List.map hids ~f:(fun reg -> t,(C.Data.Ptr data, reg)),
+        rest
 
-let args _ _ {C.Type.Proto.return; args=ps} =
-  let return,hidden,regs = ret return in
-  let _,_,params =
-    List.fold ps ~init:(regs,mems,[]) ~f:(fun (regs,mems,args) (_,t) ->
-        let words = Option.value (size#bits t) ~default:32 / 32 in
-        let exps,regs = List.split_n (align regs t) words in
-        let rest,mems = Seq.split_n mems (words - List.length exps) in
-        regs,mems, (C.Abi.data size t, (concat (exps@rest))) :: args) in
-  Some C.Abi.{return; hidden; params = List.rev params}
+  let args _ _ {C.Type.Proto.return; args=ps} =
+    let return,hidden,regs = ret return in
+    let _,_,params =
+      List.fold ps ~init:(regs,mems,[]) ~f:(fun (regs,mems,args) (_,t) ->
+          let words = Option.value (size#bits t) ~default:32 / 32 in
+          let exps,regs = List.split_n (align regs t) words in
+          let rest,mems = Seq.split_n mems (words - List.length exps) in
+          regs,mems, (C.Abi.data size t, (concat (exps@rest))) :: args) in
+    Some C.Abi.{return; hidden; params = List.rev params}
 
-let abi = C.Abi.{
-    insert_args = args;
-    apply_attrs = fun _ -> ident
-  }
+  let abi = C.Abi.{
+      insert_args = args;
+      apply_attrs = fun _ -> ident
+    }
 
-let api arch = C.Abi.create_api_processor arch abi
+  let api size = C.Abi.create_api_processor size abi
+end
 
 let main proj = match Project.arch proj with
-  | #Arch.arm  | #Arch.thumb ->
+  | #Arch.arm  | #Arch.thumb | #Arch.armeb | #Arch.thumbeb as arch ->
+    let open Define(struct let name = arch end) in
     info "using armeabi ABI";
     C.Abi.register "eabi" abi;
     Bap_api.process (api size);


### PR DESCRIPTION
We reuse the existing arm and thumb abi but make sure that the correct
architecture is passed to the memory-related operations.

fixes #1324