### PR TITLE
adds experimental Ghidra disassembler and lifting backend

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,6 +22,12 @@ jobs:
           ocaml-compiler: 4.08.x
           dune-cache: true
 
+      - name: Install Ghidra
+        run: |
+          sudo add-apt-repository ppa:ivg/ghidra -y
+          sudo apt-get install libghidra-dev -y
+          sudo apt-get install libghidra-data -y
+
       - name: Add the testing Repository
         run: opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
 
@@ -32,7 +38,7 @@ jobs:
         run: opam pin add bap . --no-action
 
       - name: Install system dependencies
-        run: opam depext -u bap
+        run: opam depext -u bap-extra
 
       - name: Install opam dependencies
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     env:
       OPAMJOBS: 2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,12 +22,6 @@ jobs:
           ocaml-compiler: 4.08.x
           dune-cache: true
 
-      - name: Install Ghidra
-        run: |
-          sudo add-apt-repository ppa:ivg/ghidra -y
-          sudo apt-get install libghidra-dev -y
-          sudo apt-get install libghidra-data -y
-
       - name: Add the testing Repository
         run: opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
 
@@ -39,6 +33,12 @@ jobs:
 
       - name: Install system dependencies
         run: opam depext -u bap-extra
+
+      - name: Install Ghidra
+        run: |
+          sudo add-apt-repository ppa:ivg/ghidra -y
+          sudo apt-get install libghidra-dev -y
+          sudo apt-get install libghidra-data -y
 
       - name: Install opam dependencies
         run: |

--- a/.github/workflows/build-dev-repo.yml
+++ b/.github/workflows/build-dev-repo.yml
@@ -43,7 +43,6 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           rm -rf /usr/local/bin/2to3
-          brew unlink gcc@8
           brew unlink gcc@9
           brew update
           brew upgrade

--- a/.github/workflows/build-from-opam.yml
+++ b/.github/workflows/build-from-opam.yml
@@ -10,7 +10,7 @@ jobs:
           - 4.11.x
           - 4.08.x
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     env:
       OPAMJOBS: 2

--- a/.github/workflows/build-from-opam.yml
+++ b/.github/workflows/build-from-opam.yml
@@ -23,11 +23,17 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           dune-cache: true
 
+      - name: Install Ghidra
+        run: |
+          sudo add-apt-repository ppa:ivg/ghidra -y
+          sudo apt-get install libghidra-dev -y
+          sudo apt-get install libghidra-data -y
+
       - name: Add the testing Repository
         run: opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
 
       - name: Install system dependencies
-        run: opam depext -u bap
+        run: opam depext -u bap-extra
 
       - name: Cleanup the Caches
         run: sudo apt clean --yes
@@ -36,7 +42,7 @@ jobs:
         run: df -h
 
       - name: Build and Install BAP Packages
-        run: opam clean -a; opam install bap
+        run: opam clean -a; opam install bap-extra
 
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}

--- a/.github/workflows/nightly-testing.yml
+++ b/.github/workflows/nightly-testing.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-18.04
         ocaml-compiler:
           - 4.11.x
           - 4.08.x

--- a/.github/workflows/nightly-testing.yml
+++ b/.github/workflows/nightly-testing.yml
@@ -29,30 +29,25 @@ jobs:
           dune-cache: true
           cache-prefix: nightly
 
-      - name: Configure Homebrew
-        if: matrix.os == 'macos-latest'
+      - name: Install Ghidra
         run: |
-          rm -rf /usr/local/bin/2to3
-          brew unlink gcc@8
-          brew unlink gcc@9
-          brew update
-          brew upgrade
-          echo 'LLVM_CONFIG=/usr/local/opt/llvm@9/bin/llvm-config' >> $GITHUB_ENV
+          sudo add-apt-repository ppa:ivg/ghidra -y
+          sudo apt-get install libghidra-dev -y
+          sudo apt-get install libghidra-data -y
 
       - name: Add the Testing Repository
         run: opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
       - name: Install System Dependencies
-        run: opam depext -u bap
+        run: opam depext -u bap-extra
 
       - name: Install radare2 Dependencies
         run: opam depext -u bap-radare2
 
       - name: Cleanup the Caches
-        if: matrix.os == 'ubuntu-latest'
         run: sudo apt clean --yes
 
       - name: Build and Install BAP
-        run: opam install bap bap-radare2
+        run: opam install bap-extra bap-radare2
 
       - name: Checkout the Tests
         uses: actions/checkout@v2

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -21,4 +21,4 @@ jobs:
         with:
           push: true
           tags: binaryanalysisplatform/bap:latest
-          file: docker/ubuntu/xenial/Dockerfile
+          file: docker/ubuntu/bionic/Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,12 @@ jobs:
           ocaml-compiler: ocaml-variants.4.11.2+flambda
           dune-cache: true
 
+      - name: Install Ghidra
+        run: |
+          sudo add-apt-repository ppa:ivg/ghidra -y
+          sudo apt-get install libghidra-dev -y
+          sudo apt-get install libghidra-data -y
+
       - name: Add the testing Repository
         run: opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
       - name: Build deb packages

--- a/docker/ubuntu/bionic/Dockerfile
+++ b/docker/ubuntu/bionic/Dockerfile
@@ -2,13 +2,16 @@ FROM ocaml/opam2:ubuntu-18.04
 
 WORKDIR /home/opam
 
-RUN sudo apt-get update  \
+RUN sudo add-apt-repository ppa:ivg/ghidra -y
+ && sudo apt-get install libghidra-dev -y
+ && sudo apt-get install libghidra-data -y
+ && sudo apt-get update  \
  && opam switch 4.09 \
  && eval "$(opam env)" \
  && opam remote set-url default https://opam.ocaml.org \
  && opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository --all \
  && opam update \
- && opam depext --install bap --yes -j 1 \
+ && opam depext --install bap-extra --yes -j 1 \
  && opam clean -acrs \
  && rm -rf /home/opam/.opam/4.0[2-8,10] \
  && rm -rf /home/opam/.opam/4.09/.opam-switch/sources/* \

--- a/lib/arm/arm_target.mli
+++ b/lib/arm/arm_target.mli
@@ -115,4 +115,4 @@ val llvm_a64 : Theory.language
     a symbol there with an odd address (which is used to indicate
     thumb encoding) then interworking is enabled.
 *)
-val load : ?interworking:bool -> unit -> unit
+val load : ?interworking:bool -> ?backend:string -> unit -> unit

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -6874,6 +6874,9 @@ module Std : sig
 
       (** the set of destinations (not including the fall-through edge).  *)
       val dests : Set.M(Theory.Label).t option t
+
+      (** the array of subinstructions *)
+      val subs : Theory.Semantics.t array t
     end
 
     (** [of_basic ?bil insn] derives semantics from the machine code instruction.*)

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -6988,9 +6988,36 @@ module Std : sig
         by evaluating in many languages, e.g. Python, Js, etc *)
     val pp_adt : Format.formatter -> t -> unit
 
+
+    (** Subinstruction Sequence Number.
+
+        A subinstruction sequence number plays the role of an address
+        for sub-instruction (which otherwise share the same physical
+        address).
+
+        Each subinstruction is having a unique address across the
+        whole program (not only unique across to other subinstructions
+        of the same instruction) and much like [Theory.Label.for_addr]
+        it is possible to get a label that corresponds to an
+        instruction with the given sequence number using
+        [Seqnum.label].
+
+        The sequence number is represented with an integer to enable
+        address arithemetics. A subinstruction that follows a
+        subinstruction with the sequence number [N] has the sequence
+        number [N+1].
+
+        @since 2.4.0
+    *)
     module Seqnum : sig
       type t = int
+
+
+      (** [label seqnum] returns the program label that corresponds
+          to [seqnum].  *)
       val label : ?package:string -> t -> Theory.Label.t KB.t
+
+      (** [slot] for accessing the sequence number of a subinstruction.  *)
       val slot : (Theory.program, t option) KB.slot
     end
 

--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -2412,6 +2412,18 @@ module Std : sig
     val intrinsic: string Attribute.t
 
 
+    (** [label] a named code location.
+
+        @since 2.4.0  *)
+    val label : string Attribute.t
+
+
+    (** [goto] represents a control-flow transfer to a named label.
+
+        @since 2.4.0 *)
+    val goto : string Attribute.t
+
+
     (** Core Theory specification of BIL.  *)
     module Theory : sig
 
@@ -6874,9 +6886,6 @@ module Std : sig
 
       (** the set of destinations (not including the fall-through edge).  *)
       val dests : Set.M(Theory.Label).t option t
-
-      (** the array of subinstructions *)
-      val subs : Theory.Semantics.t array t
     end
 
     (** [of_basic ?bil insn] derives semantics from the machine code instruction.*)
@@ -6978,6 +6987,13 @@ module Std : sig
     (** [pp_adt] prints instruction in ADT format, suitable for reading
         by evaluating in many languages, e.g. Python, Js, etc *)
     val pp_adt : Format.formatter -> t -> unit
+
+    module Seqnum : sig
+      type t = int
+      val label : ?package:string -> t -> Theory.Label.t KB.t
+      val slot : (Theory.program, t option) KB.slot
+    end
+
 
     (** {3 Prefix Tree}
         This module provides a trie data structure where a sequence of

--- a/lib/bap_core_theory/bap_core_theory.mli
+++ b/lib/bap_core_theory/bap_core_theory.mli
@@ -1782,6 +1782,16 @@ module Theory : sig
     val is_subroutine : (program, bool option) KB.slot
 
 
+    (** [fresh] a fresh label (a shortcut for [KB.create cls]).
+
+        @since 2.4.0   *)
+    val fresh : t knowledge
+
+    (** [null] is a shortcut for [KB.null cls].
+
+        @since 2.4.0  *)
+    val null : t
+
     (** [for_addr x] generates a link to address [x].
 
         It is guaranteed that every call [for_addr ~package x] with

--- a/lib/bap_core_theory/bap_core_theory_program.ml
+++ b/lib/bap_core_theory/bap_core_theory_program.ml
@@ -251,6 +251,9 @@ module Label = struct
 
   open Knowledge.Syntax
 
+  let null = Knowledge.Object.null cls
+  let fresh = Knowledge.Object.create cls
+
   let for_name ?package s =
     Knowledge.Symbol.intern ?package s cls >>= fun obj ->
     Knowledge.provide name obj (Some s) >>| fun () -> obj

--- a/lib/bap_core_theory/bap_core_theory_program.mli
+++ b/lib/bap_core_theory/bap_core_theory_program.mli
@@ -86,6 +86,8 @@ module Label : sig
   val possible_name : (program, string option opinions) slot
   val is_valid : (program, bool option) slot
   val is_subroutine : (program, bool option) slot
+  val fresh : t knowledge
+  val null : t
   val for_addr : ?package:string -> Bitvec.t -> t knowledge
   val for_name : ?package:string -> string -> t knowledge
   val for_ivec : ?package:string -> int -> t knowledge

--- a/lib/bap_core_theory/bap_core_theory_var.ml
+++ b/lib/bap_core_theory/bap_core_theory_var.ml
@@ -19,9 +19,9 @@ let mut = Knowledge.Class.declare ~package "mut-var" Mut
     ~desc:"temporary mutable variables"
 
 type ident =
-  | Reg of {name : string; ver : int}
-  | Let of {num : Int63.t}
   | Var of {num : Int63.t; ver : int}
+  | Let of {num : Int63.t}
+  | Reg of {name : String.Caseless.t; ver : int}
 [@@deriving bin_io, compare, hash, sexp]
 
 type 'a var = 'a sort * ident

--- a/lib/bap_disasm/bap_disasm_basic.ml
+++ b/lib/bap_disasm/bap_disasm_basic.ml
@@ -146,8 +146,8 @@ module Reg = struct
         if reg_code = 0 then "Nil"
         else
           let off = C.insn_op_reg_name !!dis ~insn ~oper in
-          if off = -1
-          then sprintf "#%d" reg_code
+          if reg_code < 0
+          then sprintf "%c%d" (Char.of_int_exn off) ~-reg_code
           else Table.lookup (get dis).reg_table off in
       {reg_code; reg_name} in
     {insn; oper; data}

--- a/lib/bap_disasm/bap_disasm_basic.ml
+++ b/lib/bap_disasm/bap_disasm_basic.ml
@@ -144,11 +144,11 @@ module Reg = struct
       let reg_code = C.insn_op_reg_code !!dis ~insn ~oper in
       let reg_name =
         if reg_code = 0 then "Nil"
-        else if insn < 0
-        then sprintf "#%d" reg_code
         else
           let off = C.insn_op_reg_name !!dis ~insn ~oper in
-          (Table.lookup (get dis).reg_table off) in
+          if off = -1
+          then sprintf "#%d" reg_code
+          else Table.lookup (get dis).reg_table off in
       {reg_code; reg_name} in
     {insn; oper; data}
 

--- a/lib/bap_disasm/bap_disasm_basic.ml
+++ b/lib/bap_disasm/bap_disasm_basic.ml
@@ -148,6 +148,8 @@ module Reg = struct
       let reg_code = C.insn_op_reg_code !!dis ~insn ~oper in
       let reg_name =
         if reg_code = 0 then "Nil"
+        else if insn < 0
+        then sprintf "#%d" reg_code
         else
           let off = C.insn_op_reg_name !!dis ~insn ~oper in
           (Table.lookup (get dis).reg_table off) in

--- a/lib/bap_disasm/bap_disasm_basic.ml
+++ b/lib/bap_disasm/bap_disasm_basic.ml
@@ -81,10 +81,6 @@ end
 
 
 module Table = struct
-  (* Bigstring.length is very slow... we should report a bug to the
-     mantis. They need to add "noalloc" to it, otherwise on each call
-     the whole GC machinery is triggered. For now we will store the
-     size, so that later we can check it for free. *)
   type t = {
     data : Bigstring.t;
     size : int;
@@ -326,14 +322,21 @@ module Insn = struct
     asm  : bytes;
     kinds: kind list;
     opers: Op.t array;
+    subs : ins_info array;
   }
   type ('a,'k) t = ins_info
 
-  let sexp_of_t ins =
+  let rec sexp_of_t ins =
     let name = ins.name in
     let ops = Array.to_list ins.opers in
-    Sexp.List (Sexp.Atom name :: List.map ops ~f:(fun op ->
-        Sexp.Atom (Op.to_string op)))
+    let parent =
+      Sexp.List (Sexp.Atom name :: List.map ops ~f:(fun op ->
+          Sexp.Atom (Op.to_string op))) in
+    if Array.length ins.subs > 0
+    then
+      let subs = Array.map ins.subs ~f:sexp_of_t in
+      Sexp.List (parent :: Array.to_list subs)
+    else parent
 
   let compare {code=x} {code=y} = Int.compare x y
 
@@ -342,15 +345,36 @@ module Insn = struct
   let asm  x = Bytes.to_string x.asm
   let ops  x = x.opers
   let kinds x = x.kinds
+  let subs x = x.subs
   let is op x =
     let equal x y = Kind.compare x y = 0 in
     List.mem ~equal op.kinds x
 
-  let create ~asm ~kinds dis ~insn =
+  let rec create ?parent ~asm ~kinds dis ~insn =
+    let subs = Hashtbl.create (module Int) in
+    let opers =
+      Array.init (C.insn_ops_size !!dis ~insn) ~f:(fun oper ->
+          match C.insn_op_type !!dis ~insn ~oper with
+          | Reg -> Op.Reg Reg.(create dis ~insn ~oper)
+          | Imm -> Op.Imm Imm.(create dis ~insn ~oper)
+          | Fmm -> Op.Fmm Fmm.(create dis ~insn ~oper)
+          | Insn ->
+            let v = Imm.(create dis ~insn ~oper) in
+            let id = v.data.imm_small in
+            let sub = create ~parent:insn ~asm ~kinds dis ~insn:id in
+            let pos = Hashtbl.length subs in
+            Hashtbl.add_exn subs pos sub;
+            Op.Imm {v with data = {imm_small=pos; imm_large=None}}) in
+    let subs = Array.init (Hashtbl.length subs)
+        ~f:(Hashtbl.find_exn subs) in
     let code = C.insn_code !!dis ~insn in
-    let name =
+    let fullname =
       let off = C.insn_name !!dis ~insn in
+      KB.Name.read ~package:dis.enc @@
       Table.lookup (get dis).insn_table off in
+    let name = KB.Name.unqualified fullname
+    and encoding = KB.Name.package fullname in
+    let insn = Option.value parent ~default:insn in
     let asm =
       if asm then
         let data = Bytes.create (C.insn_asm_size !!dis ~insn) in
@@ -366,14 +390,7 @@ module Insn = struct
             then k :: ks
             else ks)
       else [] in
-    let opers =
-      Array.init (C.insn_ops_size !!dis ~insn) ~f:(fun oper ->
-          match C.insn_op_type !!dis ~insn ~oper with
-          | Reg -> Op.Reg Reg.(create dis ~insn ~oper)
-          | Imm -> Op.Imm Imm.(create dis ~insn ~oper)
-          | Fmm -> Op.Fmm Fmm.(create dis ~insn ~oper)
-          | Insn -> assert false) in
-    {code; name; asm; kinds; opers; encoding = dis.enc }
+    {code; name; asm; kinds; opers; encoding; subs }
 
   let encoding x = x.encoding
 

--- a/lib/bap_disasm/bap_disasm_basic.ml
+++ b/lib/bap_disasm/bap_disasm_basic.ml
@@ -401,34 +401,6 @@ module Insn = struct
       Theory.Program.cls "insn" domain
       ~public:true
       ~desc:"a decoded machine instruction"
-
-  let provide_sequence_semantics () =
-    let open KB.Syntax in
-    KB.promise Theory.Semantics.slot @@ fun obj ->
-    KB.collect slot obj >>= function
-    | None -> !!Theory.Semantics.empty
-    | Some insn when not (String.equal (name insn) "seq") ->
-      !!Theory.Semantics.empty
-    | Some insn ->
-      Theory.instance () >>= Theory.require >>= fun (module CT) ->
-      Seq.of_array insn.subs |>
-      KB.Seq.map ~f:(fun sub ->
-          KB.Object.scoped Theory.Program.cls @@ fun obj ->
-          KB.provide slot obj (Some sub) >>= fun () ->
-          KB.collect Theory.Semantics.slot obj) >>=
-      KB.Seq.reduce ~f:(fun xs ys ->
-          CT.seq !!xs !!ys) >>| function
-      | None -> Theory.Semantics.empty
-      | Some r -> r
-
-  let () =
-    let open KB.Rule in
-    declare "sequential-instruction" |>
-    require slot |>
-    provide Theory.Semantics.slot |>
-    comment "computes sequential instructions semantics";
-    provide_sequence_semantics ()
-
 end
 
 type ('a,'k) insn = ('a,'k) Insn.t

--- a/lib/bap_disasm/bap_disasm_basic.mli
+++ b/lib/bap_disasm/bap_disasm_basic.mli
@@ -101,6 +101,7 @@ module Insn : sig
   val is : ('a,kinds) t -> kind -> bool
   val asm : (asm,'k) t -> string
   val ops  : ('a,'k) t -> op array
+  val subs : ('a,'k) t -> ('a,'k) t array
   val slot : (Theory.program,full_insn option) KB.slot
 end
 

--- a/lib/bap_disasm/bap_disasm_insn.mli
+++ b/lib/bap_disasm/bap_disasm_insn.mli
@@ -42,6 +42,12 @@ val should    : may  property -> t -> t
 val shouldn't : may  property -> t -> t
 
 
+module Seqnum : sig
+  type t = int
+  val label : ?package:string -> t -> Theory.Label.t KB.t
+  val slot : (Theory.program, t option) KB.slot
+end
+
 module Slot : sig
   type 'a t = (Theory.Effect.cls, 'a) KB.slot
   val name : string t
@@ -49,7 +55,6 @@ module Slot : sig
   val ops :  op array option t
   val delay : int option t
   val dests : Set.M(Theory.Label).t option t
-  val subs : Theory.Semantics.t array t
 end
 
 

--- a/lib/bap_disasm/bap_disasm_insn.mli
+++ b/lib/bap_disasm/bap_disasm_insn.mli
@@ -49,6 +49,7 @@ module Slot : sig
   val ops :  op array option t
   val delay : int option t
   val dests : Set.M(Theory.Label).t option t
+  val subs : Theory.Semantics.t array t
 end
 
 

--- a/lib/bap_disasm/disasm.h
+++ b/lib/bap_disasm/disasm.h
@@ -255,7 +255,7 @@ void bap_disasm_run(bap_disasm_type disasm);
  */
 void bap_disasm_insns_clear(bap_disasm_type disasm);
 
-/* returns the amount of instructions in the decompiler queue.  */
+/* returns the number of instructions in the decompiler queue.  */
 int bap_disasm_insns_size(bap_disasm_type disasm);
 
 
@@ -339,8 +339,9 @@ int bap_disasm_insn_op_reg_code(bap_disasm_type disasm,
                                 int insn,
                                 int op);
 
-/* returns value of the integer immediate value.
- * @pre op_type = imm
+/* returns value of the integer immediate value or the subinstruction index.
+ * @pre op_type = imm || op_typ = insn
+ *
  */
 int64_t bap_disasm_insn_op_imm_value(bap_disasm_type disasm,
                                      int insn,

--- a/lib/bap_disasm/disasm.hpp
+++ b/lib/bap_disasm/disasm.hpp
@@ -70,7 +70,6 @@ struct reg {
 typedef int64_t imm;
 typedef double  fmm;
 
-
 struct operand {
     bap_disasm_op_type type;
 
@@ -78,6 +77,7 @@ struct operand {
         reg reg_val;
         imm imm_val;
         fmm fmm_val;
+        insn *sub_val;
     };
 };
 

--- a/lib/bap_disasm/disasm.hpp
+++ b/lib/bap_disasm/disasm.hpp
@@ -97,7 +97,7 @@ struct insn {
 
 struct memory {
     const char *data;
-    uint64_t     base;
+    uint64_t    base;
     location    loc;
 };
 

--- a/lib/bap_ghidra/OMakefile
+++ b/lib/bap_ghidra/OMakefile
@@ -3,7 +3,7 @@
 # for more documentation.
 
 CFLAGS += -O2
-CXXFLAGS += -O2 -std=c++11 -fPIC
+CXXFLAGS += -O2 -std=c++11 -fPIC -I$(ROOT)/lib/bap_disasm
 OCAMLMKLIBFLAGS += -L/usr/lib/ghidra -lsla
 
 include _oasis_hier.om

--- a/lib/bap_ghidra/OMakefile
+++ b/lib/bap_ghidra/OMakefile
@@ -4,7 +4,7 @@
 
 CFLAGS += -O2
 CXXFLAGS += -O2 -std=c++11 -fPIC -I$(ROOT)/lib/bap_disasm
-OCAMLMKLIBFLAGS += -L/usr/lib/ghidra -lsla
+OCAMLMKLIBFLAGS += -L/usr/lib/ghidra -ldecomp
 
 include _oasis_hier.om
 

--- a/lib/bap_ghidra/OMakefile
+++ b/lib/bap_ghidra/OMakefile
@@ -1,0 +1,48 @@
+# You may modify this file freely. It is not overwritten by oasis
+# setup once it exists. See the OMakefile in the topmost directory
+# for more documentation.
+
+CFLAGS += -O2
+CXXFLAGS += -O2 -std=c++11 -fPIC
+OCAMLMKLIBFLAGS += -L/usr/lib/ghidra -lsla
+
+include _oasis_hier.om
+
+# subdirectories
+.SUBDIRS: $(OASIS_SUBDIRS)
+
+# local phonies
+.PHONY: build-here doc-here install-here uninstall-here reinstall-here pre-install-here clean-here distclean-here
+
+include _oasis_build.om
+include _oasis_install.om
+
+DefineBuildRules()
+DefineInstallRules()
+
+build-here: $(BUILD_TARGETS)
+doc-here: $(BUILD_DOC_TARGETS)
+install-here: $(INSTALL_TARGETS)
+uninstall-here: $(UNINSTALL_TARGETS)
+reinstall-here: $(REINSTALL_TARGETS)
+pre-install-here:
+
+clean-here:
+    rm -f $(OASIS_clean_list)
+    rm -rf $(OASIS_rec_clean_list)
+    section
+        OASIS_rmdir($(OASIS_dir_clean_list))
+
+distclean-here:
+    rm -f $(OASIS_distclean_list)
+    rm -rf $(OASIS_rec_distclean_list)
+    section
+        OASIS_rmdir($(OASIS_dir_distclean_list))
+
+build: build-here
+doc: doc-here
+install: install-here
+uninstall: uninstall-here
+reinstall: reinstall-here
+clean: clean-here
+distclean: distclean-here

--- a/lib/bap_ghidra/bap_ghidra.ml
+++ b/lib/bap_ghidra/bap_ghidra.ml
@@ -1,0 +1,3 @@
+external ghidra_init : unit -> unit = "disasm_ghidra_init_stub"
+
+let init () = ghidra_init ()

--- a/lib/bap_ghidra/bap_ghidra.ml
+++ b/lib/bap_ghidra/bap_ghidra.ml
@@ -1,3 +1,6 @@
-external ghidra_init : unit -> unit = "disasm_ghidra_init_stub"
+external ghidra_init : string -> bool -> int = "disasm_ghidra_init_stub"
 
-let init () = ghidra_init ()
+let init ?(paths=["/usr/share/ghidra"]) ?(print_targets=false) () =
+  let paths = String.concat ":" paths in
+  if ghidra_init paths print_targets < 0 then
+    failwith "failed to initialize ghidra backend. See stderr for information"

--- a/lib/bap_ghidra/bap_ghidra.mli
+++ b/lib/bap_ghidra/bap_ghidra.mli
@@ -1,0 +1,1 @@
+val init : unit -> unit

--- a/lib/bap_ghidra/bap_ghidra.mli
+++ b/lib/bap_ghidra/bap_ghidra.mli
@@ -1,1 +1,4 @@
-val init : unit -> unit
+val init :
+  ?paths:string list ->
+  ?print_targets:bool ->
+  unit -> unit

--- a/lib/bap_ghidra/ghidra_disasm.cpp
+++ b/lib/bap_ghidra/ghidra_disasm.cpp
@@ -61,20 +61,26 @@ bap::table table_from_string(const std::string &data) {
     return res;
 }
 
+enum CoreOpCode {
+    CORE_SEQ = CPUI_MAX,
+    CORE_MAX
+};
+
 class OpcodesTable {
     std::string opnames;
-    std::map<OpCode,int> offsets;
+    std::map<OpCode,int> cpui_offsets;
+    std::map<CoreOpCode, int> core_offsets;
+
 public:
     OpcodesTable() {
         std::stringstream ss;
-        int offset = 0;
         for (int i = 0; i < CPUI_MAX; i++) {
             OpCode op = static_cast<OpCode>(i);
-            std::string name = get_opname(op);
-            ss << name << '\000';
-            offsets[op] = offset;
-            offset += name.length() + 1;
+            cpui_offsets[op] = ss.tellp();
+            ss << get_opname(op) << '\000';
         }
+        core_offsets[CORE_SEQ] = ss.tellp();
+        ss << "core:seq" << '\000';
         opnames = ss.str();
     }
 
@@ -82,9 +88,16 @@ public:
         return table_from_string(opnames);
     }
 
-    int intern(OpCode op) const {
-        return offsets.at(op);
+    int intern(int op) const {
+        if (op > 0 && op < CPUI_MAX) {
+            return cpui_offsets.at(static_cast<OpCode>(op));
+        } else if (op > 0 && op < CORE_MAX) {
+            return core_offsets.at(static_cast<CoreOpCode>(op));
+        } else {
+            return 0;
+        }
     }
+
 };
 
 class RegistersTable {
@@ -96,15 +109,14 @@ public:
     void populate_registers(const Translate& translator) {
         offsets = {};
         std::map<VarnodeData,std::string> registers;
-        int offset = 0;
         std::stringstream ss;
+        ss << "Nil" << '\000';
         translator.getAllRegisters(registers);
         for (const auto& elt : registers) {
             VarnodeData node = elt.first;
             std::string name = elt.second;
+            offsets[node] = ss.tellp();
             ss << name << '\000';
-            offsets[node] = offset;
-            offset += name.length() + 1;
         }
         regnames = ss.str();
     }
@@ -149,7 +161,7 @@ class InstructionBuilder : public PcodeEmit {
     const Loader &loader;
     const RegistersTable &registers;
     const OpcodesTable &opcodes;
-    bap::insn insn;
+    std::vector<bap::insn> insns;
 public:
     InstructionBuilder(const Loader &loader_,
                        const RegistersTable &registers_,
@@ -161,21 +173,44 @@ public:
                       VarnodeData *outvar,
                       VarnodeData *invars,
                       int4 number_of_inputs) {
-        insn.code = opcode;
-        insn.name = opcodes.intern(opcode);
-        insn.loc.off = loader.offset(addr);
+        insns.push_back(bap::insn());
+        int p = insns.size() - 1;
+        insns[p].code = opcode;
+        insns[p].name = opcodes.intern(opcode);
+        insns[p].loc.off = loader.offset(addr);
         if (outvar != nullptr) {
-            insn.ops.push_back(operand(*outvar));
+            insns[p].ops.push_back(operand(*outvar));
         }
-
         for (int i = 0; i < number_of_inputs; i++) {
-            insn.ops.push_back(operand(invars[i]));
+            insns[p].ops.push_back(operand(invars[i]));
         }
     }
 
+    void reset() {
+        insns.clear();
+    }
+
     bap::insn result(int len) {
-        insn.loc.len = len;
-        return insn;
+        if (insns.size() == 0) {
+            return bap::insn();
+        } else if (insns.size() == 1) {
+            insns[0].loc.len = len;
+            return insns[0];
+        } else {
+            bap::insn insn;
+            insn.code = CORE_SEQ;
+            insn.name = opcodes.intern(CORE_SEQ);
+            for (int i = 0; i < insns.size(); i++) {
+                bap::operand op;
+                op.type = bap_disasm_op_insn;
+                op.sub_val = &insns[i];
+                insns[i].loc.len = len;
+                insn.ops.push_back(op);
+            }
+            insn.loc.off = insns[0].loc.off;
+            insn.loc.len = len;
+            return insn;
+        }
     }
 
 private:
@@ -200,13 +235,18 @@ class Disassembler : public bap::disassembler_interface {
     OpcodesTable opcodes;
     RegistersTable regs;
     bap::insn current;
+    InstructionBuilder builder;
 
 public:
     explicit Disassembler(const std::string &slafile)
-        : translator(&loader, &context), current() {
+        : translator(&loader, &context)
+        , current()
+        , builder(loader, regs, opcodes) {
         Document *doc = specification.openDocument(slafile);
         specification.registerTag(doc->getRoot());
         translator.initialize(specification);
+        context.setVariableDefault("addrsize", 1);
+        context.setVariableDefault("opsize", 1);
         regs.populate_registers(translator);
     }
 
@@ -224,8 +264,8 @@ public:
 
     virtual void step(uint64_t pc) {
         current = {};
+        builder.reset();
         if (loader.is_mapped(pc)) {
-            InstructionBuilder builder(loader, regs, opcodes);
             Address addr(translator.getDefaultCodeSpace(), pc);
             int length = translator.oneInstruction(builder, addr);
             current = builder.result(length);

--- a/lib/bap_ghidra/ghidra_disasm.cpp
+++ b/lib/bap_ghidra/ghidra_disasm.cpp
@@ -483,9 +483,6 @@ public:
 
     bap::result<bap::disassembler_interface>
     create(const char *triple, const char *cpu, int debug_level) {
-
-        debug_level = 1;
-
         bap::result<bap::disassembler_interface> r;
 
         auto it = languages.find(triple);

--- a/lib/bap_ghidra/ghidra_disasm.cpp
+++ b/lib/bap_ghidra/ghidra_disasm.cpp
@@ -126,7 +126,7 @@ public:
     }
 
     bap::reg create_reg(const VarnodeData &node) const{
-        bap::reg reg;
+        bap::reg reg = {};
         if (node.space->getType() == IPTR_INTERNAL) {
             reg.code = node.offset;
             reg.name = -1;
@@ -135,9 +135,6 @@ public:
             if (pos != offsets.end()) {
                 reg.code = pos->second;
                 reg.name = pos->second;
-            } else {
-                reg.code = 0;
-                reg.name = 0;
             }
         }
         return reg;

--- a/lib/bap_ghidra/ghidra_disasm.cpp
+++ b/lib/bap_ghidra/ghidra_disasm.cpp
@@ -367,6 +367,7 @@ public:
         load_document(paths, language.getProcessorSpec());
         load_document(paths, language.getSlaFile());
         translator.initialize(specification);
+        initialize_processor(err);
         opcodes.populate_opcodes(translator);
         regs.populate_registers(translator);
     }
@@ -421,6 +422,18 @@ private:
         std::string path;
         paths.findFile(path, name);
         specification.registerTag(specification.openDocument(path)->getRoot());
+    }
+
+    void initialize_processor(std::ostream &err) {
+        if (const Element *spec = specification.getTag("processor_spec")) {
+            for (auto elt : spec->getChildren()) {
+                if (elt->getName() == "context_data") {
+                    context.restoreFromSpec(elt, &translator);
+                }
+            }
+        } else {
+            err << "Warning: no processor specification was found\n";
+        }
     }
 };
 

--- a/lib/bap_ghidra/ghidra_disasm.cpp
+++ b/lib/bap_ghidra/ghidra_disasm.cpp
@@ -404,13 +404,17 @@ public:
     virtual void step(uint64_t pc) {
         current = {};
         builder.reset();
-        if (loader.is_mapped(pc)) {
-            Address addr(translator.getDefaultCodeSpace(), pc);
-            int length = translator.oneInstruction(builder, addr);
-            current = builder.result(length);
-            if (!loader.is_mapped(pc + current.loc.len - 1)) {
-                current = {};
+        try {
+            if (loader.is_mapped(pc)) {
+                Address addr(translator.getDefaultCodeSpace(), pc);
+                int length = translator.oneInstruction(builder, addr);
+                current = builder.result(length);
+                if (!loader.is_mapped(pc + current.loc.len - 1)) {
+                    current = {};
+                }
             }
+        } catch (LowlevelError &err) {
+            current = {};
         }
     }
 

--- a/lib/bap_ghidra/ghidra_disasm.cpp
+++ b/lib/bap_ghidra/ghidra_disasm.cpp
@@ -1,0 +1,303 @@
+#include "ghidra_disasm.hpp"
+
+#include <ghidra/loadimage.hh>
+#include <ghidra/sleigh.hh>
+#include <ghidra/emulate.hh>
+
+#include <iostream>
+
+// These are the bytes for an example x86 binary
+// These bytes are loaded at address 0x80483b4
+static uint1 myprog[] = {
+  0x8d, 0x4c, 0x24, 0x04, 0x83, 0xe4, 0xf0, 0xff, 0x71, 0xfc, 0x55,
+  0x89, 0xe5, 0x51, 0x81, 0xec, 0xb4, 0x01, 0x00, 0x00, 0xc7, 0x45, 0xf4,
+  0x00, 0x00, 0x00, 0x00, 0xeb, 0x12, 0x8b, 0x45, 0xf4, 0xc7, 0x84,
+  0x85, 0x64, 0xfe, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x83, 0x45, 0xf4,
+  0x01, 0x83, 0x7d, 0xf4, 0x63, 0x7e, 0xe8, 0xc7, 0x45, 0xf4, 0x02,
+  0x00, 0x00, 0x00, 0xeb, 0x28, 0x8b, 0x45, 0xf4, 0x01, 0xc0, 0x89, 0x45,
+  0xf8, 0xeb, 0x14, 0x8b, 0x45, 0xf8, 0xc7, 0x84, 0x85, 0x64, 0xfe,
+  0xff, 0xff, 0x01, 0x00, 0x00, 0x00, 0x8b, 0x45, 0xf4, 0x01, 0x45, 0xf8,
+  0x83, 0x7d, 0xf8, 0x63, 0x7e, 0xe6, 0x83, 0x45, 0xf4, 0x01, 0x83,
+  0x7d, 0xf4, 0x31, 0x7e, 0xd2, 0xc7, 0x04, 0x24, 0x40, 0x85, 0x04, 0x08,
+  0xe8, 0x9c, 0xfe, 0xff, 0xff, 0xc7, 0x45, 0xf4, 0x02, 0x00, 0x00,
+  0x00, 0xeb, 0x25, 0x8b, 0x45, 0xf4, 0x8b, 0x84, 0x85, 0x64, 0xfe, 0xff,
+  0xff, 0x85, 0xc0, 0x75, 0x13, 0x8b, 0x45, 0xf4, 0x89, 0x44, 0x24,
+  0x04, 0xc7, 0x04, 0x24, 0x47, 0x85, 0x04, 0x08, 0xe8, 0x62, 0xfe, 0xff,
+  0xff, 0x83, 0x45, 0xf4, 0x01, 0x83, 0x7d, 0xf4, 0x63, 0x7e, 0xd5,
+  0x81, 0xc4, 0xb4, 0x01, 0x00, 0x00, 0x59, 0x5d, 0x8d, 0x61, 0xfc, 0xc3,
+  0x90, 0x90, 0x90, 0x90, 0x55, 0x89, 0xe5, 0x5d, 0xc3, 0x8d, 0x74,
+  0x26, 0x00, 0x8d, 0xbc, 0x27, 0x00, 0x00, 0x00, 0x00, 0x55, 0x89, 0xe5,
+  0x57, 0x56, 0x53, 0xe8, 0x5e, 0x00, 0x00, 0x00, 0x81, 0xc3, 0xa5,
+  0x11, 0x00, 0x00, 0x83, 0xec, 0x1c, 0xe8, 0xd7, 0xfd, 0xff, 0xff, 0x8d,
+  0x83, 0x20, 0xff, 0xff, 0xff, 0x89, 0x45, 0xf0, 0x8d, 0x83, 0x20,
+  0xff, 0xff, 0xff, 0x29, 0x45, 0xf0, 0xc1, 0x7d, 0xf0, 0x02, 0x8b, 0x55,
+  0xf0, 0x85, 0xd2, 0x74, 0x2b, 0x31, 0xff, 0x89, 0xc6, 0x8d, 0xb6,
+  0x00, 0x00, 0x00, 0x00, 0x8b, 0x45, 0x10, 0x83, 0xc7, 0x01, 0x89, 0x44,
+  0x24, 0x08, 0x8b, 0x45, 0x0c, 0x89, 0x44, 0x24, 0x04, 0x8b, 0x45,
+  0x08, 0x89, 0x04, 0x24, 0xff, 0x16, 0x83, 0xc6, 0x04, 0x39, 0x7d, 0xf0,
+  0x75, 0xdf, 0x83, 0xc4, 0x1c, 0x5b, 0x5e, 0x5f, 0x5d, 0xc3, 0x8b,
+  0x1c, 0x24, 0xc3, 0x90, 0x90, 0x90, 0x55, 0x89, 0xe5, 0x53, 0xbb, 0x50,
+  0x95, 0x04, 0x08, 0x83, 0xec, 0x04, 0xa1, 0x50, 0x95, 0x04, 0x08,
+  0x83, 0xf8, 0xff, 0x74, 0x0c, 0x83, 0xeb, 0x04, 0xff, 0xd0, 0x8b, 0x03,
+  0x83, 0xf8, 0xff, 0x75, 0xf4, 0x83, 0xc4, 0x04, 0x5b, 0x5d, 0xc3,
+  0x55, 0x89, 0xe5, 0x53, 0x83, 0xec, 0x04, 0xe8, 0x00, 0x00, 0x00, 0x00,
+  0x5b, 0x81, 0xc3, 0x0c, 0x11, 0x00, 0x00, 0xe8, 0x00, 0xfe, 0xff,
+  0xff, 0x59, 0x5b, 0xc9, 0xc3, 0x03, 0x00, 0x00, 0x00, 0x01, 0x00, 0x02,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x50, 0x72, 0x69, 0x6d, 0x65, 0x73,
+  0x00, 0x25, 0x64, 0x0a, 0x00, 0x00
+};  // Size of 408 bytes
+
+// This is a tiny LoadImage class which feeds the executable bytes to the translator
+class MyLoadImage : public LoadImage {
+  uintb baseaddr;
+  int4 length;
+  uint1 *data;
+public:
+  MyLoadImage(uintb ad,uint1 *ptr,int4 sz) : LoadImage("nofile") { baseaddr = ad; data = ptr; length = sz; }
+  virtual void loadFill(uint1 *ptr,int4 size,const Address &addr);
+  virtual string getArchType(void) const { return "myload"; }
+  virtual void adjustVma(long adjust) { }
+};
+
+// This is the only important method for the LoadImage. It returns bytes from the static array
+// depending on the address range requested
+void MyLoadImage::loadFill(uint1 *ptr,int4 size,const Address &addr)
+
+{
+  uintb start = addr.getOffset();
+  uintb max = baseaddr + (length-1);
+  for(int4 i=0;i<size;++i) {	// For every byte requestes
+    uintb curoff = start + i; // Calculate offset of byte
+    if ((curoff < baseaddr)||(curoff>max)) {	// If byte does not fall in window
+      ptr[i] = 0;		// return 0
+      continue;
+    }
+    uintb diff = curoff - baseaddr;
+    ptr[i] = data[(int4)diff];	// Otherwise return data from our window
+  }
+}
+
+// -------------------------------
+//
+// These are the classes/routines relevant to doing disassembly
+
+// Here is a simple class for emitting assembly.  In this case, we send the strings straight
+// to standard out.
+class AssemblyRaw : public AssemblyEmit {
+public:
+  virtual void dump(const Address &addr,const string &mnem,const string &body) {
+    addr.printRaw(cout);
+    cout << ": " << mnem << ' ' << body << endl;
+  }
+};
+
+static void dumpAssembly(Translate &trans)
+
+{ // Print disassembly of binary code
+  AssemblyRaw assememit;	// Set up the disassembly dumper
+  int4 length;			// Number of bytes of each machine instruction
+
+  Address addr(trans.getDefaultCodeSpace(),0x80483b4); // First disassembly address
+  Address lastaddr(trans.getDefaultCodeSpace(),0x804846c); // Last disassembly address
+
+  while(addr < lastaddr) {
+    length = trans.printAssembly(assememit,addr);
+    addr = addr + length;
+  }
+}
+
+// -------------------------------
+//
+// These are the classes/routines relevant to printing a pcode translation
+
+// Here is a simple class for emitting pcode. We simply dump an appropriate string representation
+// straight to standard out.
+class PcodeRawOut : public PcodeEmit {
+public:
+  virtual void dump(const Address &addr,OpCode opc,VarnodeData *outvar,VarnodeData *vars,int4 isize);
+};
+
+static void print_vardata(ostream &s,VarnodeData &data)
+
+{
+  s << '(' << data.space->getName() << ',';
+  data.space->printOffset(s,data.offset);
+  s << ',' << dec << data.size << ')';
+}
+
+void PcodeRawOut::dump(const Address &addr,OpCode opc,VarnodeData *outvar,VarnodeData *vars,int4 isize)
+
+{
+  if (outvar != (VarnodeData *)0) {
+    print_vardata(cout,*outvar);
+    cout << " = ";
+  }
+  cout << get_opname(opc);
+  // Possibly check for a code reference or a space reference
+  for(int4 i=0;i<isize;++i) {
+    cout << ' ';
+    print_vardata(cout,vars[i]);
+  }
+  cout << endl;
+}
+
+static void dumpPcode(Translate &trans)
+
+{ // Dump pcode translation of machine instructions
+  PcodeRawOut emit;		// Set up the pcode dumper
+  AssemblyRaw assememit;	// Set up the disassembly dumper
+  int4 length;			// Number of bytes of each machine instruction
+
+  Address addr(trans.getDefaultCodeSpace(),0x80483b4); // First address to translate
+  Address lastaddr(trans.getDefaultCodeSpace(),0x80483bf); // Last address
+
+  while(addr < lastaddr) {
+    cout << "--- ";
+    trans.printAssembly(assememit,addr);
+    length = trans.oneInstruction(emit,addr); // Translate instruction
+    addr = addr + length;		// Advance to next instruction
+  }
+}
+
+// -------------------------------------
+//
+// These are the classes/routines relevant for emulating the executable
+
+// A simple class for emulating the system "puts" call.
+// It justs looks up the string data and dumps it to standard out.
+class PutsCallBack : public BreakCallBack {
+public:
+  virtual bool addressCallback(const Address &addr);
+};
+
+bool PutsCallBack::addressCallback(const Address &addr)
+
+{
+  MemoryState *mem = static_cast<EmulateMemory *>(emulate)->getMemoryState();
+  uint1 buffer[256];
+  uint4 esp = mem->getValue("ESP");
+  AddrSpace *ram = mem->getTranslate()->getSpaceByName("ram");
+
+  uint4 param1 = mem->getValue(ram,esp+4,4);
+  mem->getChunk(buffer,ram,param1,255);
+
+  cout << (char *)&buffer << endl;
+
+  uint4 returnaddr = mem->getValue(ram,esp,4);
+  mem->setValue("ESP",esp+8);
+  emulate->setExecuteAddress(Address(ram,returnaddr));
+
+  return true;			// This replaces the indicated instruction
+}
+
+// A simple class for emulating the system "printf" call.
+// We don't really emulate all of it.  The only printf call in the example
+// has an initial string of "%d\n". So we grab the second parameter from the
+// memory state and print it as an integer
+class PrintfCallBack : public BreakCallBack {
+public:
+  virtual bool addressCallback(const Address &addr);
+};
+
+bool PrintfCallBack::addressCallback(const Address &addr)
+
+{
+  MemoryState *mem = static_cast<EmulateMemory *>(emulate)->getMemoryState();
+
+  AddrSpace *ram = mem->getTranslate()->getSpaceByName("ram");
+
+  uint4 esp = mem->getValue("ESP");
+  uint4 param2 = mem->getValue(ram,esp+8,4);
+  cout << (int4)param2 << endl;
+
+  uint4 returnaddr = mem->getValue(ram,esp,4);
+  mem->setValue("ESP",esp+12);
+  emulate->setExecuteAddress(Address(ram,returnaddr));
+
+  return true;
+}
+
+// A callback that terminates the emulation
+class TerminateCallBack : public BreakCallBack {
+public:
+  virtual bool addressCallback(const Address &addr);
+};
+
+bool TerminateCallBack::addressCallback(const Address &addr)
+
+{
+  emulate->setHalt(true);
+
+  return true;
+}
+
+static void doEmulation(Translate &trans,LoadImage &loader)
+
+{
+  // Set up memory state object
+  MemoryImage loadmemory(trans.getDefaultCodeSpace(),8,4096,&loader);
+  MemoryPageOverlay ramstate(trans.getDefaultCodeSpace(),8,4096,&loadmemory);
+  MemoryHashOverlay registerstate(trans.getSpaceByName("register"),8,4096,4096,(MemoryBank *)0);
+  MemoryHashOverlay tmpstate(trans.getUniqueSpace(),8,4096,4096,(MemoryBank *)0);
+
+  MemoryState memstate(&trans);	// Instantiate the memory state object
+  memstate.setMemoryBank(&ramstate);
+  memstate.setMemoryBank(&registerstate);
+  memstate.setMemoryBank(&tmpstate);
+
+  BreakTableCallBack breaktable(&trans); // Set up the callback object
+  EmulatePcodeCache emulater(&trans,&memstate,&breaktable); // Set up the emulator
+
+  // Set up the initial register state for execution
+  memstate.setValue("ESP",0xbffffffc);
+  emulater.setExecuteAddress(Address(trans.getDefaultCodeSpace(),0x80483b4));
+
+  // Register callbacks
+  PutsCallBack putscallback;
+  PrintfCallBack printfcallback;
+  TerminateCallBack terminatecallback;
+  breaktable.registerAddressCallback(Address(trans.getDefaultCodeSpace(),0x80482c8),&putscallback);
+  breaktable.registerAddressCallback(Address(trans.getDefaultCodeSpace(),0x80482b8),&printfcallback);
+  breaktable.registerAddressCallback(Address(trans.getDefaultCodeSpace(),0x804846b),&terminatecallback);
+
+  emulater.setHalt(false);
+
+  do {
+    emulater.executeInstruction();
+  } while(!emulater.getHalt());
+}
+
+static void test() {
+  // Set up the loadimage
+  MyLoadImage loader(0x80483b4,myprog,408);
+  //  loader->open();
+  //    loader->adjustVma(adjustvma);
+
+  // Set up the context object
+  ContextInternal context;
+
+  // Set up the assembler/pcode-translator
+  string sleighfilename = "/usr/share/ghidra/Ghidra/Processors/x86/data/languages/x86.sla";
+  Sleigh trans(&loader,&context);
+
+  // Read sleigh file into DOM
+  DocumentStorage docstorage;
+  Element *sleighroot = docstorage.openDocument(sleighfilename)->getRoot();
+  docstorage.registerTag(sleighroot);
+  trans.initialize(docstorage); // Initialize the translator
+
+  // Now that context symbol names are loaded by the translator
+  // we can set the default context
+
+  context.setVariableDefault("addrsize",1); // Address size is 32-bit
+  context.setVariableDefault("opsize",1); // Operand size is 32-bit
+
+  // dumpAssembly(trans);
+  // dumpPcode(trans);
+  // doEmulation(trans,loader);
+}
+
+int disasm_ghidra_init () {
+    test();
+    return 0;
+}

--- a/lib/bap_ghidra/ghidra_disasm.cpp
+++ b/lib/bap_ghidra/ghidra_disasm.cpp
@@ -77,7 +77,7 @@ public:
         for (int i = 0; i < CPUI_MAX; i++) {
             OpCode op = static_cast<OpCode>(i);
             cpui_offsets[op] = ss.tellp();
-            ss << get_opname(op) << '\000';
+            ss << "pcode:" << get_opname(op) << '\000';
         }
         core_offsets[CORE_SEQ] = ss.tellp();
         ss << "core:seq" << '\000';

--- a/lib/bap_ghidra/ghidra_disasm.h
+++ b/lib/bap_ghidra/ghidra_disasm.h
@@ -2,7 +2,7 @@
 extern "C" {
 #endif
 
-    int disasm_ghidra_init();
+    int disasm_ghidra_init(const char *paths, int print_targets);
 
 #ifdef __cplusplus
 }

--- a/lib/bap_ghidra/ghidra_disasm.h
+++ b/lib/bap_ghidra/ghidra_disasm.h
@@ -1,0 +1,9 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    int disasm_ghidra_init();
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/bap_ghidra/ghidra_disasm.hpp
+++ b/lib/bap_ghidra/ghidra_disasm.hpp
@@ -1,0 +1,1 @@
+#include "ghidra_disasm.h"

--- a/lib/bap_ghidra/ghidra_stubs.c
+++ b/lib/bap_ghidra/ghidra_stubs.c
@@ -1,7 +1,15 @@
 #include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+
+#include <string.h>
 
 #include "ghidra_disasm.h"
 
-value disasm_ghidra_init_stub(value unit) {
-    return Val_int(disasm_ghidra_init());
+value disasm_ghidra_init_stub(value paths, value print_targets) {
+    CAMLparam2(paths, print_targets);
+    char *s = strdup(String_val(paths));
+    int r = Val_int(disasm_ghidra_init(s, Bool_val(print_targets)));
+    free(s);
+    CAMLreturn(r);
 }

--- a/lib/bap_ghidra/ghidra_stubs.c
+++ b/lib/bap_ghidra/ghidra_stubs.c
@@ -1,0 +1,7 @@
+#include <caml/mlvalues.h>
+
+#include "ghidra_disasm.h"
+
+value disasm_ghidra_init_stub(value unit) {
+    return Val_int(disasm_ghidra_init());
+}

--- a/lib/bap_mips/bap_mips_target.mli
+++ b/lib/bap_mips/bap_mips_target.mli
@@ -37,4 +37,4 @@ val llvm_mips64 : Theory.language
     This includes parsing the loader output and enabling backward
     compatibility with the old [Arch.t] representation.
 *)
-val load : unit -> unit
+val load : ?backend:string -> unit -> unit

--- a/lib/bap_powerpc/bap_powerpc_target.mli
+++ b/lib/bap_powerpc/bap_powerpc_target.mli
@@ -36,4 +36,4 @@ val llvm_powerpc64 : Theory.language
     This includes parsing the loader output and enabling backward
     compatibility with the old [Arch.t] representation.
 *)
-val load : unit -> unit
+val load : ?backend:string -> unit -> unit

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -3987,8 +3987,9 @@ text ::= ?any atom that is not recognized as a <word>?
         val declare :
           ?types:Type.signature ->
           ?docs:string ->
-          ?package:string -> string -> unit
-
+          ?package:string ->
+          ?body:(Theory.Target.t -> (Theory.Label.t -> Theory.Value.Top.t list -> unit Theory.eff) KB.t) ->
+          string -> unit
 
         (** [documentation unit] documentation for [unit]'s lisp source.
 

--- a/lib/bap_primus/bap_primus_lisp.ml
+++ b/lib/bap_primus/bap_primus_lisp.ml
@@ -264,9 +264,8 @@ module Interpreter(Machine : Machine) = struct
 
   let lookup_parameter prog {data={exp=name}} =
     Lisp.Program.in_package (KB.Name.package name) prog @@ fun prog ->
-    Lisp.Program.get prog para |>
-    List.find ~f:(fun p ->
-        String.equal (Lisp.Def.name p) (KB.Name.unqualified name))
+    Lisp.Program.get ~name:(KB.Name.unqualified name) prog para |>
+    List.hd
 
 
   (* Still an open question. Shall we register an call to an external

--- a/lib/bap_primus/bap_primus_lisp.mli
+++ b/lib/bap_primus/bap_primus_lisp.mli
@@ -151,9 +151,14 @@ module Semantics : sig
   val symbol : (Theory.Value.cls, String.t option) KB.slot
   val static : (Theory.Value.cls, Bitvec.t option) KB.slot
   val enable : ?stdout:Format.formatter -> unit -> unit
+
   val declare :
     ?types:Type.signature ->
-    ?docs:string -> ?package:string -> string -> unit
+    ?docs:string ->
+    ?package:string ->
+    ?body:(Theory.Target.t -> (Theory.Label.t -> Theory.Value.Top.t list -> unit Theory.eff) KB.t) ->
+    string -> unit
+
 
   val documentation : Theory.Unit.t -> Doc.index KB.t
 end

--- a/lib/bap_primus/bap_primus_lisp_attribute.mli
+++ b/lib/bap_primus/bap_primus_lisp_attribute.mli
@@ -11,7 +11,8 @@ open Bap_primus_lisp_types
 open Bap_core_theory
 
 type 'a t
-type set
+type cls
+type set = (cls, unit) KB.cls KB.value
 
 type error = ..
 exception Unknown_attr of string * tree

--- a/lib/bap_primus/bap_primus_lisp_program.mli
+++ b/lib/bap_primus/bap_primus_lisp_program.mli
@@ -15,7 +15,7 @@ val is_empty : t -> bool
 val equal : t -> t -> bool
 val merge : t -> t -> t
 val add : t -> 'a item -> 'a Def.t -> t
-val get : t -> 'a item -> 'a Def.t list
+val get : ?name:string -> t -> 'a item -> 'a Def.t list
 val fold : t -> 'a item -> init:'s ->
   f:(package:string -> 'a Def.t -> 's -> 's) -> 's
 val context : t -> Context.t

--- a/lib/bap_primus/bap_primus_lisp_resolve.ml
+++ b/lib/bap_primus/bap_primus_lisp_resolve.ml
@@ -151,7 +151,7 @@ let run choose namespace overload prog item name =
   Program.in_package (KB.Name.package name) prog @@ fun prog ->
   let name = KB.Name.unqualified name in
   let ctxts = Program.context prog in
-  let defs = Program.get prog item in
+  let defs = Program.get ~name prog item in
   let s1 = stage1 namespace defs name in
   let s2 = stage2 ctxts s1 in
   let s3 = stage3 s2 in

--- a/lib/bap_primus/bap_primus_lisp_semantics.ml
+++ b/lib/bap_primus/bap_primus_lisp_semantics.ml
@@ -326,7 +326,8 @@ module Scope = struct
 end
 
 module Prelude(CT : Theory.Core) = struct
-  let label = Meta.lift (KB.Object.create Theory.Program.cls)
+  let null = KB.Object.null Theory.Program.cls
+  let fresh = Meta.lift (KB.Object.create Theory.Program.cls)
 
   let rec seq = function
     | [] -> Meta.lift@@CT.perform Theory.Effect.Sort.bot
@@ -358,14 +359,12 @@ module Prelude(CT : Theory.Core) = struct
     create eff res
 
   let data xs =
-    label >>= fun lbl ->
     let* data = seq xs in
-    Meta.lift@@CT.blk lbl !data skip
+    Meta.lift@@CT.blk null !data skip
 
   let ctrl xs =
-    label >>= fun lbl ->
     let* ctrl = seq xs in
-    Meta.lift@@CT.blk lbl pass !ctrl
+    Meta.lift@@CT.blk null pass !ctrl
 
   let blk lbl xs = seq [
       Meta.lift@@CT.blk lbl pass skip;
@@ -472,7 +471,7 @@ module Prelude(CT : Theory.Core) = struct
           rep cnd body
       | None ->
         let* body = eval body in
-        let* head = label and* loop = label and* tail = label in
+        let* head = fresh and* loop = fresh and* tail = fresh in
         coerce_bool (res r) @@ fun cres ->
         full [
           blk head [ctrl [Meta.lift@@CT.goto tail]];

--- a/lib/bap_primus/bap_primus_lisp_semantics.mli
+++ b/lib/bap_primus/bap_primus_lisp_semantics.mli
@@ -21,7 +21,9 @@ val declare :
   ?types:(Theory.Target.t -> Bap_primus_lisp_type.signature) ->
   ?docs:string ->
   ?package:string ->
-  string -> unit
+  ?body:(Theory.Target.t -> (Theory.Label.t -> Theory.Value.Top.t list -> unit Theory.eff) KB.t) ->
+  string ->
+  unit
 
 module Unit : sig
   val create : ?name:string -> Theory.Target.t -> Theory.Unit.t KB.t

--- a/lib/bap_types/bap_stmt.ml
+++ b/lib/bap_types/bap_stmt.ml
@@ -36,6 +36,16 @@ module Special = struct
       ~decode:ident
       ~package:"bap"
 
+  let label = Attribute.declare "label"
+      ~package:"bap"
+      ~encode:ident
+      ~decode:ident
+
+  let goto = Attribute.declare "goto"
+      ~package:"bap"
+      ~encode:ident
+      ~decode:ident
+
   let prefix = "@attribute:"
 
 
@@ -125,6 +135,8 @@ module Stmt = struct
     | _ -> None
   let call = Special.call
   let intrinsic = Special.intrinsic
+  let goto = Special.goto
+  let label = Special.label
 end
 
 module Infix = struct

--- a/lib/bap_types/bap_stmt.mli
+++ b/lib/bap_types/bap_stmt.mli
@@ -20,7 +20,6 @@ module Attribute : sig
     'a t
 end
 
-
 module Stmt : sig
   val move : var -> exp -> stmt
   val jmp : exp -> stmt
@@ -30,6 +29,8 @@ module Stmt : sig
   val cpuexn : int -> stmt
   val call : string Attribute.t
   val intrinsic : string Attribute.t
+  val goto : string Attribute.t
+  val label : string Attribute.t
   val encode : 'a Attribute.t -> 'a -> stmt
   val decode : 'a Attribute.t -> stmt -> 'a option
 end

--- a/lib/knowledge/bap_knowledge.mli
+++ b/lib/knowledge/bap_knowledge.mli
@@ -501,6 +501,27 @@ module Knowledge : sig
     *)
     val scoped : ('a,_) cls -> ('a obj -> 'b knowledge) -> 'b knowledge
 
+
+    (** [null cls] is the null object of the class [cls].
+
+        For each class [cls] there is [null] that represents an
+        absence of object. It is unique and is represented as zero.
+
+        Dereference of the null object (e.g., using [collect]) always
+        returns an empty denotation. Any information stored in the
+        object is forgotten (discarded). Promises are never run on the
+        null object, therefore the promise will never receive the null
+        object as its input.
+
+        @since 2.4.0
+    *)
+    val null : ('a,_) cls -> 'a obj
+
+    (** [is_null obj] is [true] iff [obj] is the null object of its class.
+
+        @since 2.4.0 *)
+    val is_null : _ obj -> bool
+
     (** [repr x] returns a textual representation of the object [x] *)
     val repr : ('a,_) cls -> 'a t -> string knowledge
 
@@ -1214,7 +1235,7 @@ module Knowledge : sig
     val bool : bool option domain
 
 
-    (** [obj] is a flat domain with a nil object at the bottom.  *)
+    (** [obj] is a flat domain with a null object at the bottom.  *)
     val obj : ('a,_) cls -> 'a obj domain
 
 

--- a/lib/x86_cpu/x86_target.ml
+++ b/lib/x86_cpu/x86_target.ml
@@ -292,8 +292,8 @@ let llvm_x86_encoding =
 let llvm_x86_64_encoding =
   Theory.Language.declare ~package "llvm-x86_64"
 
-let sleigh =
-  Theory.Language.declare ~package "sla-x86"
+let pcode =
+  Theory.Language.declare ~package "pcode-x86"
 
 let register_x86_llvm_disassembler () =
   Disasm_expert.Basic.register llvm_x86_encoding @@ fun _ ->
@@ -304,7 +304,7 @@ let register_x86_64_llvm_disassembler () =
   Disasm_expert.Basic.create ~backend:"llvm" "x86_64"
 
 let register_sleigh_disassembler () =
-  Disasm_expert.Basic.register sleigh @@ fun target ->
+  Disasm_expert.Basic.register pcode @@ fun target ->
   let target = if Theory.Target.belongs amd64 target
     then "x86:LE:64:default"
     else "x86:LE:32:default" in
@@ -325,7 +325,7 @@ let enable_decoder backend =
       if Theory.Target.belongs parent t
       then llvm_x86_encoding
       else Theory.Language.unknown
-    else sleigh
+    else pcode
   else Theory.Language.unknown
 
 let load ?(backend="llvm") () =

--- a/lib/x86_cpu/x86_target.mli
+++ b/lib/x86_cpu/x86_target.mli
@@ -25,4 +25,4 @@ val amd64 : Theory.Target.t
     This includes parsing the loader output and enabling backward
     compatibility with the old [Arch.t] representation.
 *)
-val load : unit -> unit
+val load : ?backend:string -> unit -> unit

--- a/oasis/ghidra
+++ b/oasis/ghidra
@@ -9,7 +9,7 @@ Library bap_ghidra
   FindlibName:   bap-ghidra
   Modules:       Bap_ghidra
   CCOpt:         -fPIC
-  CCLib:         -L/usr/lib/ghidra -lsla
+  CCLib:         -L/usr/lib/ghidra -ldecomp
   CSources:      ghidra_disasm.h,
                  ghidra_disasm.c,
                  ghidra_stubs.c

--- a/oasis/ghidra
+++ b/oasis/ghidra
@@ -1,0 +1,24 @@
+Flag ghidra
+ Description: Build with the ghidra backend
+ Default: false
+
+Library bap_ghidra
+  Path:          lib/bap_ghidra
+  Build$:        flag(everything) || flag(ghidra)
+  BuildDepends:  bap, core_kernel, ppx_bap, mmap
+  FindlibName:   bap-ghidra
+  Modules:       Bap_ghidra
+  CCOpt:         -fPIC
+  CCLib:         -L/usr/lib/ghidra -lsla
+  CSources:      ghidra_disasm.h,
+                 ghidra_disasm.c,
+                 ghidra_stubs.c
+
+Library ghidra_plugin
+  XMETADescription: provide loader and disassembler using GHIDRA library
+  Path:            plugins/ghidra
+  Build$:          flag(everything) || flag(ghidra)
+  FindlibName:     bap-plugin-ghidra
+  InternalModules: Ghidra_main
+  BuildDepends:    bap, bap-ghidra, bap-main, core_kernel
+  XMETAExtraLines: tags="disassembler, ghidra, p-code, lifter, semantics"

--- a/oasis/ghidra
+++ b/oasis/ghidra
@@ -21,4 +21,5 @@ Library ghidra_plugin
   FindlibName:     bap-plugin-ghidra
   InternalModules: Ghidra_main
   BuildDepends:    bap, bap-ghidra, bap-main, core_kernel
+  DataFiles:        semantics/*.lisp ($datadir/bap/primus/semantics)
   XMETAExtraLines: tags="disassembler, ghidra, p-code, lifter, semantics"

--- a/opam/opam
+++ b/opam/opam
@@ -52,6 +52,7 @@ build: [
     "--with-llvm-config=%{conf-bap-llvm:config}%" {conf-bap-llvm:installed}
     "--mandir=%{man}%"
     "--enable-everything"
+    "--disable-ghidra"
     "--enable-tests" {with-test}
     "--%{conf-ida:enable}%-ida"
     "--ida-path=%{conf-ida:path}%" {conf-ida:installed}

--- a/plugins/arm/arm_main.ml
+++ b/plugins/arm/arm_main.ml
@@ -16,6 +16,12 @@ let interworking =
     ~doc:"Enable ARM/Thumb interworking. Defaults to (auto),
           i.e., to the automatic detection of interworking"
 
+let backend =
+  let open Extension in
+  Configuration.parameter Type.(some string) "backend"
+    ~doc:"Specify the backend that is used for disassembly and
+  lifting."
+
 type arms = [
   | Arch.arm
   | Arch.armeb
@@ -23,7 +29,8 @@ type arms = [
 
 let () = Bap_main.Extension.declare ~doc @@ fun ctxt ->
   let interworking = ctxt-->interworking in
-  Arm_target.load ?interworking ();
+  let backend = ctxt-->backend in
+  Arm_target.load ?backend ?interworking ();
   List.iter all_of_arms ~f:(fun arch ->
       register_target (arch :> arch) (module ARM);
       Arm_gnueabi.setup ());

--- a/plugins/bil/bil_ir.ml
+++ b/plugins/bil/bil_ir.ml
@@ -70,7 +70,7 @@ end
 
 
 let pp_cfg ppf ir =
-  fprintf ppf "%a" (pp_print_list Blk.pp) (BIR.reify ir)
+  fprintf ppf "@[<v>%a@]" (pp_print_list Blk.pp) (BIR.reify ir)
 
 let inspect cfg = Sexp.Atom (asprintf "%a" pp_cfg cfg)
 

--- a/plugins/bil/bil_lifter.ml
+++ b/plugins/bil/bil_lifter.ml
@@ -22,15 +22,12 @@ let provide_bir () =
            require Bil_ir.slot |>
            provide Theory.Semantics.slot |>
            comment "reifies IR");
-  let reify sema =
-    match Bil_ir.reify @@ KB.Value.get Bil_ir.slot sema with
-    | [] -> Insn.empty
-    | bir -> KB.Value.put Term.slot sema bir in
   KB.promise Theory.Semantics.slot @@ fun obj ->
   KB.collect Theory.Semantics.slot obj >>| fun sema ->
-  let sema = reify sema in
-  let subs = Array.map ~f:reify (KB.Value.get Insn.Slot.subs sema) in
-  KB.Value.put Insn.Slot.subs sema subs
+  match Bil_ir.reify @@ KB.Value.get Bil_ir.slot sema with
+  | [] -> Insn.empty
+  | bir -> KB.Value.put Term.slot sema bir
+
 
 module Relocations = struct
 
@@ -321,7 +318,6 @@ let provide_basic () =
   KB.collect Disasm_expert.Basic.Insn.slot obj >>= function
   | None -> !!Theory.Semantics.empty
   | Some insn ->
-    KB.Object.repr Theory.Program.cls obj >>= fun lbl ->
     KB.collect Bil.code obj >>| function
     | [] -> Theory.Semantics.empty
     | bil -> Insn.of_basic ~bil insn

--- a/plugins/bil/bil_lifter.ml
+++ b/plugins/bil/bil_lifter.ml
@@ -22,12 +22,15 @@ let provide_bir () =
            require Bil_ir.slot |>
            provide Theory.Semantics.slot |>
            comment "reifies IR");
+  let reify sema =
+    match Bil_ir.reify @@ KB.Value.get Bil_ir.slot sema with
+    | [] -> Insn.empty
+    | bir -> KB.Value.put Term.slot sema bir in
   KB.promise Theory.Semantics.slot @@ fun obj ->
   KB.collect Theory.Semantics.slot obj >>| fun sema ->
-  match Bil_ir.reify @@  KB.Value.get Bil_ir.slot sema with
-  | [] -> Insn.empty
-  | bir -> KB.Value.put Term.slot sema bir
-
+  let sema = reify sema in
+  let subs = Array.map ~f:reify (KB.Value.get Insn.Slot.subs sema) in
+  KB.Value.put Insn.Slot.subs sema subs
 
 module Relocations = struct
 

--- a/plugins/ghidra/.merlin
+++ b/plugins/ghidra/.merlin
@@ -1,0 +1,2 @@
+REC
+B ../../lib/bap_ghidra

--- a/plugins/ghidra/ghidra_main.ml
+++ b/plugins/ghidra/ghidra_main.ml
@@ -1,0 +1,6 @@
+open Bap_main
+
+
+let () = Bap_main.Extension.declare @@ fun _ctxt ->
+  Bap_ghidra.init ();
+  Ok ()

--- a/plugins/ghidra/ghidra_main.ml
+++ b/plugins/ghidra/ghidra_main.ml
@@ -1,6 +1,25 @@
+open Core_kernel
 open Bap_main
 
+let default_paths =
+  let (/) = Filename.concat in
+  Extension.Configuration.[
+    datadir / "ghidra";
+    sysdatadir / "ghidra";
+    "/usr/share/ghidra";
+  ]
 
-let () = Bap_main.Extension.declare @@ fun _ctxt ->
-  Bap_ghidra.init ();
-  Ok ()
+let show_targets = Extension.Configuration.flag "list-targets"
+    ~aliases:["targets"]
+
+let paths = Extension.Configuration.parameters
+    Extension.Type.(list string) "path"
+
+let () = Extension.declare @@ fun ctxt ->
+  let open Extension.Syntax in
+  Bap_ghidra.init ()
+    ~paths:(List.concat (ctxt-->paths) @ default_paths)
+    ~print_targets:(ctxt-->show_targets);
+  if (ctxt-->show_targets)
+  then Error (Extension.Error.Exit_requested 0)
+  else Ok ()

--- a/plugins/ghidra/ghidra_main.mli
+++ b/plugins/ghidra/ghidra_main.mli
@@ -1,0 +1,1 @@
+(* a private module *)

--- a/plugins/ghidra/semantics/pcode.lisp
+++ b/plugins/ghidra/semantics/pcode.lisp
@@ -68,14 +68,14 @@
 (defun INT_LESS (tr r tx x ty y)
   (set# tr r (get# < tx x ty y)))
 
-;; (defun INT_SLESS (tr r tx x ty y)
-;;   (set# r (s< x y)))
+(defun INT_SLESS (tr r tx x ty y)
+  (set# tr r (get# s< tx x ty y)))
 
 (defun INT_LESSEQUAL (tr r tx x ty y)
-  (set# tr r (<= x y)))
+  (set# tr r (get# <= tx x ty y)))
 
-;; (defun INT_SLESSEQUAL (tr r tx x ty y)
-;;   (set# r (s<= x y)))
+(defun INT_SLESSEQUAL (tr r tx x ty y)
+  (set# tr r (get# s<= tx x ty y)))
 
 (defun INT_ZEXT (tr r tx x)
   ;; TODO: fix the width

--- a/plugins/ghidra/semantics/pcode.lisp
+++ b/plugins/ghidra/semantics/pcode.lisp
@@ -12,7 +12,7 @@
   (store-word ptr val))
 
 (defun LOAD (dst _ ptr)
-  (load-word ptr))
+  (set$ dst (load-word ptr)))
 
 (defun BRANCH (dst)
   (exec-addr dst))

--- a/plugins/ghidra/semantics/pcode.lisp
+++ b/plugins/ghidra/semantics/pcode.lisp
@@ -3,137 +3,156 @@
 (defpackage pcode (:use core target))
 (in-package pcode)
 
-(defmacro set# (dst src)
-  (if (is-symbol dst) (set$ dst src)
-      (store-word (cast-unsigned (word-width) dst) src)))
+(defmacro cast-word (x) (cast word-width x))
 
-(defun COPY (dst src)
-  (set# dst src))
+(defmacro set# (typ dst src)
+  (case (symbol typ)
+    'mem (store-word (cast-word dst) src)
+    'imm (set$ dst src)))
 
-(defun STORE (_ ptr val)
+(defmacro get# (typ src)
+  (case (symbol typ)
+    'mem (load-word (cast-word src))
+    'imm src))
+
+(defmacro get# (op typ src)
+  (op (get# typ src)))
+
+(defmacro get# (op tx x ty y)
+  (op (get# tx x) (get# ty y)))
+
+(defun COPY (td d ts s)
+  (set# td d (get# ts s)))
+
+(defun STORE (_ _ _ ptr _ val)
   (store-word ptr val))
 
-(defun LOAD (dst _ ptr)
-  (set# dst (load-word ptr)))
+(defun LOAD (td dst _ _ _ ptr)
+  (set# td dst (load-word ptr)))
 
-(defun BRANCH (dst)
+(defun branch (typ dst)
+  (case (symbol typ)
+    'mem (exec-addr dst)
+    'imm (goto-subinstruction dst)))
+
+(defun BRANCH (typ dst)
+  (branch typ dst))
+
+(defun CBRANCH (typ dst tc cnd)
+  (when (get# tc cnd) (branch typ dst)))
+
+(defun BRANCHIND (_ dst)
   (exec-addr dst))
 
-(defun CBRANCH (dst cnd)
-  (when cnd (exec-addr dst)))
-
-(defun BRANCHIND (dst)
+(defun CALL (typ dst)
   (exec-addr dst))
 
-(defun CALL (dst)
+(defun CALLIND (typ dst)
   (exec-addr dst))
 
-(defun CALLIND (dst)
+(defun RETURN (typ dst)
   (exec-addr dst))
 
-(defun RETURN (dst)
-  (exec-addr dst))
+(defun PIECE (tr r tx x ty y)
+  (set# tr r (get# concat tx x ty y)))
 
-(defun PIECE (r x y)
-  (set# r (concat x y)))
+(defun SUBPIECE (tr r tx x ts s)
+  (set# tr r (rshift (get# tx x) (* 8 (get# ts s)))))
 
-(defun SUBPIECE (r x s)
-  (set# r (rshift x (* 8 s))))
+(defun INT_EQUAL (tr r tx x ty y)
+  (set# tr r (get# = tx x ty y)))
 
-(defun INT_EQUAL (r x y)
-  (set# r (= x y)))
+(defun INT_NOTEQUAL (tr r tx x ty y)
+  (set# tr r (get# /= tx x ty y)))
 
-(defun INT_NOTEQUAL (r x y)
-  (set# r (/= x y)))
+(defun INT_LESS (tr r tx x ty y)
+  (set# tr r (get# < tx x ty y)))
 
-(defun INT_LESS (r x y)
-  (set# r (< x y)))
-
-;; (defun INT_SLESS (r x y)
+;; (defun INT_SLESS (tr r tx x ty y)
 ;;   (set# r (s< x y)))
 
-(defun INT_LESSEQUAL (r x y)
-  (set# r (<= x y)))
+(defun INT_LESSEQUAL (tr r tx x ty y)
+  (set# tr r (<= x y)))
 
-;; (defun INT_SLESSEQUAL (r x y)
+;; (defun INT_SLESSEQUAL (tr r tx x ty y)
 ;;   (set# r (s<= x y)))
 
-(defun INT_ZEXT (r x)
+(defun INT_ZEXT (tr r tx x)
   ;; TODO: fix the width
-  (set# r (cast-unsigned (word-width) x)))
+  (set# tr r (cast-unsigned (word-width) (get# tx x))))
 
-(defun INT_SEXT (r x)
+(defun INT_SEXT (tr r tx x)
   ;; TODO: fix the width
-  (set# r (cast-signed (word-width) x)))
+  (set# tr r (cast-signed (word-width) (get# tx x))))
 
-(defun INT_ADD (r x y)
-  (set# r (+ x y)))
+(defun INT_ADD (tr r tx x ty y)
+  (set# tr r (get# + tx x ty y)))
 
-(defun INT_SUB (r x y)
-  (set# r (- x y)))
+(defun INT_SUB (tr r tx x ty y)
+  (set# tr r (get# - tx x ty y)))
 
-(defun INT_CARRY (r x y)
-  (let ((z (+ x y)))
-    (set# r (carry z x y))))
+(defun INT_CARRY (tr r tx x ty y)
+  (let ((x (get# tx x))
+        (y (get# ty y))
+        (z (+ x y)))
+    (set# tr r (carry z x y))))
 
-(defun INT_SCARRY (r x y)
-  (let ((z (+ x y)))
-    (set# r (overflow z x y))))
+(defun INT_SCARRY (tr r tx x ty y)
+  (let ((x (get# tx x))
+        (y (get# ty y))
+        (z (+ x y)))
+    (set# tr r (overflow z x y))))
 
-(defun INT_SBORROW (r x y)
-  (let ((z (- x y)))
-    (set# r (overflow z x (- y)))))
+(defun INT_SBORROW (tr r tx x ty y)
+  (let ((x (get# tx x))
+        (y (get# ty y))
+        (z (- x y)))
+    (set# tr r (overflow z x (- y)))))
 
-(defun INT_2COMP (r x)
-  (set# r (- x)))
+(defun INT_2COMP (tr r tx x)
+  (set# tr r (get# - tx x)))
 
-(defun INT_NEGATE (r x)
-  (set# r (lnot x)))
+(defun INT_NEGATE (tr r tx x)
+  (set# tr r (get# lnot tx x)))
 
-(defun INT_XOR (r x y)
-  (set# r (logxor x y)))
+(defun INT_XOR (tr r tx x ty y)
+  (set# tr r (get# logxor tx x ty y)))
 
-(defun INT_AND (r x y)
-  (set# r (logand x y)))
+(defun INT_AND (tr r tx x ty y)
+  (set# tr r (get# logand tx x ty y)))
 
-(defun INT_OR (r x y)
-  (set# r (logor x y)))
+(defun INT_OR (tr r tx x ty y)
+  (set# tr r (get# logor tx x ty y)))
 
-(defun INT_LEFT (r x y)
-  (set# r (lshift x y)))
+(defun INT_LEFT (tr r tx x ty y)
+  (set# tr r (get# lshift tx x ty y)))
 
-(defun INT_RIGHT (r x y)
-  (set# r (rshift x y)))
+(defun INT_RIGHT (tr r tx x ty y)
+  (set# tr r (get# rshift tx x ty y)))
 
-(defun INT_SRIGHT (r x y)
-  (set# r (arshift x y)))
+(defun INT_SRIGHT (tr r tx x ty y)
+  (set# tr r (get# arshift tx x ty y)))
 
-(defun INT_MULT (r x y)
-  (set# r (* x y)))
+(defun INT_MULT (tr r tx x ty y)
+  (set# tr r (get# * tx x ty y)))
 
-(defun INT_DIV (r x y)
-  (set# r (/ x y)))
+(defun INT_DIV (tr r tx x ty y)
+  (set# tr r (get# / tx x ty y)))
 
-(defun INT_SDIV (r x y)
-  (set# r (s/ x y)))
+(defun INT_SDIV (tr r tx x ty y)
+  (set# tr r (get# s/ tx x ty y)))
 
-(defun INT_MOD (r x y)
-  (set# r (mod x y)))
+(defun INT_MOD (tr r tx x ty y)
+  (set# tr r (get# mod tx x ty y)))
 
-(defun INT_SMOD (r x y)
-  (set# r (signed-mod x y)))
+(defun INT_SMOD (tr r tx x ty y)
+  (set# tr r (get# signed-mod tx x ty y)))
 
-(defun BOOL_AND (r x y)
-  (set# r (logand x y)))
+(defun BOOL_AND (tr r tx x ty y)
+  (set# tr r (get# logand tx x ty y)))
 
-(defun BOOL_OR (r x y)
-  (set# r (logor x y)))
+(defun BOOL_OR (tr r tx x ty y)
+  (set# tr r (get# logor tx x ty y)))
 
-(defun BOOL_XOR (r x y)
-  (set# r (logxor x y)))
-
-(defun pcode-extra:CGOTO (dst cnd)
-  (when cnd (goto-subinstruction dst)))
-
-(defun pcode-extra:GOTO (dst)
-  (goto-subinstruction dst))
+(defun BOOL_XOR (tr r tx x ty y)
+  (set# tr r (get# logxor tx x ty y)))

--- a/plugins/ghidra/semantics/pcode.lisp
+++ b/plugins/ghidra/semantics/pcode.lisp
@@ -3,14 +3,18 @@
 (defpackage pcode (:use core target))
 (in-package pcode)
 
+(defmacro set# (dst src)
+  (if (is-symbol dst) (set$ dst src)
+      (store-word (cast-unsigned (word-width) dst) src)))
+
 (defun COPY (dst src)
-  (set$ dst src))
+  (set# dst src))
 
 (defun STORE (_ ptr val)
   (store-word ptr val))
 
 (defun LOAD (dst _ ptr)
-  (set$ dst (load-word ptr)))
+  (set# dst (load-word ptr)))
 
 (defun BRANCH (dst)
   (exec-addr dst))
@@ -31,102 +35,102 @@
   (exec-addr dst))
 
 (defun PIECE (r x y)
-  (set$ r (concat x y)))
+  (set# r (concat x y)))
 
 (defun SUBPIECE (r x s)
-  (set$ r (rshift x (* 8 s))))
+  (set# r (rshift x (* 8 s))))
 
 (defun INT_EQUAL (r x y)
-  (set$ r (= x y)))
+  (set# r (= x y)))
 
 (defun INT_NOTEQUAL (r x y)
-  (set$ r (/= x y)))
+  (set# r (/= x y)))
 
 (defun INT_LESS (r x y)
-  (set$ r (< x y)))
+  (set# r (< x y)))
 
 ;; (defun INT_SLESS (r x y)
-;;   (set$ r (s< x y)))
+;;   (set# r (s< x y)))
 
 (defun INT_LESSEQUAL (r x y)
-  (set$ r (<= x y)))
+  (set# r (<= x y)))
 
 ;; (defun INT_SLESSEQUAL (r x y)
-;;   (set$ r (s<= x y)))
+;;   (set# r (s<= x y)))
 
 (defun INT_ZEXT (r x)
   ;; TODO: fix the width
-  (set$ r (cast-unsigned (word-width) x)))
+  (set# r (cast-unsigned (word-width) x)))
 
 (defun INT_SEXT (r x)
   ;; TODO: fix the width
-  (set$ r (cast-signed (word-width) x)))
+  (set# r (cast-signed (word-width) x)))
 
 (defun INT_ADD (r x y)
-  (set$ r (+ x y)))
+  (set# r (+ x y)))
 
 (defun INT_SUB (r x y)
-  (set$ r (- x y)))
+  (set# r (- x y)))
 
 (defun INT_CARRY (r x y)
   (let ((z (+ x y)))
-    (set$ r (carry z x y))))
+    (set# r (carry z x y))))
 
 (defun INT_SCARRY (r x y)
   (let ((z (+ x y)))
-    (set$ r (overflow z x y))))
+    (set# r (overflow z x y))))
 
 (defun INT_SBORROW (r x y)
   (let ((z (- x y)))
-    (set$ r (overflow z x (- y)))))
+    (set# r (overflow z x (- y)))))
 
 (defun INT_2COMP (r x)
-  (set$ r (- x)))
+  (set# r (- x)))
 
 (defun INT_NEGATE (r x)
-  (set$ r (lnot x)))
+  (set# r (lnot x)))
 
 (defun INT_XOR (r x y)
-  (set$ r (logxor x y)))
+  (set# r (logxor x y)))
 
 (defun INT_AND (r x y)
-  (set$ r (logand x y)))
+  (set# r (logand x y)))
 
 (defun INT_OR (r x y)
-  (set$ r (logor x y)))
+  (set# r (logor x y)))
 
 (defun INT_LEFT (r x y)
-  (set$ r (lshift x y)))
+  (set# r (lshift x y)))
 
 (defun INT_RIGHT (r x y)
-  (set$ r (rshift x y)))
+  (set# r (rshift x y)))
 
 (defun INT_SRIGHT (r x y)
-  (set$ r (arshift x y)))
+  (set# r (arshift x y)))
 
 (defun INT_MULT (r x y)
-  (set$ r (* x y)))
+  (set# r (* x y)))
 
 (defun INT_DIV (r x y)
-  (set$ r (/ x y)))
+  (set# r (/ x y)))
 
 (defun INT_SDIV (r x y)
-  (set$ r (s/ x y)))
+  (set# r (s/ x y)))
 
 (defun INT_MOD (r x y)
-  (set$ r (mod x y)))
+  (set# r (mod x y)))
 
 (defun INT_SMOD (r x y)
-  (set$ r (signed-mod x y)))
+  (set# r (signed-mod x y)))
 
 (defun BOOL_AND (r x y)
-  (set$ r (logand x y)))
+  (set# r (logand x y)))
 
 (defun BOOL_OR (r x y)
-  (set$ r (logor x y)))
+  (set# r (logor x y)))
 
 (defun BOOL_XOR (r x y)
-  (set$ r (logxor x y)))
+  (set# r (logxor x y)))
 
 (defun pcode-extra:CGOTO (dst cnd)
   (when cnd (goto-subinstruction dst)))

--- a/plugins/ghidra/semantics/pcode.lisp
+++ b/plugins/ghidra/semantics/pcode.lisp
@@ -147,7 +147,7 @@
   (set# tr r (get# signed-mod tx x ty y)))
 
 (defun BOOL_NEGATE (tr r tx x)
-  (set# tr r (get# lnot tx x)))
+  (set# tr r (get# not tx x)))
 
 (defun BOOL_AND (tr r tx x ty y)
   (set# tr r (get# logand tx x ty y)))

--- a/plugins/ghidra/semantics/pcode.lisp
+++ b/plugins/ghidra/semantics/pcode.lisp
@@ -1,0 +1,9 @@
+(require bits)
+
+(defpackage ghidra (:use core target))
+(defpackage ghidra-x86-unknown (:use ghidra))
+
+(in-package ghidra)
+
+(defun COPY (dst src)
+  (set$ dst src))

--- a/plugins/ghidra/semantics/pcode.lisp
+++ b/plugins/ghidra/semantics/pcode.lisp
@@ -1,9 +1,7 @@
 (require bits)
 
-(defpackage ghidra (:use core target))
-(defpackage ghidra-x86-unknown (:use ghidra))
-
-(in-package ghidra)
+(defpackage pcode (:use core target))
+(in-package pcode)
 
 (defun COPY (dst src)
   (set$ dst src))

--- a/plugins/ghidra/semantics/pcode.lisp
+++ b/plugins/ghidra/semantics/pcode.lisp
@@ -35,8 +35,8 @@
 (defun PIECE (r x y)
   (set$ r (concat x y)))
 
-(defun SUBPIECE (r s x)
-  (set$ r (cast-low s x)))
+(defun SUBPIECE (r x s)
+  (set$ r (rshift x (* 8 s))))
 
 (defun INT_EQUAL (r x y)
   (set$ r (= x y)))
@@ -60,8 +60,9 @@
   ;; TODO: fix the width
   (set$ r (cast-unsigned (word-width) x)))
 
-(defun INT_SEXT (r s x)
-  (set$ r (cast-signed s x)))
+(defun INT_SEXT (r x)
+  ;; TODO: fix the width
+  (set$ r (cast-signed (word-width) x)))
 
 (defun INT_ADD (r x y)
   (set$ r (+ x y)))

--- a/plugins/ghidra/semantics/pcode.lisp
+++ b/plugins/ghidra/semantics/pcode.lisp
@@ -127,3 +127,9 @@
 
 (defun BOOL_XOR (r x y)
   (set$ r (logxor x y)))
+
+(defun pcode-extra:CGOTO (dst cnd)
+  (when cnd (goto-subinstruction dst)))
+
+(defun pcode-extra:GOTO (dst)
+  (goto-subinstruction dst))

--- a/plugins/ghidra/semantics/pcode.lisp
+++ b/plugins/ghidra/semantics/pcode.lisp
@@ -7,3 +7,124 @@
 
 (defun COPY (dst src)
   (set$ dst src))
+
+(defun STORE (_ ptr val)
+  (store-word ptr val))
+
+(defun LOAD (dst _ ptr)
+  (load-word ptr))
+
+(defun BRANCH (dst)
+  (exec-addr dst))
+
+(defun CBRANCH (dst cnd)
+  (when cnd (exec-addr dst)))
+
+(defun BRANCHIND (dst)
+  (exec-addr dst))
+
+(defun CALL (dst)
+  (exec-addr dst))
+
+(defun CALLIND (dst)
+  (exec-addr dst))
+
+(defun RETURN (dst)
+  (exec-addr dst))
+
+(defun PIECE (r x y)
+  (set$ r (concat x y)))
+
+(defun SUBPIECE (r s x)
+  (set$ r (cast-low s x)))
+
+(defun INT_EQUAL (r x y)
+  (set$ r (= x y)))
+
+(defun INT_NOTEQUAL (r x y)
+  (set$ r (/= x y)))
+
+(defun INT_LESS (r x y)
+  (set$ r (< x y)))
+
+;; (defun INT_SLESS (r x y)
+;;   (set$ r (s< x y)))
+
+(defun INT_LESSEQUAL (r x y)
+  (set$ r (<= x y)))
+
+;; (defun INT_SLESSEQUAL (r x y)
+;;   (set$ r (s<= x y)))
+
+(defun INT_ZEXT (r x)
+  ;; TODO: fix the width
+  (set$ r (cast-unsigned (word-width) x)))
+
+(defun INT_SEXT (r s x)
+  (set$ r (cast-signed s x)))
+
+(defun INT_ADD (r x y)
+  (set$ r (+ x y)))
+
+(defun INT_SUB (r x y)
+  (set$ r (- x y)))
+
+(defun INT_CARRY (r x y)
+  (let ((z (+ x y)))
+    (set$ r (carry z x y))))
+
+(defun INT_SCARRY (r x y)
+  (let ((z (+ x y)))
+    (set$ r (overflow z x y))))
+
+(defun INT_SBORROW (r x y)
+  (let ((z (- x y)))
+    (set$ r (overflow z x (- y)))))
+
+(defun INT_2COMP (r x)
+  (set$ r (- x)))
+
+(defun INT_NEGATE (r x)
+  (set$ r (lnot x)))
+
+(defun INT_XOR (r x y)
+  (set$ r (logxor x y)))
+
+(defun INT_AND (r x y)
+  (set$ r (logand x y)))
+
+(defun INT_OR (r x y)
+  (set$ r (logor x y)))
+
+(defun INT_LEFT (r x y)
+  (set$ r (lshift x y)))
+
+(defun INT_RIGHT (r x y)
+  (set$ r (rshift x y)))
+
+(defun INT_SRIGHT (r x y)
+  (set$ r (arshift x y)))
+
+(defun INT_MULT (r x y)
+  (set$ r (* x y)))
+
+(defun INT_DIV (r x y)
+  (set$ r (/ x y)))
+
+(defun INT_SDIV (r x y)
+  (set$ r (s/ x y)))
+
+(defun INT_MOD (r x y)
+  (set$ r (mod x y)))
+
+(defun INT_SMOD (r x y)
+  (set$ r (signed-mod x y)))
+
+(defun BOOL_AND (r x y)
+  (set$ r (logand x y)))
+
+(defun BOOL_OR (r x y)
+  (set$ r (logor x y)))
+
+(defun BOOL_XOR (r x y)
+  (set$ r (logxor x y)))

--- a/plugins/ghidra/semantics/pcode.lisp
+++ b/plugins/ghidra/semantics/pcode.lisp
@@ -146,6 +146,9 @@
 (defun INT_SMOD (tr r tx x ty y)
   (set# tr r (get# signed-mod tx x ty y)))
 
+(defun BOOL_NEGATE (tr r tx x)
+  (set# tr r (get# lnot tx x)))
+
 (defun BOOL_AND (tr r tx x ty y)
   (set# tr r (get# logand tx x ty y)))
 

--- a/plugins/mc/mc_main.ml
+++ b/plugins/mc/mc_main.ml
@@ -343,7 +343,7 @@ let print_insn_memory formats mem =
 
 let print_knowledge formats =
   List.iter formats ~f:(fun _ ->
-      printf "%a" KB.pp_state (Toplevel.current ()))
+      printf "%a@." KB.pp_state (Toplevel.current ()))
 
 let print_insn insn_formats insn =
   List.iter insn_formats ~f:(fun fmt ->
@@ -353,13 +353,13 @@ let print_insn insn_formats insn =
 let print_bil formats insn =
   let bil = Insn.bil insn in
   List.iter formats ~f:(fun fmt ->
-      printf "%s@." (Bytes.to_string @@ Bil.to_bytes ~fmt bil))
+      printf "%a@." Bytes.pp (Bil.to_bytes ~fmt bil))
 
 let print_bir formats insn  =
   let bs = Blk.from_insn insn in
   List.iter formats ~f:(fun fmt ->
-      printf "%s" @@ String.concat ~sep:"\n"
-        (List.map bs ~f:(fun b -> Bytes.to_string @@ Blk.to_bytes ~fmt b)))
+      List.iter bs ~f:(fun b ->
+          printf "%a@." Bytes.pp (Blk.to_bytes ~fmt b)))
 
 let print_sema formats sema = match formats with
   | [] -> ()

--- a/plugins/mips/mips_main.ml
+++ b/plugins/mips/mips_main.ml
@@ -37,9 +37,12 @@ module MIPS32_le = Make(M32LE)
 module MIPS64 = Make(M64BE)
 module MIPS64_le = Make(M64LE)
 
+let backend = Config.param Config.(some string) "backend"
+    ~doc:"Specify which backend to use"
+
 let () =
-  Config.when_ready (fun _ ->
-      Bap_mips_target.load ();
+  Config.when_ready (fun {get} ->
+      Bap_mips_target.load ?backend:(get backend) ();
       register_target `mips (module MIPS32);
       register_target `mipsel (module MIPS32_le);
       register_target `mips64 (module MIPS64);

--- a/plugins/powerpc/powerpc_main.ml
+++ b/plugins/powerpc/powerpc_main.ml
@@ -37,10 +37,12 @@ module PowerPC32 = Make(T32)
 module PowerPC64 = Make(T64)
 module PowerPC64_le = Make(T64_le)
 
+let backend = Config.param Config.(some string) "backend"
+
 let () =
-  Config.when_ready (fun _ ->
+  Config.when_ready (fun {get} ->
       info "Providing PowerPC semantics in BIL";
-      Bap_powerpc_target.load ();
+      Bap_powerpc_target.load ?backend:(get backend)();
       Powerpc_add.init ();
       Powerpc_branch.init ();
       Powerpc_compare.init ();

--- a/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
+++ b/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
@@ -456,10 +456,10 @@ module Primitives(CT : Theory.Core) = struct
     | None -> CT.jmp !!dst
     | Some dst ->
       KB.collect Primus.Lisp.Semantics.definition lbl >>= function
-      | None -> failwith "no definition"
+      | None -> illformed "no definition was provided for a label"
       | Some lbl ->
         KB.collect Insn.Seqnum.slot lbl >>= function
-        | None -> failwith "no label for a subinstruction"
+        | None -> illformed "not a subinstruction"
         | Some pos ->
           let dst = Bitvec.to_int dst + pos in
           Bap.Std.Insn.Seqnum.label dst >>=

--- a/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
+++ b/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
@@ -247,7 +247,7 @@ let nothing = KB.Value.empty Theory.Semantics.cls
 let size = Theory.Bitv.size
 let forget x = x >>| Theory.Value.forget
 let empty s = Theory.Value.(forget @@ empty s)
-let fresh = KB.Object.create Theory.Program.cls
+let null = KB.Object.null Theory.Program.cls
 let sort = Theory.Value.sort
 let bits x = size @@ sort x
 
@@ -411,16 +411,13 @@ module Primitives(CT : Theory.Core) = struct
   let pure res = full (seq []) res
 
   let ctrl eff =
-    let* lbl = fresh in
-    CT.blk lbl (seq []) eff
+    CT.blk null (seq []) eff
 
   let data eff =
-    let* lbl = fresh in
-    CT.blk lbl eff (seq [])
+    CT.blk null eff (seq [])
 
   let memory eff res =
-    let* lbl = fresh in
-    full CT.(blk lbl (perform eff) skip) res
+    full CT.(blk null (perform eff) skip) res
 
   let loads = memory Theory.Effect.Sort.rmem
   let stores = memory Theory.Effect.Sort.wmem

--- a/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
+++ b/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
@@ -117,10 +117,10 @@ let export = Primus.Lisp.Type.Spec.[
      true. Equivalent to (is-zero X Y Z)";
 
     "is-positive", all any @-> any,
-    "(is-zero X Y ... Z) returns one if all numbers are positive.";
+    "(is-positive X Y ... Z) returns one if all numbers are positive.";
 
     "is-negative", all any @-> any,
-    "(is-zero X Y ... Z) returns one if all numbers are negative.";
+    "(is-negative X Y ... Z) returns one if all numbers are negative.";
 
     "word-width", all any @-> any,
     "(word-width X Y ... Z) returns the maximum width of its \
@@ -178,6 +178,9 @@ let export = Primus.Lisp.Type.Spec.[
 
     "symbol", one any @-> sym,
     "(symbol X) returns a symbol representation of X.";
+
+    "is-symbol", one any @-> bool,
+    "(is-symbol X) is true if X has a symbolic value.";
 
     "cast-low", tuple [int; a] @-> b,
     "(cast-low S X) extracts low S bits from X.";
@@ -583,6 +586,11 @@ module Primitives(CT : Theory.Core) = struct
     | None ->
       illformed "symbol requires a value reified to a variable"
 
+  let is_symbol v =
+    forget@@match KB.Value.get var_slot v with
+    | Some _ -> true_
+    | _ -> false_
+
   let mk_cast t cast xs =
     binary xs @@ fun sz x ->
     to_sort sz >>= fun s ->
@@ -719,6 +727,7 @@ module Primitives(CT : Theory.Core) = struct
     | "get-current-program-counter",[] -> pure@@get_pc s lbl
     | "set-symbol-value",[sym;x] -> data@@set_symbol sym x
     | "symbol",[x] ->  pure@@symbol s x
+    | "is-symbol", [x] -> pure@@is_symbol x
     | "cast-low",xs -> pure@@low xs
     | "cast-high",xs -> pure@@high xs
     | "cast-signed",xs -> pure@@signed xs

--- a/plugins/print/print_main.ml
+++ b/plugins/print/print_main.ml
@@ -283,7 +283,7 @@ module Ir_pp = struct
             | Some _ -> None) in
     let lines =
       List.concat @@ List.map [phis; defs; jmps] ~f:Seq.to_list in
-    let body = String.concat lines |> String.concat_map
+    let body = String.concat ~sep:"\n" lines |> String.concat_map
                  ~f:(function '\n' -> "\\l"
                             | c -> Char.to_string c) in
     sprintf "\\%s\n%s" (Term.name blk) body

--- a/plugins/systemz/systemz_lifter.ml
+++ b/plugins/systemz/systemz_lifter.ml
@@ -49,7 +49,7 @@ module Systemz(CT : Theory.Core) = struct
      packs them into a basic block that has the required type of [unit
      eff].  *)
   let data xs =
-    KB.Object.create Theory.Program.cls >>= fun lbl ->
+    let lbl = KB.Object.null Theory.Program.cls in
     CT.blk lbl (seq xs) (seq [])
 
   let (@) = CT.append r64

--- a/plugins/thumb/thumb_core.ml
+++ b/plugins/thumb/thumb_core.ml
@@ -66,19 +66,14 @@ module Make(CT : Theory.Core) = struct
   let is_set flag = bool flag
   let is_clear flag = CT.(eq bit0 flag)
 
-  let label = KB.Object.create Theory.Program.cls
-  let data eff =
-    label >>= fun lbl ->
-    CT.blk lbl (seq eff) (seq [])
-
-  let ctrl eff =
-    label >>= fun lbl ->
-    CT.blk lbl (seq []) eff
+  let null = Theory.Label.null
+  let label = Theory.Label.fresh
+  let data eff = CT.blk null (seq eff) (seq [])
+  let ctrl eff = CT.blk null (seq []) eff
 
   let goto dst =
     Theory.Label.for_addr dst >>= fun dst ->
     ctrl (CT.goto dst)
-
 
   let with_result rd f =
     Theory.Var.fresh (Theory.Var.sort rd) >>= fun v ->

--- a/plugins/thumb/thumb_core.mli
+++ b/plugins/thumb/thumb_core.mli
@@ -51,8 +51,13 @@ module Make(CT : Theory.Core) : sig
   val load : 'a Bitv.t Value.sort -> r32 bitv -> 'a bitv
   val store : r32 bitv -> 'a bitv -> data eff
 
+
+  (** [null] is shorcut for [Theory.Label.null]  *)
+  val null : Theory.label
+
   (** [label] a fresh label  *)
   val label : Theory.label KB.t
+
   (** [data eff] labels [eff] as data effects  *)
   val data : data eff list -> unit eff
 

--- a/plugins/thumb/thumb_mem.ml
+++ b/plugins/thumb/thumb_mem.ml
@@ -105,8 +105,7 @@ module Make(CT : Theory.Core) = struct
         sp += const Int.(List.length regs * 4);
       ] in
     let ctrl = CT.jmp (load s32 (var sp)) in
-    label >>= fun lbl ->
-    CT.blk lbl data ctrl
+    CT.blk null data ctrl
 
   let push regs = data [
       sp -= const Int.(List.length regs * 4);

--- a/plugins/x86/x86_legacy_bil_semantics.ml
+++ b/plugins/x86/x86_legacy_bil_semantics.ml
@@ -197,7 +197,7 @@ module Semantics = struct
 
     let vsort x = sort x
     let effect x = KB.Value.get effects x
-    let esort x = Theory.Effect.sort
+    let esort _ = Theory.Effect.sort
 
     let (>>->) v f = v >>= fun v -> f (vsort v) (value v)
     let lift1 s f v = v >>-> fun sort -> function
@@ -421,10 +421,14 @@ module Semantics = struct
       y >>= fun y ->
       eff (effect x @ effect y)
 
-    let blk _ x y =
+    let blk lbl x y =
       x >>:= fun x ->
       y >>:= fun y ->
-      eff (x @ y)
+      if KB.Object.is_null lbl
+      then eff (x @ y)
+      else
+        KB.Object.repr Theory.Program.cls lbl >>= fun lbl ->
+        eff Bil.(Label (Name lbl,[]) :: x @ y)
 
     let let_ var rhs body =
       rhs >>-> fun _ rhs ->

--- a/plugins/x86/x86_main.ml
+++ b/plugins/x86/x86_main.ml
@@ -50,7 +50,8 @@ let () =
   let x32 = abi `x86 "abi" in
   let x64 = abi `x86_64 "64-abi" in
   let fp_lifter = Config.flag "with-floating-points" in
-  let backend = Config.param Config.(some string) "backend" in
+  let backend = Config.param Config.(some string) "backend"
+      ~synonyms:["64-backend"] in
   let kind =
     let kinds = ["legacy", Legacy;
                  "modern", Modern;

--- a/plugins/x86/x86_main.ml
+++ b/plugins/x86/x86_main.ml
@@ -1,4 +1,5 @@
 open Core_kernel
+open Poly
 open Bap.Std
 open X86_targets
 include Self()
@@ -6,8 +7,8 @@ include Self()
 type kind = Legacy | Modern | Merge [@@deriving equal]
 
 let main backend kind x32 x64 =
-  X86_target.load ~backend ();
-  let kind = if String.(backend <> "llvm") then Modern else kind in
+  X86_target.load ?backend ();
+  let kind = if backend = Some "ghidra" then Modern else kind in
   let ia32, amd64 = match kind with
     | Legacy -> (module IA32L : Target), (module AMD64L : Target)
     | Modern -> (module IA32 : Target), (module AMD64 : Target)
@@ -49,7 +50,7 @@ let () =
   let x32 = abi `x86 "abi" in
   let x64 = abi `x86_64 "64-abi" in
   let fp_lifter = Config.flag "with-floating-points" in
-  let backend = Config.param Config.string "backend" in
+  let backend = Config.param Config.(some string) "backend" in
   let kind =
     let kinds = ["legacy", Legacy;
                  "modern", Modern;


### PR DESCRIPTION
## Overview

[Ghidra][1] is an open-source reverse-engineering tool and framework developed by NSA. It comes in two parts - the Ghidra client, which is a graphical user interface developed in Java, and the decompiler, which is written in C++ and performs disassembling, lifting, and decompilation. The disassembler part of the decompiler is using Sleigh as the language for specifying instruction semantics and automatically lifts binary code into the language code [P-Code][3]. Ghidra supports more than 150 targets, including all targets already supported by BAP, as well as new targets, such as AVR, SPARC, z80, PIC, etc.

This PR adds an implementation of the BAP disassembler backend interface that uses the C++ interface to the Sleigh translator. The PR also includes the specification of the P-Code semantics, written in Primus Lisp. There are also a few optimizations that make both the existing lifting facilities and the new facilities faster.

We integrated backend with all targets currently supported by BAP. Right now, Ghidra backend is able to correctly lift (verified by our testing framework) ARM, x86, x86-64, and PowerPC. Concerning MIPS and RISCV, the lifting looks legit, but we fail the tests.

The PR doesn't bring any dependency on Java or requires a Ghidra installation and is fully self-contained. The library and data files are built and distributed via the Ubuntu PPA. So if you want to be able to play with the Ghidra backend locally and you have Ubuntu Bionic, you can install the necessary packages, using the following commands:

```sh
sudo add-apt-repository ppa:ivg/ghidra -y
sudo apt-get install libghidra-dev -y
sudo apt-get install libghidra-data -y
```

Support for more distributions is coming, please don't hesitate to open a ticket on our issue tracker. The Ghidra decompiler is written in old and portable C++ and is quite easy to build on any modern (and not that modern) operating system. Also, help in packaging Ghidra is highly welcome.

To prevent any issues with BAP installation now and in the future, we're splitting BAP into three meta-packages. The `bap-core` package contains the minimum set of feature that are necessary for successfully disassemble and lift a binary. The `bap` package, contains `bap-core` and most of the analyses that are included in the current `bap` package. Finally, `bap-extra` includes extra heavy-weight and less portable stuff such as the ghidra backend and z3 based symbolic executor, and probably some other not very popular analysis. This split enables faster installation and better portability of BAP.


## Status and Next Steps

The Ghidra backend is in its beta. (And the version of Ghidra that we're currently using is also 10~beta). The backend is disabled by default but could be easily enabled from the command-line or configuration files (see below).

We currently support the necessary subset of the P-Code operations, but will soon add more (and this might probably fix the tests). After that, we will focus on adding architecture that are not currently present in BAP (which will be using ghidra as the default backend).

The quality of the lifted code is good albeit much more verbose. It is recommended to use `--optimization-level=2` (or even `3`) to make it more readable. It is also much slower than the existing lifters. Roughly x2 times slower for x86, for example. It should be seen as an acceptable price as Ghidra produces roughly x8 times more (sub)instructions. Also, it was even slower (x10) but we are glad that we were able to optimize many hotspots and in fact even the existing lifters are now nearly 40% faster so that the Ghidra backend is only 20% slower than the llvm backend before this PR. The set of supported instructions is in general larger than corresponding sets in BAP, especially for the newly added architectures, that motivates us to switch to Ghidra as the default backend. The main road-blocker, right now, is the lack of proper packaging of Ghidra on most distributions (the decompiler in the Ghidra distribution available from NSA is just shipped as a binary which communicates with the client via a pipe interface).



### Enabling Ghidra

To enable it for the architecture `<ARCH>` pass the option `--<ARCH>-backend=ghidra`. Once satisfied with the result, you can persist your choice in a personal configuration file. Create a file in the  `~/.config/bap` folder, that sets a backend per each architecture that you want to switch to Ghidra, e.g.,

```conf
# file ~/.config/bap/disassemblers.conf

arm-backed=ghidra
powerpc-backend=ghidra
```

### Other Changes

In order to fit Ghidra representation into BAP abstractions, we had to massage them a bit. First of all, Ghidra represents each instruction as a sequence of subinstructions (much like BIL statements) but the intra-instruction logic is also described using conditional jumps. So we had to add support for intra-instructional control-flow, a new kind of address, called seqnum, that uniquely addresses each subinstruction. The semantics of the existing languages, BIR, BIL, Legacy BIL, etc were also updated to respect the labels that are passed to them. There are also a few changes that I will collect and properly document later. Since it is a very preliminary work expect everything to change.

As usual, the discussion is welcome and any feedback is highly appreciated. Especially in the form of code review!

[1]: https://github.com/NationalSecurityAgency/ghidra
[2]: https://ghidra.re/courses/languages/html/sleigh.html
[3]: https://ghidra.re/courses/languages/html/pcoderef.html