### PR TITLE
fixes C.ABI.Args `popn` and `align_even` operators

### DIFF
--- a/lib/bap_c/bap_c_abi.ml
+++ b/lib/bap_c/bap_c_abi.ml
@@ -330,10 +330,12 @@ module Arg = struct
       | Some (k,x) ->
         Some ({self with args = Map.remove self.args k},x)
 
-    let popn n self = match Map.split self.args n with
-      | _,None,_ -> None
-      | lt,Some (k,x),rt ->
-        Some ({self with args = Map.add_exn rt k x}, Map.data lt)
+    let popn n self = match Map.min_elt self.args with
+      | None -> None
+      | Some (k,_) -> match Map.split self.args (k+n) with
+        | _,None,_ -> None
+        | lt,Some (k,x),rt ->
+          Some ({self with args = Map.add_exn rt k x}, Map.data lt)
 
     let align n self = match Map.min_elt self.args with
       | None -> None
@@ -448,6 +450,7 @@ module Arg = struct
         Arg.return res
     let pop s n = update s n File.pop
     let popn ~n s a = update s a (File.popn n)
+    let align ~n s a = update s a (File.align n)
     let deplet s n = update s n @@ fun s -> Some (File.deplet s,())
   end
 
@@ -504,7 +507,7 @@ module Arg = struct
 
   let align_even file =
     let* s = Arg.get () in
-    Arena.popn ~n:2 s file >>| ignore
+    Arena.align ~n:2 s file >>| ignore
 
   let deplet file =
     let* s = Arg.get () in

--- a/lib/bap_c/bap_c_abi.mli
+++ b/lib/bap_c/bap_c_abi.mli
@@ -107,7 +107,7 @@ end
     function. The DSL describes the semantics of argument passing that
     is then reified to the [args] structure. The [DSL] is a choice
     monad that enables describing the argument passing grammar using
-    backtracing when the chosen strategy doesn't fit. The [reject ()]
+    backtracking when the chosen strategy doesn't fit. The [reject ()]
     operator will reject the current computation up until the nearest
     choice prompt, e.g., in the following example, computations [e1],
     [e2], and [e3] are rejected and any side-effects that they might


### PR DESCRIPTION
The `popn` was always poping from the first register and `align_even`
was also doing `popn` instead of aligning.