### PR TITLE
fixes frame layout calculation in the Primus loader

### DIFF
--- a/plugins/primus_loader/primus_loader_basic.ml
+++ b/plugins/primus_loader/primus_loader_basic.ml
@@ -22,7 +22,8 @@ module Make(Param : Param)(Machine : Primus.Machine.S)  = struct
   module Val = Primus.Value.Make(Machine)
 
   let make_word addr =
-    Machine.gets Project.target >>| Theory.Target.bits >>| fun width ->
+    Machine.gets Project.target >>|
+    Theory.Target.code_addr_size >>| fun width ->
     Addr.of_int64 ~width addr
 
   let set_word name x =


### PR DESCRIPTION
It should be using the address size everywhere (instead it was using
the number of bits in the architecture, which is 8 for AVR8).