### PR TITLE
fixes the address size computation in the llvm backend

### DIFF
--- a/lib/bap_llvm/llvm_loader.hpp
+++ b/lib/bap_llvm/llvm_loader.hpp
@@ -98,6 +98,18 @@ void verbose_fails(const error_or<T> &loaded) {
     }
 }
 
+int addr_size(const Triple &target, const object::ObjectFile *obj) {
+    if (target.isArch64Bit()) {
+        return 64;
+    } else if (target.isArch32Bit()) {
+        return 32;
+    } else if (target.isArch16Bit()) {
+        return 16;
+    } else {
+        return obj->getBytesInAddress() * 8;
+    }
+}
+
 void emit_common_header(ogre_doc &s, const object::ObjectFile *obj) {
     s.raw_entry(scheme);
     auto target = obj->makeTriple();
@@ -106,7 +118,7 @@ void emit_common_header(ogre_doc &s, const object::ObjectFile *obj) {
     s.entry("vendor") << target.getVendorName();
     s.entry("system") << target.getOSName();
     s.entry("abi") << prim::string_of_abi(target.getEnvironment());
-    s.entry("bits") << (obj->getBytesInAddress() * 8);
+    s.entry("bits") << addr_size(target, obj);
     s.entry("is-little-endian") << target.isLittleEndian();
 }
 


### PR DESCRIPTION
The `getBytesInAddress` virutal member-function for ELF files is
implemented incorrectly in LLVM,
```
template <class ELFT>
uint8_t ELFObjectFile<ELFT>::getBytesInAddress() const {
  return ELFT::Is64Bits ? 8 : 4;
}
```

It is actually a static file that returns 32 for ELF32 and 64 for
ELF64, which has nothing to do with the actual bitness of the target
architecture address.

The if is using the information obtained from the target (triple) and
falls back to `getBytesInAddress` only if the target is not 16, 32, or
64 bit (the target interface is also strange as it doesn't allow any
other values).