### PR TITLE
improves the `main` function discovery heuristics

### DIFF
--- a/oasis/glibc-runtime
+++ b/oasis/glibc-runtime
@@ -7,7 +7,7 @@ Library glibc_runtime_plugin
   Path:             plugins/glibc_runtime
   FindlibName:      bap-plugin-glibc_runtime
   CompiledObject:   best
-  BuildDepends:     core_kernel, bap-main, bap, bap-abi, bap-c, ogre
+  BuildDepends:     core_kernel, bap-main, bap, bap-abi, bap-c, ogre, bap-core-theory
   InternalModules:  Glibc_runtime_main
   XMETADescription: detects main and libc_start_main functions
   XMETAExtraLines:  tags="abi, pass"

--- a/plugins/abi/abi_main.ml
+++ b/plugins/abi/abi_main.ml
@@ -12,4 +12,5 @@ let () = Config.manpage [
     `P "$(b,bap-plugin-x86)(1), $(b,bap-plugin-arm)(1), $(b,bap-abi)(3)"
   ]
 
-let () = Config.when_ready (fun _ -> Project.register_pass ~autorun:true Bap_abi.pass)
+let () = Config.when_ready (fun _ ->
+    Project.register_pass ~autorun:true Bap_abi.pass)


### PR DESCRIPTION
The problem was not in heuristic per se, but in the cyclic dependency between the abi pass that discovers __libc_start_main, main, abi passes, and api passes. Ideally, we should reimplement our ABI/API infrastructure using the Knowledge Base, which was originally designed to handle such dependencies, but it will take much more time than we currently have.

Therefore, right now we discover `__libc_start_main` in the ABI pass, to be sure that we have types applied to it (which we need as we will use them later to get the storage for the first argument). And we delay the `main` function discovery after the api pass. After we find `main` we also want types to be applied. Unfortunately, we can't can call the api pass again (which is responsible for that), but we know the prototype of `main`, so we don't really need to parse the C headers anymore and can manually apply the prototype and translate it to the arg terms.

Now the main function discovery works perfectly for the programs that use glibc runtime, so yeah we can finally execute `/bin/true` and `/bin/false` :)

```
$ bap /bin/false --run --primus-print-obs=call-return | grep main
(call-return (main 0 0x40000008 1))
$ bap /bin/true --run --primus-print-obs=call-return | grep main
(call-return (main 0 0x40000008 0))
```