### PR TITLE
adds more primus lisp stubs and fixes some existing

### DIFF
--- a/plugins/api/api/c/posix.h
+++ b/plugins/api/api/c/posix.h
@@ -21,6 +21,7 @@ long          a64l(const char *)
 void          abort(void) __attribute__((noreturn));
 int           abs(int x) __attribute__((__const__, warn_unused_result));
 int           atexit(void (*callback)(void)) __attribute__((nonnull(1)));
+int           __cxa_atexit(void (*callback)(void)) __attribute__((nonnull(1)));
 double        atof(const char *)  __attribute__((pure, nonnull(1), warn_unused_result));
 int           atoi(const char *)  __attribute__((pure, nonnull(1), warn_unused_result));
 long          atol(const char *)  __attribute__((pure, nonnull(1), warn_unused_result));
@@ -117,25 +118,39 @@ int feof(FILE *stream) __attribute__((warn_unused_result));
 int ferror(FILE *stream) __attribute__((warn_unused_result));
 int fgetc(FILE *stream);
 int fgetc(FILE *stream);
+int fgetc_unlocked(FILE *stream);
+int fgetc_unlocked(FILE *stream);
 int fileno(FILE *stream) __attribute__((warn_unused_result));
 int fputc(int c, FILE *stream);
 int fputs(const char *s, FILE *stream);
+int fputc_unlocked(int c, FILE *stream);
+int fputs_unlocked(const char *s, FILE *stream);
 int getc(FILE *stream);
+int getc_unlocked(FILE *stream);
 int getchar(void);
 int putchar(int c);
+int getchar_unlocked(void);
+int putchar_unlocked(int c);
 int putc(int c, FILE *stream);
 int puts(const char *s);
+int putc_unlocked(int c, FILE *stream);
+int puts_unlocked(const char *s);
 int remove(const char *);
 int rename(const char *, const char *);
 int ungetc(int c, FILE *stream);
 
 size_t fread(void * restrict ptr, size_t size, size_t nmemb, FILE * restrict stream)
     __attribute__((warn_unused_result, storage(1,2,3)));
+size_t fread_unlocked(void * restrict ptr, size_t size, size_t nmemb, FILE * restrict stream)
+    __attribute__((warn_unused_result, storage(1,2,3)));
 size_t fwrite(const void * restrict ptr, size_t size, size_t nmemb, FILE * restrict stream)
+    __attribute__((warn_unused_result, storage(1,2,3)));
+size_t fwrite_unlocked(const void * restrict ptr, size_t size, size_t nmemb, FILE * restrict stream)
     __attribute__((warn_unused_result, storage(1,2,3)));
 void clearerr(FILE *stream);
 
 int fflush(FILE *stream);
+int fflush_unlocked(FILE *stream);
 
 int __isoc99_fscanf (FILE *__restrict __stream, const char *__restrict __format, ...)  __attribute__((warn_unused_result));
 int __isoc99_scanf (const char *__restrict __format, ...)  __attribute__((warn_unused_result));
@@ -354,6 +369,13 @@ int          gethostname(char *buf, size_t len) __attribute__((nonnull(1), stora
 char        *getlogin(void) __attribute__((warn_unused_result));
 int          getlogin_r(char *buf, size_t size) __attribute__((warn_unused_result, nonnull(1), storage(1,2)));
 int          getopt(int argc, char * const *argv, const char *shortopts);
+int getopt_long(int argc, char * const argv[],
+                const char *optstring,
+                const struct option *longopts, int *longindex);
+
+int getopt_long_only(int argc, char * const argv[],
+                     const char *optstring,
+                     const struct option *longopts, int *longindex);
 pid_t        getpgid(pid_t pid) __attribute__((warn_unused_result));
 pid_t        getpgrp(void) __attribute__((warn_unused_result));
 pid_t        getpid(void) __attribute__((warn_unused_result));
@@ -361,6 +383,8 @@ pid_t        getppid(void) __attribute__((warn_unused_result));
 pid_t        getsid(pid_t pid) __attribute__((warn_unused_result));
 uid_t        getuid(void) __attribute__((warn_unused_result));
 int          isatty(int fd);
+int          ioctl(int fd, unsigned long request, ...);
+int          getpagesize(void);
 int          lchown(const char *file, uid_t owner, gid_t group) __attribute__((warn_unused_result,nonnull(1)));
 int          link(const char *from, const char *to) __attribute__((warn_unused_result,nonnull(1,2)));
 int          linkat(int fromfd, const char *from, int tofd, const char *to, int flags) __attribute__((warn_unused_result,nonnull(2,4)));
@@ -448,3 +472,25 @@ int isblank(int c);
 
 int toupper(int c);
 int tolower(int c);
+
+
+// locale.h
+
+char *setlocale(int category, const char *locale);
+struct lconv *localeconv(void);
+
+// #include <libintl.h>
+char * bindtextdomain (const char * domainname, const char * dirname);
+char * textdomain (const char * domainname);
+
+// #include <setjmp.h>
+typedef void * jmp_buf;
+typedef void * sigjmp_buf;
+int setjmp(jmp_buf env);
+int sigsetjmp(sigjmp_buf env, int savesigs);
+void longjmp(jmp_buf env, int val);
+void siglongjmp(sigjmp_buf env, int val);
+int _setjmp(jmp_buf env);
+int _sigsetjmp(sigjmp_buf env, int savesigs);
+void _longjmp(jmp_buf env, int val);
+void _siglongjmp(sigjmp_buf env, int val);

--- a/plugins/primus_lisp/primus_lisp_io.ml
+++ b/plugins/primus_lisp/primus_lisp_io.ml
@@ -18,7 +18,7 @@ type state = {
 let default_channels = Int.Map.of_alist_exn [
     0, {
       input = Some In_channel.stdin;
-      output = None;
+      output = Some Out_channel.stdout;
     };
     1, {
       input = None;

--- a/plugins/primus_lisp/site-lisp/libintl.lisp
+++ b/plugins/primus_lisp/site-lisp/libintl.lisp
@@ -1,0 +1,9 @@
+(in-package posix)
+
+(defun bindtextdomain (_ dir)
+  (declare (external "bindtextdomain"))
+  dir)
+
+(defun textdomain (dom)
+  (declare (external "textdomain"))
+  dom)

--- a/plugins/primus_lisp/site-lisp/locale.lisp
+++ b/plugins/primus_lisp/site-lisp/locale.lisp
@@ -1,0 +1,19 @@
+(in-package posix)
+
+(require types)
+
+(defparameter *lconv-size* (* 20 (sizeof ptr_t)))
+
+(declare (static LCONV))
+
+(defmethod init ()
+  (set LCONV brk)
+  (+= brk *lconv-size*))
+
+(defun setlocale (_ locale)
+  (declare (external "setlocale"))
+  locale)
+
+(defun lconv ()
+  (declare (external "lconv"))
+  LCONV)

--- a/plugins/primus_lisp/site-lisp/posix.lisp
+++ b/plugins/primus_lisp/site-lisp/posix.lisp
@@ -3,3 +3,8 @@
 (require string)
 (require errno)
 (require ascii)
+(require locale)
+(require libintl)
+(require unistd)
+(require setjmp)
+(require getopt)

--- a/plugins/primus_lisp/site-lisp/setjmp.lisp
+++ b/plugins/primus_lisp/site-lisp/setjmp.lisp
@@ -1,0 +1,13 @@
+(in-package posix)
+
+(defun setjmp (_)
+  (declare (external "setjmp" "_setjmp"))
+  0)
+
+(defun sigsetjmp (_ _)
+  (declare (external "sigsetjmp" "_sigsetjmp"))
+  0)
+
+(defun longjmp (_ _)
+  (declare (external "longjmp" "_longjmp" "siglongjmp" "_siglongjmp"))
+  (exit 1))

--- a/plugins/primus_lisp/site-lisp/stdio.lisp
+++ b/plugins/primus_lisp/site-lisp/stdio.lisp
@@ -5,15 +5,15 @@
 (in-package posix)
 
 (defun fputc (char stream)
-  (declare (external "fputc" "putc"))
+  (declare (external "fputc" "putc" "fputs_unlocked putc_unlocked"))
   (if (= 0 (channel-output stream char)) char -1))
 
 (defun putchar (char)
-  (declare (external "putchar"))
+  (declare (external "putchar" "putchar_unlocked"))
   (fputc char *standard-output*))
 
 (defun fputs (p stream)
-  (declare (external "fputs"))
+  (declare (external "fputs" "fputs_unlocked"))
   (while (not (points-to-null p))
     (fputc (cast int (memory-read p)) stream)
     (incr p))
@@ -22,11 +22,11 @@
     r))
 
 (defun puts (p)
-  (declare (external "puts"))
+  (declare (external "puts" "puts_unlocked"))
   (fputs p *standard-output*))
 
 (defun fflush (s)
-  (declare (external "fflush"))
+  (declare (external "fflush" "fflush_unlocked"))
   (channel-flush s))
 
 
@@ -36,12 +36,12 @@
 ;; ignoring modes, we will add them later, of course.
 (defun fopen (path mode)
   (declare (external "fopen" "open" "fdopen"))
-  (channel-open path))
+  (let ((file (channel-open path)))
+    (if (< file 0) 0 file)))
 
 (defun fileno (stream)
   (declare (external "fileno"))
   stream)
-
 
 (defun open3 (path flags mode)
   (declare (external "open"))
@@ -61,7 +61,7 @@
     i))
 
 (defun fwrite (buf size n stream)
-  (declare (external "fwrite"))
+  (declare (external "fwrite" "fwrite_unlocked"))
   (let ((i 0))
     (while (and (< i n)
                 (= size (output-item buf size i stream)))
@@ -90,7 +90,7 @@
     i))
 
 (defun fread (ptr size n stream)
-  (declare (external "fread"))
+  (declare (external "fread" "fread_unlocked"))
   (let ((i 0))
     (while (and
             (< i n)
@@ -104,7 +104,7 @@
 
 
 (defun fgetc (stream)
-  (declare (external "fgetc" "getc"))
+  (declare (external "fgetc" "getc" "fgetc_unlocked" "getc_unlocked"))
   (channel-input stream))
 
 (defun terminate-string-and-return-null (ptr)
@@ -113,7 +113,7 @@
   0)
 
 (defun fgets (ptr len str)
-  (declare (external "fgets"))
+  (declare (external "fgets" "fgets_unlocked"))
   (if (= len 0) (terminate-string-and-return-null ptr)
     (let ((i 0)
           (n (-1 len))
@@ -132,7 +132,7 @@
 
 
 (defun getchar ()
-  (declare (external "getchar"))
+  (declare (external "getchar" "getchar_unlocked"))
   (fgetc *standard-input*))
 
 (defmethod primus:machine-kill ()

--- a/plugins/primus_lisp/site-lisp/stdlib.lisp
+++ b/plugins/primus_lisp/site-lisp/stdlib.lisp
@@ -32,7 +32,7 @@
 
 
 (defun atexit (cb)
-  (declare (external "atexit"))
+  (declare (external "atexit" "__cxa_atexit"))
   0)
 
 (defun abs (x)

--- a/plugins/primus_lisp/site-lisp/unistd.lisp
+++ b/plugins/primus_lisp/site-lisp/unistd.lisp
@@ -1,0 +1,15 @@
+(in-package posix)
+
+(defun isatty (fd)
+  (declare (external "isatty"))
+  (< fd 3))
+
+(defun ioctl (_ _) (declare (external "ioctl")) 0)
+(defun ioctl (_ _ _) (declare (external "ioctl")) 0)
+(defun ioctl (_ _ _ _) (declare (external "ioctl")) 0)
+(defun ioctl (_ _ _ _ _) (declare (external "ioctl")) 0)
+(defun ioctl (_ _ _ _ _ _) (declare (external "ioctl")) 0)
+
+(defun getpagesize ()
+  (declare (external "getpagesize"))
+  (* 64 1024))


### PR DESCRIPTION
Adds some stubs from locale.h, libintl.h, unistd.h, setjmp.h, and getopt.h. These are the stubs that are commonly used by coreutils so that we can now even run `/bin/echo`, e.g., `bap /bin/echo --run --run-argv=echo,hello` and it will output `hello` successfully passing through the locale and i17n mumbo-jumbo. 

Also fixed a few stubs, like `fopen` that was returning `-1` on error instead of NULL. Also tried to fix `getopt` but it is most likely broken. 

See the diff for more details on changes. 
