### PR TITLE
fixes core:eff theory

### DIFF
--- a/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
+++ b/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
@@ -836,7 +836,7 @@ module CST : Theory.Core = struct
     x >>= fun v ->
     let s = esort v in
     match KB.Value.get eslot v with
-    | None -> ret (Theory.Effect.empty s)
+    | None -> f s (list [])
     | Some x -> f s x
 
 


### PR DESCRIPTION
This theory is used for debugging and introspection purposes. The bug
was in the denotation of `branch` and `repeat` operations, which were
denoted as empty denotations if any of its effects are empty. It is
now corrected.