### PR TITLE
adds context variables to the knowledge base

### DIFF
--- a/lib/knowledge/bap_knowledge.mli
+++ b/lib/knowledge/bap_knowledge.mli
@@ -258,6 +258,57 @@ module Knowledge : sig
   val save : state -> string -> unit
 
 
+  (** Context variables.
+
+      Context variables could be used to implement stateful
+      analyses. They are not part of the knowledge base per se, but
+      enable convience that is otherwise achieavable through adding a
+      state to the knowledge monad using a monad transformer.
+
+      It is important to keep in mind that the contex variables are
+      not a part of the knowledge and that every knowledge computation
+      starts with a fresh set of variables, i.e., variables are not
+      persistent.
+
+      The data type of the context variable is not required to have
+      the domain structure or be comparable. The only requirement is
+      that when a variable is declared it should be initialized.
+
+      @since 2.4.0
+
+  *)
+  module Context : sig
+
+
+    (** an abstract type denoting a context variable and its name.  *)
+    type 'a var
+
+
+    (** [declare ~package name init] declares a new context variable.
+
+        The declared variable has the initial value [init]. The
+        [inspect] function could be used for debugging and
+        instrospection. *)
+    val declare : ?inspect:('a -> Sexp.t) -> ?package:string -> string ->
+      'a knowledge -> 'a var
+
+    (** [set v x] assings to the variable [v] a new value [x].  *)
+    val set : 'a var -> 'a -> unit knowledge
+
+    (** [get v] is the current value assigned to [v]. *)
+    val get : 'a var -> 'a knowledge
+
+    (** [update v f] applies [f] to the current value of [v] and
+        assigns the result back.
+    *)
+    val update : 'a var -> ('a -> 'a) -> unit knowledge
+
+
+    (** [with_var v x f] dynamically binds [v] to [x] while [f] is run.*)
+    val with_var : 'a var -> 'a -> (unit -> 'b knowledge) -> 'b knowledge
+  end
+
+
   (** prints the state of the knowledge base.  *)
   val pp_state : Format.formatter -> state -> unit
 


### PR DESCRIPTION
Context variables are regular state variables and are introduced to enable stateful analyses. They are not stored in the knowledge base nor they are persistent. They are also not involved in the fixed point computation. At the same time, the data type of a stateful variable is not required to have the domain structure or even be ordered. Anything could be stored in the state.

Many analyses require a regular, non-monotonic and unordered, state. A good example, is an optimization analysis or a variable desugaring analysis that will come in one of the next pull requests. We may also find it useful and much more efficient to store some state of the analysis, like the current target or theory, in the context, rather than in the knowledge base or in the temporal promise.

Previously, if we needed to implement a stateful analysis we have to wrap the knowledge monad into the state monad, e.g., this is what we are doing in the Primus interpreter. It is however a little bit tedious and comes with some performance penalty. Essentially since it is superfluous, as the knowledge monad is already having the state. Another option to add an arbitrary state to the analysis is to cheat with the domain ordering and implement a timed data structure with the chain structure (i.e., where a more recent version is considered to have more informational content than the previous, despite the actual content). This approach is rather artificial and again comes with some unnecessary performance cost.