### PR TITLE
uses context variables to store the current theory

### DIFF
--- a/lib/bap/bap_project.ml
+++ b/lib/bap/bap_project.ml
@@ -408,7 +408,10 @@ let create
     Signal.send Info.got_code code;
     Signal.send Info.got_spec spec;
     let run k =
-      let k = KB.(set_package package >>= fun () -> k) in
+      let k = KB.(set_package package >>= fun () ->
+                  Theory.instance () >>= fun theory ->
+                  Theory.with_current theory @@ fun () ->
+                  k) in
       State.Toplevel.run spec target ~code ~memory file k in
     let state = match state with
       | Some state -> state

--- a/lib/bap_core_theory/bap_core_theory_manager.mli
+++ b/lib/bap_core_theory/bap_core_theory_manager.mli
@@ -18,6 +18,10 @@ val instance :
 
 val require : theory -> (module Core) knowledge
 
+val with_current : theory -> (unit -> 'a knowledge) -> 'a knowledge
+
+val current : (module Core) knowledge
+
 module Documentation : sig
   module Theory : sig
     type t

--- a/lib/knowledge/bap_knowledge.mli
+++ b/lib/knowledge/bap_knowledge.mli
@@ -258,6 +258,57 @@ module Knowledge : sig
   val save : state -> string -> unit
 
 
+  (** Context variables.
+
+      Context variables could be used to implement stateful
+      analyses. They are not part of the knowledge base per se, but
+      enable convience that is otherwise achieavable through adding a
+      state to the knowledge monad using a monad transformer.
+
+      It is important to keep in mind that the contex variables are
+      not a part of the knowledge and that every knowledge computation
+      starts with a fresh set of variables, i.e., variables are not
+      persistent.
+
+      The data type of the context variable is not required to have
+      the domain structure or be comparable. The only requirement is
+      that when a variable is declared it should be initialized.
+
+      @since 2.4.0
+
+  *)
+  module Context : sig
+
+
+    (** an abstract type denoting a context variable and its name.  *)
+    type 'a var
+
+
+    (** [declare ~package name init] declares a new context variable.
+
+        The declared variable has the initial value [init]. The
+        [inspect] function could be used for debugging and
+        instrospection. *)
+    val declare : ?inspect:('a -> Sexp.t) -> ?package:string -> string ->
+      'a knowledge -> 'a var
+
+    (** [set v x] assings to the variable [v] a new value [x].  *)
+    val set : 'a var -> 'a -> unit knowledge
+
+    (** [get v] is the current value assigned to [v]. *)
+    val get : 'a var -> 'a knowledge
+
+    (** [update v f] applies [f] to the current value of [v] and
+        assigns the result back.
+    *)
+    val update : 'a var -> ('a -> 'a) -> unit knowledge
+
+
+    (** [with_var v x f] dynamically binds [v] to [x] while [f] is run.*)
+    val with_var : 'a var -> 'a -> (unit -> 'b knowledge) -> 'b knowledge
+  end
+
+
   (** prints the state of the knowledge base.  *)
   val pp_state : Format.formatter -> state -> unit
 


### PR DESCRIPTION
This PR turns the current theory into an implicit parameter of all functions that depend on a theory but don't really know which theory to pick. For example, a lifter is not supposed to pick the theory structure but instead shall receive the theory from the calling party. The lifters are, however, called via the promises, which doesn't provide any explicit interfaces for passing the theory instance. The newly introduced context variables offer the proper mechanism for passing theory as an implicit parameter.

The idea is that a generic algorithm uses the `Theory.current` (which is a shortcut for `Theory.(instance >=> require)`) to obtain the theory structure. Then the caller of that algorithm may either rely on the implicit theory or override it using `Theory.with_current` function. The callee itself, if it needs to use a specific theory or to change the context, may instantiate another theory, use it, via the `Theory.with_current` and then go back to the original theory.

The context variables essentially implements dynamically scoped parameters, like in Common Lisp or elisp, which fits nicely into the general idea that the knowledge base is a lisp-like runtime. This PR demonstrates just one use case of the new feature. More PRs will come. We also plan to provide a plugin that will give a user control over the set of theories and constraints, as well as select the set of transformations and optimizations that should be applied to the theory. Stay tuned.