### PR TITLE
adds register aliases to the Core Theory

### DIFF
--- a/lib/bap_core_theory/bap_core_theory.ml
+++ b/lib/bap_core_theory/bap_core_theory.ml
@@ -26,6 +26,8 @@ module Theory = struct
   module Filetype = Target.Filetype
   module Enum = KB.Enum
   module Role = Target.Role
+  module Alias = Target.Alias
+  module Origin = Target.Origin
 
   type program = Program.cls
   type source = Source.t
@@ -35,6 +37,8 @@ module Theory = struct
   type language = Language.t
   type compiler = Compiler.t
   type role = Role.t
+  type alias = Alias.t
+  type ('a,'k) origin = ('a,'k) Origin.t
   type system = System.t
   type abi = Abi.t
   type fabi = Fabi.t
@@ -86,5 +90,6 @@ module Theory = struct
   module Empty : Core = Bap_core_theory_empty.Core
   module IEEE754 = Bap_core_theory_IEEE754
   module Parser = Bap_core_theory_parser
+  module Pass = Bap_core_theory_pass
   include Bap_core_theory_manager
 end

--- a/lib/bap_core_theory/bap_core_theory_pass.ml
+++ b/lib/bap_core_theory/bap_core_theory_pass.ml
@@ -1,0 +1,202 @@
+open Core_kernel
+open Bap_knowledge
+open Bap_core_theory_definition
+
+module KB = Knowledge
+
+open KB.Syntax
+open KB.Let
+
+module Target = Bap_core_theory_target
+module Program = Bap_core_theory_program
+module Effect = Bap_core_theory_effect
+module Origin = Target.Origin
+module Var = Bap_core_theory_var
+module Val = Bap_core_theory_value
+
+
+module type trans = functor (_ : Core) -> Core
+
+type pass = (module trans)
+
+let passes = Hashtbl.create (module KB.Name)
+let info = Hashtbl.create (module KB.Name)
+
+let no_such_pass name =
+  invalid_argf "Unknown core theory pass %s"
+    (KB.Name.show name) ()
+
+let name_is_taken name =
+  invalid_argf "The name %s is already taken, please
+    select a unique name" (KB.Name.show name) ()
+
+let register ?desc ?package name pass =
+  let name = KB.Name.create ?package name in
+  if Hashtbl.mem passes name then name_is_taken name;
+  Option.iter desc ~f:(fun desc -> Hashtbl.add_exn info name desc);
+  Hashtbl.add_exn passes name pass
+
+
+let lookup name = match Hashtbl.find passes name with
+  | None -> no_such_pass name
+  | Some p -> p
+
+let compose : pass -> pass -> pass =
+  fun (module T1) (module T2) ->
+  let module T(X : Core) = T2(T1(X)) in
+  (module T)
+
+let apply names : (module Core) -> (module Core) =
+  fun (module CT) ->
+  match List.map names ~f:lookup with
+  | [] -> (module CT)
+  | ps ->
+    let (module T) = List.reduce_balanced_exn ps ~f:compose in
+    (module T(CT))
+
+module Scope = struct
+  let vars = KB.Context.declare ~package:"core" "desugar-scope-vars"
+      !!(Map.empty (module Var.Ident))
+
+  let update slot obj f =
+    KB.collect slot obj >>| f >>=
+    KB.provide slot obj
+
+  let push var =
+    KB.Context.update vars @@ fun vars ->
+    Map.update vars (Var.ident var) ~f:(function
+        | None -> 1
+        | Some n -> n + 1)
+
+  let pop var =
+    KB.Context.update vars @@ fun vars ->
+    Map.change vars (Var.ident var) ~f:(function
+        | None | Some 1 -> None
+        | Some n -> Some (n-1))
+
+  let mem var =
+    KB.Context.get vars >>| fun vars ->
+    Map.mem vars (Var.ident var)
+end
+
+
+module Desugar(CT : Core) : Core = struct
+
+  module Delta = struct
+    let target =
+      KB.Object.scoped Program.cls Program.Label.target
+
+    let pass = Effect.empty Effect.Sort.bot
+
+    let assign_sub dst src off =
+      src >>= fun src ->
+      let s = Var.sort dst in
+      let dst_len = Val.Bitv.size s
+      and src_len = Val.Bitv.size @@ Val.sort src in
+      let src = CT.unsigned s !!src in
+      let open Bitvec.Make(struct
+          let modulus = Bitvec.modulus dst_len
+        end) in
+      let mask = (one lsl int src_len - one) lsl int off in
+      let x = CT.(logand (var dst) (int s mask)) in
+      let off = int off in
+      let y = if Bitvec.equal off zero
+        then src
+        else CT.(lshift src (int s off)) in
+      CT.(set dst (logor x y))
+
+
+    let pos x =
+      let module Pos = Bitvec.M32 in
+      CT.int (Val.Bitv.define 32) (Pos.int x)
+
+    let assign_regs lhs rhs =
+      rhs >>= fun rhs ->
+      let total = Val.(Bitv.size (sort rhs)) in
+      fst@@List.fold lhs ~init:(!!pass,total+1) ~f:(fun (data,hi) lhs ->
+          let s = Var.sort lhs in
+          let bits = Val.Bitv.size s in
+          let lo = hi - bits in
+          let rhs = CT.extract s (pos hi) (pos lo) !!rhs in
+          CT.(seq data (set lhs rhs),hi - bits))
+
+
+    (* module Alias ensures that only bitvec registers
+       are involved in aliasing *)
+    let cast_var v =
+      match Val.Bitv.refine @@ Val.Sort.forget @@ Var.sort v with
+      | None -> assert false
+      | Some s -> Var.resort v s
+    and cast_val v = v >>| fun v ->
+      match Val.resort Val.Bitv.refine (Val.forget v) with
+      | None -> assert false
+      | Some v -> v
+
+    let set v x =
+      Scope.mem v >>= function
+      | true -> CT.set v x
+      | false ->
+        let* t = target in
+        if Target.has_roles t [Target.Role.Register.constant] v
+        then !!pass
+        else match Target.unalias t v with
+          | None -> CT.set v x
+          | Some origin ->
+            let x = cast_val x in
+            match Origin.cast_sub origin with
+            | Some s when Origin.is_alias s ->
+              CT.set (Origin.reg s) x
+            | Some s -> assign_sub (Origin.reg s) x (Origin.lo s)
+            | None -> match Origin.cast_sup origin with
+              | None -> !!pass
+              | Some s -> assign_regs (Origin.regs s) x
+
+    let var r =
+      Scope.mem r >>= function
+      | true -> CT.var r
+      | false ->
+        let* t = target in
+        let s = Var.sort r in
+        let ret x = x >>| fun x -> KB.Value.refine x s in
+        if Target.has_roles t [Target.Role.Register.zero] r
+        then match Val.Bitv.refine (Val.Sort.forget s) with
+          | None -> CT.unk s
+          | Some s' ->
+            ret@@CT.int s' Bitvec.zero
+        else
+          match Target.unalias t r with
+          | None -> CT.var r
+          | Some origin ->
+            match Origin.cast_sub origin with
+            | Some sub when Origin.is_alias sub ->
+              CT.var (Var.resort (Origin.reg sub) s)
+            | Some sub ->
+              let hi = Origin.hi sub and lo = Origin.lo sub in
+              let bs = Val.Bitv.define (hi-lo+1) in
+              ret @@
+              CT.extract bs (pos hi) (pos lo) (CT.var (Origin.reg sub))
+            | None -> match Origin.cast_sup origin with
+              | None -> CT.unk s
+              | Some sup ->
+                let regs = Origin.regs sup in
+                let total = List.sum (module Int) regs ~f:(fun r ->
+                    Val.Bitv.size (Var.sort r)) in
+                let bs = Val.Bitv.define total in
+                ret @@ CT.concat bs (List.map regs ~f:CT.var)
+
+    let let_ v x y =
+      x >>= fun x ->
+      Scope.push v >>= fun () ->
+      y >>= fun y ->
+      Scope.pop v >>= fun () ->
+      CT.let_ v !!x !!y
+
+  end
+
+  include CT
+  include Delta
+end
+
+let () = register "desugar-variables" (module Desugar)
+    ~package:"core"
+    ~desc:"desugars assignments and access to register aliases"

--- a/lib/bap_core_theory/bap_core_theory_pass.mli
+++ b/lib/bap_core_theory/bap_core_theory_pass.mli
@@ -1,0 +1,16 @@
+open Core_kernel
+open Bap_knowledge
+open Bap_core_theory_definition
+
+module type trans = functor (_ : Core) -> Core
+
+
+val register :
+  ?desc:string ->
+  ?package:string -> string -> (module trans) -> unit
+
+val lookup : Knowledge.Name.t -> (module trans)
+
+val apply : Knowledge.Name.t list -> (module Core) -> (module Core)
+
+module Desugar(CT : Core) : Core

--- a/lib/bap_primus/bap_primus_lisp_semantics.ml
+++ b/lib/bap_primus/bap_primus_lisp_semantics.ml
@@ -378,25 +378,10 @@ module Prelude(CT : Theory.Core) = struct
       seq xs;
     ]
 
-  let cast s x =
-    Meta.lift@@CT.cast (bits s) CT.b0 !x
-
   let nil = !!(Theory.Value.empty Theory.Bool.t)
   let undefined = full [] nil
   let purify eff =
     full [] !!(res eff)
-
-  let unified x y f =
-    Theory.Value.Match.(begin
-        let|() = both
-            Theory.Bitv.refine x
-            Theory.Bitv.refine y @@ fun x y ->
-          let s = Int.max (size x) (size y) in
-          cast s x >>= fun x ->
-          cast s y >>= fun y ->
-          f x y in
-        undefined
-      end)
 
   let coerce_bits s x f =
     let open Theory.Value.Match in

--- a/oasis/core-theory
+++ b/oasis/core-theory
@@ -20,6 +20,7 @@ Library bap_core_theory
         Bap_core_theory_program,
         Bap_core_theory_manager,
         Bap_core_theory_parser,
+        Bap_core_theory_pass,
         Bap_core_theory_target,
         Bap_core_theory_value,
         Bap_core_theory_var

--- a/plugins/arm/semantics/aarch64.lisp
+++ b/plugins/arm/semantics/aarch64.lisp
@@ -13,7 +13,7 @@
   (set$ dst (lshift imm pos)))
 
 (defun MOVZWi (dst imm pos)
-  (set$ (base-reg dst) (lshift imm pos)))
+  (set$ dst (lshift imm pos)))
 
 (defun ADDXri (dst src imm off)
   (set$ dst (+ src (lshift imm off))))
@@ -27,11 +27,11 @@
              (load-hword (+ base (lshift off 2))))))
 
 (defun LDRWui (dst reg off)
-  (set$ (base-reg dst)
+  (set$ dst
         (cast-unsigned (word) (load-hword (+ reg (lshift off 2))))))
 
 (defun LDRBBui (dst reg off)
-  (set$ (base-reg dst)
+  (set$ dst
         (cast-unsigned (word) (load-byte (+ reg off)))))
 
 (defmacro make-BFM (cast xd xr ir is)
@@ -56,9 +56,9 @@
   (set$ rd (logor rn (shifted rm is))))
 
 (defun ORRWrs (rd rn rm is)
-  (set$ (base-reg rd)
-        (logor (base-reg rn)
-               (shifted (base-reg rm) is))))
+  (set$ rd
+        (logor rn
+               (shifted rm is))))
 
 (defun ADRP (dst imm)
   (set$ dst (+
@@ -66,10 +66,10 @@
              (cast-signed (word) (lshift imm 12)))))
 
 (defun ADDWrs (dst r1 v s)
-  (set$ (base-reg dst) (+ (base-reg r1) (lshift (base-reg v) s))))
+  (set$ dst (+ r1 (lshift v s))))
 
 (defun ADDWri (dst r1 imm s)
-  (set$ (base-reg dst) (+ (base-reg r1) (lshift imm s))))
+  (set$ dst (+ r1 (lshift imm s))))
 
 
 (defun SUBXrx64 (rd rn rm off)
@@ -80,11 +80,11 @@
 
 (defun SUBSWrs (rd rn rm off)
   (add-with-carry
-   (base-reg rd)
-   (base-reg rn) (lnot (shifted (base-reg rm) off)) 1))
+   rd
+   rn (lnot (shifted rm off)) 1))
 
 (defun SUBSWri (rd rn imm off)
-  (add-with-carry (base-reg rd) (base-reg rn) (lnot (lshift imm off)) 1))
+  (add-with-carry rd rn (lnot (lshift imm off)) 1))
 
 
 (defun SUBSXri (rd rn imm off)
@@ -97,7 +97,7 @@
   (set$ rd (- rn (lshift imm off))))
 
 (defun SUBWri (rd rn imm off)
-  (set$ (base-reg rd) (- (base-reg rn) (lshift imm off))))
+  (set$ rd (- rn (lshift imm off))))
 
 (defun ADDXrs (rd rn rm off)
   (set$ rd (+ rn (shifted rm off))))
@@ -155,7 +155,7 @@
 
 (defun STRWui (src reg off)
   (let ((off (lshift off 2)))
-    (store-word (+ reg off) (cast-low 32 (base-reg src)))))
+    (store-word (+ reg off) (cast-low 32 src))))
 
 (defun STRXroX (rt rn rm _ shift)
   (store-word (+ rn (lshift rm (* shift 3))) rt))
@@ -166,7 +166,7 @@
 
 
 (defun STRBBui (src reg off)
-  (store-byte (+ reg off) (base-reg src)))
+  (store-byte (+ reg off) src))
 
 (defun relative-jump (off)
   (exec-addr (+ (get-program-counter) (lshift off 2))))
@@ -194,7 +194,7 @@
     (relative-jump off)))
 
 (defun CBZW (reg off)
-  (when (is-zero (base-reg reg))
+  (when (is-zero reg)
     (relative-jump off)))
 
 (defun CBNZX (reg off)
@@ -202,7 +202,7 @@
     (relative-jump off)))
 
 (defun CBNZW (reg off)
-  (when (/= (base-reg reg) 0)
+  (when (/= reg 0)
     (relative-jump off)))
 
 (defun Bcc (cnd off)
@@ -226,40 +226,3 @@
     0b1100 (logand (= NF VF) (= ZF 0))
     0b1101 (logor (/= NF VF) (/= ZF 0))
     true))
-
-(defun base-reg (reg)
-  (case (symbol reg)
-    'W0  X0
-    'W1  X1
-    'W2  X2
-    'W3  X3
-    'W4  X4
-    'W5  X5
-    'W6  X6
-    'W7  X7
-    'W8  X8
-    'W9  X9
-    'W10 X10
-    'W11 X11
-    'W12 X12
-    'W13 X13
-    'W14 X14
-    'W15 X15
-    'W16 X16
-    'W17 X17
-    'W18 X18
-    'W19 X19
-    'W20 X20
-    'W21 X21
-    'W22 X22
-    'W23 X23
-    'W24 X24
-    'W25 X25
-    'W26 X26
-    'W27 X27
-    'W28 X28
-    'W29 FP
-    'W30 LR
-    'WSP SP
-    'WZR XZR
-    (msg "unknown register $0" reg)))

--- a/plugins/bil/bil_ir.ml
+++ b/plugins/bil/bil_ir.ml
@@ -165,22 +165,18 @@ module IR = struct
       {entry = label; blks}
 
   let set v x =
-    target >>= fun t ->
-    if Theory.Target.has_roles t [Theory.Role.Register.constant] v
-    then !!empty
-    else
-      x >>= fun x ->
-      fresh >>= fun entry ->
-      fresh >>= fun tid ->
-      data {
-        entry;
-        blks = [{
-            name=entry;
-            keep=false;
-            jmps=[];
-            defs=[Def.reify ~tid v x]
-          }]
-      }
+    x >>= fun x ->
+    fresh >>= fun entry ->
+    fresh >>= fun tid ->
+    data {
+      entry;
+      blks = [{
+          name=entry;
+          keep=false;
+          jmps=[];
+          defs=[Def.reify ~tid v x]
+        }]
+    }
 
   (** reifies a [while (<cnd>) <body>] loop to
 

--- a/plugins/bil/bil_lifter.ml
+++ b/plugins/bil/bil_lifter.ml
@@ -12,7 +12,7 @@ include Self()
 
 let package = "bap"
 
-module Optimizer = Theory.Parser.Make(Bil_semantics.Core)
+module Optimizer = Theory.Parser.Make(Theory.Pass.Desugar(Bil_semantics.Core))
 [@@inlined]
 
 

--- a/plugins/bil/bil_semantics.ml
+++ b/plugins/bil/bil_semantics.ml
@@ -167,15 +167,7 @@ module Basic : Theory.Basic = struct
 
     let var r =
       let v = Var.reify r in
-      let s = Theory.Var.sort r in
-      match Var.typ v with
-      | Mem _ | Unk -> exp s (Var v)
-      | Imm w ->
-        KB.Object.scoped Theory.Program.cls @@ fun lbl ->
-        Theory.Label.target lbl >>= fun t ->
-        if Theory.Target.has_roles t [Theory.Role.Register.zero] r
-        then exp s @@ Bil.Int (Word.zero w)
-        else exp s (Var v)
+      exp (Theory.Var.sort r) (Var v)
 
     let b0 = bit Bil.(int Word.b0)
     let b1 = bit Bil.(int Word.b1)
@@ -427,14 +419,9 @@ module Basic : Theory.Basic = struct
       | _ -> gen bs @@ Let (v,rhs,body)
 
     let set var rhs =
-      KB.Object.scoped Theory.Program.cls @@ fun lbl ->
-      Theory.Label.target lbl >>= fun t ->
-      if Theory.Target.has_roles t [Theory.Role.Register.constant] var
-      then data []
-      else
-        rhs >>-> fun _ rhs ->
-        let var = Var.reify var in
-        data [Bil.Move (var,rhs)]
+      rhs >>-> fun _ rhs ->
+      let var = Var.reify var in
+      data [Bil.Move (var,rhs)]
 
     let repeat cnd body =
       cnd >>= fun cnd ->

--- a/plugins/primus_lisp/primus_lisp_main.ml
+++ b/plugins/primus_lisp/primus_lisp_main.ml
@@ -293,7 +293,7 @@ module Semantics = struct
       end);
     KB.promise Lisp.Semantics.args @@ fun this ->
     KB.collect Insn.slot this >>=? fun insn ->
-    Theory.instance () >>= Theory.require >>= fun theory ->
+    Theory.current >>= fun theory ->
     Theory.Label.target this >>= fun target ->
     args_of_ops theory target insn >>| Option.some
 

--- a/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
+++ b/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
@@ -261,12 +261,6 @@ let pslot = KB.Class.property Theory.Value.cls "val"
     ~public:true
     domain
 
-let var_slot = KB.Class.property Theory.Value.cls "variable"
-    ~package:"core" @@
-  KB.Domain.optional "var"
-    ~equal:Theory.Var.Top.equal
-    ~inspect:Theory.Var.Top.sexp_of_t
-
 let nothing = KB.Value.empty Theory.Semantics.cls
 let size = Theory.Bitv.size
 let forget x = x >>| Theory.Value.forget
@@ -589,21 +583,22 @@ module Primitives(CT : Theory.Core)(T : Target) = struct
     | Some addr -> forget@@const_int s addr
 
   let set_symbol v x =
-    match KB.Value.get var_slot v with
-    | Some var ->
+    match KB.Value.get Primus.Lisp.Semantics.symbol v with
+    | Some name ->
+      let var = Theory.Var.define (Theory.Value.sort x) name in
       CT.set var !!x
     | None ->
-      illformed "set-variable (set$) requires a value reified to a variable"
+      illformed "requires a value reified to a variable"
 
   let symbol s v =
-    match KB.Value.get var_slot v with
-    | Some var ->
-      intern (Theory.Var.name var) >>= const_int s |> forget
+    match KB.Value.get Primus.Lisp.Semantics.symbol v with
+    | Some name ->
+      intern name >>= const_int s |> forget
     | None ->
       illformed "symbol requires a value reified to a variable"
 
   let is_symbol v =
-    forget@@match KB.Value.get var_slot v with
+    forget@@match KB.Value.get Primus.Lisp.Semantics.symbol v with
     | Some _ -> true_
     | _ -> false_
 
@@ -773,12 +768,6 @@ module Primitives(CT : Theory.Core)(T : Target) = struct
     | _ -> !!nothing
 end
 
-module VarTheory : Theory.Core = struct
-  include Theory.Empty
-  let var v =
-    var v >>| fun x ->
-    KB.Value.put var_slot x (Some (Theory.Var.forget v))
-end
 
 module CST : Theory.Core = struct
   type t = Sexp.t
@@ -1255,16 +1244,7 @@ end
 
 module Lisp = Primus.Lisp.Semantics
 
-let enable_var_theory () =
-  Theory.declare ~provides:["primus-lisp"; "lisp"]
-    ~package:"core"
-    ~name:"vars"
-    ~desc:"tracks terms that are variables"
-    (KB.return (module VarTheory : Theory.Core))
-
-
 let provide () =
-  enable_var_theory ();
   List.iter export ~f:(fun (name,types,docs) ->
       Primus.Lisp.Semantics.declare ~types ~docs ~package:"core" name
         ~body:(fun target ->
@@ -1274,7 +1254,8 @@ let provide () =
             KB.return @@ fun obj args ->
             KB.catch (P.dispatch obj name args) @@ function
             | Illformed err ->
-              KB.fail (Failed_primitive (assert false,args,err))
+              let name = KB.Name.create ~package:"core" name in
+              KB.fail (Failed_primitive (name,args,err))
             | other -> KB.fail other))
 
 

--- a/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
+++ b/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
@@ -372,7 +372,7 @@ module Primitives(CT : Theory.Core)(T : Target) = struct
     if Theory.Value.Sort.same (Theory.Value.sort x) s then !!x
     else match const x with
       | Some x -> const_int s x
-      | None -> CT.cast s CT.b0 !!x
+      | None -> CT.signed s !!x
 
   let monoid s sf df init xs =
     with_nbitv s xs @@ fun s xs -> match xs with

--- a/plugins/primus_lisp/semantics/bits.lisp
+++ b/plugins/primus_lisp/semantics/bits.lisp
@@ -2,7 +2,7 @@
 
 (defun msb (x)
   "(msb X) is the most significant bit of X."
-  (select (- (word-width) 1) x))
+  (select (- (word-width x) 1) x))
 
 (defun lsb (x)
   "(msb X) is the least significant bit of X."


### PR DESCRIPTION
For the whole history of BAP it was the responsibility of a lifter to resolve all registers aliases and special registers and use some predefined and arbitrary selected set of registers as the base registers.

However, recent additions of new lifters, e.g., Ghidra, and architectures that use various names for the same registers to denote different semantics (aarch64, avr), showed us the current approach doesn't scale well and that we're missing an abstraction that is widely used in the domain that we are modeling.

This PR introduces to the Core Theory register aliases and defines their semantics. It is now possible to set and access pseudo registers and the core theory machinery will automatically resolve it to the corresponding extracts, concatenations, and updates, e.g., `set w1 wzr` will be translated to `set r1 (logand r1 0xFFFFFFFF00000000)` so that the user theories will never even see the pseudo-registers. The idea is general, and in the future we might even handle the pc registers, e.g., that `set pc r0` would be translated into `jmp r0`. But right now it is only possible to express registers in terms of other registers (i.e., as a continuous part of another register or as a concatenation of registers). Zero registers and constant registers are also supported via the corresponding roles.

The register aliasing rules themselves are defined in a pretty arbitrary manner and the underlying solver will automatically resolve each register in terms of operations on the base registers. It is necessary, though, to tell to the solver which registers are pseudo using the corresponding register role in the target description.

Overall, this mechanism makes our life much easier when we are dealing with different lifters and disassembly backends as they may have committed to different choices in the register names, or which registers to be considered the base registers, or whether to represent the status as a single register or keep each flag as a boolean register, and so on. Now we have the single view on the register file that is set up during target definition and the backends can safely use whatever aliases they like.

So far, this new feature is only used in aarch64 but we will later use it for all other architectures, new and existing. If anyone wants to specify aliasing for the existing architectures, like x86, the help is much appreciated.

# Implementation Details

The desugaring (translating operations on pseudo registers to operations on the base registers) is applied using the `Theory.Pass.Desugar` functor, which is applied automatically to any theory that is obtained through the `Theory` interface, e.g., `Theory.require` or `Theory.current`. It is also possible to apply this functor manually to your theory, if for some reason you're not getting the theory from the knowledge base.

The `Theory.Pass` module is currently a tip of a newly emerging iceberg that will include the transformation pipeline for theories. In particular, we plan to add some useful passes for optimization and code simplification, which will be especially useful for ghidra backend that produces extremely suboptimal encoding.