### PR TITLE
nightly tests are failing due to a bug upstream

### DIFF
--- a/.github/workflows/nightly-testing.yml
+++ b/.github/workflows/nightly-testing.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@master
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           dune-cache: true


### PR DESCRIPTION
which is presumabely fixed but is only available in the master and is
not released.

We will start with the master branch and if it will break stick to the
last working sha.