### PR TITLE
fixes a knowledge base race condition in the run plugin

### DIFF
--- a/plugins/run/run_main.ml
+++ b/plugins/run/run_main.ml
@@ -309,7 +309,6 @@ let find_first_unvisited_blk prog =
 
 let main {Config.get=(!)} proj =
   let open Param in
-  let state = Toplevel.current () in
   let run_until_visited = !until_visited in
   let enqueue_jobs = if !in_isolation
     then enqueue_separate_jobs else enqueue_super_job in
@@ -330,7 +329,8 @@ let main {Config.get=(!)} proj =
           ~args:!argv ~envp:!envp
           ~name:(Primus.Linker.Name.to_string p)
           ~start:(exec p)) in
-  let rec run proj state =
+  let rec run proj =
+    let state = Toplevel.current () in
     let result = Primus.Jobs.run ~on_failure ~on_success proj state in
     let state = Primus.Jobs.knowledge result in
     Toplevel.set state;
@@ -339,14 +339,14 @@ let main {Config.get=(!)} proj =
     if run_until_visited
     then match find_first_unvisited_sub prog with
       | Some sub ->
-        enqueue_term sub; run proj state
+        enqueue_term sub; run proj
       | None -> match find_first_unvisited_blk prog with
         | Some blk ->
           enqueue_term blk;
-          run proj state
+          run proj
         | None -> proj
     else proj in
-  run proj state
+  run proj
 
 let deps = [
   "trivial-condition-form"


### PR DESCRIPTION
The run plugin was resetting the state of the toplevel knowledge base
to the initial and effectively discarding the knowledge that was
accumulated when the Program.t and Symtab.t were constructed as well
discarding any information that might be added to the knowledge base
in project passes.

The run pass was capturing the state at the time when the Project.t is
not fully ready, and at then end was using `Toplevel.set` to reset any
accumulated knowledge.

Effectively, this bug is a race condition, which we could prevent if
the toplevel interface provided safe functions. This will be addressed
in the next couple of pull requests (they will be more aggresive and
change the semantics of several constructs so I decided to split them
for this hotfix).

Big thanks to @anwarmamat for providing a minimal reproducible
example, without it would be nearly impossible to identify it.