### PR TITLE
fixes and improves aarch64 lifter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ testsuite:
 	git clone https://github.com/BinaryAnalysisPlatform/bap-testsuite.git testsuite
 
 check: testsuite
-	make REVISION=3720beda -C testsuite
+	make REVISION=f8af868e4f61 -C testsuite
 
 .PHONY: indent check-style status-clean
 

--- a/lib/arm/arm_target.ml
+++ b/lib/arm/arm_target.ml
@@ -105,7 +105,7 @@ let (.$()) = List.nth_exn
 
 let aliases =
   xs @< ws @< qs @< ds @< ss @< hs @< bs
-  @<[fp64; lr64; sp64; zr; zr64]
+  @<[fp64; lr64; sp64; zr64]
   @<[sp32; zr32]
 
 let varsv8 = rs @< flagsv8 @< [datav8]
@@ -137,7 +137,6 @@ let aliasing = Theory.Alias.[
       def lr64 [reg xs.$(30)];
       def sp64 [reg xs.$(31)];
       def sp64 [unk; reg sp32];
-      def zr [reg xs.$(31)];
       def zr [reg zr64];
       def zr [unk; reg zr32];
     ];
@@ -152,10 +151,6 @@ let aliasing = Theory.Alias.[
 
 
 let parent = CT.Target.declare ~package "arm"
-
-module type v4 = sig
-end
-
 
 module type ARM = sig
   val endianness : CT.endianness
@@ -511,9 +506,8 @@ let is_little t = Theory.Target.endianness t = Theory.Endianness.le
 let register_pcode () =
   Dis.register pcode @@ fun t ->
   let triple = match is_64bit t,is_little t,is_big t with
-    | true,true,_ -> "ARM:LE:32:v8"
-    | true,_,true -> "ARM:BE:32:v8"
-    | true,_,_    -> "ARM:LEBE:32:v8LEInstruction"
+    | true,true,_ -> "AARCH64:LE:64:v8A"
+    | true,_,_ -> "AARCH64:BE:64:v8A"
     | false,true,_ -> "ARM:LE:32:v7"
     | false,_,true -> "ARM:BE:32:v7"
     | false,_,_    -> "ARM:LEBE:32:v7LEInstruction" in

--- a/plugins/arm/semantics/arm-bits.lisp
+++ b/plugins/arm/semantics/arm-bits.lisp
@@ -11,6 +11,17 @@
     (set CF (carry r x y))
     (set$ rd r)))
 
+(defun add-with-carry/clear-base (rd x y c)
+  (let ((r (+ c y x)))
+    (set NF (msb r))
+    (set VF (overflow r x y))
+    (set ZF (is-zero r))
+    (set CF (carry r x y))
+    (clear-base rd)
+    (set$ rd r)))
+
+
+
 (defun logandnot (rd rn)
   (logand rd (lnot rn)))
 
@@ -20,3 +31,30 @@
     (set$ rd (shift r rm))
     (set ZF (is-zero rd))
     (set NF (msb rd))))
+
+(defun condition-holds (cnd)
+  (case cnd
+    0b0000 ZF
+    0b0001 (lnot ZF)
+    0b0010 CF
+    0b0010 (lnot CF)
+    0b0100 NF
+    0b0101 (lnot NF)
+    0b0110 VF
+    0b0111 (lnot VF)
+    0b1000 (logand CF (lnot ZF))
+    0b1001 (logor (lnot CF) ZF)
+    0b1010 (= NF VF)
+    0b1011 (/= NF VF)
+    0b1100 (logand (= NF VF) (lnot ZF))
+    0b1101 (logor (/= NF VF) ZF)
+    true))
+
+(defun clear-base (reg)
+  (set$ (alias-base-register reg) 0))
+
+(defmacro setw (reg val)
+  "(set Wx V) sets a Wx register clearing the upper 32 bits."
+  (let ((res val))
+    (clear-base reg)
+    (set$ reg res)))

--- a/plugins/primus_lisp/primus_lisp_main.ml
+++ b/plugins/primus_lisp/primus_lisp_main.ml
@@ -376,8 +376,8 @@ let () =
     Config.(param (list dir) ~doc:"paths to lisp libraries" "add") in
 
   let features =
-    Config.(param (list string) ~doc:"load specified module" "load"
-              ~default:["posix"]) in
+    Config.(param_all (list string) ~doc:"load specified module" "load"
+              ~default:[["posix"]]) in
 
   let semantics =
     let doc = sprintf "prepend the specified folders to the list of
@@ -413,7 +413,7 @@ let () =
       if !!enable_typecheck then
         Project.register_pass' ~deps:["api"] ~autorun:true typecheck;
       let paths = [Filename.current_dir_name] @ !!libs @ library_paths in
-      let features = "core" :: !!features in
+      let features = "core" :: List.concat !!features in
       Primus.Components.register_generic ~package:"bap" "lisp-type-checker"
         (module TypeErrorSummary)
         ~desc:"Typechecks program and outputs the summary in the standard output.";


### PR DESCRIPTION
1) adds proper aarch64 language ids for the ghidra backend
2) adds about 20 more instructions
3) dealiases R31 and ZR, WZR, and XZR
4) adds the full set of tests (that use symbolic executor)
5) fixes instructions with 32-bit operands, the new `setw` macro
   now correctly zeros the uppert 32 bits.

Also some number of quality of life changes:

1) `--primus-lisp-semantics` now fails with a clear message when the
passed argument doesn't name a folder (previously it was silently
ignoring it).

2) moves arm-wide operations to `arm-bits`

3) allows to repeat of the `--primus-lisp-load` parameter, to make it
easier to use it in scripts and recipes.