### PR TITLE
fixes several Primus Lisp stubs

### DIFF
--- a/plugins/primus_lisp/site-lisp/simple-memory-allocator.lisp
+++ b/plugins/primus_lisp/site-lisp/simple-memory-allocator.lisp
@@ -66,9 +66,10 @@
         (malloc/put-chunk-size ptr n)
         (+ ptr header-size)))))
 
-(defun brk ()
+(defun brk (val)
   (declare (external "brk"))
-  brk)
+  (set brk val)
+  0)
 
 (defun sbrk (increment)
   (declare (external "sbrk"))

--- a/plugins/primus_lisp/site-lisp/stdlib.lisp
+++ b/plugins/primus_lisp/site-lisp/stdlib.lisp
@@ -8,13 +8,13 @@
 
 (defun getenv (name)
   "finds a value of an environment variable with the given name"
-  (declare (external "getenv"))
+  (declare (external "getenv" "secure_getenv"))
   (let ((p environ)
         (n (strlen name)))
     (while (and (not (points-to-null p))
                 (/= (memcmp (read-word ptr_t p) name n) 0))
       (set p (ptr+1 ptr_t p)))
-    (if (and (not (points-to-null p)) (/= p environ))
+    (if (not (points-to-null p))
         (let ((p (read-word ptr_t p)))
           (if (= (memory-read (+ p n)) ?=) (+ p n 1) 0))
       0)))


### PR DESCRIPTION
1) brk was returning the brk address instead of setting it;
2) getenv was missing the first entry in the envop array.