### PR TITLE
extends the knowledge monad interface

### DIFF
--- a/plugins/primus_lisp/primus_lisp_main.ml
+++ b/plugins/primus_lisp/primus_lisp_main.ml
@@ -292,7 +292,7 @@ module Semantics = struct
         comment "translates instruction operands to lisp arguments"
       end);
     KB.promise Lisp.Semantics.args @@ fun this ->
-    KB.collect Insn.slot this >>=? fun insn ->
+    let*? insn = KB.collect Insn.slot this in
     Theory.current >>= fun theory ->
     Theory.Label.target this >>= fun target ->
     args_of_ops theory target insn >>| Option.some
@@ -306,8 +306,8 @@ module Semantics = struct
       end);
     KB.promise Lisp.Semantics.name @@ fun this ->
     KB.collect Insn.slot this >>|? fun insn ->
-    let name = KB.Name.create ~package:(Insn.encoding insn) (Insn.name insn) in
-    Some name
+    KB.Name.create ~package:(Insn.encoding insn) (Insn.name insn) |>
+    Option.some
 
   let strip_lisp_extension = String.chop_suffix ~suffix:".lisp"
 

--- a/plugins/radare2/radare2_main.ml
+++ b/plugins/radare2/radare2_main.ml
@@ -20,12 +20,13 @@ let provide_roots file funcs =
     if Theory.Target.belongs Arm_target.parent t
     then !!None
     else
-      KB.collect Theory.Label.addr label >>=? fun addr ->
-      KB.collect Theory.Label.unit label >>=? fun unit ->
-      KB.collect Theory.Unit.bias unit >>= fun bias ->
-      KB.collect Theory.Unit.target unit >>|
-      Theory.Target.code_addr_size >>= fun bits ->
-      KB.collect Theory.Unit.path unit >>|? fun path ->
+      let*? addr = label-->Theory.Label.addr in
+      let*? unit = label--> Theory.Label.unit in
+      let*? path = unit-->Theory.Unit.path in
+      let* bias = unit-->Theory.Unit.bias in
+      let+ bits =
+        KB.collect Theory.Unit.target unit >>|
+        Theory.Target.code_addr_size in
       if String.equal path file then
         let bias = Option.value bias ~default:Bitvec.zero in
         let addr =

--- a/plugins/x86/x86_legacy_bil_lifter.ml
+++ b/plugins/x86/x86_legacy_bil_lifter.ml
@@ -361,18 +361,14 @@ module Bap_integration = struct
       let prog = fixrip next prog in
       Parser.run grammar prog
 
-  let (>>?) x f = x >>= function
-    | None -> KB.return empty
-    | Some x -> f x
-
   let provide_lifter () =
     info "providing a lifter for all Legacy AST lifters";
     let lifter obj =
       Knowledge.collect Arch.slot obj >>= fun arch ->
       Theory.instance ~context:["floating-point"] () >>=
       Theory.require >>= fun theory ->
-      Knowledge.collect Memory.slot obj >>? fun mem ->
-      Knowledge.collect Disasm_expert.Basic.Insn.slot obj >>? fun insn ->
+      let* mem = obj-->?Memory.slot in
+      let* insn = obj-->?Disasm_expert.Basic.Insn.slot in
       match arch with
       | `x86 | `x86_64 as arch ->
         KB.catch (lift theory arch mem insn)


### PR DESCRIPTION
This is a quality of life PR (an extract from another PR that I am currently working on) that adds a few useful primitives to the knowledge base monad interface.

The most important addition is the new operator `require` that works like `collect` but raises the empty value conflict if the returned value is empty. This function is inteded to be used in the context of promises and proposals that now catch this exception and evaluate the whole scoped expression to the empty value of the computed domain. This vastly simplify the implementation logic of promises for domains that do not use `None` as the empty value.

To make things work even more smoothly we extend the KB.Syntax module with a few new operators. First of all, we include the `Monad.Let` directly into the `KB.Syntax` so that you don't need to open `KB.Let` anymore. Next, we introduce `let*?` and `let+?`, which let-binding couterparts of the already existing `>>=?` and `>>|?` infix operators. Next, we add `-->?` to complement `-->`, it collects an optional domain value and fails if it is `None`.

Finally, we add indexing operators for accessing fields of KB values. The also come with the empty-checking variants.

The PR also applies the new operators to the existing code for the demonstration purposes (and to show that it works). I also believe that the rewritten code is more reable, even despite that I still prefer the infix syntax to the let-binding operators.