### PR TITLE
adds forward-chaining rules and Primus Lisp methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ testsuite:
 	git clone https://github.com/BinaryAnalysisPlatform/bap-testsuite.git testsuite
 
 check: testsuite
-	make REVISION=81d9159 -C testsuite
+	make REVISION=c2324bf -C testsuite
 
 .PHONY: indent check-style status-clean
 

--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -3867,6 +3867,11 @@ text ::= ?any atom that is not recognized as a <word>?
       *)
       module Semantics : sig
 
+        (** the representation of semantic values.
+
+            @since 2.4.0  *)
+        type value = unit Theory.Value.t
+
         (** occurs when no matching definition is found
 
             The reason why no match is selected is provided as the
@@ -3994,15 +3999,35 @@ text ::= ?any atom that is not recognized as a <word>?
           ?types:Type.signature ->
           ?docs:string ->
           ?package:string ->
-          ?body:(Theory.Target.t -> (Theory.Label.t -> Theory.Value.Top.t list -> unit Theory.eff) KB.t) ->
+          ?body:(Theory.Target.t -> (Theory.Label.t -> value list -> unit Theory.eff) KB.t) ->
           string -> unit
+
+
+        (** [signal ~params ~docs property args] declares a signal.
+
+            Emits a signal with arguments [args l v], when the
+            [property] value of a program label [l] changes to
+            [v]. The name of the signal is the same as the name of the
+            property.
+
+            The signal triggers all methods with the same method name
+            as the signal.
+
+            @since 2.4.0
+        *)
+        val signal :
+          ?params:[< Type.parameters] ->
+          ?docs:string ->
+          (Theory.program, 'p) KB.slot ->
+          (Theory.Label.t -> 'p -> value list KB.t) ->
+          unit
 
         (** [failp err_msg args...] terminates a primitive with error.
 
             Must be called from a primitive implementation to stop
             the evaluation with the [Failed_primitive] conflict.
 
-            This conflict should used to report programmers errors
+            This conflict should used to report programmer errors
             that are not representable via the type system (or slipped
             through the gradual type checker).
 
@@ -4020,7 +4045,7 @@ text ::= ?any atom that is not recognized as a <word>?
 
             @since 2.4.0  *)
         module Value : sig
-          type t = unit Theory.Value.t
+          type t = value
 
           (** [static x] a value statically equal to [x].*)
           val static : Bitvec.t -> t

--- a/lib/bap_primus/bap_primus_lisp.mli
+++ b/lib/bap_primus/bap_primus_lisp.mli
@@ -141,6 +141,7 @@ module Make (Machine : Machine) : sig
 end
 
 module Semantics : sig
+  type value = unit Theory.Value.t
   type KB.conflict += Unresolved_definition of string
   type KB.conflict += Illtyped_program of Type.error list
   type KB.conflict += Failed_primitive of KB.Name.t * string
@@ -162,6 +163,7 @@ module Semantics : sig
     ?body:(Theory.Target.t -> (Theory.Label.t -> Theory.Value.Top.t list -> unit Theory.eff) KB.t) ->
     string -> unit
 
+
   module Value : sig
     type t = unit Theory.Value.t
     val static : Bitvec.t -> t
@@ -176,6 +178,13 @@ module Semantics : sig
     val pure : Value.t -> t
     val return : Value.t -> t KB.t
   end
+
+  val signal :
+    ?params:[< Type.parameters] ->
+    ?docs:string ->
+    (Theory.program,'p) KB.slot ->
+    (Theory.Label.t -> 'p -> Value.t list KB.t) ->
+    unit
 
   val documentation : Theory.Unit.t -> Doc.index KB.t
 end

--- a/lib/bap_primus/bap_primus_lisp.mli
+++ b/lib/bap_primus/bap_primus_lisp.mli
@@ -143,6 +143,7 @@ end
 module Semantics : sig
   type KB.conflict += Unresolved_definition of string
   type KB.conflict += Illtyped_program of Type.error list
+  type KB.conflict += Failed_primitive of KB.Name.t * string
 
   val program : (Theory.Source.cls, program) KB.slot
   val definition : (Theory.program, Theory.Label.t option) KB.slot
@@ -151,6 +152,8 @@ module Semantics : sig
   val symbol : (Theory.Value.cls, String.t option) KB.slot
   val static : (Theory.Value.cls, Bitvec.t option) KB.slot
   val enable : ?stdout:Format.formatter -> unit -> unit
+  val failp : ('a, Format.formatter, unit, 'b KB.t) format4 -> 'a
+
 
   val declare :
     ?types:Type.signature ->
@@ -159,6 +162,20 @@ module Semantics : sig
     ?body:(Theory.Target.t -> (Theory.Label.t -> Theory.Value.Top.t list -> unit Theory.eff) KB.t) ->
     string -> unit
 
+  module Value : sig
+    type t = unit Theory.Value.t
+    val static : Bitvec.t -> t
+    val symbol : string -> t
+    val custom : (Theory.Value.cls, 'a) KB.slot -> 'a -> t
+    val nil : t
+  end
+
+
+  module Effect : sig
+    type t = unit Theory.Effect.t
+    val pure : Value.t -> t
+    val return : Value.t -> t KB.t
+  end
 
   val documentation : Theory.Unit.t -> Doc.index KB.t
 end
@@ -168,6 +185,8 @@ module Unit : sig
   val is_lisp : Theory.Unit.t -> bool KB.t
   val language : Theory.language
 end
+
+
 
 module Attribute : sig
   type 'a t

--- a/lib/bap_primus/bap_primus_lisp_program.ml
+++ b/lib/bap_primus/bap_primus_lisp_program.ml
@@ -115,7 +115,7 @@ let targets {exports} package = match Map.find exports package with
   | Some packs -> packs
 
 (* [transitive_closure p] is the set of packages in which
-   definition from p are visible (p including).
+   the definitions from p are visible (p including).
 *)
 let rec transitive_closure program from =
   let init = Set.singleton (module String) from in
@@ -1447,6 +1447,7 @@ module Typing = struct
       let name = KB.Name.unqualified name in
       match Map.find sigs name with
       | Some [x] -> Some x
+      | Some _ -> None
       | _ -> None
 
   let check_methods glob {context; library} g =

--- a/lib/bap_primus/bap_primus_lisp_resolve.ml
+++ b/lib/bap_primus/bap_primus_lisp_resolve.ml
@@ -35,10 +35,10 @@ type ('t,'a,'b) many = ('t,'a,('t Def.t * 'b) list) resolver
 
 type exn += Failed of string * Context.t * resolution
 
-let interns d name = String.equal (Def.name d) name
+let has_name d name = String.equal (Def.name d) name
 
 (* all definitions with the given name *)
-let stage1 has_name defs name =
+let stage1 defs name =
   List.filter defs ~f:(fun def -> has_name def name)
 
 let context def =
@@ -147,12 +147,12 @@ let one = function
 
 let many xs = Some xs
 
-let run choose namespace overload prog item name =
+let run choose overload prog item name =
   Program.in_package (KB.Name.package name) prog @@ fun prog ->
   let name = KB.Name.unqualified name in
   let ctxts = Program.context prog in
   let defs = Program.get ~name prog item in
-  let s1 = stage1 namespace defs name in
+  let s1 = stage1 defs name in
   let s2 = stage2 ctxts s1 in
   let s3 = stage3 s2 in
   let s4 = stage4 s3 in
@@ -171,25 +171,25 @@ let run choose namespace overload prog item name =
       })
 
 let extern typechecks prog item name args =
-  run one interns (overload_defun typechecks args) prog item name
+  run one (overload_defun typechecks args) prog item name
 
 let defun typechecks prog item name args =
-  run one interns (overload_defun typechecks args) prog item name
+  run one (overload_defun typechecks args) prog item name
 
 let meth typechecks prog item name args =
-  run many interns (overload_meth typechecks args) prog item name
+  run many (overload_meth typechecks args) prog item name
 
 let macro prog item name code =
-  run one interns (overload_macro code) prog item name
+  run one (overload_macro code) prog item name
 
 let primitive prog item name () =
-  run one interns overload_primitive prog item name
+  run one overload_primitive prog item name
 
 let semantics prog item name () =
-  run one interns overload_primitive prog item name
+  run one overload_primitive prog item name
 
 let subst prog item name () =
-  run one interns overload_primitive prog item name
+  run one overload_primitive prog item name
 
 let const = subst
 

--- a/lib/bap_primus/bap_primus_lisp_semantics.ml
+++ b/lib/bap_primus/bap_primus_lisp_semantics.ml
@@ -512,7 +512,7 @@ module Prelude(CT : Theory.Core) = struct
       | None ->
         match Resolve.semantics prog Key.semantics name () with
         | Some Ok (sema,()) ->
-          Def.Sema.apply sema defn xs
+          Def.Sema.apply sema defn xs >>= reify_sym
         | Some (Error problem) -> unresolved name problem
         | None ->
           let msg = Format.asprintf "No definition is found for %a"
@@ -579,7 +579,7 @@ module Prelude(CT : Theory.Core) = struct
           !!beff;
         ] !!(res beff)
     and prim ?(package="core") name args =
-      call (KB.Name.read ~package name) args >>= reify_sym in
+      call (KB.Name.read ~package name) args in
     match args with
     | Some args ->
       call ~toplevel:true name args

--- a/lib/bap_primus/bap_primus_lisp_semantics.mli
+++ b/lib/bap_primus/bap_primus_lisp_semantics.mli
@@ -6,6 +6,7 @@ open Bap_primus_lisp_program
 
 type KB.conflict += Unresolved_definition of string
 type KB.conflict += Illtyped_program of Type.error list
+type KB.conflict += Failed_primitive of KB.Name.t * string
 
 val program : (Theory.Source.cls, program) KB.slot
 val definition : (Theory.program, Theory.Label.t option) KB.slot
@@ -14,6 +15,8 @@ val args : (Theory.program, unit Theory.Value.t list option) KB.slot
 val symbol : (Theory.Value.cls, String.t option) KB.slot
 val static : (Theory.Value.cls, Bitvec.t option) KB.slot
 val enable : ?stdout:Format.formatter -> unit -> unit
+val failp : ('a, Format.formatter, unit, 'b KB.t) format4 -> 'a
+
 
 val typed_program : Theory.Unit.t -> program KB.t
 
@@ -29,4 +32,20 @@ module Unit : sig
   val create : ?name:string -> Theory.Target.t -> Theory.Unit.t KB.t
   val is_lisp : Theory.Unit.t -> bool KB.t
   val language : Theory.language
+end
+
+
+module Value : sig
+  type t = unit Theory.Value.t
+  val static : Bitvec.t -> t
+  val symbol : string -> t
+  val custom : (Theory.Value.cls, 'a) KB.slot -> 'a -> t
+  val nil : t
+end
+
+
+module Effect : sig
+  type t = unit Theory.Effect.t
+  val pure : Value.t -> t
+  val return : Value.t -> t KB.t
 end

--- a/lib/bap_primus/bap_primus_lisp_semantics.mli
+++ b/lib/bap_primus/bap_primus_lisp_semantics.mli
@@ -3,7 +3,7 @@ open Bap.Std
 open Bap_primus_lisp_types
 open Bap_primus_lisp_program
 
-
+type value = unit Theory.Value.t
 type KB.conflict += Unresolved_definition of string
 type KB.conflict += Illtyped_program of Type.error list
 type KB.conflict += Failed_primitive of KB.Name.t * string
@@ -28,6 +28,8 @@ val declare :
   string ->
   unit
 
+
+
 module Unit : sig
   val create : ?name:string -> Theory.Target.t -> Theory.Unit.t KB.t
   val is_lisp : Theory.Unit.t -> bool KB.t
@@ -49,3 +51,13 @@ module Effect : sig
   val pure : Value.t -> t
   val return : Value.t -> t KB.t
 end
+
+val signal :
+  ?params:[< `All of Theory.target -> Bap_primus_lisp_types.typ
+          | `Gen of
+               (Theory.target -> Bap_primus_lisp_types.typ) list *
+               (Theory.target -> Bap_primus_lisp_types.typ)
+          | `Tuple of (Theory.target -> Bap_primus_lisp_types.typ) list ] ->
+  ?docs:string -> (Theory.program, 'p) KB.slot ->
+  (Theory.Label.t -> 'p -> Value.t list KB.t) ->
+  unit

--- a/lib/knowledge/bap_knowledge.mli
+++ b/lib/knowledge/bap_knowledge.mli
@@ -269,6 +269,29 @@ module Knowledge : sig
   val proposing : agent -> ('a, 'p opinions) slot ->
     propose:('a obj -> 'p t) -> (unit -> 's t) -> 's t
 
+  (** [observe property push] calls [push] when the [property] changes.
+
+      Dual to [promise], [observe] enables forward-chaining rules and
+      propagates knowledge whenever [property] value is refined.
+
+      Calls [push x v] when the [property] value of an object [x] is
+      refined to [v]. It is guaranteed that [v] is never empty.
+
+      @since 2.4.0
+  *)
+  val observe : ('a,'p) slot -> ('a obj -> 'p -> unit knowledge) -> unit
+
+  (** [observing property ~observe:push scope] observes the property in a [scope].
+
+      This operation is dual to [promising] and it observes the
+      property only during the time when the [scope] computation is
+      evaluate and removes the observer after that.
+
+      @since 2.4.0
+
+  *)
+  val observing : ('a,'p) slot -> observe:('a obj -> 'p -> unit knowledge) ->
+    (unit -> 'r knowledge) -> 'r knowledge
 
   (** [with_empty ~missing f x] evaluates [f ()] and if it fails on an empty
       immediately evaluates to [return missing].

--- a/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
+++ b/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
@@ -626,7 +626,7 @@ module Primitives(CT : Theory.Core)(T : Target) = struct
     | Some name ->
       intern name >>= const_int s |> forget
     | None ->
-      illformed "symbol requires a value reified to a variable"
+      illformed "symbol requires a symbolic value"
 
   let is_symbol v =
     forget@@match KB.Value.get Primus.Lisp.Semantics.symbol v with


### PR DESCRIPTION
This pull request enables forward-chaining rules in the knowledge base and uses them to implement Primus Lisp methods. In addition, it adds a few goodies that makes it easier to write Primus Lisp semantics primitives. It also tweaks a little bit the Primus Lisp parser to enable proper handling of keywords.


## Forward Chaining Rules

So far, the knowledge base was only supporting backward-chaining via the `promise` operation, i.e., promises were called lazily only when a property was collected, which triggered the chain of property computations. Now it is possible to push knowledge forward using the dual of `promise`, the `observe` operation. The `observe` operation registers a `push` action for a property `p`, and the knowledge base calls `push x v` when the value of property `p` of an object `x` is changed (refined) to `v`. The `push` action may change properties of other slots or perform arbitrary knowledge base computations. Not only it enables a more straightforward implementation of some knowledge base rules, but it also enables general event-driven knowledge base analysis. For example, we can use forward-chaining rules to unify Primus Lisp dynamic analyses that use the incident system with static analysis by introducing the `incident` property and storing detected incidents directly in the knowledge base.

## Primus Lisp Methods

The important application of the forward-chaining rules is the implementation of the Primus Lisp semantic methods. Much like their dynamic counterparts that map Primus observations to signals, the semantic methods map Knowledge Base observations to signals so that now we can write a Primus Lisp method that will be called every time some property of a program object is changed. This feature will be heavily used in the next pull request that introduces byte-driven pattern matching, but the potential is much higher than that. We can finally write nearly arbitrary static analysis directly in Primus Lisp by reflecting various properties into signals.

## Primitive Writers Goodies

This PR also brings some number of quality of life improvements in the form of small helpers that make the life of a primitive writer much easier. We now have `Primus.Lisp.Semantics.Value` and `Primus.Lisp.Semantics.Effect` class that facilitate the creation of values and effects that the primitives consume and produce. The Primus Lisp Semantic Interpreter was also tweaked to better support symbols and keywords. In particular, a primitive now can return a symbol and the interpreter will take care of interning it. Finally, the kewords are now treated the same as in other lisp dialects, they self-evaluate to their symbols, so we no longer need to write `':foo` and instead can write `:foo`. This change is applied on the reader (parser) level, so it will affect the dynamic interpreter as well.