### PR TITLE
handles conditional instructions inside IT blocks in thumb

### DIFF
--- a/plugins/arm/semantics/arm-bits.lisp
+++ b/plugins/arm/semantics/arm-bits.lisp
@@ -3,34 +3,40 @@
 
 (in-package arm)
 
+(defun set-flags (r x y)
+  (set NF (msb r))
+  (set VF (overflow r x y))
+  (set ZF (is-zero r))
+  (set CF (carry r x y)))
+
 (defun add-with-carry (rd x y c)
   (let ((r (+ c y x)))
-    (set NF (msb r))
-    (set VF (overflow r x y))
-    (set ZF (is-zero r))
-    (set CF (carry r x y))
+    (set-flags r x y)
     (set$ rd r)))
 
 (defun add-with-carry/clear-base (rd x y c)
   (let ((r (+ c y x)))
-    (set NF (msb r))
-    (set VF (overflow r x y))
-    (set ZF (is-zero r))
-    (set CF (carry r x y))
+    (set-flags r y x)
     (clear-base rd)
     (set$ rd r)))
 
-
+(defun add-with-carry/it-block (rd x y c cnd)
+  (let ((r (+ c y x)))
+    (when (is-unconditional cnd)
+      (set-flags r x y))
+    (set$ rd r)))
 
 (defun logandnot (rd rn)
   (logand rd (lnot rn)))
 
-(defmacro shift-with-carry (shift rd rn rm)
-  (let ((r (cast-signed (word-width) rn)))
-    (set CF (msb r))
-    (set$ rd (shift r rm))
-    (set ZF (is-zero rd))
-    (set NF (msb rd))))
+(defmacro shift-with-carry (shift rd rn rm cnd)
+  (when (condition-holds cnd)
+    (let ((r (cast-signed (word-width) rn)))
+      (when (is-unconditional cnd)
+        (set CF (msb r))
+        (set$ rd (shift r rm))
+        (set ZF (is-zero rd))
+        (set NF (msb rd))))))
 
 (defun condition-holds (cnd)
   (case cnd
@@ -49,6 +55,9 @@
     0b1100 (logand (= NF VF) (lnot ZF))
     0b1101 (logor (/= NF VF) ZF)
     true))
+
+(defun is-unconditional (cnd)
+  (= cnd 0b1110))
 
 (defun clear-base (reg)
   (set$ (alias-base-register reg) 0))

--- a/plugins/arm/semantics/arm-bits.lisp
+++ b/plugins/arm/semantics/arm-bits.lisp
@@ -21,10 +21,11 @@
     (set$ rd r)))
 
 (defun add-with-carry/it-block (rd x y c cnd)
-  (let ((r (+ c y x)))
-    (when (is-unconditional cnd)
-      (set-flags r x y))
-    (set$ rd r)))
+  (when (condition-holds cnd)
+    (let ((r (+ c y x)))
+      (when (is-unconditional cnd)
+        (set-flags r x y))
+      (set$ rd r))))
 
 (defun logandnot (rd rn)
   (logand rd (lnot rn)))

--- a/plugins/thumb/thumb_bits.ml
+++ b/plugins/thumb/thumb_bits.ml
@@ -7,11 +7,9 @@ module Make(CT : Theory.Core) = struct
   open Thumb_core.Make(CT)
   open Syntax
 
-  let sx rd rm = data [
-      rd := CT.signed s32 (var rm)
-    ]
+  let sx rd rm =
+    rd <-? CT.signed s32 (var rm)
 
-  let ux rd rm = data [
-      rd := CT.unsigned s32 (var rm)
-    ]
+  let ux rd rm =
+    rd <-? CT.unsigned s32 (var rm)
 end

--- a/plugins/thumb/thumb_bits.mli
+++ b/plugins/thumb/thumb_bits.mli
@@ -1,8 +1,9 @@
 open Bap_core_theory
 open Thumb_core
+open Thumb_opcodes
 
 module Make(CT : Theory.Core) : sig
   open Theory
-  val sx : r32 reg -> _ reg -> unit eff
-  val ux : r32 reg -> _ reg -> unit eff
+  val sx : r32 reg -> _ reg -> cond -> unit eff
+  val ux : r32 reg -> _ reg -> cond -> unit eff
 end

--- a/plugins/thumb/thumb_branch.ml
+++ b/plugins/thumb/thumb_branch.ml
@@ -27,26 +27,6 @@ module Make(CT : Theory.Core) = struct
   open T
   open T.Syntax
 
-  let holds cond =
-    let is_set x = is_set ~@x and is_clear x = is_clear ~@x in
-    match cond with
-    | `EQ -> is_set zf
-    | `NE -> is_clear zf
-    | `CS -> is_set cf
-    | `CC -> is_clear cf
-    | `MI -> is_set nf
-    | `PL -> is_clear nf
-    | `VS -> is_set vf
-    | `VC -> is_clear vf
-    | `HI -> is_set cf && is_clear zf
-    | `LS -> is_clear cf || is_set zf
-    | `GE -> ~@nf = ~@vf
-    | `LT -> ~@nf <> ~@vf
-    | `GT -> is_clear zf && ~@nf = ~@vf
-    | `LE -> is_set zf || ~@nf <> ~@vf
-    | `AL -> assert false
-
-
   let b pc dst = goto (pc +> dst)
 
   let bcc pc cnd dst = match cnd with

--- a/plugins/thumb/thumb_main.ml
+++ b/plugins/thumb/thumb_main.ml
@@ -70,42 +70,42 @@ module Thumb(CT : Theory.Core) = struct
     let module T = Thumb_mov.Make(CT) in
     let open T in
     match opcode, (MC.Insn.ops insn : Op.t array) with
-    | `tADDi3, [| Reg rd; _; Reg rn; Imm x; _; _|] ->
-      addi3 (reg rd) (reg rn) (imm x)
-    | `tADDi8, [|Reg rd; _; _ ; Imm x; _; _|] ->
-      addi8 (reg rd) (imm x)
-    | `tADDrr, [|Reg rd; _; Reg rn; Reg rm; _; _|] ->
-      addrr (reg rd) (reg rn) (reg rm)
-    | `tADC, [|Reg rd; Reg _; Reg rn; Reg rm; _; _|] ->
-      adcs (reg rd) (reg rn) (reg rm)
-    | `tADDrSPi, [|Reg rd; _; Imm x; _; _;|] ->
-      addrspi (reg rd) (imm x * 4)
-    | `tADDspi, [|_; _; Imm x; _; _|] ->
-      addspi (imm x * 4)
-    | `tSUBi3, [| Reg rd; _; Reg rn; Imm x; _; _|] ->
-      subi3 (reg rd) (reg rn) (imm x)
-    | `tSUBi8, [|Reg rd; _; _ ; Imm x; _; _|] ->
-      subi8 (reg rd) (imm x)
-    | `tSUBrr, [|Reg rd; _; Reg rn; Reg rm; _; _|] ->
-      subrr (reg rd) (reg rn) (reg rm)
-    | `tSUBspi, [|_; _; Imm x; _; _|] ->
-      subspi (imm x * 4)
-    | `tMOVi8, [|Reg rd; _; Imm x; _; _|] ->
-      movi8 (reg rd) (imm x)
+    | `tADDi3, [| Reg rd; _; Reg rn; Imm x; Imm c; _|] ->
+      addi3 (reg rd) (reg rn) (imm x) (cnd c)
+    | `tADDi8, [|Reg rd; _; _ ; Imm x; Imm c; _|] ->
+      addi8 (reg rd) (imm x) (cnd c)
+    | `tADDrr, [|Reg rd; _; Reg rn; Reg rm; Imm c; _|] ->
+      addrr (reg rd) (reg rn) (reg rm) (cnd c)
+    | `tADC, [|Reg rd; Reg _; Reg rn; Reg rm; Imm c; _|] ->
+      adcs (reg rd) (reg rn) (reg rm) (cnd c)
+    | `tADDrSPi, [|Reg rd; _; Imm x; Imm c; _;|] ->
+      addrspi (reg rd) (imm x * 4) (cnd c)
+    | `tADDspi, [|_; _; Imm x; Imm c; _|] ->
+      addspi (imm x * 4) (cnd c)
+    | `tSUBi3, [| Reg rd; _; Reg rn; Imm x; Imm c; _|] ->
+      subi3 (reg rd) (reg rn) (imm x) (cnd c)
+    | `tSUBi8, [|Reg rd; _; _ ; Imm x; Imm c; _|] ->
+      subi8 (reg rd) (imm x) (cnd c)
+    | `tSUBrr, [|Reg rd; _; Reg rn; Reg rm; Imm c; _|] ->
+      subrr (reg rd) (reg rn) (reg rm) (cnd c)
+    | `tSUBspi, [|_; _; Imm x; Imm c; _|] ->
+      subspi (imm x * 4) (cnd c)
+    | `tMOVi8, [|Reg rd; _; Imm x; Imm c; _|] ->
+      movi8 (reg rd) (imm x) (cnd c)
     | `tMOVSr, [|Reg rd; Reg rn|] ->
       movsr (reg rd) (reg rn)
-    | `tASRri, [|Reg rd; _; Reg rm; Imm x; _; _|] ->
-      asri (reg rd) (reg rm) (imm x)
-    | `tLSRri, [|Reg rd; _; Reg rm; Imm x; _; _|] ->
-      lsri (reg rd) (reg rm) (imm x)
-    | `tLSLri, [|Reg rd; _; Reg rm; Imm x; _; _|] ->
-      lsli (reg rd) (reg rm) (imm x)
+    | `tASRri, [|Reg rd; _; Reg rm; Imm x; Imm c; _|] ->
+      asri (reg rd) (reg rm) (imm x) (cnd c)
+    | `tLSRri, [|Reg rd; _; Reg rm; Imm x; Imm c; _|] ->
+      lsri (reg rd) (reg rm) (imm x) (cnd c)
+    | `tLSLri, [|Reg rd; _; Reg rm; Imm x; Imm c; _|] ->
+      lsli (reg rd) (reg rm) (imm x) (cnd c)
     | `tCMPi8, [|Reg rn; Imm x;_;_|] ->
       cmpi8 (reg rn) (imm x)
     | `tCMPr, [|Reg rn; Reg rm;_;_|] ->
       cmpr (reg rn) (reg rm)
-    | `tORR, [|Reg rd; _; _; Reg rm; _; _|] ->
-      lorr (reg rd) (reg rm)
+    | `tORR, [|Reg rd; _; _; Reg rm; Imm c; _|] ->
+      lorr (reg rd) (reg rm) (cnd c)
     | insn ->
       info "unhandled move instruction: %a: %a" Bitvec.pp addr pp_insn insn;
       !!Insn.empty
@@ -115,53 +115,53 @@ module Thumb(CT : Theory.Core) = struct
     let module Mem = Thumb_mem.Make(CT) in
     let open Mem in
     match opcode, (MC.Insn.ops insn : Op.t array) with
-    | `tLDRi,   [|Reg rd; Reg rm; Imm i; _; _|]
-    | `tLDRspi, [|Reg rd; Reg rm; Imm i; _; _|] ->
-      ldri (reg rd) (reg rm) (imm i * 4)
-    | `tLDRr, [|Reg rd; Reg rm; Reg rn; _; _|] ->
-      ldrr (reg rd) (reg rm) (reg rn)
-    | `tLDRpci, [|Reg rd; Imm i; _; _|] ->
-      ldrpci (reg rd) W32.(pc + int 2) (imm i)
-    | `t2LDRpci, [|Reg rd; Imm i; _; _|] ->
-      ldrpci (reg rd) W32.(pc + int 4) (imm i)
-    | `tLDRBi, [|Reg rd; Reg rm; Imm i; _; _|] ->
-      ldrbi (reg rd) (reg rm) (imm i)
-    | `tLDRBr, [|Reg rd; Reg rm; Reg rn; _; _|] ->
-      ldrbr (reg rd) (reg rm) (reg rn)
-    | `tLDRSB, [|Reg rd; Reg rm; Reg rn; _; _|] ->
-      ldrsb (reg rd) (reg rm) (reg rn)
-    | `tLDRHi, [|Reg rd; Reg rm; Imm i; _; _|] ->
-      ldrhi (reg rd) (reg rm) (imm i * 2)
-    | `tLDRHr, [|Reg rd; Reg rm; Reg rn; _; _|] ->
-      ldrhr (reg rd) (reg rm) (reg rn)
-    | `tLDRSH, [|Reg rd; Reg rm; Reg rn; _; _|] ->
-      ldrsh (reg rd) (reg rm) (reg rn)
-    | `tSTRspi, [|Reg rd; Reg rm; Imm i; _; _|]
-    | `tSTRi,   [|Reg rd; Reg rm; Imm i; _; _|] ->
-      stri (reg rd) (reg rm) (imm i * 4)
-    | `tSTRr, [|Reg rd; Reg rm; Reg rn; _; _|] ->
-      strr (reg rd) (reg rm) (reg rn)
-    | `tSTRBi, [|Reg rd; Reg rm; Imm i;_;_|] ->
-      strbi (reg rd) (reg rm) (imm i)
-    | `tSTRBr, [|Reg rd; Reg rm; Reg rn; _; _|] ->
-      strbr (reg rd) (reg rm) (reg rn)
-    | `tSTRHi, [|Reg rd; Reg rm; Imm i; _; _|] ->
-      strhi (reg rd) (reg rm) (imm i * 2)
-    | `tSTRHr, [|Reg rd; Reg rm; Reg rn; _; _|] ->
-      strhr (reg rd) (reg rm) (reg rn)
+    | `tLDRi,   [|Reg rd; Reg rm; Imm i; Imm c; _|]
+    | `tLDRspi, [|Reg rd; Reg rm; Imm i; Imm c; _|] ->
+      ldri (reg rd) (reg rm) (imm i * 4) (cnd c)
+    | `tLDRr, [|Reg rd; Reg rm; Reg rn; Imm c; _|] ->
+      ldrr (reg rd) (reg rm) (reg rn) (cnd c)
+    | `tLDRpci, [|Reg rd; Imm i; Imm c; _|] ->
+      ldrpci (reg rd) W32.(pc + int 2) (imm i) (cnd c)
+    | `t2LDRpci, [|Reg rd; Imm i; Imm c; _|] ->
+      ldrpci (reg rd) W32.(pc + int 4) (imm i) (cnd c)
+    | `tLDRBi, [|Reg rd; Reg rm; Imm i; Imm c; _|] ->
+      ldrbi (reg rd) (reg rm) (imm i) (cnd c)
+    | `tLDRBr, [|Reg rd; Reg rm; Reg rn; Imm c; _|] ->
+      ldrbr (reg rd) (reg rm) (reg rn) (cnd c)
+    | `tLDRSB, [|Reg rd; Reg rm; Reg rn; Imm c; _|] ->
+      ldrsb (reg rd) (reg rm) (reg rn) (cnd c)
+    | `tLDRHi, [|Reg rd; Reg rm; Imm i; Imm c; _|] ->
+      ldrhi (reg rd) (reg rm) (imm i * 2) (cnd c)
+    | `tLDRHr, [|Reg rd; Reg rm; Reg rn; Imm c; _|] ->
+      ldrhr (reg rd) (reg rm) (reg rn) (cnd c)
+    | `tLDRSH, [|Reg rd; Reg rm; Reg rn; Imm c; _|] ->
+      ldrsh (reg rd) (reg rm) (reg rn) (cnd c)
+    | `tSTRspi, [|Reg rd; Reg rm; Imm i; Imm c; _|]
+    | `tSTRi,   [|Reg rd; Reg rm; Imm i; Imm c; _|] ->
+      stri (reg rd) (reg rm) (imm i * 4) (cnd c)
+    | `tSTRr, [|Reg rd; Reg rm; Reg rn; Imm c; _|] ->
+      strr (reg rd) (reg rm) (reg rn) (cnd c)
+    | `tSTRBi, [|Reg rd; Reg rm; Imm i; Imm c;_|] ->
+      strbi (reg rd) (reg rm) (imm i) (cnd c)
+    | `tSTRBr, [|Reg rd; Reg rm; Reg rn; Imm c; _|] ->
+      strbr (reg rd) (reg rm) (reg rn) (cnd c)
+    | `tSTRHi, [|Reg rd; Reg rm; Imm i; Imm c; _|] ->
+      strhi (reg rd) (reg rm) (imm i * 2) (cnd c)
+    | `tSTRHr, [|Reg rd; Reg rm; Reg rn; Imm c; _|] ->
+      strhr (reg rd) (reg rm) (reg rn) (cnd c)
     | #opmem_multi as op,ops ->
       begin match op, Array.to_list ops with
-        | `tSTMIA_UPD, Reg rd :: _ :: _ :: ar ->
-          stm (reg rd) (regs ar)
-        | `tLDMIA, Reg rd :: _ :: _ :: ar ->
-          ldm (reg rd) (regs ar)
-        | `tPUSH, _ :: _ :: ar ->
-          push (regs ar)
-        | `tPOP, _ :: _ :: ar ->
+        | `tSTMIA_UPD, Reg rd :: Imm c :: _ :: ar ->
+          stm (reg rd) (regs ar) (cnd c)
+        | `tLDMIA, Reg rd :: Imm c :: _ :: ar ->
+          ldm (reg rd) (regs ar) (cnd c)
+        | `tPUSH, Imm c :: _ :: ar ->
+          push (regs ar) (cnd c)
+        | `tPOP, Imm c :: _ :: ar ->
           let regs = regs ar in
           if has_pc regs
-          then popret (remove_pc regs)
-          else pop regs
+          then popret (remove_pc regs) (cnd c)
+          else pop regs (cnd c)
         | op,_ ->
           info "unhandled multi-reg instruction: %a" pp_insn (op,ops);
           !!Insn.empty
@@ -173,18 +173,16 @@ module Thumb(CT : Theory.Core) = struct
   let lift_bits opcode insn =
     let open Thumb_bits.Make(CT) in
     match opcode, (MC.Insn.ops insn : Op.t array) with
-    | `tSXTB, [|Reg rd; Reg rm; _; _|] -> sx (reg rd) (reg rm)
-    | `tSXTH, [|Reg rd; Reg rm; _; _|] -> sx (reg rd) (reg rm)
-    | `tUXTB, [|Reg rd; Reg rm; _; _|] -> ux (reg rd) (reg rm)
-    | `tUXTH, [|Reg rd; Reg rm; _; _|] -> ux (reg rd) (reg rm)
+    | `tSXTB, [|Reg rd; Reg rm; Imm c; _|] -> sx (reg rd) (reg rm) (cnd c)
+    | `tSXTH, [|Reg rd; Reg rm; Imm c; _|] -> sx (reg rd) (reg rm) (cnd c)
+    | `tUXTB, [|Reg rd; Reg rm; Imm c; _|] -> ux (reg rd) (reg rm) (cnd c)
+    | `tUXTH, [|Reg rd; Reg rm; Imm c; _|] -> ux (reg rd) (reg rm) (cnd c)
     | insn ->
       info "unhandled bit-wise instruction: %a" pp_insn insn;
       !!Insn.empty
 
   let unpredictable =
     Theory.Label.for_name "arm:unpredictable" >>= CT.goto
-
-
 
   (* these are not entirely complete *)
   let lift_branch pc opcode insn =

--- a/plugins/thumb/thumb_mem.ml
+++ b/plugins/thumb/thumb_mem.ml
@@ -3,8 +3,9 @@ open Base
 open KB.Syntax
 
 open Thumb_core
+open Thumb_opcodes
 
-type eff = unit Theory.effect KB.t
+type eff = cond -> unit Theory.effect KB.t
 
 module Make(CT : Theory.Core) = struct
   module T = Thumb_core.Make(CT)
@@ -18,85 +19,78 @@ module Make(CT : Theory.Core) = struct
 
   (**************************************************************)
 
-  let ldri rd r i = data [
-      rd := load s32 (var r + const i)
-    ]
 
-  let ldrr rd rn rm = data [
-      rd := load s32 (var rn + var rm);
-    ]
+  let ldri rd r i =
+    rd <-? load s32 (var r + const i)
 
-  let ldrbi rd rn i = data [
-      rd := unsigned @@ load s8 (var rn + const i)
-    ]
+  let ldrr rd rn rm =
+    rd <-? load s32 (var rn + var rm)
 
-  let ldrbr rd rn rm = data [
-      rd := unsigned @@ load s8 (var rn + var rm)
-    ]
+  let ldrbi rd rn i =
+    rd <-? unsigned @@ load s8 (var rn + const i)
 
-  let ldrsb rd rn rm = data [
-      rd := signed @@ load s8 (var rn + var rm)
-    ]
 
-  let ldrhi rd rn i = data [
-      rd := unsigned @@ load s16 (var rn + const i)
-    ]
+  let ldrbr rd rn rm =
+    rd <-? unsigned @@ load s8 (var rn + var rm)
 
-  let ldrhr rd rn rm = data [
-      rd := unsigned @@ load s16 (var rn + var rm)
-    ]
 
-  let ldrsh rd rn rm = data [
-      rd := signed @@ load s16 (var rn + var rm);
-    ]
+  let ldrsb rd rn rm =
+    rd <-? signed @@ load s8 (var rn + var rm)
 
-  let ldrpci rd pc off = data [
-      rd := load s32 @@ bitv pc + const off;
-    ]
 
-  let ldm b regs = data [
+  let ldrhi rd rn i =
+    rd <-? unsigned @@ load s16 (var rn + const i)
+
+
+  let ldrhr rd rn rm =
+    rd <-? unsigned @@ load s16 (var rn + var rm)
+
+  let ldrsh rd rn rm =
+    rd <-? signed @@ load s16 (var rn + var rm)
+
+  let ldrpci rd pc off =
+    rd <-? load s32 @@ bitv pc + const off
+
+  let ldm b regs cnd =
+    branch cnd [
       foreachi regs @@ begin fun i r -> [
           r := load s32 @@ var b + const Int.(i*4);
         ]
       end;
       b += const Int.(List.length regs * 4);
-    ]
+    ] []
 
-  let stri rd rm i = data [
-      var rm + const i <-- var rd
-    ]
+  let stri rd rm i =
+    var rm + const i <--? var rd
 
-  let strr rd rm rn = data [
-      var rm + var rn <-- var rd
-    ]
+  let strr rd rm rn =
+    var rm + var rn <--? var rd
 
-  let strhi rd rm i = data [
-      var rm + const i <-- half (var rd);
-    ]
+  let strhi rd rm i =
+    var rm + const i <--? half (var rd)
 
-  let strhr rd rm rn = data [
-      var rm + var rn <-- half (var rd);
-    ]
+  let strhr rd rm rn =
+    var rm + var rn <--? half (var rd)
 
-  let strbi rd rm i = data [
-      var rm + const i <-- byte (var rd);
-    ]
+  let strbi rd rm i =
+    var rm + const i <--? byte (var rd)
 
-  let strbr rd rm rn = data [
-      var rm + var rn <-- byte (var rd)
-    ]
 
-  let stm b regs = data [
+  let strbr rd rm rn =
+    var rm + var rn <--? byte (var rd)
+
+  let stm b regs cnd =
+    branch cnd [
       foreachi regs @@ begin fun i r -> [
           var b + const Int.(i * 4) <-- var r;
         ]
       end;
       b += const Int.(List.length regs * 4);
-    ]
+    ] []
 
   let pop regs = ldm sp regs
 
-  let popret regs =
+  let popret regs cnd =
     let data = seq [
         foreachi regs @@ begin fun i r -> [
             r := load s32 @@ var sp + const Int.(i*4);
@@ -105,13 +99,14 @@ module Make(CT : Theory.Core) = struct
         sp += const Int.(List.length regs * 4);
       ] in
     let ctrl = CT.jmp (load s32 (var sp)) in
-    CT.blk null data ctrl
+    CT.branch ~?cnd (CT.blk null data ctrl) (seq [])
 
-  let push regs = data [
+
+  let push regs cnd = branch cnd [
       sp -= const Int.(List.length regs * 4);
       foreachi regs @@ fun i r -> [
         var sp + const Int.(i*4) <-- var r;
       ]
-    ]
+    ] []
 
 end

--- a/plugins/thumb/thumb_mem.mli
+++ b/plugins/thumb/thumb_mem.mli
@@ -1,8 +1,9 @@
 open Bap_core_theory
 open Theory
 open Thumb_core
+open Thumb_opcodes
 
-type eff = unit effect KB.t
+type eff = cond -> unit effect KB.t
 
 module Make(Core : Theory.Core) : sig
 

--- a/plugins/thumb/thumb_mov.ml
+++ b/plugins/thumb/thumb_mov.ml
@@ -17,8 +17,8 @@ module Make(CT : Theory.Core) = struct
 
   let borrow_from_sub ~rn ~rm = bit (rn < rm)
 
-  let movi8 rd x = data [
-      rd := const x;
+  let movi8 rd x = it_set rd (const x) @@ fun v -> [
+      v := const x;
       nf := if Int.(x lsr 7 = 1) then bit1 else bit0;
       zf := if Int.(x = 0) then bit1 else bit0;
     ]
@@ -29,123 +29,114 @@ module Make(CT : Theory.Core) = struct
       zf := is_zero (var rd);
     ]
 
-  let addi3 rd rn x = with_result rd @@ fun r -> [
-      r := var rn + const x;
+  let addi3 rd rn x = it_set rd (var rn + const x) @@ fun r -> [
       nf := msb (var r);
       zf := is_zero (var r);
       cf := carry_from_add (var r) (var rn);
       vf := overflow_from_add (var r) (var rn) (const x);
     ]
 
-  let addi8 rd x = with_result rd @@ fun r -> [
-      r := var rd + const x;
+  let addi8 rd x = it_set rd (var rd + const x) @@ fun r -> [
       nf := msb (var r);
       zf := is_zero (var r);
       cf := carry_from_add (var r) (var rd);
       vf := overflow_from_add (var r) (var rd) (const x);
     ]
 
-  let addrr rd rn rm = with_result rd @@ fun r -> [
-      r := var rn + var rm;
+  let addrr rd rn rm = it_set rd (var rn + var rm) @@ fun r -> [
       nf := msb (var r);
       zf := is_zero (var r);
       cf := carry_from_add (var r) (var rn);
       vf := overflow_from_add (var r) (var rn) (var rm);
     ]
 
-
-  let adcs rd rn rm = with_result rd @@ fun r -> [
-      r := var rn + var rm + CT.unsigned s32 (var zf);
+  let adcs rd rn rm =
+    it_set rd (var rn + var rm + CT.unsigned s32 (var zf)) @@ fun r -> [
       nf := msb (var r);
       zf := is_zero (var r);
       cf := carry_from_add (var r) (var rn);
       vf := overflow_from_add (var r) (var rn) (var rm);
     ]
 
-  let addspi off = data [
-      sp += const off;
-    ]
+  let addspi off =
+    it_set sp (var sp + const off) @@ fun _ -> []
 
-  let addrspi rd off = data [
-      rd := var sp + const off;
-    ]
+  let addrspi rd off =
+    it_set rd (var sp + const off) @@ fun _ -> []
 
-  let sub r x y = [
-    r := x - y;
+  let cmp x y r = [
     nf := msb (var r);
     zf := is_zero (var r);
     cf := lnot @@ borrow_from_sub x y;
     vf := overflow_from_sub (var r) x y;
-
   ]
 
-  let subi3 rd rn x = with_result rd @@ fun r ->
-    sub r (var rn) (const x)
 
-  let subi8 rd x = with_result rd @@ fun r ->
-    sub r (var rd) (const x)
+  let sub rd x y = it_set rd (x-y) (cmp x y)
 
-  let subrr rd rn rm = with_result rd @@ fun r ->
-    sub r (var rn) (var rm)
+  let subi3 rd rn x =
+    sub rd (var rn) (const x)
 
-  let subrspi rd off = data [
-      rd := var sp - const off;
-    ]
+  let subi8 rd x =
+    sub rd (var rd) (const x)
 
-  let subspi off = data [
-      sp -= const off;
-    ]
+  let subrr rd rn rm =
+    sub rd (var rn) (var rm)
+
+  let subrspi rd off =
+    rd <-? var sp - const off
+
+  let subspi off =
+    sp <-? var sp - const off
 
   let asri rd rm = function
-    | 0 -> data [
+    | 0 ->
+      it_set rd (CT.ite (CT.msb (var rm)) (const ~-1) (const 0))
+      @@ fun rd -> [
         cf := msb (var rm);
-        rd := CT.ite (CT.msb (var rm)) (const ~-1) (const 0);
         nf := msb (var rd);
         zf := is_zero (var rd);
       ]
-    | n -> data [
+    | n ->
+      it_set rd (var rm asr const n) @@ fun rd -> [
         cf := nth Int.(n-1) (var rm);
-        rd := var rm asr const n;
         nf := msb (var rd);
         zf := is_zero (var rd);
       ]
 
   let lsri rd rm = function
-    | 0 -> data [
+    | 0 ->
+      it_set rd (const 0) @@ fun _ -> [
         cf := msb (var rm);
-        rd := const 0;
         nf := bit0;
         zf := bit1;
       ]
-    | n -> data [
+    | n ->
+      it_set rd (var rm lsr const n) @@ fun rd -> [
         cf := nth Int.(n-1) (var rm);
-        rd := var rm lsr const n;
         nf := msb (var rd);
         zf := is_zero (var rd);
       ]
 
   let lsli rd rm = function
-    | 0 -> data [
-        rd := var rm;
+    | 0 -> it_set rd (var rm) @@ fun rd -> [
         nf := msb (var rd);
         zf := is_zero (var rd);
       ]
-    | n -> data [
+    | n -> it_set rd (var rm lsl const n) @@ fun rd -> [
         cf := nth Int.(32-n) (var rm);
-        rd := var rm lsl const n;
         nf := msb (var rd);
         zf := is_zero (var rd);
       ]
 
-  let lorr rd rm = data [
-      rd := var rd lor var rm;
+  let lorr rd rm = it_set rd (var rd lor var rm) @@ fun rd -> [
       nf := msb (var rd);
       zf := is_zero (var rd);
     ]
 
   let cmpi8 rd x = Theory.Var.fresh s32 >>= fun r ->
-    data @@ sub r (var rd) (const x)
+    data @@ cmp (var rd) (const x) r
 
   let cmpr rn rm = Theory.Var.fresh s32 >>= fun r ->
-    data @@ sub r (var rn) (var rm)
+    data @@ cmp (var rn) (var rm) r
 end

--- a/plugins/thumb/thumb_mov.ml
+++ b/plugins/thumb/thumb_mov.ml
@@ -51,7 +51,7 @@ module Make(CT : Theory.Core) = struct
     ]
 
   let adcs rd rn rm =
-    it_set rd (var rn + var rm + CT.unsigned s32 (var zf)) @@ fun r -> [
+    it_set rd (var rn + var rm + CT.unsigned s32 (var cf)) @@ fun r -> [
       nf := msb (var r);
       zf := is_zero (var r);
       cf := carry_from_add (var r) (var rn);

--- a/plugins/thumb/thumb_mov.mli
+++ b/plugins/thumb/thumb_mov.mli
@@ -1,56 +1,57 @@
 open Bap_core_theory
 open Thumb_core
+open Thumb_opcodes
 
 module Make(CT : Theory.Core) : sig
   open Theory
 
   (** [adds rd, rn, #x] aka add(1)  *)
-  val addi3 : r32 reg -> r32 reg -> int -> unit eff
+  val addi3 : r32 reg -> r32 reg -> int -> cond -> unit eff
 
   (** [adds rd, #x] aka add(2) *)
-  val addi8 : r32 reg -> int -> unit eff
+  val addi8 : r32 reg -> int -> cond -> unit eff
 
   (** [adds rd,rn,rm] aka add(3) and add(4) *)
-  val addrr : r32 reg -> r32 reg -> r32 reg -> unit eff
+  val addrr : r32 reg -> r32 reg -> r32 reg -> cond -> unit eff
 
   (** [add rd, sp, #x] aka add(6) *)
-  val addrspi : r32 reg -> int -> unit eff
+  val addrspi : r32 reg -> int -> cond -> unit eff
 
   (** [add sp, #x] aka add(7)  *)
-  val addspi : int -> unit eff
+  val addspi : int -> cond -> unit eff
 
   (** [adcs rd rn rm]  *)
-  val adcs : r32 reg -> r32 reg -> r32 reg -> unit eff
+  val adcs : r32 reg -> r32 reg -> r32 reg -> cond -> unit eff
 
   (** [subs rd, rn, #x] aka sub(1) *)
-  val subi3 : r32 reg -> r32 reg -> int -> unit eff
+  val subi3 : r32 reg -> r32 reg -> int -> cond -> unit eff
 
   (** [subs rd, #x] aka sub(2)  *)
-  val subi8 : r32 reg -> int -> unit eff
+  val subi8 : r32 reg -> int -> cond -> unit eff
 
   (** [subs rd, rn, rm] aka sub(3) *)
-  val subrr : r32 reg -> r32 reg -> r32 reg -> unit eff
+  val subrr : r32 reg -> r32 reg -> r32 reg -> cond -> unit eff
 
   (** [subs sp, #i] aka sub(4) *)
-  val subspi : int -> unit eff
+  val subspi : int -> cond -> unit eff
 
   (** [mov rd, #x]  *)
-  val movi8 : r32 reg -> int -> unit eff
+  val movi8 : r32 reg -> int -> cond -> unit eff
 
   (** [movs rd, rn]  *)
   val movsr : r32 reg -> r32 reg -> unit eff
 
   (** [asrs rd, rn, #i]  *)
-  val asri : r32 reg -> r32 reg -> int -> unit eff
+  val asri : r32 reg -> r32 reg -> int -> cond -> unit eff
 
   (** [lsrs rd, rn, #i]  *)
-  val lsri : r32 reg -> r32 reg -> int -> unit eff
+  val lsri : r32 reg -> r32 reg -> int -> cond -> unit eff
 
   (** [lsls rd, rn, #i]  *)
-  val lsli : r32 reg -> r32 reg -> int -> unit eff
+  val lsli : r32 reg -> r32 reg -> int -> cond -> unit eff
 
   (** [orrs rd, rn]  *)
-  val lorr : r32 reg -> r32 reg -> unit eff
+  val lorr : r32 reg -> r32 reg -> cond -> unit eff
 
   (** [cmp rn, #i] *)
   val cmpi8 : r32 reg -> int -> unit eff


### PR DESCRIPTION
When an unconditional thumb instruction belong to an IT block, it has to be turned into conditional but it must not set the flags if it is 16 bit and is not CMP, CMN, or TST (A8.8.55). This PR updates all handled t1 instructions to properly handle this constraint.