### PR TITLE
fixes a bug in the `cmp` semantics

### DIFF
--- a/plugins/thumb/thumb_mov.ml
+++ b/plugins/thumb/thumb_mov.ml
@@ -135,8 +135,8 @@ module Make(CT : Theory.Core) = struct
     ]
 
   let cmpi8 rd x = Theory.Var.fresh s32 >>= fun r ->
-    data @@ cmp (var rd) (const x) r
+    data @@ (r := var rd - const x) :: cmp (var rd) (const x) r
 
   let cmpr rn rm = Theory.Var.fresh s32 >>= fun r ->
-    data @@ cmp (var rn) (var rm) r
+    data @@ (r := var rn - var rm) :: cmp (var rn) (var rm) r
 end


### PR DESCRIPTION
also moves arm-specific patterns actions to the arm directory and
constrains their context (so that they do not trigger for non-arm
targets and do not fail when arm is disabled and `arm-set-encoding`
is not available).

Thanks @bmourad01 for timely catch of this bug!