### PR TITLE
error handling and performance tweaks

### DIFF
--- a/lib/bap_disasm/bap_disasm_target_factory.ml
+++ b/lib/bap_disasm/bap_disasm_target_factory.ml
@@ -5,7 +5,7 @@ include Bap_disasm_target_intf
 
 let create_stub_target arch =
   let module Lifter = struct
-    let lift _ _ = Or_error.error_string "not implemented"
+    let lift _ _ = Ok []
     let addr_size = Arch.addr_size arch
 
     module CPU = struct

--- a/plugins/bil/bil_lifter.ml
+++ b/plugins/bil/bil_lifter.ml
@@ -274,10 +274,8 @@ let lift ~enable_intrinsics:{for_all; for_unk; for_special; predicates}
   else
     let module Target = (val target_of_arch arch) in
     match Target.lift mem insn with
-    | Error _ as err ->
-      if for_unk
-      then Ok (create_intrinsic target mem insn)
-      else err
+    | Error _ as err -> err
+    | Ok [] when for_unk -> Ok (create_intrinsic target mem insn)
     | Ok bil ->
       if for_special && has_special bil
       then Ok (create_intrinsic target mem insn)

--- a/plugins/bil/bil_lifter.ml
+++ b/plugins/bil/bil_lifter.ml
@@ -297,7 +297,7 @@ let provide_bil ~enable_intrinsics () =
   let* insn = obj-->?Disasm_expert.Basic.Insn.slot in
   match lift ~enable_intrinsics target arch mem insn with
   | Error err ->
-    info "BIL: the BIL lifter failed with %a" Error.pp err;
+    warning "BIL: the BIL lifter failed with %a" Error.pp err;
     KB.return []
   | Ok [] -> KB.return []
   | Ok bil ->
@@ -327,12 +327,12 @@ let provide_lifter ~with_fp () =
     else base_context in
   let is_empty = KB.Domain.is_empty Bil.domain in
   let lifter obj =
-    Theory.Label.target obj >>= fun target ->
-    Theory.instance ~context:(context target) () >>=
-    Theory.require >>= fun (module Core) ->
     KB.collect Bil.code obj >>= fun bil ->
     if is_empty bil then !!Insn.empty
     else
+      Theory.Label.target obj >>= fun target ->
+      Theory.instance ~context:(context target) () >>=
+      Theory.require >>= fun (module Core) ->
       let module Lifter = Theory.Parser.Make(Core) in
       Lifter.run Bil.Theory.parser bil in
   KB.Rule.(declare ~package "bil-semantics" |>

--- a/plugins/radare2/radare2_main.ml
+++ b/plugins/radare2/radare2_main.ml
@@ -34,7 +34,6 @@ let provide_roots file funcs =
           Bitvec.((addr - bias) mod modulus bits) in
         Option.some_if (Hashtbl.mem funcs addr) true
       else None in
-  promise_property Theory.Label.is_valid;
   promise_property Theory.Label.is_subroutine
 
 let strip str =

--- a/plugins/thumb/thumb_opcodes.ml
+++ b/plugins/thumb/thumb_opcodes.ml
@@ -3,43 +3,24 @@ open Bap.Std
 
 (* all the `mov` series, registers marked with `e` means extended *)
 type opmov = [
-  | `tMOVi8 (* Rd imm8 *)
-  | `tMOVSr (* Rd Rm affect CSPR *)
-  | `tMVN (* Rd Rm *)
-  | `tADC (* Rd Rn Rm *)
-  | `tADDi3 (* Rd Rs imm *)
-  | `tADDi8 (* Rd imm *)
-  | `tADDrr (* Rd Rn Rm *)
-  | `tADDhirr (* Rde Rse *)
-  | `tADR (* Rd imm *)
-  | `tADDrSPi (* Rd imm *)
-  | `tADDspi (* imm *)
-  | `tAND
+  |  `tADC
+  | `tADDi3
+  | `tADDi8
+  | `tADDrSPi
+  | `tADDrr
+  | `tADDspi
   | `tASRri
-  | `tASRrr
-  | `tBIC
-  | `tCMNz
   | `tCMPi8
   | `tCMPr
-  | `tCMPhir
-  | `tEOR
   | `tLSLri
-  | `tLSLrr
   | `tLSRri
-  | `tLSRrr
+  | `tMOVSr
+  | `tMOVi8
   | `tORR
-  | `tRSB (* NEG *)
-  | `tREV
-  | `tREV16
-  | `tREVSH
-  | `tROR
-  | `tSBC (* Rd Rm *)
-  | `tSUBi3 (* See the corresponding ADD insns. *)
+  | `tSUBi3
   | `tSUBi8
   | `tSUBrr
   | `tSUBspi
-  | `tTST
-  | `tMUL (* Rd Rn *)
 ] [@@deriving bin_io, compare, sexp, enumerate]
 
 type opbit = [
@@ -61,36 +42,29 @@ type opmem_multi = [
 
 
 type opmem = [
-  | `tLDRi
-  | `tLDRr
-  | `tLDRpci | `t2LDRpci
-  | `tLDRspi
+  | opmem_multi
+  | `t2LDRpci
   | `tLDRBi
   | `tLDRBr
   | `tLDRHi
   | `tLDRHr
   | `tLDRSB
   | `tLDRSH
-  | `tSTRi
-  | `tSTRr
-  | `tSTRspi
+  | `tLDRi
+  | `tLDRpci
+  | `tLDRr
+  | `tLDRspi
   | `tSTRBi
   | `tSTRBr
   | `tSTRHi
   | `tSTRHr
-  | opmem_multi
+  | `tSTRi
+  | `tSTRr
+  | `tSTRspi
 ] [@@deriving bin_io, compare, sexp, enumerate]
 
-type opbranch = [
-  | `tBcc
-  | `tB
-  | `tBL
-  | `tBLXi
-  | `tBLXr
-  | `tBX
-  | `tCBNZ
-  | `tCBZ
-] [@@deriving bin_io, compare, sexp, enumerate]
+type opbranch = [ `tB | `tBL | `tBLXi | `tBLXr | `tBX | `tBcc | `tCBNZ | `tCBZ ]
+[@@deriving bin_io, compare, sexp, enumerate]
 
 type opcode = [
   | opmov

--- a/plugins/x86/x86_utils.ml
+++ b/plugins/x86/x86_utils.ml
@@ -141,6 +141,7 @@ let sig_to_mask =
   | MSB -> Bytemask
 
 exception Arch_exception of Arch.x86 * string [@@deriving sexp]
+exception No_semantics
 
 (** disfailwith is a non-fatal disassembly exception. *)
 let disfailwith m s =
@@ -149,7 +150,7 @@ let disfailwith m s =
     | X8664 -> `x86_64 in
   raise (Arch_exception (a, s))
 
-let unimplemented a s  = disfailwith a ("disasm x86: unimplemented feature: "^s)
+let unimplemented _ _ = raise No_semantics
 
 (* eflags *)
 let df_to_offset mode e =


### PR DESCRIPTION
Sorry for a little bit dirty pull request featuring several independent changes, but it is really tedious to split it into several PRs.

The most important and controversial change is that we now capture conflicts when disassemble. The conflict is reported, the instruction is marked as invalid and the whole chain instructions that led to it, is rejected. The previous behavior was terminating the program with an error message, which to my taste is more correct, but is unsatisfying from the user-perspective. We might return the old behavior after the release, in the development version of bap, as most of the conflicts are programmers' errors. The motivation for capturing conflicts was introducing pattern-based instruction encoding identification, which naturally can have false positives (which we occasionally see in some ARM interworked binaries).

The other changes concern how our lifters report and handle errors. Since we can now have multiple lifters each supplying semantics for a subset of the instruction set, we no longer assume that an unhandled instruction is an error (it might be handled by some other lifter). We still report errors on instructions that a lifter claim to lift but failed to lift.

And since the log file is now much cleaner, I was able to detect some missing cases, mostly for thumb2 (via arm) instructions, which are now handled.

Finally, this PR removes the `is-valid` promise from thumb, which wasn't necessary but was introducing a little bit of slowdown.