### PR TITLE
fixes fresh variable generation

### DIFF
--- a/lib/bap_core_theory/bap_core_theory_var.mli
+++ b/lib/bap_core_theory/bap_core_theory_var.mli
@@ -6,6 +6,7 @@ open Bap_core_theory_value
 type 'a t
 type ord
 type ident [@@deriving bin_io, compare, sexp]
+type id
 type 'a pure = 'a Bap_core_theory_value.t knowledge
 
 
@@ -25,6 +26,8 @@ val is_mutable : 'a t -> bool
 val fresh : 'a sort -> 'a t knowledge
 val scoped : 'a sort -> ('a t -> 'b pure) -> 'b pure
 val pp : Format.formatter -> 'a t -> unit
+
+val reset_temporary_counter : unit knowledge
 
 module Ident : sig
   type t = ident [@@deriving bin_io, compare, sexp]

--- a/lib/bap_types/bap_var.ml
+++ b/lib/bap_types/bap_var.ml
@@ -57,6 +57,7 @@ let sort_of_typ t =
   | Type.Unk -> ret @@ unknown
 
 module Generator = struct
+  let counter = ref 0xC00000;
   module Toplevel = Bap_toplevel
   open KB.Syntax
 
@@ -76,6 +77,10 @@ module Generator = struct
       Theory.Var.fresh s >>|  Theory.Var.ident
     end;
     Toplevel.get ident
+
+  let fresh _ =
+    decr counter;
+    Theory.Var.Ident.of_string (sprintf "#%d" !counter)
 end
 
 let create ?(is_virtual=false) ?(fresh=false) name typ =


### PR DESCRIPTION
This PR is a cherry pick from a big effort on reducing the number of calls to `Toplevel.exec`, with the end goal to forbid any nesting calls. The amount of work turned to be much greater than expected as we still rely very much on the old abstractions (spoiler: the main issue is with how we encode CPU exceptions). The problem with nested calls, is that they have inconsistent views on the knowledge base and that the outer calls undo the knowledge of the inner calls. The real impact is not that tragic but there are some number of annoying artifacts with which we would like to deal.

In this PR we will deal with the way how fresh variables are generated. So far they were using the knowledge base to store the number of generated variables and since `Bap.Std.Var.create` is having non-monadic type we had to use `Toplevel.exec` to evaluate the creation of a fresh variable in the knowledge base. This function is still heavily used, especially by the old lifters, which in turn are run during disassembly, which is a knowledge computation by itself, so we have the nested call to `Toplevel.exec` every time we create a new variable in the legacy lifters. As a result we have intersecting variables, on targets that use both new and old lifters, e.g., ARM. The semantics is still correct, because the variables have non-intersecting scopes, although this argument could be discarded by using a different definition of a variable scope. To remove this nuisance, we no longer use the knowledge base to generate fresh identifiers for variables in Bap.Std.Var but instead use the good old reference counter, which is set to a high value that shouldn't intersect with the theory fresh variables, which occupy the lower spectrum of the variable numbers. Of course, theoretically they can still clash, but in practice such a possibility could be safely ignored, especially since they still will have non-intersecting scopes.

Note, that in the future, we will define the scope more precisely and will reuse variable identifiers more aggressively. So it is better not to rely on the current behavior that each fresh variable has indefinite scope and never changes its type.