### PR TITLE
fixes the IR theory implementation

### DIFF
--- a/plugins/bil/bil_ir.ml
+++ b/plugins/bil/bil_ir.ml
@@ -26,7 +26,9 @@ type t = cfg
 
 let null = KB.Object.null Theory.Program.cls
 let is_null x = KB.Object.is_null x
-let is_empty {entry} = is_null entry
+let is_empty = function
+  | {entry; blks=[]} -> is_null entry
+  | _ -> false
 
 module BIR = struct
   type t = blk term list


### PR DESCRIPTION
The `seq` function was incorrectly dropping blocks because the is_empty predicate was not updated in #1326 when subinstructions were introduced and the null label started to be used everywhere.