### PR TITLE
improves reification of calls in the IR theory

### DIFF
--- a/plugins/bil/bil_ir.ml
+++ b/plugins/bil/bil_ir.ml
@@ -26,7 +26,9 @@ type t = cfg
 
 let null = KB.Object.null Theory.Program.cls
 let is_null x = KB.Object.is_null x
-let is_empty {entry} = is_null entry
+let is_empty = function
+  | {entry; blks=[]} -> is_null entry
+  | _ -> false
 
 module BIR = struct
   type t = blk term list


### PR DESCRIPTION
It looks like that the IR theory could be more clever and reify
`seq (call <fun>) <rest>` into
```
call <fun> return @next
...
next:
<rest>
```