### PR TITLE
fixes the path plugin loader path handling

### DIFF
--- a/lib/bap_plugins/bap_plugins.ml
+++ b/lib/bap_plugins/bap_plugins.ml
@@ -237,7 +237,7 @@ module Plugins = struct
     | Error (name,_) -> name
 
   let collect ?env ?provides ?(library=[]) () =
-    let (/) = Filename.concat in
+    let (/) x y = x ^ "/" ^ y in
     let strset = Set.of_list (module String) in
     let provides = Option.map provides ~f:strset in
     let env = strset (Option.value env ~default:[]) in


### PR DESCRIPTION
We use URI instead of file paths to reference plugins, however when we search for the plugins in the library folders we use `Filename.concat` to create paths before turning them into URI. `Filename.concat` is clever enough to use `\\` as the directory separator on Windows. The problem, however, is that `Uri.of_string` is not trying to support Windows paths at all and expects a correctly encoded URI with the path section, which has to use `/` as the separator.

Since Windows should work fine with forward slashes as the directory separator, it is easier just to use them everywhere.