### PR TITLE
fixes the macOS CI build

### DIFF
--- a/.github/workflows/build-dev-repo.yml
+++ b/.github/workflows/build-dev-repo.yml
@@ -44,6 +44,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           rm -rf /usr/local/bin/2to3
+          rm -f $(opam var lib)/ocaml/version
           brew unlink gcc@9
           brew update
           brew upgrade


### PR DESCRIPTION
The culprit was an update of the C++ toolchain on macOS to the C++20 standard that includes the `version` file. Unfortunately, OCaml is installing the `VERSION` file that's picked up on the search path instead of the correct file (the macOS file system is case-insensitive). The problem is fixed in the upstream (https://github.com/ocaml/ocaml/pull/9895) but there are no backports, so right now the workaround is to remove this file manually, e.g., 
```
rm $(opam var lib)/ocaml/VERSION
```
