### PR TITLE
provides the assembly string as a promise (removes #undefined)

### DIFF
--- a/lib/bap_image/bap_memory.ml
+++ b/lib/bap_image/bap_memory.ml
@@ -465,6 +465,12 @@ let () =
   Some (Addr.to_bitvec (min_addr mem))
 
 let () =
+  KB.Rule.(begin
+      declare ~package:"bap" "code-of-mem" |>
+      require slot |>
+      provide Theory.Semantics.code |>
+      comment "extracts the memory contents"
+    end);
   let open KB.Syntax in
   KB.promise Theory.Semantics.slot @@ fun label ->
   let+ {data; off; size} = label-->?slot in


### PR DESCRIPTION
This PR fixes a bug that was a feature for a long time, it removes `#undefined` from the output of the disassembly so that even if we don't have full semantics for it. We do this by providing the assembly string as a promise.

The PR also adds the rule specification for the recently added `insn-code` property promise.