### PR TITLE
updates the url of the testing repo to use the encrypted version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,7 +23,7 @@ jobs:
           dune-cache: true
 
       - name: Add the testing Repository
-        run: opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
+        run: opam repo add bap git+https://github.com/BinaryAnalysisPlatform/opam-repository#testing
 
       - name: Pin OASIS
         run: opam pin add oasis https://github.com/BinaryAnalysisPlatform/oasis.git

--- a/.github/workflows/build-dev-repo.yml
+++ b/.github/workflows/build-dev-repo.yml
@@ -35,7 +35,7 @@ jobs:
           dune-cache: ${{  matrix.os != 'macos-latest' }}
 
       - name: Add the testing Repository
-        run: opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
+        run: opam repo add bap git+https://github.com/BinaryAnalysisPlatform/opam-repository#testing
 
       - name: Pin BAP
         run: opam pin add bap . --no-action

--- a/.github/workflows/build-from-opam.yml
+++ b/.github/workflows/build-from-opam.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get install libghidra-data -y
 
       - name: Add the testing Repository
-        run: opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
+        run: opam repo add bap git+https://github.com/BinaryAnalysisPlatform/opam-repository#testing
 
       - name: Install system dependencies
         run: opam depext -u bap-extra

--- a/.github/workflows/nightly-testing.yml
+++ b/.github/workflows/nightly-testing.yml
@@ -36,7 +36,7 @@ jobs:
           sudo apt-get install libghidra-data -y
 
       - name: Add the Testing Repository
-        run: opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
+        run: opam repo add bap git+https://github.com/BinaryAnalysisPlatform/opam-repository#testing
       - name: Install System Dependencies
         run: opam depext -u bap-extra
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           sudo apt-get install libghidra-data -y
 
       - name: Add the testing Repository
-        run: opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing
+        run: opam repo add bap git+https://github.com/BinaryAnalysisPlatform/opam-repository#testing
       - name: Build deb packages
         run: ./tools/release.sh ${{ env.VERSION }}
 


### PR DESCRIPTION
The unencrypted git protocol is [no longer supported][1] by GitHub.

[1]: https://github.blog/2021-09-01-improving-git-protocol-security-github/