### PR TITLE
improves the performance of bitvectors (2/3)

### DIFF
--- a/lib/bitvec/bitvec.ml
+++ b/lib/bitvec/bitvec.ml
@@ -90,6 +90,7 @@ let int x m = norm m @@ Z.of_int x [@@inline]
 let int32 x m = norm m @@ Z.of_int32 x [@@inline]
 let int64 x m = norm m @@ Z.of_int64 x [@@inline]
 let bigint x m  = norm m @@ x [@@inline]
+let bigint_unsafe x = x
 
 let append w1 w2 x y =
   let w = w1 + w2 in

--- a/lib/bitvec/bitvec.mli
+++ b/lib/bitvec/bitvec.mli
@@ -21,7 +21,7 @@ val m1  : modulus
 (** [m8 = modulus 8] = $255$ is the modulus of bitvectors with size [8]  *)
 val m8  : modulus
 
-(** [m16 = modulus 16] = $65535$ is the modulus of bitvectors with size [16] 
+(** [m16 = modulus 16] = $65535$ is the modulus of bitvectors with size [16]
     @since 2.5.0 *)
 val m16  : modulus
 
@@ -398,6 +398,16 @@ val to_string : t -> string
 val of_string : string -> t
 
 
+
+(** [bigint_unsafe x] directly interprets a zarith value as bitvector.
+
+    The function is safe only if [x] is the result of [to_bigint],
+    otherwise the resulting value is unpredictable.
+
+    @since 2.5.0
+*)
+val bigint_unsafe : Z.t -> t
+
 (** [of_substring ~pos ~len s] is a bitvector that corresponds to a
     substring of [s] designated by the start position [pos] and length
     [len].
@@ -621,6 +631,6 @@ module M32 : D
 module M64 : D
 
 (** [modular n] returns a module [M], which implements
-    all operations in [S] modulo the bitwidth [n]. 
+    all operations in [S] modulo the bitwidth [n].
     @since 2.5.0 *)
 val modular : int -> (module D)


### PR DESCRIPTION
The comparison function was very heavyweight and was allocating objects on each call. The new version will allocate only when comparing unsigned bitvectors.

In addition, this removes superflous renormalizations of bitvectors and adds the bigint_unsafe function to bitvec, so that we can create bitvec from bap_bitvectors without forcing a renormalization.

This PR changes the semantics of ordering. The default ordering now allows bitvectors with different sizes (though I was assuming that this was the behavior and this is what was written in the documentation, so that this change could be seen as a bug fix).