### PR TITLE
adds several new Primus Lisp primitives and new instructions

### DIFF
--- a/oasis/powerpc
+++ b/oasis/powerpc
@@ -40,6 +40,7 @@ Library powerpc_plugin
                     Powerpc_shift,
                     Powerpc_store,
                     Powerpc_sub
+  DataFiles:        semantics/*.lisp ($datadir/bap/primus/semantics)
   XMETAExtraLines:  tags="powerpc, lifter"
 
 Library powerpc_test

--- a/oasis/x86
+++ b/oasis/x86
@@ -75,6 +75,7 @@ Library x86_plugin
                    X86_legacy_fp_lifter,
                    X86_legacy_bil_register,
                    X86_legacy_operands
+ DataFiles:        semantics/*.lisp ($datadir/bap/primus/semantics)
  XMETAExtraLines:  tags="disassembler, lifter, x86, abi"
 
 Library x86_test

--- a/plugins/arm/semantics/aarch64.lisp
+++ b/plugins/arm/semantics/aarch64.lisp
@@ -250,3 +250,10 @@
 (defun Bcc (cnd off)
   (when (condition-holds cnd)
     (relative-jump off)))
+
+(defun HINT (_)
+  (empty))
+
+
+(defun UDF (exn)
+  (special :undefined-instruction))

--- a/plugins/powerpc/semantics/powerpc.lisp
+++ b/plugins/powerpc/semantics/powerpc.lisp
@@ -1,0 +1,8 @@
+(declare (context (target powerpc)))
+
+(defpackage powerpc (:use core target))
+(defpackage llvm-powerpc32 (:use powerpc))
+
+
+(defun NOP ()
+  (empty))

--- a/plugins/riscv/semantics/riscv.lisp
+++ b/plugins/riscv/semantics/riscv.lisp
@@ -214,3 +214,10 @@
 
 (defun C_BNEZ (rs1 off)
   (conditional-jump (not (is-zero rs1)) off))
+
+
+(defun C_NOP ()
+  (empty))
+
+(defun NOP ()
+  (empty))

--- a/plugins/x86/semantics/x86-32.lisp
+++ b/plugins/x86/semantics/x86-32.lisp
@@ -1,0 +1,18 @@
+(declare (context (target i386) (bits 32)))
+
+(require x86-common)
+(in-package x86-32)
+
+(defun pop (dst)
+  (set$ dst (load-word ESP))
+  (+= ESP 4))
+
+(defun POPA32 ()
+  (pop 'EDI)
+  (pop 'ESI)
+  (pop 'EBP)
+  (+= ESP 4)
+  (pop 'EBX)
+  (pop 'EDX)
+  (pop 'ECX)
+  (pop 'EAX))

--- a/plugins/x86/semantics/x86-64.lisp
+++ b/plugins/x86/semantics/x86-64.lisp
@@ -1,0 +1,2 @@
+(declare (context (target amd 64) (bits 64)))
+(require x86-common)

--- a/plugins/x86/semantics/x86-common.lisp
+++ b/plugins/x86/semantics/x86-common.lisp
@@ -1,0 +1,21 @@
+(declare (context (target x86)))
+
+(defpackage x86-common (:use core target))
+(defpackage x86-32 (:use x86-common))
+(defpackage x86-64 (:use x86-common))
+(defpackage llvm-x86 (:use x86-32))
+(defpackage llvm-x86_64 (:use x86-64))
+
+(in-package x86-common)
+
+(defun HLT ()
+  (special :hlt))
+
+(defun NOOP ()
+  (empty))
+
+(defun NOOPL (_ _ _ _ _)
+  (empty))
+
+(defun NOOPW (_ _ _ _ _)
+  (empty))


### PR DESCRIPTION
This PR adds three new primitives that could be used in definition instruction semantics:
 - invoke-subroutine, especially useful for intrinsic calls
 - empty, which denotes empty semantics, useful for nops
 - special to denote special semantics, like `hlt`

It also implements semantics for several missing semantics (detected with `--print-missing`), mostly nops, but there's one significant finding - the `popa` (POPA32 in llvm parlance) instruction from x86, which was surprisingly missing.