### PR TITLE
updates bap to latest OCaml, switches to newer bitstrings

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,7 +23,7 @@ jobs:
           dune-cache: true
 
       - name: Add the testing Repository
-        run: opam repo add bap git+https://github.com/BinaryAnalysisPlatform/opam-repository#testing
+        run: opam repo add bap git+https://github.com/BinaryAnalysisPlatform/opam-repository#PR1413
 
       - name: Pin OASIS
         run: opam pin add oasis https://github.com/BinaryAnalysisPlatform/oasis.git

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,7 +23,7 @@ jobs:
           dune-cache: true
 
       - name: Add the testing Repository
-        run: opam repo add bap git+https://github.com/BinaryAnalysisPlatform/opam-repository#PR1413
+        run: opam repo add bap git+https://github.com/BinaryAnalysisPlatform/opam-repository#testing
 
       - name: Pin OASIS
         run: opam pin add oasis https://github.com/BinaryAnalysisPlatform/oasis.git

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,11 +28,11 @@ jobs:
       - name: Pin OASIS
         run: opam pin add oasis https://github.com/BinaryAnalysisPlatform/oasis.git
 
-      - name: Pin BAP
-        run: opam pin add bap . --no-action
-
       - name: Install system dependencies
         run: opam depext -u bap-extra
+
+      - name: Pin BAP
+        run: opam pin add bap . --no-action
 
       - name: Install Ghidra
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Pin BAP
         run: opam pin add bap . --no-action
 
+      - name: Install rest of the system dependencies
+        run: opam depext -u bap
+
       - name: Install Ghidra
         run: |
           sudo add-apt-repository ppa:ivg/ghidra -y

--- a/OMakefile
+++ b/OMakefile
@@ -33,6 +33,7 @@ OCAMLFLAGS += -bin-annot               # (create .cmt/.cmti files)
 OCAMLFLAGS_ANNOT = -annot -bin-annot
 OCAMLFLAGS += $(OCAMLFLAGS_ANNOT)
 OCAMLFLAGS += -opaque
+OCAMLFLAGS += -w -6-16-58
 OCAMLOPTFLAGS += -O3
 
 # Until this point we allow to override variables via the command-line.

--- a/configure-omake
+++ b/configure-omake
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+export OPAMCLI=2.0
+
 rm -f _oasis setup.log.om setup.data _oasis_setup.om
 mv oasis/benchmarks oasis/benchmarks.backup
 mv oasis/piqi-printers oasis/piqi-printers.backup
@@ -9,7 +11,7 @@ SECTIONS=`ocaml tools/oasis_sections.ml --sections --enable-everything`
 SETUPS=`ocaml tools/collect.ml setup.ml $SECTIONS`
 AB=`ocaml tools/collect.ml files.ab $SECTIONS`
 ocaml tools/cat.ml '"\n# $name\n"' -- $SECTIONS $AB _oasis
-ocaml tools/cat.ml '"\n#1 \"$name\"\n"' -- $SETUPS setup.ml.in setup.ml
+ocaml tools/cat.ml '"\n#1 \"$name\"\n"' -- setup.ml.pre.in $SETUPS setup.ml.in setup.ml
 cp oasis/common.backup oasis/common
 cp oasis/benchmarks.backup oasis/benchmarks
 cp oasis/piqi-printers.backup oasis/piqi-printers

--- a/lib/bap/bap_init_toplevel.ml
+++ b/lib/bap/bap_init_toplevel.ml
@@ -3,6 +3,7 @@ open Bap_plugins.Std
 let install_printer printer =
   Topdirs.dir_install_printer Format.err_formatter
     (Longident.parse printer)
+[@@warning "-D"]
 
 let install_printers () =
   Core_kernel.Pretty_printer.all () |>

--- a/oasis/elf-loader
+++ b/oasis/elf-loader
@@ -7,7 +7,7 @@ Library elf
   Path:          lib/bap_elf
   Build$:        flag(everything) || flag(elf_loader)
   FindlibName:   bap-elf
-  BuildDepends:  bitstring, bitstring.ppx, regular, core_kernel, ppx_bap
+  BuildDepends:  bitstring, ppx_bitstring, regular, core_kernel, ppx_bap
   Modules: Bap_elf
   InternalModules:
                  Elf_parse,

--- a/opam/opam
+++ b/opam/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
 depends: [
   "ocaml" {>= "4.07.0"}
   "base-unix"
-  "bitstring" {>= "3.0.0" & < "4.0.0"}
+  "ppx_bitstring" {>= "4.0.0"}
   "camlzip"
   "linenoise" {>= "1.1" & < "2.0"}
   "cmdliner" {>= "1.0" & < "2.0"}

--- a/plugins/mips/mips.ml
+++ b/plugins/mips/mips.ml
@@ -101,7 +101,7 @@ let () =
       Hashtbl.find_and_call Std.delayed_opcodes name
         ~if_found:(fun delay ->
             KB.Value.put Insn.Slot.delay insn (Some delay))
-        ~if_not_found:(fun _ -> insn)
+        ~if_not_found:(fun _ -> Insn.empty)
     else !!Insn.empty in
   Bap_main.Extension.declare @@ fun _ctxt ->
   KB.Rule.(declare ~package:"mips" "delay-slot" |>


### PR DESCRIPTION
This is a small technical PR that removes warnings produced by the latest OCaml. We also switch to bitstrings.4.x since this version is available for OCaml 4.08 and above so it covers all available versions. (the opam-repository will be correspondingly updated).