### PR TITLE
Fix pc value in pc-relative thumb ldr

### DIFF
--- a/plugins/thumb/thumb_main.ml
+++ b/plugins/thumb/thumb_main.ml
@@ -111,9 +111,10 @@ module Thumb(CT : Theory.Core) = struct
       !!Insn.empty
 
 
-  let lift_mem pc opcode insn =
+  let lift_mem addr opcode insn =
     let module Mem = Thumb_mem.Make(CT) in
     let open Mem in
+    let pc = W32.(addr + int 4) in
     match opcode, (MC.Insn.ops insn : Op.t array) with
     | `tLDRi,   [|Reg rd; Reg rm; Imm i; Imm c; _|]
     | `tLDRspi, [|Reg rd; Reg rm; Imm i; Imm c; _|] ->
@@ -121,9 +122,9 @@ module Thumb(CT : Theory.Core) = struct
     | `tLDRr, [|Reg rd; Reg rm; Reg rn; Imm c; _|] ->
       ldrr (reg rd) (reg rm) (reg rn) (cnd c)
     | `tLDRpci, [|Reg rd; Imm i; Imm c; _|] ->
-      ldrpci (reg rd) W32.(pc + int 2) (imm i) (cnd c)
+      ldrpci (reg rd) pc (imm i) (cnd c)
     | `t2LDRpci, [|Reg rd; Imm i; Imm c; _|] ->
-      ldrpci (reg rd) W32.(pc + int 4) (imm i) (cnd c)
+      ldrpci (reg rd) pc (imm i) (cnd c)
     | `tLDRBi, [|Reg rd; Reg rm; Imm i; Imm c; _|] ->
       ldrbi (reg rd) (reg rm) (imm i) (cnd c)
     | `tLDRBr, [|Reg rd; Reg rm; Reg rn; Imm c; _|] ->

--- a/plugins/thumb/thumb_mem.ml
+++ b/plugins/thumb/thumb_mem.ml
@@ -49,7 +49,7 @@ module Make(CT : Theory.Core) = struct
     rd <-? signed @@ load s16 (var rn + var rm)
 
   let ldrpci rd pc off =
-    rd <-? load s32 @@ bitv pc + const off
+    rd <-? load s32 @@ bitv W32.(pc land ~~(int 3)) + const off
 
   let ldm b regs cnd =
     branch cnd [


### PR DESCRIPTION
For reference: https://developer.arm.com/documentation/ddi0487/latest
on page 4252:
> When executing a T32 instruction, PC reads as the address of the current instruction plus 4.

then later on page 4743 in the pseudocode for "LDR (literal)":

> `base = Align(PC,4);`

Here are some concrete examples while debugging on real hardware. Notice especially which value from the `thumb_data` array has been loaded into `r0` after executing the `ldr` instructions. The `;-- pc:` flag shows the "typical" notion of a program counter, not pc+4 or so.
![Bildschirmfoto 2022-01-30 um 11 31 43](https://user-images.githubusercontent.com/1460997/151696109-34f587eb-004b-42c7-a184-913c0839c317.png)
![Bildschirmfoto 2022-01-30 um 11 31 51](https://user-images.githubusercontent.com/1460997/151696112-54785888-3cef-4951-b0bc-c41cc5645309.png)
![Bildschirmfoto 2022-01-30 um 11 32 01](https://user-images.githubusercontent.com/1460997/151696113-dc8a0506-a1c3-4bf9-bc79-62ea30c9786d.png)
![Bildschirmfoto 2022-01-30 um 11 32 08](https://user-images.githubusercontent.com/1460997/151696114-86c68a1a-8f96-45a6-b8be-103094fdd4ab.png)
![Bildschirmfoto 2022-01-30 um 11 32 14](https://user-images.githubusercontent.com/1460997/151696116-56ca7331-c49f-4b53-ae09-32e92aca97ae.png)
![Bildschirmfoto 2022-01-30 um 11 32 21](https://user-images.githubusercontent.com/1460997/151696117-97efbf1a-1a86-4270-ba6c-ea6d15dad7f1.png)
