### PR TITLE
allows bapbuild to work when bap and other defaults are not present

### DIFF
--- a/lib/bap_build/bap_build.ml
+++ b/lib/bap_build/bap_build.ml
@@ -10,7 +10,13 @@ module Plugin_rules = struct
 
   let (/) = Pathname.concat
 
-  let default_packages = ["bap"; "core_kernel"; "ppx_bap"]
+  let is_installed pkg =
+    try ignore (Fl.package_directory pkg); true
+    with Fl.No_such_package _ -> false
+
+  let default_packages = List.filter ~f:is_installed [
+      "bap"; "core_kernel"; "ppx_bap"
+    ]
   let default_predicates = [
   ]
 


### PR DESCRIPTION
The default packages are still the same, but the defaults are not enforced if they are not present.

This PR is an attempt to fix #1402 that partially broke BAP installation from the testing opam-repository (including docker builds). The problem is that the core-theory plugin can't be built since bapbuild links everything with bap, which is not available (and can't be available) when core-theory builds.