### PR TITLE
fixes the low-level Disasm_expert.Basic.create function

### DIFF
--- a/lib/bap_disasm/bap_disasm_basic.ml
+++ b/lib/bap_disasm/bap_disasm_basic.ml
@@ -618,7 +618,9 @@ let lookup target encoding =
     | Some create -> create target
 
 let create ?(debug_level=0) ?(cpu="") ?(attrs="") ?(backend="llvm") triple =
-  let name = String.concat ~sep:"-" [backend; triple; cpu] ^ attrs in
+  let parts = [backend; triple; cpu] |>
+              List.filter ~f:(Fn.non String.is_empty) in
+  let name = String.concat ~sep:"-" parts ^ attrs in
   match Hashtbl.find disassemblers name with
   | Some d ->
     d.users <- d.users + 1;


### PR DESCRIPTION
It was creating an incorrect encoding for instructions, namely `bap:llvm-armv7-` (notice the dangling dash in the end).

Also affects the `Disasm_expert.Basic.with_disasm` function.