### PR TITLE
fixes the core-theory plugin semantics tags

### DIFF
--- a/plugins/core_theory/core_theory_main.ml
+++ b/plugins/core_theory/core_theory_main.ml
@@ -10,7 +10,10 @@ let herbrand_provides = [
   "lisp";
   "debug";
   "core:eff";
-  "core:val"
+  "core:val";
+  "lifter";
+  "semantics";
+  "symbolizer";
 ]
 
 let decide_name_from_possible_name () : unit =

--- a/plugins/disassemble/disassemble_main.ml
+++ b/plugins/disassemble/disassemble_main.ml
@@ -95,6 +95,7 @@ include Self()
 open Bap_main
 
 let features_used = [
+  "semantics";
   "function-starts";
   "disassembler";
   "lifter";


### PR DESCRIPTION
This fix will ensure that if anything is changed in the core theory configuration, then it will be reflected in the output of disassembly.

Semantic tags describe the set of features that are provided by a plugin. The caching subsystem relies on them to properly identify the program context and capture it in the context digest that is used to store and retrieve caches. Before this fix, there were no intersection between the tags that describe the disassembler requires (uses) and the set of tags that the core-theory plugin provides.