### PR TITLE
applies ARM modified immediate (MIC) decoding in more places

### DIFF
--- a/lib/arm/arm_mov.ml
+++ b/lib/arm/arm_mov.ml
@@ -45,9 +45,9 @@ let lift ?(encoding=Theory.Language.unknown)
     | None     -> tmp reg32_t
     | Some (`Reg reg) -> Env.of_reg reg
     | Some (`Imm _) -> fail [%here] "dest is not a reg" in
-  let s1 : exp = exp_of_op src1 in
+  let s1 : exp = MIC.decode encoding @@ exp_of_op src1 in
   let s2 : exp = match src2 with
-    | Some src -> exp_of_op src
+    | Some src -> MIC.decode encoding @@ exp_of_op src
     | None     -> zero reg32_t in
 
   let unshifted = tmp reg32_t in
@@ -75,7 +75,7 @@ let lift ?(encoding=Theory.Language.unknown)
       let shifted, carry = Shift.lift_i
           ~src:Bil.(var unshifted) simm reg32_t in
       s1, shifted, [Bil.move unshifted s2], carry
-    | _ -> s1, (MIC.decode encoding s2), [], Bil.var Env.cf in
+    | _ -> s1, s2, [], Bil.var Env.cf in
 
   let stmts, flags = match itype, src1, src2 with
     | `MOV, `Imm i64, _

--- a/lib/bap_traces/bap_trace_events.ml
+++ b/lib/bap_traces/bap_trace_events.ml
@@ -5,7 +5,7 @@ open Bap_trace_event_types
 
 let pp_bytes fmt s =
   let pp fmt s =
-    String.iter ~f:(fun c -> Format.fprintf fmt "%X@ " (Char.to_int c)) s in
+    String.iter ~f:(fun c -> Format.fprintf fmt "%02X@ " (Char.to_int c)) s in
   Format.fprintf fmt "@[<hv>%a@]" pp s
 
 let pp_array pp fmt ar =


### PR DESCRIPTION
Previously, we added MIC decoding very conservatively, only to places where we have seen them. Further experiments with qemu tracing showed that we have to apply them in all places where immediates occur.