### PR TITLE
fixes arm predication

### DIFF
--- a/lib/arm/arm_utils.ml
+++ b/lib/arm/arm_utils.ml
@@ -54,7 +54,7 @@ let exec
     | Some f, Some (`Reg `CPSR) -> stmts @ f
     | _ -> stmts in
   (* generates an expression for the given McCond *)
-  let set_cond mccond =
+  let set_cond cond =
     let z = Bil.var Env.zf in
     let c = Bil.var Env.cf in
     let v = Bil.var Env.vf in
@@ -81,8 +81,9 @@ let exec
   match cond with
   | `AL -> stmts
   | _ when List.for_all stmts ~f:is_move ->
-    let cond = set_cond cond in
-    List.map stmts ~f:(function
+    let cval = set_cond cond and cvar = tmp bool_t in
+    let cond = Bil.var cvar in
+    Bil.(cvar := cval) :: List.map stmts ~f:(function
         | Bil.Move (v,_) as s when Var.is_virtual v -> s
         | Bil.Move (v,x) ->
           Bil.(v := ite ~if_:cond ~then_:x ~else_:(var v))


### PR DESCRIPTION
Predicated instructions that update flags themselves were lifted incorrectly, e.g.,

```
$ bap mc --arch=armv7 --show-bil --show-insn=asm  -- 01 20 52 22
subshs r2, r2, #1
{
  #12582910 := R2
  R2 := if CF then R2 - 1 else R2
  CF := if CF then 1 <= #12582910 else CF
  VF := if CF then high:1[(#12582910 ^ 1) & (#12582910 ^ R2)] else VF
  NF := if CF then high:1[R2] else NF
  ZF := if CF then R2 = 0 else ZF
}
```

In this example, the assignment to CF kills the real value of CF it was true. And easy solution would be just to keep the condition in a temporary variable, e.g.,

```
bap mc --arch=armv7 --show-bil --show-insn=asm  -- 01 20 52 22
subshs r2, r2, #1
{
  #12582908 := CF
  #12582910 := R2
  R2 := if #12582908 then R2 - 1 else R2
  CF := if #12582908 then 1 <= #12582910 else CF
  VF := if #12582908 then high:1[(#12582910 ^ 1) & (#12582910 ^ R2)] else VF
  NF := if #12582908 then high:1[R2] else NF
  ZF := if #12582908 then R2 = 0 else ZF
}
```