### PR TITLE
refines and extends target definitions

### DIFF
--- a/lib/bap_mips/bap_mips_target.ml
+++ b/lib/bap_mips/bap_mips_target.ml
@@ -46,7 +46,7 @@ let parent = Theory.Target.declare ~package "mips"
 let array bits pref n =
   List.init n ~f:(fun i -> reg bits (sprintf "%s%d" pref i))
 
-let define ?(parent=parent) bits endianness =
+let define ?(parent=parent) ?nicknames bits endianness =
   let size = Theory.Bitv.size bits in
   let gprs = List.map gpr_names ~f:(reg bits) in
   let fprs = array bits "R" 32 in
@@ -56,6 +56,7 @@ let define ?(parent=parent) bits endianness =
   let regs = List.map ~f:(fun name -> Theory.Var.forget (reg bits name)) in
   Theory.Target.declare ~package (name size endianness)
     ~parent
+    ?nicknames
     ~bits:size
     ~endianness
     ~code:data
@@ -71,12 +72,18 @@ let define ?(parent=parent) bits endianness =
       ]
 
 let mips32bi = define r32 Theory.Endianness.bi
-let mips32eb = define r32 Theory.Endianness.eb ~parent:mips32bi
-let mips32le = define r32 Theory.Endianness.le ~parent:mips32bi
+    ~nicknames:["mipsbi"; "mips32bi"]
+let mips32eb = define r32 Theory.Endianness.eb
+    ~nicknames:["mipseb"; "mips32eb"; "mipsbe"; "mips32be"]
+let mips32le = define r32 Theory.Endianness.le
+    ~nicknames:["mipsle"; "mipsel"; "mips32le"; "mips32el"]
 
 let mips64bi = define r64 Theory.Endianness.bi
-let mips64le = define r64 Theory.Endianness.le ~parent:mips64bi
-let mips64eb = define r64 Theory.Endianness.eb ~parent:mips64bi
+    ~nicknames:["mips64bi"]
+let mips64le = define r64 Theory.Endianness.le
+    ~nicknames:["misp64le"; "mips64el"]
+let mips64eb = define r64 Theory.Endianness.eb
+    ~nicknames:["mips64"; "mips64eb"; "mips64be"]
 
 let enable_loader () =
   KB.Rule.(declare ~package "mips-target" |>

--- a/lib/bap_powerpc/bap_powerpc_target.ml
+++ b/lib/bap_powerpc/bap_powerpc_target.ml
@@ -43,7 +43,7 @@ let flags = List.map ~f:(reg bool) [
     "C"; "FL"; "FE"; "FG"; "FU"
   ] @ crflags
 
-let define ?(parent=parent) bits endianness =
+let define ?(parent=parent) ?nicknames bits endianness =
   let size = Theory.Bitv.size bits in
   let mems = Theory.Mem.define bits r8 in
   let data = Theory.Var.define mems "mem" in
@@ -55,6 +55,7 @@ let define ?(parent=parent) bits endianness =
              [data] in
   Theory.Target.declare ~package (name size endianness)
     ~parent
+    ?nicknames
     ~bits:size
     ~endianness
     ~vars
@@ -76,12 +77,36 @@ let define ?(parent=parent) bits endianness =
       ]
 
 let powerpc32bi = define r32 Theory.Endianness.bi
-let powerpc32eb = define r32 Theory.Endianness.eb ~parent:powerpc32bi
-let powerpc32le = define r32 Theory.Endianness.le ~parent:powerpc32bi
+    ~nicknames:["powerpc32bi"; "ppc32bi"]
+
+let powerpc32eb = define r32 Theory.Endianness.eb
+    ~nicknames:[
+      "powerpc"; "ppc"; "powerpc32"; "ppc32";
+      "powerpc32eb"; "powerpc32be"; "ppc32eb"; "ppc32be";
+      "power"; "power32";
+    ]
+let powerpc32le = define r32 Theory.Endianness.le
+    ~nicknames:[
+      "powerpcle"; "ppcle"; "ppcel";
+      "powerpc32le"; "powerpc32el";
+      "ppc32le"; "ppc32el"
+    ]
 
 let powerpc64bi = define r64 Theory.Endianness.bi
-let powerpc64le = define r64 Theory.Endianness.le ~parent:powerpc64bi
-let powerpc64eb = define r64 Theory.Endianness.eb ~parent:powerpc64bi
+    ~nicknames:["powerpc64bi"; "power64bi"]
+let powerpc64eb = define r64 Theory.Endianness.eb
+    ~nicknames:[
+      "powerpc64"; "ppc64"; "power64";
+      "powerpc64eb"; "powerpc64be";
+      "ppc64eb"; "ppc64be";
+      "power64eb"; "power64be"
+    ]
+let powerpc64le = define r64 Theory.Endianness.le
+    ~nicknames:[
+      "powerpc64el"; "powerpc64le";
+      "ppc64el"; "ppc64le";
+      "power64el"; "power64le"
+    ]
 
 let enable_loader () =
   let open KB.Syntax in

--- a/lib/x86_cpu/x86_target.ml
+++ b/lib/x86_cpu/x86_target.ml
@@ -218,12 +218,12 @@ module M64 = struct
 end
 
 let parent = Theory.Target.declare ~package "x86"
+    ~bits:16
+    ~byte:8
 
 let i86 = Theory.Target.declare ~package "i86"
     ~parent
     ~nicknames:["8086"]
-    ~bits:16
-    ~byte:8
     ~data:M16.data
     ~code:M16.data
     ~vars:M16.vars


### PR DESCRIPTION
1. adds a few nicknames for various targets
2. rectifies target hierarachies
3. fixes bitness for the x86 parent