### PR TITLE
adds arm unpredicated BL instruction

### DIFF
--- a/lib/arm/arm_lifter.ml
+++ b/lib/arm/arm_lifter.ml
@@ -957,7 +957,8 @@ let lift_branch mem ops insn =
   | `BL, [|offset; cond; _|]
   | `BL_pred, [|offset; cond; _|] ->
     Branch.lift offset ~cond ~link:true addr
-
+  | `BL, [|offset|] ->
+    Branch.lift offset ~link:true addr
   | `BX_RET, [|cond; _|] ->
     Branch.lift (`Reg `LR) ~cond ~x:true addr
 


### PR DESCRIPTION
apparently this instruction existed for a long time but was never produced by llvm up until 11+ (confirmed on 13 and 14, not sure about 11 and 12)