### PR TITLE
reads correctly unqualified system names

### DIFF
--- a/lib/bap_primus/bap_primus_system.ml
+++ b/lib/bap_primus/bap_primus_system.ml
@@ -53,7 +53,7 @@ module Repository = struct
     | None -> invalid_argf "Unknown system %s" (Name.show name) ()
 
   let get ?package name =
-    require @@ Name.create ?package name
+    require @@ Name.read ?package name
 
   let find = Hashtbl.find self
 


### PR DESCRIPTION
This is a minor bug fix, that enables proper reading of unqualified system names in Primus, so that `Primus.System.Repository.get ~package:"bap" "foo:xxxx` gets `foo:xxx` not `bap:foo\:xxx`.