### PR TITLE
wraps proposals into with_empty and adds more guards

### DIFF
--- a/lib/knowledge/bap_knowledge.ml
+++ b/lib/knowledge/bap_knowledge.ml
@@ -2949,14 +2949,22 @@ module Knowledge = struct
     current slot obj >>= fun opinions ->
     provide slot obj (Opinions.add agent x opinions)
 
+  let wrap_opinion get obj =
+    with_empty ~missing:None @@ fun () ->
+    get obj >>| Option.some
+
   let propose agent s get =
     ignore @@
     register_promise s @@ fun obj ->
-    get obj >>= suggest agent s obj
+    wrap_opinion get obj >>= function
+    | None -> Knowledge.return ()
+    | Some opinions -> suggest agent s obj opinions
 
   let proposing agent s ~propose:get scoped =
     let pid = register_promise s @@ fun obj ->
-      get obj >>= suggest agent s obj in
+      wrap_opinion get obj >>= function
+      | None -> Knowledge.return ()
+      | Some opinions -> suggest agent s obj opinions in
     scoped () >>= fun r ->
     remove_promise s pid;
     Knowledge.return r

--- a/plugins/mips/mips_main.ml
+++ b/plugins/mips/mips_main.ml
@@ -47,4 +47,5 @@ let () =
       register_target `mipsel (module MIPS32_le);
       register_target `mips64 (module MIPS64);
       register_target `mips64el (module MIPS64_le);
+      Mips.promise_delay_slots ();
       Mips_abi.setup ());


### PR DESCRIPTION
The proposals (promises with options) now can use the choice monad interface as well as the other promises could do. Also adds a few guards to the existing code to make it more readable and improve performance.