### PR TITLE
adds the x86/amd64 plt corrector component to the Primus base system

### DIFF
--- a/plugins/primus_systems/systems/core.asd
+++ b/plugins/primus_systems/systems/core.asd
@@ -3,6 +3,7 @@
   :components (bap:load-binary
                bap:program-loader
                bap:x86-registers-initializer
+               bap:x86-setup-plt
                bap:powerpc-init
                bap:observation-printer))
 


### PR DESCRIPTION
The component is responsible for properly restoring the stack frame after a call to the Primus Lisp stub. 

This PR re-closes #879 