### PR TITLE
fixes an accidental dependency on the bap-traces internal module

### DIFF
--- a/lib/arm/arm_target.ml
+++ b/lib/arm/arm_target.ml
@@ -5,9 +5,9 @@ open Bap_core_theory
 open Bap.Std
 open KB.Syntax
 open Poly
+open Bap_traces.Std
 
 module CT = Theory
-module Mode = Bap_trace_event_types.Mode
 
 type r128 and r80 and r64 and r32 and r16 and r8
 

--- a/plugins/arm/.merlin
+++ b/plugins/arm/.merlin
@@ -10,6 +10,7 @@ B ../../lib/bap_c
 B ../../lib/arm
 B ../../lib/bap_api
 B ../../lib/bap_abi
+B ../../lib/bap_traces
 
 S ../../lib/bap_c
 S ../../lib/arm


### PR DESCRIPTION
A quick followup on #1433, which introduced a dependency on the internal module `Bap_trace_event_types`. The build passed on the PR testing as it wasn't building from opam, but all in the same tree, which can't notice such accesses.