### PR TITLE
fixes unconditional pop with return in thumb

### DIFF
--- a/plugins/thumb/thumb_mem.ml
+++ b/plugins/thumb/thumb_mem.ml
@@ -99,7 +99,9 @@ module Make(CT : Theory.Core) = struct
         sp += const Int.(List.length regs * 4);
       ] in
     let ctrl = CT.jmp (load s32 (var sp)) in
-    CT.branch ~?cnd (CT.blk null data ctrl) (seq [])
+    match cnd with
+    | `AL -> CT.blk null data ctrl
+    | _ -> CT.branch ~?cnd (CT.blk null data ctrl) (seq [])
 
 
   let push regs cnd = branch cnd [


### PR DESCRIPTION
Not really a bug but an ugly code generated for the unconditional pop
instruction that involves the PC register,
```
bap mc --arch=thumb --show-bil --show-insn=asm --show-mem --addr=0x1c04 -- f0 bd
1c04: f0 bd
pop {r4, r5, r6, r7, pc}
{
  if (1) {
    R4 := mem[SP, el]:u32
    R5 := mem[SP + 4, el]:u32
    R6 := mem[SP + 8, el]:u32
    R7 := mem[SP + 0xC, el]:u32
    SP := SP + 0x10
    jmp (mem[SP, el]:u32)
  }
}
```

This change removes this bogus `if(1)`.