### PR TITLE
hushes bil lifters

### DIFF
--- a/plugins/mips/mips.ml
+++ b/plugins/mips/mips.ml
@@ -64,7 +64,7 @@ module Std = struct
             insn_name n in
         Error (Error.of_string str) in
     match String.Table.find lifters (Insn.name insn) with
-    | None -> Or_error.errorf "unknown instruction %s" insn_name
+    | None -> Ok []
     | Some lifter -> lift lifter
 
   module M32BE = struct

--- a/plugins/powerpc/powerpc.ml
+++ b/plugins/powerpc/powerpc.ml
@@ -53,7 +53,6 @@ module Std = struct
 
   let lift addr_size endian mem insn =
     let insn = Insn.of_basic insn in
-    let insn_name = Insn.name insn in
     let cpu = make_cpu addr_size endian mem  in
     let lift lifter =
       try
@@ -63,7 +62,7 @@ module Std = struct
       with
       | Failure str -> Error (Error.of_string str) in
     match Hashtbl.find lifters (Insn.name insn) with
-    | None -> Or_error.errorf "unknown instruction %s" insn_name
+    | None -> Ok []
     | Some lifter -> lift lifter
 
   module T32 = struct

--- a/plugins/x86/x86_backend.ml
+++ b/plugins/x86/x86_backend.ml
@@ -33,10 +33,7 @@ module Make (PR : PR) = struct
     let lift mem insn =
       let lift = search lifts insn in
       try match lift mem insn with
-        | Error err ->
-          warning "failed to lift %a - %a"
-            X86_utils.pp_insn (mem,insn) Error.pp err;
-          Error err
+        | Error err -> Error err
         | Ok bil as ok -> match Type.check bil with
           | Ok () -> ok
           | Error te ->

--- a/plugins/x86/x86_targets.ml
+++ b/plugins/x86/x86_targets.ml
@@ -8,14 +8,12 @@ module AMD64L = X86_lifter.AMD64
 
 module IA32D = struct
   module CPU = IA32L.CPU
-  let lift _mem insn =
-    Or_error.error "unimplemented" insn Insn.sexp_of_t
+  let lift _mem _insn = Ok []
 end
 
 module AMD64D = struct
   module CPU = AMD64L.CPU
-  let lift _mem insn =
-    Or_error.error "unimplemented" insn Insn.sexp_of_t
+  let lift _mem _insn = Ok []
 end
 
 module IA32 = X86_backend.IA32.Make(IA32D)


### PR DESCRIPTION
The BIL lifters are no longer alone but they still spam the logs every time there is an instruction that they can't live. This is especially annoying with the Ghidra backend. This PR removes the noise.