### PR TITLE
removes falls-through from unconditional branches in IR reification

### DIFF
--- a/plugins/bil/bil_ir.ml
+++ b/plugins/bil/bil_ir.ml
@@ -388,6 +388,7 @@ module IR = struct
           jmp';
         ]
       }
+    | [jmp] when is_unconditional jmp -> x
     | jmps -> {x with jmps = goto ~tid dst :: jmps}
 
   let appgraphs fst snd =


### PR DESCRIPTION
The IR theory will no longer add fall-throughs from a block that has an unconditional jump.