### PR TITLE
implements pcode floating-point and special operators

### DIFF
--- a/lib/bap_primus/bap_primus_lisp_attribute.ml
+++ b/lib/bap_primus/bap_primus_lisp_attribute.ml
@@ -3,7 +3,6 @@ open Bap_core_theory
 open Bap.Std
 
 open Bap_primus_lisp_types
-
 module Name = KB.Name
 
 type cls
@@ -14,7 +13,7 @@ let cls : (cls,unit) KB.cls = KB.Class.declare  "attributes" ()
 type attrs = (cls,unit) KB.cls KB.Value.t
 type set = attrs
 
-type error = ..
+type error = exn = ..
 
 exception Unknown_attr of string * tree
 exception Failure of error * tree list
@@ -37,8 +36,6 @@ module Parse = struct
   type nonrec error = error = ..
 
   type error += Expect_atom | Expect_list
-
-
 
   let atom = function
     | {data=Atom s} -> Some s
@@ -101,3 +98,11 @@ module Set = struct
 
   include Self
 end
+
+
+let () = Caml.Printexc.register_printer (function
+    | Failure (error,_) ->
+      let msg = Format.asprintf "Attribute parse error: %s"
+          (Caml.Printexc.to_string error) in
+      Some msg
+    | _ -> None)

--- a/plugins/ghidra/semantics/pcode.lisp
+++ b/plugins/ghidra/semantics/pcode.lisp
@@ -158,3 +158,119 @@
 
 (defun BOOL_XOR (tr r tx x ty y)
   (set# tr r (get# logxor tx x ty y)))
+
+(defparameter fp-rmode 'rne
+  "the floating-point operations rounding mode")
+
+(defparameter fp-format 'ieee754_binary
+  "the floating-point representation")
+
+
+(defmacro fp-binary (name tr r tx x ty y)
+  (set# tr r
+        (intrinsic
+         (symbol-concat name fp-rmode fp-format :sep '_)
+         (get# tx x)
+         (get# ty y)
+         :result tr)))
+
+(defmacro fp-unary (name tr r tx x)
+  (set# tr r
+        (intrinsic
+         (symbol-concat name fp-format :sep '_)
+         (get# tx x)
+         :result tr)))
+
+(defmacro fp-unary/rmode (name tr r tx x)
+  (set# tr r
+        (intrinsic
+         (symbol-concat name fp-rmode fp-format :sep '_)
+         (get# tx x)
+         :result tr)))
+
+(defmacro fp-predicate (name tr r tx x)
+  (set# tr r
+        (intrinsic
+         (symbol-concat 'is name fp-format :sep '_)
+         (get# tx x)
+         :result tr)))
+
+(defun fp-order (tx x ty y)
+  (intrinsic 'forder_ieee754_binary
+             (get# tx x)
+             (get# ty y)
+             :result 8))
+
+(defun fp-round (tr tx x)
+  (intrinsic
+   (symbol-concat 'fround fp-rmode fp-format :sep '_)
+   (get# tx x)
+   :result tr))
+
+(defun INT2FLOAT (tr r tx x)
+  (set# tr r
+        (intrinsic
+         (symbol-concat 'cast_sfloat fp-rmode fp-format :sep '_)
+         (get# tx x)
+         :result tr)))
+
+(defun TRUNC (tr r tx x)
+  (set# tr r
+        (intrinsic
+         (symbol-concat 'cast_sint 'rtz fp-format :sep '_)
+         (get# tx x)
+         :result tr)))
+
+(defun FLOAT2FLOAT (tr r tx x)
+  (set# tr r
+        (intrinsic
+         (symbol-concat 'fconvert fp-rmode fp-format)
+         (get# tx x)
+         :result tr)))
+
+(defun FLOAT_ADD (tr r tx x ty y)
+  (fp-binary 'fadd tr r tx x ty y))
+
+(defun FLOAT_SUB (tr r tx x ty y)
+  (fp-binary 'fsub tr r tx x ty y))
+
+(defun FLOAT_DIV (tr r tx x ty y)
+  (fp-binary 'fdiv tr r tx x ty y))
+
+(defun FLOAT_MULT (tr r tx x ty y)
+  (fp-binary 'fmul tr r tx x ty y))
+
+(defun FLOAT_NEG (tr r tx x)
+  (fp-unary 'fneg tr r tx x))
+
+(defun FLOAT_ABS (tr r tx x)
+  (fp-unary 'fabs tr r tx x))
+
+(defun FLOAT_SQRT (tr r tx x)
+  (fp-unary/rmode 'fsqrt tr r tx x))
+
+(defun FLOAT_NAN (tr r tx x)
+  (fp-predicate 'fnan tr r tx x))
+
+(defun FLOAT_EQUAL (tr r tx x ty y)
+  (set# tr r (is-zero (fp-order tx x ty y))))
+
+(defun FLOAT_NOTEQUAL (tr r tx x ty y)
+  (set# tr r (not (is-zero (fp-order tx x ty y)))))
+
+(defun FLOAT_LESS (tr r tx x ty y)
+  (set# tr r (is-negative (fp-order tx x ty y))))
+
+(defun FLOAT_LESSEQUAL (tr r tx x ty y)
+  (set# tr r (not (is-positive tx x ty y))))
+
+(defun FLOAT_ROUND (tr r tx x)
+  (set# tr r (fp-round tr tx x)))
+
+(defun FLOAT_CEIL (tr r tx x)
+  (let ((fp-rmode 'rtp))
+    (set# tr r (fp-round tr tx x))))
+
+(defun FLOAT_FLOOR (tr r tx x)
+  (let ((fp-rmode 'rtn))
+    (set# tr r (fp-round tr tx x))))

--- a/plugins/x86/semantics/pcode-cpuid.lisp
+++ b/plugins/x86/semantics/pcode-cpuid.lisp
@@ -1,0 +1,58 @@
+(defpackage pcode-x86 (:use pcode))
+(in-package pcode-x86)
+
+(require pcode)
+
+(defmacro cpuid-subr (name tr r tx x)
+  (set# tr r (intrinsic name
+                        (get# tx x)
+                        :result tr)))
+
+(defun cpuid (tr r tx x)
+  (cpuid-subr 'cpuid tr r tx x))
+
+(defun cpuid_basic_info (tr r tx x)
+  (cpuid-subr 'cpuid_basic_info tr r tx x))
+
+(defun cpuid_Version_info (tr r tx x)
+  (cpuid-subr 'cpuid_version_info tr r tx x))
+
+(defun cpuid_cache_tlb_info (tr r tx x)
+  (cpuid-subr 'cpuid_cache_tlb_info tr r tx x))
+
+(defun cpuid_serial_info (tr r tx x)
+  (cpuid-subr 'cpuid_serial_info tr r tx x))
+
+(defun cpuid_Deterministic_Cache_Parameters_info (tr r tx x)
+  (cpuid-subr 'cpuid_deterministic_cache_parameters_info tr r tx x))
+
+(defun cpuid_MONITOR_MWAIT_Features_info (tr r tx x)
+  (cpuid-subr 'cpuid_monitor_mwait_features_info tr r tx x))
+
+(defun cpuid_Extended_Feature_Enumeration_info (tr r tx x)
+  (cpuid-subr 'cpuid_extended_feature_enumeration_info tr r tx x))
+
+(defun cpuid_Direct_Cache_Access_info (tr r tx x)
+  (cpuid-subr 'cpuid_direct_cache_access_info tr r tx x))
+
+(defun cpuid_Architectural_Performance_Monitoring_info (tr r tx x)
+  (cpuid-subr 'cpuid_architectural_performance_monitoring_info tr r tx x))
+
+
+(defun cpuid_Extended_Topology_info (tr r tx x)
+  (cpuid-subr 'cpuid_extended_topology_info tr r tx x))
+
+(defun cpuid_Processor_Extended_States_info (tr r tx x)
+  (cpuid-subr 'cpuid_processor_extended_states_info tr r tx x))
+
+(defun cpuid_Quality_of_Service_info (tr r tx x)
+  (cpuid-subr 'cpuid_quality_of_service_info tr r tx x))
+
+(defun cpuid_brand_part1_info (tr r tx x)
+  (cpuid-subr 'cpuid_brand_part1_info tr r tx x))
+
+(defun cpuid_brand_part2_info (tr r tx x)
+  (cpuid-subr 'cpuid_brand_part2_info tr r tx x))
+
+(defun cpuid_brand_part3_info (tr r tx x)
+  (cpuid-subr 'cpuid_brand_part3_info tr r tx x))


### PR DESCRIPTION
Adds an `intrinsic` and `symbol-concat` primitives to Primus Lisp and uses them to implement all floating-point operators in pcode and cpuid routines for pcode-x86.

Also rewrites the subinstruction contraction procedure, which was broken. The new version is more aggressive and contracts all contractable subinstructions. 

Another minor fix: fixes the pretty-printing for the attributes parsing error. 

Below is the demonstration how intrinsic are reified into BIR code with the `ucomisd` instruction as an example, 

```
$ bap mc --show-insn=asm --show-bir --x86-backend=ghidra -- 66 0f 2e 05 e6 02 00 00 
UCOMISD XMM0, qword ptr [0x2ee]
0000007d:
0000006c: intrinsic:x0 := extract:63:0[YMM0]
0000006e: call @intrinsic:is_fnan_ieee754_binary with return %00000070
00000070:
00000071: u98944 := intrinsic:y0
0000005e: intrinsic:x0 := mem[0x2EE, el]:u64
00000061: call @intrinsic:is_fnan_ieee754_binary with return %00000063
00000063:
00000064: u99072 := intrinsic:y0
00000057: PF := extract:7:0[u98944] | extract:7:0[u99072]
00000047: intrinsic:x0 := extract:63:0[YMM0]
0000004a: intrinsic:x1 := mem[0x2EE, el]:u64
0000004c: call @intrinsic:forder_ieee754_binary with return %0000004e
0000004e:
0000004f: u99328 := intrinsic:y0 = 0
0000003f: ZF := extract:7:0[PF] | extract:7:0[u99328]
0000002e: intrinsic:x0 := extract:63:0[YMM0]
00000031: intrinsic:x1 := mem[0x2EE, el]:u64
00000034: call @intrinsic:forder_ieee754_binary with return %00000036
00000036:
00000037: u99584 := high:1[intrinsic:y0]
00000026: CF := extract:7:0[PF] | extract:7:0[u99584]
00000020: OF := 0
0000001c: AF := 0
00000018: SF := 0
```
