### PR TITLE
improves the setw function used by the aarch64 lifter

### DIFF
--- a/plugins/arm/semantics/arm-bits.lisp
+++ b/plugins/arm/semantics/arm-bits.lisp
@@ -17,8 +17,7 @@
 (defun add-with-carry/clear-base (rd x y c)
   (let ((r (+ c y x)))
     (set-flags r y x)
-    (clear-base rd)
-    (set$ rd r)))
+    (setw rd r)))
 
 (defun add-with-carry/it-block (rd x y c cnd)
   (when (condition-holds cnd)
@@ -60,11 +59,6 @@
 (defun is-unconditional (cnd)
   (= cnd 0b1110))
 
-(defun clear-base (reg)
-  (set$ (alias-base-register reg) 0))
-
 (defmacro setw (reg val)
   "(set Wx V) sets a Wx register clearing the upper 32 bits."
-  (let ((res val))
-    (clear-base reg)
-    (set$ reg res)))
+  (set$ (alias-base-register reg) val))


### PR DESCRIPTION
This macro assigns the lower 32 bits of the register. To prevent the desugaring pass from preserving the upper bits the destination register is first zeroed. This also requires let-bound the right-hand side for the case when it references the left-hand side. Altogether it resulted in ugly and inefficient code, albeit semantically correct.

A much more simple and direct approach is to assign directly to the base register and let Primus Lisp coerce (by zero-padding) the right-hand side.