### PR TITLE
Fix compatibility with Core_kernel >= 0.15

### DIFF
--- a/lib/bap/bap_self.ml
+++ b/lib/bap/bap_self.ml
@@ -7,6 +7,7 @@ open Cmdliner
 
 module Event = Bap_main_event
 module Buffer = Caml.Buffer
+module Sys = Caml.Sys
 
 module Create() = struct
   let bundle = main_bundle ()

--- a/lib/bap_bundle/bap_bundle.ml
+++ b/lib/bap_bundle/bap_bundle.ml
@@ -1,6 +1,7 @@
 open Core_kernel
 
 module Filename = Caml.Filename
+module Sys = Caml.Sys
 
 module Std = struct
   exception Not_a_bundle

--- a/lib/bap_byteweight/bap_byteweight_signatures.ml
+++ b/lib/bap_byteweight/bap_byteweight_signatures.ml
@@ -1,6 +1,7 @@
 open Core_kernel
 open Bap_core_theory
 open Bap.Std
+module Sys = Caml.Sys
 
 module Config = Bap_main.Extension.Configuration
 

--- a/lib/bap_image/bap_image.ml
+++ b/lib/bap_image/bap_image.ml
@@ -5,6 +5,7 @@ open Bap_types.Std
 open Monads.Std
 open Format
 open Image_internal_std
+module Sys = Caml.Sys
 
 module Fact = Ogre.Make(Monad.Ident)
 module Result = Monad.Result.Error

--- a/lib/bap_llvm/bap_llvm_loader.ml
+++ b/lib/bap_llvm/bap_llvm_loader.ml
@@ -3,6 +3,7 @@ open Bap.Std
 open Monads.Std
 open Or_error
 
+module Sys = Caml.Sys
 module Unix = Caml_unix
 
 module Primitive = struct

--- a/lib/bap_main/bap_main_event.ml
+++ b/lib/bap_main/bap_main_event.ml
@@ -5,6 +5,7 @@ open Bap_bundle.Std
 open Format
 
 module Buffer = Caml.Buffer
+module Sys = Caml.Sys
 
 (* we're reusing [exn] type only because we want to use
    Printexc magic printer. It is not visible from outside,

--- a/lib/bap_main/bap_main_log.ml
+++ b/lib/bap_main/bap_main_log.ml
@@ -5,6 +5,7 @@ open Format
 
 module Event = Bap_main_event
 module Filename = Caml.Filename
+module Sys = Caml.Sys
 module Unix = Caml_unix
 
 let perm = 0o770

--- a/lib/bap_plugins/bap_plugins.ml
+++ b/lib/bap_plugins/bap_plugins.ml
@@ -5,6 +5,7 @@ open Or_error.Monad_infix
 
 module Units = Bap_plugins_units
 module Filename = Caml.Filename
+module Sys = Caml.Sys
 
 module Plugin = struct
 

--- a/lib/bap_primus/bap_primus_lisp_parse.ml
+++ b/lib/bap_primus/bap_primus_lisp_parse.ml
@@ -3,6 +3,8 @@ open Bap.Std
 open Format
 open Bap_core_theory
 
+module Sys = Caml.Sys
+
 open Bap_primus_lisp_types
 
 module Attribute = Bap_primus_lisp_attribute

--- a/lib/bap_primus/bap_primus_observation.ml
+++ b/lib/bap_primus/bap_primus_observation.ml
@@ -64,6 +64,7 @@ let of_statement = ident
 module Key = struct
   type 'a t = 'a Type_equal.Id.t [@@deriving sexp_of]
   let to_type_id = ident
+  let type_id = ident
 end
 
 module Map = Univ_map.Make1(Key)(struct

--- a/lib/bap_traces/bap_trace.ml
+++ b/lib/bap_traces/bap_trace.ml
@@ -1,6 +1,6 @@
 open Core_kernel
 open Regular.Std
-open Result
+open Result.Monad_infix
 open Bap.Std
 
 module Id = Bap_trace_id

--- a/lib/bap_traces/bap_trace_binprot.ml
+++ b/lib/bap_traces/bap_trace_binprot.ml
@@ -1,8 +1,7 @@
-
 open Core_kernel
 open Regular.Std
 open Bap.Std
-open Result
+open Result.Monad_infix
 open Bin_prot
 
 module Trace = Bap_trace

--- a/lib/regular/regular_data.ml
+++ b/lib/regular/regular_data.ml
@@ -101,6 +101,7 @@ module Class = struct
 
   module Key = struct
     type 'a t = 'a key
+    let type_id {key} = key
     let to_type_id {key} = key
     let sexp_of_t _ {key} = Sexp.Atom (Type_equal.Id.name key)
   end

--- a/opam/opam
+++ b/opam/opam
@@ -14,7 +14,7 @@ depends: [
   "linenoise" {>= "1.1" & < "2.0"}
   "cmdliner" {>= "1.0" & < "2.0"}
   "ppx_bap" {>= "v0.14" & < "v0.15"}
-  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "core_kernel" {>= "v0.14" & < "v0.16"}
   "ezjsonm"
   "fileutils"
   "FrontC" {>= "4.1" & < "4.2"}

--- a/plugins/analyze/analyze_main.ml
+++ b/plugins/analyze/analyze_main.ml
@@ -50,6 +50,7 @@ open Core_kernel
 open Bap_main
 open Bap_knowledge
 open Bap.Std
+module Sys = Caml.Sys
 
 include Loggers()
 

--- a/plugins/api/api_main.ml
+++ b/plugins/api/api_main.ml
@@ -1,11 +1,12 @@
 open Core_kernel
-open Result
+open Result.Monad_infix
 open Bap.Std
+module Sys = Caml.Sys
 include Self()
 
 module Configuration = Bap_main.Extension.Configuration
 
-let try_with f = match try_with f with
+let try_with f = match Result.try_with f with
   | Ok r -> Ok r
   | Error exn -> Error (`Fail exn)
 
@@ -116,7 +117,7 @@ module Api = struct
       Some {desc = {lang; name}; path;}
     else None
 
-  let ok_if_true2 f x ~error = f x >>= fun r -> ok_if_true r ~error
+  let ok_if_true2 f x ~error = f x >>= fun r -> Result.ok_if_true r ~error
 
   let cp api dest =
     ok_if_true2 Api_path.exists dest ~error:`No_dst >>= fun () ->

--- a/plugins/byteweight/byteweight_main.ml
+++ b/plugins/byteweight/byteweight_main.ml
@@ -45,6 +45,7 @@ open Core_kernel
 open Bap_main
 open Bap_core_theory
 open Bap.Std
+module Sys = Caml.Sys
 
 open KB.Syntax
 include Loggers()

--- a/plugins/cache/bap_cache.ml
+++ b/plugins/cache/bap_cache.ml
@@ -7,6 +7,7 @@ include Self ()
 
 module Filename = Caml.Filename
 module Random = Caml.Random
+module Sys = Caml.Sys
 module Unix = Caml_unix
 module Utils = Bap_cache_utils
 

--- a/plugins/cache/bap_cache_gc.ml
+++ b/plugins/cache/bap_cache_gc.ml
@@ -80,6 +80,7 @@ include Self ()
 
 module Cache = Bap_cache
 module CDF = Int.Map
+module Sys = Caml.Sys
 module Unix = Caml_unix
 
 type entry = {

--- a/plugins/cache/bap_cache_utils.ml
+++ b/plugins/cache/bap_cache_utils.ml
@@ -2,6 +2,7 @@ open Core_kernel
 open Regular.Std
 
 module Filename = Caml.Filename
+module Sys = Caml.Sys
 module Unix = Caml_unix
 
 let ( / ) = Filename.concat

--- a/plugins/dependencies/dependencies_main.ml
+++ b/plugins/dependencies/dependencies_main.ml
@@ -58,6 +58,7 @@ open Core_kernel
 open Bap.Std
 open Regular.Std
 open Bap_main
+module Sys = Caml.Sys
 
 include Loggers()
 

--- a/plugins/disassemble/disassemble_main.ml
+++ b/plugins/disassemble/disassemble_main.ml
@@ -91,6 +91,8 @@ open Monads.Std
 open Format
 open Bap_plugins.Std
 
+module Sys = Caml.Sys
+
 include Self()
 open Bap_main
 

--- a/plugins/patterns/patterns_main.ml
+++ b/plugins/patterns/patterns_main.ml
@@ -113,6 +113,7 @@ open Bap_core_theory
 open Bap.Std
 open Bap_main
 open Bap_primus.Std
+module Sys = Caml.Sys
 
 module Sigma = Primus.Lisp.Semantics
 module Lambda = Theory.Label

--- a/plugins/phoenix/phoenix_root.ml
+++ b/plugins/phoenix/phoenix_root.ml
@@ -1,5 +1,6 @@
 open Core_kernel
 
+module Sys = Caml.Sys
 module Unix = Caml_unix
 
 exception Target_directory_is_a_file

--- a/plugins/primus_lisp/primus_lisp_main.ml
+++ b/plugins/primus_lisp/primus_lisp_main.ml
@@ -4,6 +4,7 @@ open Bap.Std
 open Monads.Std
 open Bap_primus.Std
 open Format
+module Sys = Caml.Sys
 include Self()
 
 module Primitives = Primus_lisp_primitives

--- a/plugins/primus_systems/primus_systems_main.ml
+++ b/plugins/primus_systems/primus_systems_main.ml
@@ -45,6 +45,7 @@ open Core_kernel
 open Bap_main
 open Bap_primus.Std
 open Format
+module Sys = Caml.Sys
 
 let command what =
   sprintf "

--- a/plugins/read_symbols/read_symbols_main.ml
+++ b/plugins/read_symbols/read_symbols_main.ml
@@ -88,6 +88,7 @@ open Core_kernel
 open Bap_main
 open Bap_core_theory
 open KB.Syntax
+module Sys = Caml.Sys
 include Bap_main.Loggers()
 
 let anonymous_prefix = "__anonymous_sub%"

--- a/plugins/stub_resolver/stub_resolver_main.ml
+++ b/plugins/stub_resolver/stub_resolver_main.ml
@@ -43,6 +43,7 @@ open Bap_core_theory
 open Bap_knowledge
 open Bap_main
 open KB.Syntax
+module Sys = Caml.Sys
 
 include Loggers()
 

--- a/src/bap_byteweight_main.ml
+++ b/src/bap_byteweight_main.ml
@@ -73,6 +73,7 @@ module BW = Bap_byteweight.Bytes
 module Sigs = Bap_byteweight_signatures
 module Digest = Caml.Digest
 module Config = Extension.Configuration
+module Sys = Caml.Sys
 
 (* we still have to update this tool to support modern bap *)
 let sigs_load = Sigs.load[@warning "-D"]

--- a/src/bap_frontend.ml
+++ b/src/bap_frontend.ml
@@ -28,6 +28,8 @@ open Core_kernel
 open Regular.Std
 open Bap_main.Extension
 
+module Sys = Caml.Sys
+
 module type unit = sig end
 
 

--- a/tools/bapbundle.ml
+++ b/tools/bapbundle.ml
@@ -2,6 +2,8 @@ open Core_kernel
 open Bap_bundle.Std
 open Format
 
+module Sys = Caml.Sys
+
 open Manifest.Fields
 
 exception Provides_field_syntax_error


### PR DESCRIPTION
Core_kernel 0.15 introduces a Sys module (which is a deprecated value that refers users to core_unix.sys_unix).  Also, Result now contains an Error module (which is a monad over the Error case rather than the Ok case).