### PR TITLE
adds arbitrary-precision loopless clz and popcount to Primus Lisp

### DIFF
--- a/plugins/arm/semantics/arm.lisp
+++ b/plugins/arm/semantics/arm.lisp
@@ -6,4 +6,4 @@
 
 (defun CLZ (rd rn pre _)
   (when (condition-holds pre)
-    (set$ rd (clz32 rn))))
+    (set$ rd (clz rn))))


### PR DESCRIPTION
The pure Primus Lisp implementation supports both statically known and unknown inputs of any lengths. For statically unknown inputs, the generated code will not have any loops and will be proportional in size to the size of inputs in bits divided by 64. The popcount implementation is also branchless.

This PR also hides specialized functions such as `clzN` and `popcountN` functions in favor of the generic `clz` and `popcount` functions.

Not, to properly function on statically known values, this PR needs #1463.