### PR TITLE
fixes a sporadic internal error in the cache garbage collector

### DIFF
--- a/plugins/cache/bap_cache_gc.ml
+++ b/plugins/cache/bap_cache_gc.ml
@@ -117,7 +117,7 @@ let select entries total_size size_to_free =
     if freed < size_to_free then
       let u = Random.int total_size in
       let (_,i) =
-        Option.value_exn (CDF.closest_key cdf `Less_than u) in
+        Option.value_exn (CDF.closest_key cdf `Less_or_equal_to u) in
       if Set.mem indexes i
       then loop indexes freed
       else loop (Set.add indexes i) (freed + entries.(i).size)


### PR DESCRIPTION
The cache GC randomly selects files for deletion and there's a sligth chance (1/total-size-of-cache) that it will fail with the following error:

```
Internal error: "Option.value_exn None"
Backtrace:
Raised at file "src/error.ml" (inlined), line 8, characters 14-30
Called from file "src/option.ml", line 136, characters 4-21
Called from file "bap_cache_gc.ml", line 120, characters 8-59
Called from file "bap_cache_gc.ml", line 125, characters 2-33
Called from file "bap_cache_gc.ml", line 151, characters 19-61
Called from file "bap_cache_main.ml", line 138, characters 2-27
Called from file "bap_main.ml", line 841, characters 37-46
Called from file "bap_main.ml", line 1013, characters 25-28
```

This happens when we use a random number to pick a file base on the cumulative distribution function of the file sizes. When the generated value is equal to zero we can't find a key that is less than 0 and get this error. After two years of testing, this finally has happened! With the way how the testing was set up, the odds of this were 1:10000 :)

The fix is trivial, as stated in the algorithm we should pick the closest key that is less than *or equal*, not that is strictly less as in the implementation.