### PR TITLE
fixes the relocation symbolizer incorrect handling of intrinsics

### DIFF
--- a/lib/bap_types/bap_core_theory_bil_parser.ml
+++ b/lib/bap_types/bap_core_theory_bil_parser.ml
@@ -170,7 +170,7 @@ let stmt : type t r. (t,exp,r,stmt) stmt_parser =
   fun s -> match Stmt.(decode call s) with
     | Some dst -> S.call dst
     | None -> match Stmt.(decode intrinsic s) with
-      | Some data -> S.call data
+      | Some data -> S.call ("intrinsic:"^data)
       | None -> match s with
         | Move (v,x) -> set v x
         | Jmp (Int x) -> S.goto (Word.to_bitvec x)

--- a/plugins/relocatable/rel_symbolizer.ml
+++ b/plugins/relocatable/rel_symbolizer.ml
@@ -163,12 +163,18 @@ let plt_size label =
   List.find_map plt_sizes ~f:(fun (p,s) ->
       Option.some_if (Theory.Target.belongs p t) s)
 
+let is_intrinsic name =
+  List.exists ~f:(fun prefix -> String.is_prefix ~prefix name) [
+    "intrinsic:";
+    "special:";
+  ]
+
 let demangle s = match String.chop_suffix ~suffix:":external" s with
   | None -> s
   | Some s -> s
 
 let extract_external stmt = match Bil.(decode call stmt) with
-  | Some dst -> Some (Name (demangle dst))
+  | Some dst when not (is_intrinsic dst) -> Some (Name (demangle dst))
   | _ -> None
 
 


### PR DESCRIPTION
The relocation symbolizer was treating intrinsic and special calls as relocations and improperly named functions that have such calls.

This problem is especially damaging when the Intel Control-flow Enforcement Technology (CET) is present in the binary. In that case, the `_start` function is renamed to `endbr` and is loaded as a self-calling function.

This commit also ensure that the `intrinsic:` prefix is preserved during lifting.