### PR TITLE
prints the jump destination address and name in the assembly output

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -7845,6 +7845,13 @@ module Std : sig
     (** [span fn] returns a memory map of a region occupied by a
         function [fn] *)
     val span : fn -> unit memmap
+
+    (** [explicit_callee symtab address] returns a callee which is
+        called from a  block with the given [address].
+
+        @since 2.5.0
+    *)
+    val callee : t -> addr -> string option
   end
 
   type lifter = mem -> Disasm_expert.Basic.full_insn -> bil Or_error.t

--- a/lib/bap_disasm/bap_disasm_symtab.ml
+++ b/lib/bap_disasm/bap_disasm_symtab.ml
@@ -120,6 +120,10 @@ let insert_call ?(implicit=false) symtab block data =
 
 let explicit_callee {ecalls} = Map.find ecalls
 let implicit_callee {icalls} = Map.find icalls
+let callee tab src = match explicit_callee tab src with
+  | Some dst -> Some dst
+  | None -> implicit_callee tab src
+
 
 
 let (<--) = fun g f -> match g with

--- a/lib/bap_disasm/bap_disasm_symtab.mli
+++ b/lib/bap_disasm/bap_disasm_symtab.mli
@@ -61,3 +61,5 @@ val explicit_callee : t -> addr -> string option
 (** [implicit_callee symtab address] returns a callee which is
     implicitly called from a block with the given [address]. *)
 val implicit_callee : t -> addr -> string option
+
+val callee : t -> addr -> string option


### PR DESCRIPTION
This is a simple quality of life update that should be done many years ago. This change adds printing the jump destination address and name, if present, in the assembly output, much like objdump does, e.g.,
```
c203: e8 70 7c ff ff            callq -0x8390 # 3e78 <malloc>
```

This commit also publishes the `Symtab.callee` function that gives this information.
