### PR TITLE
uses function starts as the entires when building the symtab

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -7846,8 +7846,8 @@ module Std : sig
         function [fn] *)
     val span : fn -> unit memmap
 
-    (** [explicit_callee symtab address] returns a callee which is
-        called from a  block with the given [address].
+    (** [callee symtab address] returns a callee which is
+        called from a block with the given [address].
 
         @since 2.5.0
     *)

--- a/lib/bap_disasm/bap_disasm_rec.ml
+++ b/lib/bap_disasm/bap_disasm_rec.ml
@@ -77,7 +77,6 @@ let has_conditional_jump blk =
 let global_cfg disasm =
   Driver.explore disasm
     ~init:Cfg.empty
-    ~entries:(Set.to_sequence@@Driver.subroutines disasm)
     ~block:(fun mem insns ->
         Driver.execution_order insns >>=
         KB.List.filter_map ~f:(fun label ->

--- a/lib/bap_disasm/bap_disasm_rec.ml
+++ b/lib/bap_disasm/bap_disasm_rec.ml
@@ -77,6 +77,7 @@ let has_conditional_jump blk =
 let global_cfg disasm =
   Driver.explore disasm
     ~init:Cfg.empty
+    ~entries:(Set.to_sequence@@Driver.subroutines disasm)
     ~block:(fun mem insns ->
         Driver.execution_order insns >>=
         KB.List.filter_map ~f:(fun label ->

--- a/lib/bap_disasm/bap_disasm_symtab.ml
+++ b/lib/bap_disasm/bap_disasm_symtab.ml
@@ -174,6 +174,7 @@ let create_intra disasm calls =
 let create_inter disasm calls init =
   Disasm.explore disasm
     ~init
+    ~entries:(Set.to_sequence@@Disasm.subroutines disasm)
     ~block:(fun mem _ -> KB.return mem)
     ~node:(fun _ s -> KB.return s)
     ~edge:(fun src dst s ->


### PR DESCRIPTION
Uses the same initial starting points when building whole program CFG and symbol table. This improves performance and prevents discrepancies between the set of instructions discovered during the disassembly and the set of instructions that are discovered when we build various graph representations. In certain cases, e.g., in the interworked binaries, such discrepancies could result in an abnormal termiantion of a program.