### PR TITLE
adds `--arm-features` and downgrades the maximum ARM v8.Xa version to 3

### DIFF
--- a/lib/arm/arm_target.ml
+++ b/lib/arm/arm_target.ml
@@ -665,25 +665,40 @@ let guess_encoding interworking label target mode =
         | false -> !!llvm_a32
   else !!CT.Language.unknown
 
+(* our lowest supported llvm is 6.0 which supports up to v8.3a *)
+let max_v8a_version = 3
+
 let v8aversions =
-  List.init 6 ~f:(fun i ->
-      sprintf "+v8.%da" (i+1)) |>
+  List.init max_v8a_version ~f:(fun i ->
+      sprintf "+v8.%da" (i+1))
+
+let is_normal_feature s =
+  String.length s > 0 && match s.[0] with
+  | '+' | '-' -> true
+  | _ -> false
+
+let normalize_features xs =
+  List.map xs ~f:(fun x ->
+      if is_normal_feature x
+      then x
+      else "+" ^ x) |>
   String.concat ~sep:","
 
-let enable_llvm ?interworking () =
+let enable_llvm ?(features=[]) ?interworking () =
   let open KB.Syntax in
-  register llvm_a32 "armv7";
-  register llvm_t32 "thumbv7" ~attrs:"+thumb2";
-  register llvm_a64 "aarch64" ~attrs:v8aversions;
+  let features xs = normalize_features (xs@features) in
+  register llvm_a32 "armv7" ~attrs:(features []);
+  register llvm_t32 "thumbv7" ~attrs:(features ["thumb2"]);
+  register llvm_a64 "aarch64" ~attrs:(features v8aversions);
   KB.promise CT.Label.encoding @@ fun label ->
   let* target = CT.Label.target label in
   let* mode = KB.collect Mode.slot label in
   guess_encoding interworking label target mode
 
-let load ?interworking ?(backend="llvm") () =
+let load ?features ?interworking ?(backend="llvm") () =
   enable_loader ();
   enable_arch ();
   Encodings.provide ();
   if String.equal backend "llvm"
-  then enable_llvm ?interworking ()
+  then enable_llvm ?features ?interworking ()
   else enable_pcode ()

--- a/lib/arm/arm_target.mli
+++ b/lib/arm/arm_target.mli
@@ -120,11 +120,17 @@ val llvm_a64 : Theory.language
     This includes parsing the loader output and enabling backward
     compatibility with the old [Arch.t] representation.
 
-    @param [interworking] if set disables/enables the interworking
+    @param interworking if set disables/enables the interworking
     mode (switching between arm and thumb modes). If not set, then
     the presence of interworking is detected using heurisitics. Right
     now if the heuristic looks into the symbol table and if there is
     a symbol there with an odd address (which is used to indicate
     thumb encoding) then interworking is enabled.
+
+    @param features is the backend-specific list of features. The
+    syntax is vastly dependent on the backend. For llvm, in
+    particular, the features are translated to the disassembler
+    attributes. If the feature doesn't start with [+] or [-] then it
+    is assumed that the feature is enabled and [+] is prepended.
 *)
-val load : ?interworking:bool -> ?backend:string -> unit -> unit
+val load : ?features:string list -> ?interworking:bool -> ?backend:string -> unit -> unit


### PR DESCRIPTION
The lowest version of LLVM that we still support is 6.0 and it doesn't support ARMv8.4a and above and spurs a warning, when we try to enable it. Therefore, we reduce the upper bound to 3 and, to compensate it, introduce a new command-line option to control the set of attributes passed to the backend disassembler. It is now possible to enable/disable features with `--arm-features=+FEATURE,-FEATURE`. The `+` is optional, so `FEATURE` defaults to enabling the `FEATURE`. For example, to enable newer versions of ARMv8 use the following command-line, `--arm-features=v8.4a,v8.5a,v8.6a`. It is also possible to enable it permanently using a configuration file. For that create a file in the `~/.config/bap/` folder (name doesn't matter) with the following content,

```
arm-features=v8.4a,v8.5a,v8.6a
```


Note, that you can override features, so for example you can disable `v8.2a` with `--arm-features=-v8.2a` or disable thumb2 with `--arm-features=-thumb2`, e.g.,

```
$ bap mc --arch=thumb --show-insn=asm --arm-features=-thumb2 -- 2d e9 f8 43
4 bytes were left non disassembled
$ bap mc --arch=thumb --show-insn=asm -- 2d e9 f8 43
push.w {r3, r4, r5, r6, r7, r8, r9, lr}
```