### PR TITLE
implements the naming scheme for interrupts

### DIFF
--- a/lib/bap_types/bap_ir.ml
+++ b/lib/bap_types/bap_ir.ml
@@ -125,8 +125,10 @@ module Tid = struct
   let pp ppf tid = Format.fprintf ppf "%s" (to_string tid)
 
   let name t = match get_name t with
-    | None -> to_string t
     | Some name -> sprintf "@%s" name
+    | None -> match get_ivec t with
+      | None -> to_string t
+      | Some ivec -> sprintf "@interrupt:#%d" ivec
 
   let from_string_exn = of_string
   let from_string x = Ok (from_string_exn x)
@@ -1735,8 +1737,11 @@ module Ir_sub = struct
     match name with
     | Some name -> name
     | None -> match Tid.get_name tid with
-      | None -> Tid.to_string tid
       | Some name -> name
+      | None -> match Tid.get_ivec tid with
+        | None -> Tid.to_string tid
+        | Some ivec ->
+          Format.asprintf "interrupt:#%d" ivec
 
   let new_empty ?(tid=Tid.create ()) ?name () : t =
     make_term tid {


### PR DESCRIPTION
Extends #1475 and adds special naming scheme for interrupts. Before that the interrupts didn't have any special treatment wrt the names so the corresponding interrupt service routines just got random tids as the name. That was hampering both readability and analysis.