### PR TITLE
reifies external subroutines and intrinsics into IR

### DIFF
--- a/lib/bap_disasm/bap_disasm_driver.mli
+++ b/lib/bap_disasm/bap_disasm_driver.mli
@@ -4,6 +4,8 @@ open Bap_image_std
 open Bap_knowledge
 open Bap_core_theory
 
+module Insn = Bap_disasm_insn
+
 type state [@@deriving bin_io]
 type insns
 type jump
@@ -14,6 +16,7 @@ val scan : mem -> state -> state knowledge
 val merge : state -> state -> state
 
 val subroutines : state -> Set.M(Addr).t
+val externals : state -> Set.M(Theory.Label).t
 val blocks : state -> Set.M(Addr).t
 val jump : state -> addr -> jump option
 

--- a/lib/bap_disasm/bap_disasm_symtab.mli
+++ b/lib/bap_disasm/bap_disasm_symtab.mli
@@ -6,6 +6,7 @@ open Image_internal_std
 
 module Disasm = Bap_disasm_driver
 module Callgraph = Bap_disasm_calls
+module Insn = Bap_disasm_insn
 
 type block = Bap_disasm_block.t
 type edge =  Bap_disasm_block.edge
@@ -31,6 +32,7 @@ val owners : t -> addr -> fn list
 val dominators : t -> mem -> fn list
 val intersecting : t -> mem -> fn list
 val to_sequence : t -> fn seq
+val externals : t -> (Theory.Label.t * Insn.t) seq
 val span : fn -> unit memmap
 
 

--- a/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
+++ b/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
@@ -722,8 +722,11 @@ module Primitives(CT : Theory.Core)(T : Target) = struct
           CT.set (ivar i s) !!x)
 
     let invoke_symbol name =
-      let name = KB.Name.(unqualified@@read name) in
-      let* dst = Theory.Label.for_name (sprintf "intrinsic:%s" name) in
+      let name = KB.Name.create
+          ~package:"intrinsic"
+          KB.Name.(unqualified@@read name) in
+      let* dst = Theory.Label.for_name (KB.Name.show name) in
+      KB.provide Primus.Lisp.Semantics.name dst (Some name) >>= fun () ->
       KB.provide Theory.Label.is_subroutine dst (Some true) >>= fun () ->
       CT.goto dst
 


### PR DESCRIPTION
Turns program objects that are external to the program, e.g., intrinsics, interrupt service routines, externally linked subroutines, into IR. The intrinsic calls in particular, are also called to Primus Lifter, the rest of externals will soon follow.

This PR, essentially, enables the lifters to have subroutines so that a heavy operation could now be turned into an intrinsic subroutine that itself reified into a concrete IR and shared among several instructions. We plan to use this feature to concretely lift all basic floating-point operations, and later employ it for handling heavy vector and crypto operations.