### PR TITLE
enables disabling the patterns plugin

### DIFF
--- a/plugins/patterns/patterns_main.ml
+++ b/plugins/patterns/patterns_main.ml
@@ -1298,11 +1298,18 @@ end = struct
     Option.some_if (Set.mem roots addr) true
 
 
+  let setup_context () =
+    KB.promise Primus.Lisp.Semantics.context @@ fun _ ->
+    KB.return @@
+    Primus.Lisp.Context.create [
+      "patterns", ["enabled"]
+    ]
 
   let enable () =
     promise_outcome ();
     promise_roots ();
-    declare_promise_root ()
+    declare_promise_root ();
+    setup_context ()
 
 end
 

--- a/plugins/patterns/semantics/pattern-actions.lisp
+++ b/plugins/patterns/semantics/pattern-actions.lisp
@@ -1,5 +1,7 @@
 (in-package bap)
 
+(declare (context (patterns enabled)))
+
 (defmethod bap:patterns-action (action addr attrs)
   (when (is-in action 'funcstart 'possiblefuncstart)
     (promise-function-start addr)))


### PR DESCRIPTION
Just passing `--no-patterns` didn't work since the plugin was defining the `promise-function-start` function therefore the `patterns-action` Primus Lisp feature was issuing a missing function type error.

To prevent this, we define a  context class that is instantiated if the plugin is enabled. An alternative solution would be to define the primitive even if the plugin is disabled.