### PR TITLE
enables BIR subroutines without an explicit return

### DIFF
--- a/lib/bap_primus/bap_primus_pos.ml
+++ b/lib/bap_primus/bap_primus_pos.ml
@@ -100,7 +100,7 @@ let next level cls t  =
         | Sub up | Arg {up} | Jmp {up={up}}  -> accept arg {me;up}
         | _ -> reject `arg)
     ~blk:(fun me -> match level with
-        | Jmp {up={up}} | Sub up | Arg {up} -> accept blk {me;up}
+        | Def {up={up}} | Jmp {up={up}} | Sub up | Arg {up} -> accept blk {me;up}
         | Top ({me=prog} as top) -> accept blk {me; up={me=parent prog me; up=top} }
         | _ -> reject `blk)
     ~phi:(fun me -> match level with


### PR DESCRIPTION
So far, the Primus Lisp interpreter was requiring that all subroutines had to pass the control to the caller with an explicit jmp term. This was a fair requirement for the disassembled subroutines but is a nuisance for intrinsic subroutines. To make writing intrinsics easier, this requirement is lifted.