### PR TITLE
implements floating-point intrinsic subroutines

### DIFF
--- a/lib/bap_core_theory/bap_core_theory.mli
+++ b/lib/bap_core_theory/bap_core_theory.mli
@@ -24,7 +24,7 @@
     subset of the language which is relevant to their tasks without
     getting bogged down by the irrelevant architectural details.
 
-    The language can express the semantics of the floating point
+    The language can express the semantics of the floating-point
     operations including operations, but not limiting to, specified in
     the IEEE754 standard.
 
@@ -61,7 +61,7 @@
 
     The Core language subsumes all other sub-languages and includes
     modular arithmetic and other operations on bitvectos, operations
-    with memories, registers, floating points including
+    with memories, registers, floating-points including
     transcendental functions.
 
     The reason to have so many languages is purely pragmatic: to
@@ -394,7 +394,7 @@ module Theory : sig
       to a value, aka expressions. Values are sorted and value sorts
       hold static information about the value representation, like the
       number of bits in a bitvector or the representation format in a
-      floating point value.
+      floating-point value.
 
       All values belong to the same Knowledge class and thus share the
       same set of properties, with each property being a specific
@@ -562,7 +562,7 @@ module Theory : sig
         A concrete and extensible representation of a value sort. The
         sort usually holds the static information about the value
         representation, like the width of a bitvector, the
-        representation format of a floating point number, and so on.
+        representation format of a floating-point number, and so on.
 
         This module is mostly needed when a new sort is defined. The
         Core Theory provides a predefined collection of sorts, here is
@@ -570,7 +570,7 @@ module Theory : sig
 
         - {!Bitv} - bitvectors, e.g., [BitVec(i)]
         - {!Mem} - memories, e.g., [Mem(BitVec(i), BitVec(j)]
-        - {!Float} - floating points, e.g., [Float(IEEE754(2, 8, 23), BitVec(32)];
+        - {!Float} - floating-points, e.g., [Float(IEEE754(2, 8, 23), BitVec(32)];
         - {!Rmode} - rounding mode, e.g., [Rmode].
 
         This module defines a simple DSL for specifying sorts, the DSL
@@ -1012,11 +1012,11 @@ module Theory : sig
   end
 
 
-  (** Sorts for floating point numbers.  *)
+  (** Sorts for floating-point numbers.  *)
   module Float : sig
 
 
-    (** Sort describing the representation format of a floating point number.  *)
+    (** Sort describing the representation format of a floating-point number.  *)
     module Format : sig
       type ('r,'s) t
 
@@ -1026,12 +1026,12 @@ module Theory : sig
 
 
       (** [bits s] returns the sort of bitvectors that are used by
-          floating point numbers of sort [s].  *)
+          floating-point numbers of sort [s].  *)
       val bits : ('r,'s) t Value.sort -> 's Bitv.t Value.sort
 
 
       (** [exp s] returns an expression that describes the
-          interpretation of the bits of the floating point numbers
+          interpretation of the bits of the floating-point numbers
           represented by the sort [s].  *)
       val exp : ('r,'s) t Value.sort -> 'r Value.sort
     end
@@ -1040,22 +1040,22 @@ module Theory : sig
     type 'f t
 
 
-    (** [define r s] defines a floating point sort, indexed by the
-        floating point format [r] that gives the interpretation to
+    (** [define r s] defines a floating-point sort, indexed by the
+        floating-point format [r] that gives the interpretation to
         the bits of bitvectors of sort [s]. *)
     val define : ('r,'s) format Value.sort -> ('r,'s) format t Value.sort
 
 
-    (** [refine s] if [s] is a floating point sort then restores its type.  *)
+    (** [refine s] if [s] is a floating-point sort then restores its type.  *)
     val refine : unit Value.sort -> ('r,'s) format t Value.sort option
 
 
-    (** [format s] returns the format of floating points of sort [s].   *)
+    (** [format s] returns the format of floating-points of sort [s].   *)
     val format : ('r,'s) format t Value.sort -> ('r,'s) format Value.sort
 
 
     (** [bits s] returns the sort of bitvectors that are used to
-        represent floating point numbers of sort [s].   *)
+        represent floating-point numbers of sort [s].   *)
     val bits : ('r,'s) format t Value.sort -> 's Bitv.t Value.sort
   end
 
@@ -2411,7 +2411,7 @@ module Theory : sig
   type ('a,'b) mem = ('a,'b) Mem.t pure
 
 
-  (** a floating point term  *)
+  (** a floating-point term  *)
   type 'f float = 'f Float.t pure
 
 
@@ -2803,47 +2803,47 @@ module Theory : sig
   end
 
 
-  (** The Basic Theory of Floating Points.
+  (** The Basic Theory of Floating-Points.
 
-      Floating point numbers represent a finite subset of the set of
+      floating-point numbers represent a finite subset of the set of
       real numbers. Some formats also extend this set with special
       values to represent infinities or error conditions. This, in
-      general, exceeds the scope of the floating point theory, however
+      general, exceeds the scope of the floating-point theory, however
       the theory includes predicates with domains that potentially may
-      include this special numbers, e.g., [is_nan]. For floating point
+      include this special numbers, e.g., [is_nan]. For floating-point
       formats that do not support special values, such predicates will
       become constant functions.
 
-      All operations in the Floating Point theory are defined in terms
-      of operations on real numbers. Since floating point numbers
+      All operations in the Floating-Point theory are defined in terms
+      of operations on real numbers. Since floating-point numbers
       represent only a subset of the real set,
       denotations select a number from the set of numbers of the
-      floating point sort using concrete rules expressed in terms of
+      floating-point sort using concrete rules expressed in terms of
       rounding modes. The rounding mode is a parameter of many
       operations, denoted with a term of sort [rmode].
 
   *)
   module type Fbasic = sig
 
-    (** [float s x] interprets [x] as a floating point number.  *)
+    (** [float s x] interprets [x] as a floating-point number.  *)
     val float : ('r,'s) format Float.t Value.sort -> 's bitv -> ('r,'s) format float
 
-    (** [fbits x] is a bitvector representation of the floating point number [x].  *)
+    (** [fbits x] is a bitvector representation of the floating-point number [x].  *)
     val fbits : ('r,'s) format float -> 's bitv
 
     (** [is_finite x] holds if [x] represents a finite number.
 
-        A floating point number is finite if it represents a
+        A floating-point number is finite if it represents a
         number from the set of real numbers [R].
 
         The predicate always holds for formats in which only finite
-        floating point numbers are representable.
+        floating-point numbers are representable.
     *)
     val is_finite : 'f float -> bool
 
     (** [is_nan x] holds if [x] represents a not-a-number.
 
-        A floating point value is not-a-number if it is neither finite
+        A floating-point value is not-a-number if it is neither finite
         nor infinite number.
 
         The predicated never holds for formats that represent only
@@ -2875,11 +2875,11 @@ module Theory : sig
 
     (** {3 Rounding modes}
 
-        Many operations in the Theory of Floating Point numbers are
+        Many operations in the Theory of Floating-Point numbers are
         defined using the rounding mode parameter.
 
         The rounding mode gives a precise meaning to the phrase
-        "the closest floating point number to [x]", where [x] is a
+        "the closest floating-point number to [x]", where [x] is a
         real number. When [x] is not representable by the given
         format, some other number [x'] is selected based on
         rules of the rounding mode.
@@ -2887,7 +2887,7 @@ module Theory : sig
 
     (** rounding to nearest, ties to even.
 
-        The denotation is the floating point number nearest to the
+        The denotation is the floating-point number nearest to the
         denoted real number. If the two nearest numbers are equally
         close, then the one with an even least significant digit shall
         be selected. The denotation is not defined, if both numbers
@@ -2897,7 +2897,7 @@ module Theory : sig
 
     (** rounding to nearest, ties away.
 
-        The denotation is the floating point number nearest to the
+        The denotation is the floating-point number nearest to the
         denoted real number. If the two nearest numbers are equally
         close, then the one with larger magnitude shall be selected.
     *)
@@ -2905,21 +2905,21 @@ module Theory : sig
 
     (** rounding towards positive.
 
-        The denotation is the floating point number that is nearest
+        The denotation is the floating-point number that is nearest
         but no less than the denoted real number.
     *)
     val rtp : rmode
 
     (** rounding towards negative.
 
-        The denotation is the floating point number that is nearest
+        The denotation is the floating-point number that is nearest
         but not greater than the denoted real number.
     *)
     val rtn : rmode
 
     (** rounding towards zero.
 
-        The denotation is the floating point number that is nearest
+        The denotation is the floating-point number that is nearest
         but not greater in magnitude than the denoted real number.
     *)
     val rtz : rmode
@@ -2935,7 +2935,7 @@ module Theory : sig
     val cast_float  : 'f Float.t Value.sort  -> rmode -> 'a bitv -> 'f float
 
 
-    (** [cast_sfloat s rm x] is the closest to [x] floating point number of sort [x].
+    (** [cast_sfloat s rm x] is the closest to [x] floating-point number of sort [x].
 
         The bitvector [x] is interpreted as a signed integer in the
         two-complement form.
@@ -2963,57 +2963,59 @@ module Theory : sig
     (** [fabs x] the absolute value of [x].  *)
     val fabs    : 'f float -> 'f float
 
-    (** [fadd m x y] is the floating point number closest to [x+y].  *)
+    (** [fadd m x y] is the floating-point number closest to [x+y].  *)
     val fadd    : rmode -> 'f float -> 'f float -> 'f float
 
-    (** [fsub m x y] is the floating point number closest to [x-y].  *)
+    (** [fsub m x y] is the floating-point number closest to [x-y].  *)
     val fsub    : rmode -> 'f float -> 'f float -> 'f float
 
-    (** [fmul m x y] is the floating point number closest to [x*y].  *)
+    (** [fmul m x y] is the floating-point number closest to [x*y].  *)
     val fmul    : rmode -> 'f float -> 'f float -> 'f float
 
-    (** [fdiv m x y] is the floating point number closest to [x/y].  *)
+    (** [fdiv m x y] is the floating-point number closest to [x/y].  *)
     val fdiv    : rmode -> 'f float -> 'f float -> 'f float
 
-    (** [fsqrt m x] is the floating point number closest to [sqrt x].
+    (** [fsqrt m x] returns the closest floating-point number to [r],
+        where [r] is such number that [r*r] is equal to [x].
 
-        The denotation is not defined if
-    *)
+        If [x] is a negative finite non-zero number, or is [nan],
+        or is the negative infinity, then [sqrt x] is [nan]. If [x] is
+        the positive infinity then [fsqrt x] is the positive infinity. *)
     val fsqrt   : rmode -> 'f float -> 'f float
 
-    (** [fdiv m x y] is the floating point number closest to the
+    (** [fdiv m x y] is the floating-point number closest to the
         remainder of [x/y].  *)
     val fmodulo : rmode -> 'f float -> 'f float -> 'f float
 
-    (** [fmad m x y z] is the floating point number closest to [x * y + z].  *)
+    (** [fmad m x y z] is the floating-point number closest to [x * y + z].  *)
     val fmad    : rmode -> 'f float -> 'f float -> 'f float -> 'f float
 
 
-    (** [fround m x] is the floating point number closest to [x]
+    (** [fround m x] is the floating-point number closest to [x]
         rounded to an integral, using the rounding mode [m].   *)
     val fround   : rmode -> 'f float -> 'f float
 
     (** [fconvert f r x] is the closest to [x] floating number in format [f].  *)
     val fconvert : 'f Float.t Value.sort ->  rmode -> _ float -> 'f float
 
-    (** [fsucc m x] is the least floating point number representable
+    (** [fsucc m x] is the least floating-point number representable
         in (sort x) that is greater than [x].  *)
     val fsucc  : 'f float -> 'f float
 
-    (** [fsucc m x] is the greatest floating point number representable
+    (** [fsucc m x] is the greatest floating-point number representable
         in (sort x) that is less than [x].  *)
     val fpred  : 'f float -> 'f float
 
-    (** [forder x y] holds if floating point number [x] is less than [y].
+    (** [forder x y] holds if floating-point number [x] is less than [y].
 
         The denotation is not defined if either of arguments do not
-        represent a floating point number.
+        represent a floating-point number.
     *)
     val forder : 'f float -> 'f float -> bool
   end
 
 
-  (** The theory of floating point numbers modulo transcendental functions.
+  (** The theory of floating-point numbers modulo transcendental functions.
 
       This signature includes several functions that can be expressed
       in terms of a finite sequence of the operations of addition,
@@ -3037,7 +3039,7 @@ module Theory : sig
     include Fbasic
 
 
-    (** [pow m b a] is a floating point number closest to [b^a].
+    (** [pow m b a] is a floating-point number closest to [b^a].
 
         Where [b^a] is [b] raised to the power of [a].
 
@@ -3048,52 +3050,52 @@ module Theory : sig
     val pow : rmode -> 'f float -> 'f float -> 'f float
 
 
-    (** [compound m x n] is the floating point number closest to [(1+x)^n].
+    (** [compound m x n] is the floating-point number closest to [(1+x)^n].
 
         Where [b^a] is [b] raised to the power of [a].
 
         The denotation is not defined if [x] is less than [-1], or if
         [x] is [n] represent zeros, or if [x] doesn't represent a
-        finite floating point number.
+        finite floating-point number.
     *)
     val compound : rmode -> 'f float -> 'a bitv -> 'f float
 
 
-    (** [rootn m x n] is the floating point number closest to [x^(1/n)].
+    (** [rootn m x n] is the floating-point number closest to [x^(1/n)].
 
         Where [b^a] is [b] raised to the power of [a].
 
         The denotation is not defined if:
         - [n] is zero;
         - [x] is zero and n is less than zero;
-        - [x] is not a finite floating point number;
+        - [x] is not a finite floating-point number;
     *)
     val rootn    : rmode -> 'f float -> 'a bitv -> 'f float
 
 
-    (** [pown m x n] is the floating point number closest to [x^n].
+    (** [pown m x n] is the floating-point number closest to [x^n].
 
         Where [b^a] is [b] raised to the power of [a].
 
         The denotation is not defined if [x] and [n] both represent
-        zero or if [x] doesn't represent a finite floating point
+        zero or if [x] doesn't represent a finite floating-point
         number.
     *)
     val pown    : rmode -> 'f float -> 'a bitv -> 'f float
 
 
-    (** [rsqrt m x] is the closest floating point number to [1 / sqrt x].
+    (** [rsqrt m x] is the closest floating-point number to [1 / sqrt x].
 
         The denotation is not defined if [x] is less than or equal to
-        zero or doesn't represent a finite floating point number.
+        zero or doesn't represent a finite floating-point number.
     *)
     val rsqrt    : rmode -> 'f float -> 'f float
 
 
-    (** [hypot m x y] is the closest floating point number to [sqrt(x^2 + y^2)].
+    (** [hypot m x y] is the closest floating-point number to [sqrt(x^2 + y^2)].
 
         The denotation is not defined if [x] or [y] do not represent
-        finite floating point numbers. *)
+        finite floating-point numbers. *)
     val hypot    : rmode -> 'f float -> 'f float -> 'f float
   end
 
@@ -3102,113 +3104,113 @@ module Theory : sig
   module type Trans = sig
 
 
-    (** [exp m x] is the floating point number closes to [e^x],
+    (** [exp m x] is the floating-point number closest to [e^x],
 
         where [b^a] is [b] raised to the power of [a] and [e] is the
         base of natural logarithm.
     *)
     val exp      : rmode -> 'f float -> 'f float
 
-    (** [expm1 m x] is the floating point number closes to [e^x - 1],
+    (** [expm1 m x] is the floating-point number closest to [e^x - 1],
 
         where [b^a] is [b] raised to the power of [a] and [e] is the
         base of natural logarithm.
     *)
     val expm1    : rmode -> 'f float -> 'f float
 
-    (** [exp2 m x] is the floating point number closes to [2^x],
+    (** [exp2 m x] is the floating-point number closest to [2^x],
 
         where [b^a] is [b] raised to the power of [a].
     *)
     val exp2     : rmode -> 'f float -> 'f float
 
-    (** [exp2 m x] is the floating point number closes to [2^x - 1],
+    (** [exp2 m x] is the floating-point number closest to [2^x - 1],
 
         where [b^a] is [b] raised to the power of [a].
     *)
     val exp2m1   : rmode -> 'f float -> 'f float
 
-    (** [exp10 m x] is the floating point number closes to [10^x],
+    (** [exp10 m x] is the floating-point number closest to [10^x],
 
         where [b^a] is [b] raised to the power of [a].
     *)
     val exp10    : rmode -> 'f float -> 'f float
 
 
-    (** [exp10m1 m x] is the floating point number closes to [10^x - 1],
+    (** [exp10m1 m x] is the floating-point number closest to [10^x - 1],
 
         where [b^a] is [b] raised to the power of [a].
     *)
     val exp10m1  : rmode -> 'f float -> 'f float
 
 
-    (** [log m x] is the floating point number closest to [log x].  *)
+    (** [log m x] is the floating-point number closest to [log x].  *)
     val log      : rmode -> 'f float -> 'f float
 
-    (** [log2 m x] is the floating point number closest to [log x / log 2].  *)
+    (** [log2 m x] is the floating-point number closest to [log x / log 2].  *)
     val log2     : rmode -> 'f float -> 'f float
 
-    (** [log10 m x] is the floating point number closest to [log x / log 10].  *)
+    (** [log10 m x] is the floating-point number closest to [log x / log 10].  *)
     val log10    : rmode -> 'f float -> 'f float
 
-    (** [logp1 m x] is the floating point number closest to [log (1+x)].  *)
+    (** [logp1 m x] is the floating-point number closest to [log (1+x)].  *)
     val logp1    : rmode -> 'f float -> 'f float
 
-    (** [logp1 m x] is the floating point number closest to [log (1+x) / log 2].  *)
+    (** [logp1 m x] is the floating-point number closest to [log (1+x) / log 2].  *)
     val log2p1   : rmode -> 'f float -> 'f float
 
-    (** [logp1 m x] is the floating point number closest to [log (1+x) / log 10].  *)
+    (** [logp1 m x] is the floating-point number closest to [log (1+x) / log 10].  *)
     val log10p1  : rmode -> 'f float -> 'f float
 
-    (** [sin m x] is the floating point number closest to [sin x].  *)
+    (** [sin m x] is the floating-point number closest to [sin x].  *)
     val sin      : rmode -> 'f float -> 'f float
 
-    (** [cos m x] is the floating point number closest to [cos x].  *)
+    (** [cos m x] is the floating-point number closest to [cos x].  *)
     val cos      : rmode -> 'f float -> 'f float
 
-    (** [tan m x] is the floating point number closest to [tan x].  *)
+    (** [tan m x] is the floating-point number closest to [tan x].  *)
     val tan      : rmode -> 'f float -> 'f float
 
-    (** [sinpi m x] is the floating point number closest to [sin (pi*x)].  *)
+    (** [sinpi m x] is the floating-point number closest to [sin (pi*x)].  *)
     val sinpi    : rmode -> 'f float -> 'f float
 
-    (** [cospi m x] is the floating point number closest to [cos (pi*x)].  *)
+    (** [cospi m x] is the floating-point number closest to [cos (pi*x)].  *)
     val cospi    : rmode -> 'f float -> 'f float
 
-    (** [atanpi m y x] is the floating point number closest to [atan(y/x) / pi].  *)
+    (** [atanpi m y x] is the floating-point number closest to [atan(y/x) / pi].  *)
     val atanpi   : rmode -> 'f float -> 'f float
 
-    (** [atanpi m y x] is the floating point number closest to [atan(y/x) / (2*pi)].  *)
+    (** [atanpi m y x] is the floating-point number closest to [atan(y/x) / (2*pi)].  *)
     val atan2pi  : rmode -> 'f float -> 'f float -> 'f float
 
-    (** [asin m x] is the floating point number closest to [asin x].  *)
+    (** [asin m x] is the floating-point number closest to [asin x].  *)
     val asin     : rmode -> 'f float -> 'f float
 
-    (** [acos m x] is the floating point number closest to [acos x].  *)
+    (** [acos m x] is the floating-point number closest to [acos x].  *)
     val acos     : rmode -> 'f float -> 'f float
 
-    (** [atan m x] is the floating point number closest to [atan x].  *)
+    (** [atan m x] is the floating-point number closest to [atan x].  *)
     val atan     : rmode -> 'f float -> 'f float
 
-    (** [atan2 m y x] is the floating point number closest to [atan (y/x)].  *)
+    (** [atan2 m y x] is the floating-point number closest to [atan (y/x)].  *)
     val atan2    : rmode -> 'f float -> 'f float -> 'f float
 
-    (** [sinh m x] is the floating point number closest to [sinh x].  *)
+    (** [sinh m x] is the floating-point number closest to [sinh x].  *)
     val sinh     : rmode -> 'f float -> 'f float
 
-    (** [cosh m x] is the floating point number closest to [cosh x].  *)
+    (** [cosh m x] is the floating-point number closest to [cosh x].  *)
     val cosh     : rmode -> 'f float -> 'f float
 
-    (** [tanh m x] is the floating point number closest to [tanh x].  *)
+    (** [tanh m x] is the floating-point number closest to [tanh x].  *)
     val tanh     : rmode -> 'f float -> 'f float
 
-    (** [asinh m x] is the floating point number closest to [asinh x].  *)
+    (** [asinh m x] is the floating-point number closest to [asinh x].  *)
     val asinh    : rmode -> 'f float -> 'f float
 
-    (** [acosh m x] is the floating point number closest to [acosh x].  *)
+    (** [acosh m x] is the floating-point number closest to [acosh x].  *)
     val acosh    : rmode -> 'f float -> 'f float
 
-    (** [atanh m x] is the floating point number closest to [atanh x].  *)
+    (** [atanh m x] is the floating-point number closest to [atanh x].  *)
     val atanh    : rmode -> 'f float -> 'f float
   end
 
@@ -3216,7 +3218,7 @@ module Theory : sig
   (** The Core Theory signature.
 
       The Core Theory signature includes operations on booleans, bitvectors,
-      floating point numbers, and memories, as well as denotations of
+      floating-point numbers, and memories, as well as denotations of
       various control-flow and data-flow effects.
   *)
   module type Core = sig
@@ -3424,7 +3426,7 @@ module Theory : sig
   (** Sorts implementing IEEE754 formats.
 
       This module provides an infinite set of indexed sorts for
-      floating point numbers defined in the IEEE754 standard.
+      floating-point numbers defined in the IEEE754 standard.
 
       This sorts are not referenced in the Core Theory (or any other
       theory in this library) and provided for user convenience. Any
@@ -4256,10 +4258,10 @@ module Theory : sig
       end
 
 
-      (** Floating point expressions.  *)
+      (** floating-point expressions.  *)
       module type Float = sig
 
-        (** an abstract type denoting a Core Theory floating point term.  *)
+        (** an abstract type denoting a Core Theory floating-point term.  *)
         type t
 
         (** the type of expressions of the target language.    *)

--- a/plugins/bil/bil_float.ml
+++ b/plugins/bil/bil_float.ml
@@ -283,6 +283,10 @@ module Make(B : Theory.Core) = struct
   let is_subnormal fsort x =
     unpack_raw fsort x @@ fun _ e _ -> B.is_zero e
 
+
+  let is_fpos = B.is_positive
+  let is_fneg = B.is_negative
+
   let is_zero x =
     let open B in
     x >>-> fun s x ->

--- a/plugins/bil/bil_float.mli
+++ b/plugins/bil/bil_float.mli
@@ -1,3 +1,13 @@
+(* Transforms floating-point operations into bitvector operations.
+
+   The reason why this module is in BIL is because it is not a theory
+   but a theory transformer in other words it is not a structure but
+   a functor that requires other theory. Right now, the other theory
+   is hardcoded to be the BIL theory and using this transformation
+   will not affect any other theories. To be able to remove this
+   transformation from the BIL plugin we need to finish the Core
+   Theory passes framework. Until then, we will keep it here. *)
+
 open Bap_knowledge
 open Bap_core_theory
 
@@ -14,6 +24,11 @@ module Make(_ : Theory.Core) : sig
   val fsqrt : ('b,'e,'t,'s) fsort -> rmode -> 's bitv -> 's bitv
 
   val is_nan : ('b,'e,'t,'s) fsort -> 's bitv -> bool
+  val is_finite : ('b,'e,'t,'s) fsort -> 's bitv -> bool
+  val is_inf : ('b,'e,'t,'s) fsort -> 's bitv -> bool
+  val is_zero : 's bitv -> bool
+  val is_fpos : 's bitv -> bool
+  val is_fneg : 's bitv -> bool
 
   val cast_int :  ('a, 'b, 'c, 'd) fsort -> 'e Bitv.t Value.sort -> 'd bitv -> 'e bitv
   val cast_float : ('a, 'b, 'c, 'd) fsort -> rmode -> 'e bitv -> 'd bitv

--- a/plugins/bil/bil_float.mli
+++ b/plugins/bil/bil_float.mli
@@ -6,7 +6,13 @@
    is hardcoded to be the BIL theory and using this transformation
    will not affect any other theories. To be able to remove this
    transformation from the BIL plugin we need to finish the Core
-   Theory passes framework. Until then, we will keep it here. *)
+   Theory passes framework. Until then, we will keep it here.
+
+   Otherwise, the trasnformation (this module) is totally generic and
+   is independent of BIL and could be put into a library if
+   necessary.
+
+*)
 
 open Bap_knowledge
 open Bap_core_theory

--- a/plugins/bil/bil_float.mli
+++ b/plugins/bil/bil_float.mli
@@ -5,13 +5,15 @@ open Theory
 
 type ('b,'e,'t,'s) fsort = (('b,'e,'t) IEEE754.t,'s) format Float.t Value.sort
 
-module Make(B : Theory.Core) : sig
+module Make(_ : Theory.Core) : sig
 
   val fadd : ('b,'e,'t,'s) fsort -> rmode -> 's bitv ->  's bitv -> 's bitv
   val fsub : ('b,'e,'t,'s) fsort -> rmode -> 's bitv ->  's bitv -> 's bitv
   val fmul : ('b,'e,'t,'s) fsort -> rmode -> 's bitv ->  's bitv -> 's bitv
   val fdiv : ('b,'e,'t,'s) fsort -> rmode -> 's bitv ->  's bitv -> 's bitv
   val fsqrt : ('b,'e,'t,'s) fsort -> rmode -> 's bitv -> 's bitv
+
+  val is_nan : ('b,'e,'t,'s) fsort -> 's bitv -> bool
 
   val cast_int :  ('a, 'b, 'c, 'd) fsort -> 'e Bitv.t Value.sort -> 'd bitv -> 'e bitv
   val cast_float : ('a, 'b, 'c, 'd) fsort -> rmode -> 'e bitv -> 'd bitv

--- a/plugins/bil/bil_main.ml
+++ b/plugins/bil/bil_main.ml
@@ -174,7 +174,6 @@ let () =
         ~package:"bap" ~name:"bil-fp-emu"
         ~extends:["bap:bil"]
         ~desc: "semantics in BIL, including FP emulation"
-        ~context:["floating-point"]
         ~provides:[
           "bil";
           "floating-point";

--- a/plugins/bil/bil_main.ml
+++ b/plugins/bil/bil_main.ml
@@ -124,9 +124,15 @@ let () =
       "Selects the list and the order of analyses to be applied during
        the lifing to BIL code." in
     Configuration.(parameter Type.(list pass) ~doc "passes") in
-  let enable_fp_emu = Configuration.flag "enable-fp-emulation"
-      ~doc:"Enable the floating point emulation mode.
-      When specified, enables reification of the floating point
+  let enable_fp_emu = Configuration.parameter
+      Type.(bool =? true)
+      "floating-point-emulation"
+      ~aliases:["enable-fp-emulation"]
+      ~as_flag:true
+      ~doc:"Enable/disable floating-point emulation (on by default).
+      When enabled the floating-point operations will be reified into
+      BIL expressions using bitvector arithmetic. Only IEEE754 binary
+      formats are supported.
       operations into Bil expressions that denote those operations
       in terms of bitvector arithmetic. This may lead to very large
       denotations." in

--- a/plugins/bil/bil_semantics.ml
+++ b/plugins/bil/bil_semantics.ml
@@ -610,7 +610,12 @@ module FPEmulator = struct
     with_fsort (sort x) ~unk_s:bool @@ fun bs fs ->
     f fs !!(resort bs x)
 
+  let is_finite x = case FBil.is_finite x
   let is_nan x = case FBil.is_nan x
+  let is_inf x = case FBil.is_inf x
+  let is_fzero x = case (fun _ -> FBil.is_zero) x
+  let is_fpos x = case (fun _ -> FBil.is_fpos) x
+  let is_fneg x = case (fun _ -> FBil.is_fneg) x
 
   let forder x y =
     x >>= fun x ->

--- a/plugins/bil/bil_semantics.ml
+++ b/plugins/bil/bil_semantics.ml
@@ -628,6 +628,13 @@ module Emulator = struct
   let cast_float s m v = make_cast_float Float.cast_float s m v
   let cast_sfloat s m v = make_cast_float Float.cast_float_signed s m v
 
+  let cast_int ts _ v =
+    v >>= fun v ->
+    with_fsort ~unk_s:ts (sort v) @@ fun bs s ->
+    Float.cast_int s ts !!(resort bs v)
+
+  let cast_sint = cast_int
+
   let case f x =
     x >>= fun x ->
     with_fsort (sort x) ~unk_s:bool @@ fun bs fs ->

--- a/plugins/bil/bil_semantics.ml
+++ b/plugins/bil/bil_semantics.ml
@@ -527,15 +527,15 @@ module Rmode = struct
 
 end
 
-module Core : Theory.Core = struct
+module CT : Theory.Core = struct
   include Theory.Empty
   include Basic
   include Rmode
 end
 
-module FBil = Bil_float.Make(Core)
+module Float = Bil_float.Make(CT)
 
-module FPEmulator = struct
+module Emulator = struct
   open Knowledge.Syntax
   type 'a t = 'a knowledge
 
@@ -560,7 +560,7 @@ module FPEmulator = struct
 
   let with_fsort ~unk_s s f =
     match ieee754_of_sort s with
-    | None -> Core.unk unk_s
+    | None -> CT.unk unk_s
     | Some ({Theory.IEEE754.k} as p) ->
       f (bits k) (Theory.IEEE754.Sort.define p)
 
@@ -575,10 +575,10 @@ module FPEmulator = struct
     let x = resort bs x and y = resort bs y in
     float xs (op s rm !!x !!y)
 
-  let fadd rm = fop FBil.fadd rm
-  let fsub rm = fop FBil.fsub rm
-  let fmul rm = fop FBil.fmul rm
-  let fdiv rm = fop FBil.fdiv rm
+  let fadd rm = fop Float.fadd rm
+  let fsub rm = fop Float.fsub rm
+  let fmul rm = fop Float.fmul rm
+  let fdiv rm = fop Float.fdiv rm
 
   let fuop : type f.
     _ ->
@@ -590,9 +590,9 @@ module FPEmulator = struct
     let x = resort bs x in
     float xs (op s rm !!x)
 
-  let fsqrt rm x = fuop FBil.fsqrt rm x
+  let fsqrt rm x = fuop Float.fsqrt rm x
 
-  open Core
+  open CT
 
   let small s x =
     let m = Bitvec.modulus (size s) in
@@ -621,31 +621,31 @@ module FPEmulator = struct
 
   let make_cast_float cast s m v =
     match ieee754_of_sort s with
-    | None -> Core.unk s
+    | None -> CT.unk s
     | Some p ->
       cast (Theory.IEEE754.Sort.define p) m v >>| resort s
 
-  let cast_float s m v = make_cast_float FBil.cast_float s m v
-  let cast_sfloat s m v = make_cast_float FBil.cast_float_signed s m v
+  let cast_float s m v = make_cast_float Float.cast_float s m v
+  let cast_sfloat s m v = make_cast_float Float.cast_float_signed s m v
 
   let case f x =
     x >>= fun x ->
     with_fsort (sort x) ~unk_s:bool @@ fun bs fs ->
     f fs !!(resort bs x)
 
-  let is_finite x = case FBil.is_finite x
-  let is_nan x = case FBil.is_nan x
-  let is_inf x = case FBil.is_inf x
-  let is_fzero x = case (fun _ -> FBil.is_zero) x
-  let is_fpos x = case (fun _ -> FBil.is_fpos) x
-  let is_fneg x = case (fun _ -> FBil.is_fneg) x
+  let is_finite x = case Float.is_finite x
+  let is_nan x = case Float.is_nan x
+  let is_inf x = case Float.is_inf x
+  let is_fzero x = case (fun _ -> Float.is_zero) x
+  let is_fpos x = case (fun _ -> Float.is_fpos) x
+  let is_fneg x = case (fun _ -> Float.is_fneg) x
 
   let forder x y =
     x >>= fun x ->
     y >>= fun y ->
     let xs = sort x in
     match ieee754_of_sort xs with
-    | None -> Core.unk bool
+    | None -> CT.unk bool
     | Some ({Theory.IEEE754.k; w; t}) ->
       let bs = bits k and ms = bits (k-1)in
       let x = resort bs x and y = resort bs y in
@@ -672,7 +672,8 @@ module FPEmulator = struct
       ]
 end
 
+module Core = CT
 module Core_with_fp_emulation = struct
   include Core
-  include FPEmulator
+  include Emulator
 end

--- a/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
+++ b/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
@@ -335,6 +335,16 @@ let export = Primus.Lisp.Type.Spec.[
     "fround", tuple [sym; any] @-> any,
     "(fround M X) rounds X to the closest integral floating-point
     number, using the rounding mode M";
+
+    "cast-float", tuple [sym; int; any] @-> any,
+    "(cast-float M S X) converts an unsigned integer X to the nearest
+    representable floating-point number with size S using the rounding
+    mode M ";
+
+    "cast-sfloat", tuple [sym; int; any] @-> any,
+    "(cast-sfloat M S X) converts a signed integer X to the nearest
+    representable floating-point number with size S using the rounding
+    mode M";
   ]
 
 type KB.conflict += Illformed of string
@@ -1028,6 +1038,9 @@ module Primitives(CT : Theory.Core)(T : Target) = struct
       let round dir x =
         prj64 (Float.round ~dir (inj x))
 
+      let cast_float _ x =
+        prj64 (Float.of_int64 (Z.to_int64 x))
+
       let zero = prj 0.0
       let one = prj 1.0
 
@@ -1099,6 +1112,18 @@ module Primitives(CT : Theory.Core)(T : Target) = struct
       | _ ->
         illformed "floating-point operators require mode and a \
                    single operand"
+
+    let with_cast_ops xs k = match xs with
+      | [x; y] ->
+        let* x = static x and* y = bitv y in
+        k x y
+      | _ ->
+        let n = List.length xs in
+        illformed
+          "the cast operaton requires rmode and two operands, \
+           but %d %s provided"
+          n (if n > 1 then "were" else "was")
+
     let fsort size =
       match Theory.IEEE754.binary size with
       | None ->
@@ -1125,6 +1150,18 @@ module Primitives(CT : Theory.Core)(T : Target) = struct
       | _ ->
         let* fs = fsort (size s) in
         forget@@df fs !!x
+
+    let cast_float sf df xs =
+      with_rmode xs @@ fun sm rm xs ->
+      with_cast_ops xs @@ fun ds x ->
+      let sx = sort x in
+      match const x with
+      | Some x when ds = 64 && size sx <= 64 ->
+        let s = Theory.Bitv.define ds in
+        forget@@const_int s (sf sm x)
+      | _ ->
+        let* fs = fsort ds in
+        forget@@df fs rm !!x
 
     let const x fs s rmode =
       forget@@CT.fbits (CT.cast_float fs rmode (const_int s x))
@@ -1214,6 +1251,8 @@ module Primitives(CT : Theory.Core)(T : Target) = struct
     | "fabs",[x] -> pure@@F.operator F.Z.abs F.abs x
     | "fsqrt",_ -> pure@@F.operator_rm F.Z.sqrt F.sqrt args
     | "fround",_ -> pure@@F.operator_rm F.Z.round F.round args
+    | "cast-float",_ -> pure@@F.cast_float F.Z.cast_float CT.cast_float args
+    | "cast-sfloat",_ -> pure@@F.cast_float F.Z.cast_float CT.cast_sfloat args
     | "<.",_|"forder",_ -> pure@@order F.Z.lt F.lt args
     | "<=.",_ -> pure@@order F.Z.le F.le args
     | ">.",_ -> pure@@order F.Z.gt F.gt args

--- a/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
+++ b/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
@@ -11,10 +11,19 @@ let export = Primus.Lisp.Type.Spec.[
      type conversions in the process. If no numbers are supplied, 0 is \
      returned.";
 
+    "+.", tuple [sym] // all any @-> any,
+    "(+. MODE X Y ... Z) evaluates to a sum of floating-point numbers \
+     X,Y,..,Z using the rounding mode MODE. (+. MODE) evaluates to 0.0.";
+
     "-", all any @-> any,
     "(- X Y ... Z) returns X - Y - ... - Z, performing any necessary \
      type conversions in the process. If no numbers are supplied \
      returns 0. If one number is supplied returns its negation.";
+
+    "-.", tuple [sym] // all any @-> any,
+    "(-. MODE X Y ... Z) performs floating-point subtraction, \
+     X - Y - ... - Z, using the rounding mode MODE. \
+     (-. MODE) evaluates to 0.0.";
 
     "neg", one any @-> any,
     "(neg X) returns the negation (2-complement) of X. Same as (- X).";
@@ -27,11 +36,20 @@ let export = Primus.Lisp.Type.Spec.[
      type conversions in the process. If no numbers are supplied, 1 is \
      returned.";
 
+    "*.", tuple [sym] // all any @-> any,
+    "(-. MODE X Y ... Z) performs floating-point multiplication, \
+     X * Y * ... * Z, using the rounding mode MODE. \
+     (*. MODE) evaluates to 1.0.";
+
     "/", all any @-> any,
     "(/  X Y ... Z) returns X / Y / ... / Z, performing any necessary \
      type conversions in the process. If no numbers are supplied, 1 is \
      returned. If one number is provided returns its reciprocal.";
 
+    "/.", tuple [sym] // all any @-> any,
+    "(-. MODE X Y ... Z) performs floating-point division, \
+     X / Y / ... / Z, using the rounding mode MODE. \
+     (/. MODE) evaluates to 1.0.";
 
     "s/", all any @-> any,
     "(s/ X Y ... Z) returns signed X / Y / ... / Z, performing any \
@@ -88,56 +106,86 @@ let export = Primus.Lisp.Type.Spec.[
      are supplied, 1 is returned. If one number is provided returns \
      that number";
 
+    "<.", all any @-> any,
+    "(< X Y ... Z) is true iff all floating-point numbers are in \
+     the strictly increasing order. Synonym to FORDER.";
+
+    "forder", all any @-> any,
+    "(forder X Y ... Z) is true iff all floating-point numbers are in \
+     the strictly increasing order.";
+
+    "=.", all any @-> any,
+    "(=. X Y ... Z) is true iff all floating-point numbers are \
+     equal in value.";
+
+    ">.", all any @-> any,
+    "(>. X Y ... Z) is true iff all floating-point numbers are \
+     in the strictly decreasing order.";
+
+    "<=.", all any @-> any,
+    "(<= X Y ... Z) is true iff all floating-point numbers are \
+     in the increasing (non-decreasing) order.";
+
+    ">=.", all any @-> any,
+    "(>=. X Y ... Z) returns true if all floating-point numbers are in \
+     the decreasing (non-increasing) order.";
+
+    "is-fzero", all any @-> any,
+    "(is-zero X Y ... Z) is true iff all floating-point numbers are zero.";
+
+    "is-nan", all any @-> any,
+    "(is-nan X Y ... Z) is true iff all values represent NaN.";
+
     "=", all any @-> any,
-    "(= X Y ... Z) returns one if all numbers are equal in value.";
+    "(= X Y ... Z) is true iff all numbers are equal in value.";
 
     "/=", all any @-> any,
-    "(/= X Y ... Z) returns one if all numbers are distinct.";
+    "(/= X Y ... Z) is true iff all numbers are distinct.";
 
     "<", all any @-> any,
-    "(< X Y ... Z) returns one if all numbers are in monotonically \
+    "(< X Y ... Z) is true iff all numbers are in the strictly \
      increasing order.";
 
     ">", all any @-> any,
-    "(> X Y ... Z) returns one if all numbers are in monotonically \
+    "(> X Y ... Z) is true iff all numbers are in the strictly \
      decreasing order.";
 
     "<=", all any @-> any,
-    "(<= X Y ... Z) returns one if all numbers are in monotonically \
-     nondecreasing order.";
+    "(<= X Y ... Z) is true iff all numbers are in the increasing  \
+     (non-decreasing) order.";
 
     ">=", all any @-> any,
-    "(> X Y ... Z) returns one if all numbers are in monotonically \
-     nonincreasing order.";
+    "(>= X Y ... Z) is true iff all numbers are in the decreasing \
+     (non-increasing) order.";
 
     "s<", all any @-> any,
-    "(s< X Y ... Z) returns one if all numbers are in monotonically \
+    "(s< X Y ... Z) is true iff all numbers are in the strictly \
      increasing signed order.";
 
     "s>", all any @-> any,
-    "(s> X Y ... Z) returns one if all numbers are in monotonically \
+    "(s> X Y ... Z) is true iff all numbers are in the strictly \
      decreasing signed order.";
 
     "s<=", all any @-> any,
-    "(s<= X Y ... Z) returns one if all numbers are in monotonically \
-     nondecreasing signed order.";
+    "(s<= X Y ... Z) is true iff all numbers are in the increasing \
+     (non-decreasing) signed order.";
 
     "s>=", all any @-> any,
-    "(> X Y ... Z) returns one if all numbers are in monotonically \
-     nonincreasing signed order.";
+    "(> X Y ... Z) is true iff all numbers are in the decreasing \
+     (non-increasing) signed order.";
 
     "is-zero", all any @-> any,
-    "(is-zero X Y ... Z) returns one if all numbers are zero.";
+    "(is-zero X Y ... Z) is true iff all numbers are zero.";
 
     "not", all any @-> any,
-    "(not X Y ... Z) returns one if all numbers are not \
+    "(not X Y ... Z) is true iff all numbers are not \
      true. Equivalent to (is-zero X Y Z)";
 
     "is-positive", all any @-> any,
-    "(is-positive X Y ... Z) returns one if all numbers are positive.";
+    "(is-positive X Y ... Z) is true iff all numbers are positive.";
 
     "is-negative", all any @-> any,
-    "(is-negative X Y ... Z) returns one if all numbers are negative.";
+    "(is-negative X Y ... Z) is true iff all numbers are negative.";
 
     "word-width", all any @-> any,
     "(word-width X Y ... Z) returns the maximum width of its \
@@ -923,6 +971,139 @@ module Primitives(CT : Theory.Core)(T : Target) = struct
     let (>=) x y = compare x y >= 0
   end
 
+
+  module IEEE754 = struct
+    module Host = struct
+      let inj = Fn.compose Int64.float_of_bits Z.to_int64
+      and prj = Fn.compose Z.int64 Int64.bits_of_float
+
+      let bop op x y = prj (op (inj x) (inj y))
+      let uop op x = prj (op (inj x))
+
+      let add = bop ( +. )
+      let sub = bop ( -. )
+      let mul = bop ( *. )
+      let div = bop ( /. )
+      let neg = uop (~-.)
+      let asb = uop Float.abs
+
+      let zero = prj 0.0
+      let one = prj 1.0
+
+      let lt x y = Float.(inj x < inj y)
+      let le x y = Float.(inj x <= inj y)
+      let gt x y = Float.(inj x > inj y)
+      let ge x y = Float.(inj x >= inj y)
+      let eq x y = Float.(inj x = inj y)
+
+      let is cls x _ =
+        Float.Class.compare cls (Float.classify (inj x)) = 0
+
+      let is_nan = is Float.Class.Nan
+      let is_zero = is Float.Class.Zero
+      let is_inf = is Float.Class.Infinite
+      let is_finite x s = not (is_nan x s) && not (is_inf x s)
+
+    end
+
+    let inj fs x = CT.float fs x
+    and prj = CT.fbits
+
+    let uop op fs x =
+      let* x = inj fs x in
+      let* r = op !!x in
+      prj !!r
+
+    let bop op fs rm x y =
+      let* x = inj fs x
+      and* y = inj fs y in
+      let* r = op rm !!x !!y in
+      prj !!r
+
+    let add s = bop CT.fadd s
+    let sub s = bop CT.fsub s
+    let mul s = bop CT.fmul s
+    let div s = bop CT.fdiv s
+    let neg s = uop CT.fneg s
+    let abs s = uop CT.fabs s
+
+    let const x fs s rmode =
+      forget@@CT.fbits (CT.cast_float fs rmode (const_int s x))
+
+    let zero = Host.zero,const Z.zero
+    let one = Host.one, const Z.one
+
+
+    let dynamic s cast df init xs =
+      with_nbitv s cast xs @@ fun s xs ->
+      match xs with
+      | [] -> forget@@init
+      | x :: xs ->
+        let* init = coerce s x in
+        KB.List.fold ~init xs ~f:(fun res x ->
+            let* x = coerce s x in
+            df !!res !!x) |>
+        forget
+
+    let fsort size =
+      match Theory.IEEE754.binary size with
+      | None ->
+        illformed "unsupported floating-point IEEE754 format: \
+                   binary%d" size
+      | Some ps -> KB.return @@ Theory.IEEE754.Sort.define ps
+
+    let mode_of_key = function
+      | ":rne" -> KB.return CT.rne
+      | ":rna" -> KB.return CT.rna
+      | ":rtp" -> KB.return CT.rtp
+      | ":rtn" -> KB.return CT.rtn
+      | ":rtz" -> KB.return CT.rtz
+      | unk -> illformed "unrecognized rounding mode: %s" unk
+
+    let monoid_rm s cast sf df (si,di) = function
+      | [] ->
+        illformed "requires the floating-point rounding mode"
+      | x::xs ->
+        require_symbol x @@ fun key ->
+        with_nbitv s cast xs @@ fun s _ ->
+        let* rm = mode_of_key key in
+        let size = size s in
+        let* fs = fsort size in
+        if size = 64
+        then monoid s cast sf (df fs rm) si xs
+        else dynamic s cast (df fs rm) (di fs s rm) xs
+
+    let lt x y =
+      let* s = x>>|sort>>|size>>=fsort in
+      let* x = inj s x
+      and* y = inj s y in
+      CT.forder !!x !!y
+
+    let le x y = CT.inv (lt y x)
+    let gt x y = lt y x
+    let ge x y = CT.inv (lt x y)
+
+    (* right now we support only IEEE754 binary format encodings,
+       which are canonical, i.e., each floating-point number or NaN
+       is represented with exactly one encoding, therefore, equal
+       encodings imply equal numbers. We could use a more generic
+       [and_ (CT.inv (lt x y)) (CT.inv (lt y x))] but it will generate
+       much more code (rough 60 expressions) and will definitely be
+       less readable. *)
+    let eq x y = CT.eq x y
+
+    let case f x =
+      let* s = x>>|sort>>|size>>=fsort in
+      f (inj s x)
+
+    let is_zero = case CT.is_fzero
+    let is_nan = case CT.is_nan
+
+    module Z = Host
+  end
+
+  module F = IEEE754
+
   let dispatch lbl name args =
     let t = target in
     match name,args with
@@ -943,6 +1124,15 @@ module Primitives(CT : Theory.Core)(T : Target) = struct
     | "logand",_-> pure@@monoid s join Z.logand CT.logand (Z.int 1) args
     | "logor",_-> pure@@monoid s join Z.logor CT.logor (Z.int 0) args
     | "logxor",_-> pure@@monoid s join Z.logxor CT.logxor (Z.int 0) args
+    | "+.",_ -> pure@@F.monoid_rm s join F.Z.add F.add F.zero args
+    | "-.",_ -> pure@@F.monoid_rm s join F.Z.sub F.sub F.zero args
+    | "*.",_ -> pure@@F.monoid_rm s join F.Z.mul F.mul F.one args
+    | "/.",_ -> pure@@F.monoid_rm s join F.Z.div F.div F.one args
+    | "<.",_|"forder",_ -> pure@@order F.Z.lt F.lt args
+    | "<=.",_ -> pure@@order F.Z.le F.le args
+    | ">.",_ -> pure@@order F.Z.gt F.gt args
+    | ">=.",_ -> pure@@order F.Z.ge F.ge args
+    | "=.",_ -> pure@@order F.Z.eq F.eq args
     | "=",_-> pure@@order Bitvec.(=) CT.eq args
     | "<",_-> pure@@order Bitvec.(<) CT.ult args
     | "s<",_ -> pure@@order SBitvec.(<) CT.slt args
@@ -954,6 +1144,8 @@ module Primitives(CT : Theory.Core)(T : Target) = struct
     | "s>=",_-> pure@@order SBitvec.(>=) CT.uge args
     | "/=",_| "distinct",_-> pure@@forget@@distinct args
     | "is-zero",_| "not",_-> pure@@all s join s_is_zero CT.is_zero args
+    | "is-fzero",_ -> pure@@all s join F.Z.is_zero F.is_zero args
+    | "is-nan",_ -> pure@@all s join F.Z.is_nan F.is_nan args
     | "is-positive",_-> pure@@all s join s_is_positive d_is_positive args
     | "is-negative",_-> pure@@all s join s_is_negative d_is_negative args
     | "word-width",_-> pure@@word_width s args

--- a/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
+++ b/plugins/primus_lisp/primus_lisp_semantic_primitives.ml
@@ -130,11 +130,27 @@ let export = Primus.Lisp.Type.Spec.[
     "(>=. X Y ... Z) returns true if all floating-point numbers are in \
      the decreasing (non-increasing) order.";
 
-    "is-fzero", all any @-> any,
-    "(is-zero X Y ... Z) is true iff all floating-point numbers are zero.";
+    "is-finite", all any @-> any,
+    "(is-finite X Y ... Z) is true iff all values represent finite \
+     floating-point numbers";
 
     "is-nan", all any @-> any,
     "(is-nan X Y ... Z) is true iff all values represent NaN.";
+
+    "is-inf", all any @-> any,
+    "(is-inf X Y ... Z) is true iff all values represent positive \
+     or negative infinities.";
+
+    "is-fzero", all any @-> any,
+    "(is-zero X Y ... Z) is true iff all floating-point numbers are zero.";
+
+    "is-fpos", all any @-> any,
+    "(is-fpos X Y ... Z) is true iff all values represent positive \
+     floating-point numbers.";
+
+    "is-fneg", all any @-> any,
+    "(is-fneg X Y ... Z) is true iff all values represent negative \
+     floating-point numbers.";
 
     "=", all any @-> any,
     "(= X Y ... Z) is true iff all numbers are equal in value.";
@@ -1003,7 +1019,8 @@ module Primitives(CT : Theory.Core)(T : Target) = struct
       let is_zero = is Float.Class.Zero
       let is_inf = is Float.Class.Infinite
       let is_finite x s = not (is_nan x s) && not (is_inf x s)
-
+      let is_pos x _ = Float.(inj x >= 0.0)
+      let is_neg x _ = Float.(inj x <= 0.0)
     end
 
     let inj fs x = CT.float fs x
@@ -1098,6 +1115,10 @@ module Primitives(CT : Theory.Core)(T : Target) = struct
 
     let is_zero = case CT.is_fzero
     let is_nan = case CT.is_nan
+    let is_inf = case CT.is_inf
+    let is_pos = case CT.is_fpos
+    let is_neg = case CT.is_fneg
+    let is_finite = case CT.is_finite
 
     module Z = Host
   end
@@ -1144,8 +1165,12 @@ module Primitives(CT : Theory.Core)(T : Target) = struct
     | "s>=",_-> pure@@order SBitvec.(>=) CT.uge args
     | "/=",_| "distinct",_-> pure@@forget@@distinct args
     | "is-zero",_| "not",_-> pure@@all s join s_is_zero CT.is_zero args
-    | "is-fzero",_ -> pure@@all s join F.Z.is_zero F.is_zero args
+    | "is-finite",_ -> pure@@all s join F.Z.is_finite F.is_finite args
     | "is-nan",_ -> pure@@all s join F.Z.is_nan F.is_nan args
+    | "is-inf",_ -> pure@@all s join F.Z.is_inf F.is_inf args
+    | "is-fzero",_ -> pure@@all s join F.Z.is_zero F.is_zero args
+    | "is-fpos",_ -> pure@@all s join F.Z.is_pos F.is_pos args
+    | "is-fneg",_ -> pure@@all s join F.Z.is_neg F.is_neg args
     | "is-positive",_-> pure@@all s join s_is_positive d_is_positive args
     | "is-negative",_-> pure@@all s join s_is_negative d_is_negative args
     | "word-width",_-> pure@@word_width s args

--- a/plugins/primus_lisp/semantics/ieee754.lisp
+++ b/plugins/primus_lisp/semantics/ieee754.lisp
@@ -22,5 +22,14 @@
 (defun is_nan_ieee754_binary ()
   (set y0 (is-nan x0)))
 
-(defun cast_sfloat_rne_binary ()
-  (set y0 (cast-sfloat :rne x0 x1)))
+(defun cast_sfloat_rne_ieee754_binary_64 ()
+  (set y0 (cast-sfloat :rne 64 x0)))
+
+(defun cast_float_rne_ieee754_binary_64 ()
+  (set y0 (cast-float :rne 64 x0)))
+
+(defun cast_sint_rne_ieee754_binary_64 ()
+  (set y0 (cast-sfloat :rne 64 x0)))
+
+(defun cast_int_rne_ieee754_binary_64 ()
+  (set y0 (cast-float :rne 64 x0)))

--- a/plugins/primus_lisp/semantics/ieee754.lisp
+++ b/plugins/primus_lisp/semantics/ieee754.lisp
@@ -21,3 +21,6 @@
 
 (defun is_nan_ieee754_binary ()
   (set y0 (is-nan x0)))
+
+(defun cast_sfloat_rne_binary ()
+  (set y0 (cast-sfloat :rne x0 x1)))

--- a/plugins/primus_lisp/semantics/ieee754.lisp
+++ b/plugins/primus_lisp/semantics/ieee754.lisp
@@ -1,0 +1,23 @@
+(defpackage intrinsic (:use core target))
+
+(in-package intrinsic)
+
+(declare (global x0 x1 x2 y0))
+
+(defun fadd_rne_ieee754_binary ()
+  (set y0 (+. :rne x0 x1)))
+
+(defun fsub_rne_ieee754_binary ()
+  (set y0 (-. :rne x0 x1)))
+
+(defun fmul_rne_ieee754_binary ()
+  (set y0 (*. :rne x0 x1)))
+
+(defun fdiv_rne_ieee754_binary ()
+  (set y0 (/. :rne x0 x1)))
+
+(defun forder_ieee754_binary ()
+  (set y0 (<. x0 x1)))
+
+(defun is_nan_ieee754_binary ()
+  (set y0 (is-nan x0)))

--- a/plugins/primus_lisp/site-lisp/posix.lisp
+++ b/plugins/primus_lisp/site-lisp/posix.lisp
@@ -8,4 +8,3 @@
 (require unistd)
 (require setjmp)
 (require getopt)
-(require ieee754)

--- a/plugins/x86/semantics/x86-64-sse-intrinsics.lisp
+++ b/plugins/x86/semantics/x86-64-sse-intrinsics.lisp
@@ -187,11 +187,24 @@
    (coerce rs rn)
    :result rt))
 
+(defun symbol-of-size (sz)
+  (case sz
+    16  '16
+    32  '32
+    64  '64
+    80  '80
+    128 '128
+    256 '256
+    'unknown))
+
 (defun sse-convert (name rt rs rn)
   (if (is-symbol *sse-rmode*)
       (intrinsic
-       (symbol-concat name *sse-rmode* *sse-format* :sep '_)
-       rt
+       (symbol-concat
+        name
+        *sse-rmode* *sse-format*
+        (symbol-of-size rt)
+        :sep '_)
        (coerce rs rn)
        :result rt)
     (case *sse-rmode*

--- a/plugins/x86/semantics/x86-64-sse-intrinsics.lisp
+++ b/plugins/x86/semantics/x86-64-sse-intrinsics.lisp
@@ -191,6 +191,7 @@
   (if (is-symbol *sse-rmode*)
       (intrinsic
        (symbol-concat name *sse-rmode* *sse-format* :sep '_)
+       rt
        (coerce rs rn)
        :result rt)
     (case *sse-rmode*


### PR DESCRIPTION
This PR uses Primus Lisp to specify semantics of the floating-point intrinsic subroutines. To be able to reify floating-point primitives into BIR, we rely
on the floating-point emulator that translates basic operations into corresponding bitvector operations. Since now we each floating-point instruction will be translated only once (as an intrinsic function), we are now able to enable the emulator by default. Before that, enabling the emulator was exploding binaries that have a lot of floating-point operations. The dynamic emulation is now disabled (and we will probably remove it in the future, as the static one works perfectly fine).

## Known Limitations

The reification of floating-point operations into bitvector operations works only with the BIL theory so other theories will not be affected. To make it available for all theories we need to finish the theory transformation pipeline.