### PR TITLE
disables byteweight by default

### DIFF
--- a/plugins/byteweight/byteweight_main.ml
+++ b/plugins/byteweight/byteweight_main.ml
@@ -121,7 +121,7 @@ let provide_roots () =
   let+ roots = unit-->roots in
   Option.some_if (Set.mem roots addr) true
 
-let main path min_length max_length threshold comp =
+let enable path min_length max_length threshold comp =
   compute_root_table path min_length max_length threshold comp;
   provide_roots ()
 
@@ -147,7 +147,10 @@ let () =
       ~doc:"Path to the signature file" in
   let compiler = parameter (some string) "compiler"
       ~doc:"Assume the input file is compiled by $(docv)" in
+  let enabled = parameter bool ~as_flag:true "enabled"
+      ~doc:"Enable/disable byteweight (off by default)" in
   Extension.declare ~doc ~provides:["roots"] @@ fun ctxt ->
   let (!) p = get ctxt p in
-  main !sigsfile !min_length !max_length !threshold !compiler;
+  if !enabled
+  then enable !sigsfile !min_length !max_length !threshold !compiler;
   Ok ()


### PR DESCRIPTION
The motivation is that byteweight is an aggressive function discovery algorithm that shouldn't be used by default. Analogous algorithms in IDA and Ghidra are also disabled by default. It should be used as the last resort, when other options do not work.

To enable byteweight back use `--byteweight-enable`. To make this persistent, add a file `enable-byteweight.conf` to the `~/.config/bap` folder with the following content,
```
byteweight-enabled = true
```