### PR TITLE
fixes little-endian MIPS disassembling

### DIFF
--- a/plugins/mc/mc_main.ml
+++ b/plugins/mc/mc_main.ml
@@ -33,8 +33,7 @@ target support packages (plugins that implement support for the given
 architecture) do their best to guess the target and encoding that
 matches the provided name. Use the common names for the architecture
 and it should work. You can use the $(b,bits) and $(b,order) options
-to give more hints to the target support packages. They default to
-$(b,32) and $(b,little) correspondingly.
+to give more hints to the target support packages.
 
 The $(b,target) and $(b,encoding) provides precise control over the
 selection of the target and the encoding that is used to represent
@@ -519,18 +518,21 @@ let compute_target provide =
   Toplevel.get result
 
 let target_of_arch arch bits order =
-  let bits = match bits with
-    | None -> 32L
-    | Some bits -> Int64.of_int bits in
-  let is_little = match order with
-    | Some BigEndian -> false
-    | _ -> true in
+  let provide_bits = match bits with
+    | None -> Ogre.return ()
+    | Some bits ->
+      Ogre.provide Image.Scheme.bits (Int64.of_int bits) in
+  let provide_order = match order with
+    | Some endian ->
+      Ogre.provide Image.Scheme.is_little_endian
+        Poly.(endian = LittleEndian)
+    | None -> Ogre.return () in
   let make_spec =
     let open Ogre.Syntax in
     Ogre.sequence [
       Ogre.provide Image.Scheme.arch arch;
-      Ogre.provide Image.Scheme.bits bits;
-      Ogre.provide Image.Scheme.is_little_endian is_little;
+      provide_bits;
+      provide_order;
     ] in
   let spec = match Ogre.exec make_spec Ogre.Doc.empty with
     | Error err ->


### PR DESCRIPTION
Re-closes #1407 as #1408 wasn't sufficient to support little-endian MIPS targets. Also fixes an incorrect encodings property of 32 bit MIPS instructions.