### PR TITLE
reduces memory footprint

### DIFF
--- a/lib/bap_core_theory/bap_core_theory_var.ml
+++ b/lib/bap_core_theory/bap_core_theory_var.ml
@@ -124,16 +124,18 @@ module Ident = struct
       String.subo ~len:n s,
       Int.of_string (String.subo ~pos:(n+1) s)
 
+  let sub1 = String.subo ~pos:1
+
   let of_string x =
     let n = String.length x in
     if n = 0
     then invalid_arg "a variable identifier can't be empty";
-    Scanf.sscanf x "%c%s" @@ function
-    | '$' -> fun s -> Let {num = num s}
-    | '#'  -> fun s ->
-      let s,ver = split_version s in
+    match x.[0] with
+    | '$' -> Let {num = num (sub1 x)}
+    | '#' ->
+      let s,ver = split_version (sub1 x) in
       Var {num = num s; ver}
-    | _ -> fun _ ->
+    | _ ->
       let name,ver = split_version x in
       Reg {name; ver}
 

--- a/lib/bap_types/bap_bitvector.ml
+++ b/lib/bap_types/bap_bitvector.ml
@@ -113,21 +113,21 @@ end = struct
     let x = payload x in
     pack Bitvec.(to_bigint (f x mod modulus w)) w
   [@@inline]
-  [@@specialize]
+  [@@specialise]
 
   let lift2 x y f =
     let w = bitwidth x in
     let x = payload x and y = payload y in
     pack Bitvec.(to_bigint (f x y mod modulus w)) w
   [@@inline]
-  [@@specialize]
+  [@@specialise]
 
   let lift3 x y z f =
     let w = bitwidth x in
     let x = payload x and y = payload y and z = payload z in
     pack Bitvec.(to_bigint (f x y z mod modulus w)) w
   [@@inline]
-  [@@specialize]
+  [@@specialise]
 
   module Stringable = struct
     type t = packed

--- a/lib/monads/monads_monad.ml
+++ b/lib/monads/monads_monad.ml
@@ -1004,7 +1004,7 @@ module State = struct
     s : 'b;
   }
 
-  type ('a,'e) state = State of ('e -> 'a) [@@unboxed]
+  type ('a,'e) state = State of ('e -> 'a)
 
 
   module Tp(T : T1)(M : Monad.S) = struct

--- a/lib/regular/regular_data_write.ml
+++ b/lib/regular/regular_data_write.ml
@@ -86,7 +86,10 @@ let create
     | None -> fun x -> Bigstring.of_bytes (to_bytes x) in
   let dump = match dump with
     | Some f -> f
-    | None -> fun c x -> Out_channel.output_bytes c (to_bytes x) in
+    | None -> fun c x ->
+      let ppf = Format.formatter_of_out_channel c in
+      pp ppf x;
+      Format.pp_print_flush ppf () in
   {size; copy; blit; dump; pp; to_bytes; to_bigstring}
 
 

--- a/plugins/disassemble/disassemble_main.ml
+++ b/plugins/disassemble/disassemble_main.ml
@@ -455,10 +455,8 @@ let setup_gc () =
   info "Setting GC parameters";
   Caml.Gc.set {
     opts with
-    window_size = 20;
-    minor_heap_size = 1024 * 1024;
+    minor_heap_size = 2 * 1024 * 1024;
     major_heap_increment = 64 * 1024 * 1024;
-    space_overhead = 200;
   }
 
 let has_env var = match Sys.getenv var with

--- a/plugins/patterns/patterns_main.ml
+++ b/plugins/patterns/patterns_main.ml
@@ -1267,7 +1267,7 @@ end = struct
     KB.Seq.iter ~f:(fun (addr,actions) ->
         Set.to_sequence actions |>
         KB.Seq.iter ~f:(fun action ->
-            let* lbl = KB.Object.create Theory.Program.cls in
+            KB.Object.scoped Theory.Program.cls @@ fun lbl ->
             KB.sequence [
               KB.provide Lambda.unit lbl (Some unit);
               KB.provide Lambda.addr lbl (Some addr);


### PR DESCRIPTION
This PR contains a series of optimizations and tweaks to reduce the memory footprint of BAP. Overall, it gives about 40 to 50 percent improvement. For example, disassembling, lifting, and printing the x86-64 libc.so binary now takes 5GB of RAM, where previously it was nearly 10GB. This is achieved by rewriting the internal representation of the knowledge base (several maps were collapsed into one), improvements in the IO subsystem (to prevent creation of intermediate data structures), and by tweaking the GC parameters. The parameters make GC more aggressive (disassembling /bin/ls now leaves only 130 MB of live data, instead of 221Mb with the default settings, and 400M before the optimizations).

All these improvements are not a compromise between space and time, in fact the timing performance is also slightly improved. Especially for large binaries that take a lot of RAM, for example, disassembling libc.so is now 20% faster.