### PR TITLE
adds semantics for the x86-64 `popq` instruction

### DIFF
--- a/plugins/x86/semantics/x86-64.lisp
+++ b/plugins/x86/semantics/x86-64.lisp
@@ -10,6 +10,9 @@
 (defun TRAP ()
   (intrinsic '__ud2 :aborts))
 
+(defun POP64rmm (ptr _ _ _ _)
+  (store-word ptr (load-word RSP))
+  (+= RSP 8))
 
 (defun is-rip (reg)
   (= (symbol reg) 'RIP))


### PR DESCRIPTION
Care should be taken to properly lift the `popq rsp` instruction, therefore, the proposed semantics is, 
```lisp
(defun POP64rmm (ptr _ _ _ _)
  (+= RSP 8)
  (store-word ptr (load-word (- RSP 8))))
```
which generates,
```
$ bap mc --show-{insn=asm,bil} -- 8f 04 24
popq (%rsp)
{
  RSP := RSP + 8
  mem := mem with [RSP, el]:u64 <- mem[RSP - 8, el]:u64
}
```

Thanks to @sjcappella for helping with this and see also https://github.com/NationalSecurityAgency/ghidra/issues/4282