### PR TITLE
makes bit-twiddling operations easier to read and analyze

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ testsuite:
 	git clone https://github.com/BinaryAnalysisPlatform/bap-testsuite.git testsuite
 
 check: testsuite
-	make REVISION=044dabe -C testsuite
+	make REVISION=07fe3462a62da1f -C testsuite
 
 .PHONY: indent check-style status-clean
 

--- a/lib/bap_types/bap_exp.ml
+++ b/lib/bap_types/bap_exp.ml
@@ -104,7 +104,7 @@ module PP = struct
     | Ite (ce, te, fe) ->
       pr "@[if %a@;then %a@;else %a@]" pp ce pp te pp fe
     | Extract (hi, lo, exp) ->
-      pr "extract:%d:%d[%a]" hi lo pp exp
+      pr "%d:%d[%a]" hi lo pp exp
     | Concat (le, re) as p ->
       pr (pfmt p le ^^ "." ^^ pfmt p re) pp le pp re
     | BinOp (EQ,e, Int x) when is_b1 x -> pr ("%a") pp e


### PR DESCRIPTION
This PR improves legibility of the lifted code by using extract/cast/concat combinations instead of bit masking for assigning aliased subregisters. In addition, it changes the default pretty-printing syntax of BIL by making the `extract` keyword optional in the extract operator, i.e., `extract:56:32[RAX]` will be now printed as just `56:32[RAX]`. Finally, the PR adds several optimization rules for extract/cast/concat combinations so that in the end, the following,

```
00000881: intrinsic:x0 := extract:63:0[extract:127:0[YMM0]]
00000884: intrinsic:x1 := mem[RBP - 0x18, el]:u64
00000887: call @intrinsic:fadd_rne_ieee754_binary with return %00000889

00000889:
0000088a: YMM0 := YMM0 &
          0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000
          | pad:256[intrinsic:y0]
```

is lifted as,
```
0000088c: intrinsic:x0 := 63:0[YMM0]
0000088f: intrinsic:x1 := mem[RBP - 0x18, el]:u64
00000891: call @intrinsic:fadd_rne_ieee754_binary with return %00000893

00000893:
00000894: YMM0 := high:192[YMM0].intrinsic:y0
```