### PR TITLE
corrects `popq rsp` semantics

### DIFF
--- a/plugins/x86/semantics/x86-64.lisp
+++ b/plugins/x86/semantics/x86-64.lisp
@@ -10,9 +10,14 @@
 (defun TRAP ()
   (intrinsic '__ud2 :aborts))
 
+;; If the ESP register is used as a base register for addressing a
+;; destination operand in memory, the POP instruction computes the
+;; effective address of the operand after it increments the ESP register.
+;; The POP ESP instruction increments the stack pointer (ESP) before data
+;; at the old top of stack is written into the destination.
 (defun POP64rmm (ptr _ _ _ _)
-  (store-word ptr (load-word RSP))
-  (+= RSP 8))
+  (+= RSP 8)
+  (store-word ptr (load-word (- RSP 8))))
 
 (defun is-rip (reg)
   (= (symbol reg) 'RIP))


### PR DESCRIPTION
I forgot to push the last commit to the branch so the merged semantics is incorrect. Again, great thanks to
@sjcappella for being vigilant!