### PR TITLE
fixes registers allocation in the abi specification DSL

### DIFF
--- a/lib/bap_c/bap_c_abi.ml
+++ b/lib/bap_c/bap_c_abi.ml
@@ -336,10 +336,10 @@ module Arg = struct
 
     let popn n self = match Map.min_elt self.args with
       | None -> None
-      | Some (k,_) -> match Map.split self.args (k+n) with
+      | Some (k,_) -> match Map.split self.args (k+n-1) with
         | _,None,_ -> None
-        | lt,Some (k,x),rt ->
-          Some ({self with args = Map.add_exn rt k x}, Map.data lt)
+        | lt,Some (_,x),rt ->
+          Some ({self with args = rt}, Map.data lt @ [x])
 
     let align n self = match Map.min_elt self.args with
       | None -> None


### PR DESCRIPTION
When several registers are used to pass a value, the last register in the arena wasn't allocated, which led to premature use of memory-based passing.