### PR TITLE
adds the extended lvalue assignment to Primus Interpreter

### DIFF
--- a/lib/bap_primus/bap_primus.mli
+++ b/lib/bap_primus/bap_primus.mli
@@ -1943,8 +1943,9 @@ module Std : sig
         (** [pos m] current program position.  *)
         val pos : pos m
 
-        (** [sub x] computes the subroutine [x].  *)
+        (** [sub x] evaluates the subroutine [x].  *)
         val sub : sub term -> unit m
+
 
         (** [blk x] interprets the block [x].  *)
         val blk : blk term -> unit m
@@ -1957,6 +1958,27 @@ module Std : sig
 
         (** [set var x] sets [var] to [x]  *)
         val set : var -> value -> unit m
+
+        (** [assign lhs rhs] assigns [rhs] to an lvalue [lhs], fails
+            if [lhs] is not an lvalue.
+
+            An lvalue is an expression that denotes a program
+            location. An expression is an lvalue, if it is a variable;
+            a load; a conditional expersion with lvalues on both branches,
+            or a cast, extract, concat, from an lvalue.
+
+            {v
+               lvalue ::= Var _
+                        | Load (_,_,_,_)
+                        | Ite (_,<lvalue>,<lvalue>)
+                        | Cast (_,_,<lvalue>)
+                        | Extract (_,_,<lvalue>)
+                        | Concat (_,_,<lvalue>)
+            v}
+
+            @since 2.5.0  *)
+        val assign : exp -> value -> unit m
+
 
         (** [binop op x y] computes a binary operation [op] on [x] and [y].
 
@@ -2012,7 +2034,6 @@ module Std : sig
         (** [branch cnd yes no] if [cnd] evaluates to [zero] then
             [yes] else [no]. *)
         val branch : value -> 'a m -> 'a m -> 'a m
-
 
         (** [repeat cnd body] evaluates [body] until [cnd] evaluates
             to [zero]. Returns the value of [cnd].  *)

--- a/lib/bap_primus/bap_primus_interpreter.mli
+++ b/lib/bap_primus/bap_primus_interpreter.mli
@@ -89,6 +89,7 @@ module Make (Machine : Machine) : sig
   val exp : exp -> value m
   val get : var -> value m
   val set : var -> value -> unit m
+  val assign : exp -> value -> unit m
   val binop : binop -> value -> value -> value m
   val unop : unop -> value -> value m
   val cast : cast -> int -> value -> value m

--- a/lib/bap_primus/bap_primus_lisp.ml
+++ b/lib/bap_primus/bap_primus_lisp.ml
@@ -682,15 +682,7 @@ module Make(Machine : Machine) = struct
 
         let eval_ret r = match ret with
           | None -> Machine.return ()
-          | Some v -> match Arg.rhs v with
-            | Bil.Var reg -> Eval.set reg r
-            | Bil.(Cast (LOW, rsize, Var reg)) ->
-              let vsize = size_of_reg reg in
-              Eval.get reg >>= fun lhs ->
-              Eval.extract ~hi:(vsize-1) ~lo:rsize lhs >>= fun high ->
-              Eval.concat high r >>= fun r ->
-              Eval.set reg r
-            | e -> failf "an unsupported return semantics: %a" Exp.pps e ()
+          | Some v -> Eval.assign (Arg.rhs v) r
 
         let exec =
           eval_args >>= fun bs ->


### PR DESCRIPTION
And uses it to specify various argument passing mechanics. An expression is an lvalue if it is a register, a load (which is a generalization of a pointer), an ite of two lvalues, or a cast (including the extraction) of an lvalue. Or, more formally,

```
lvalue ::= Var _
         | Load (_,_,_,_)
         | Ite (_,<lvalue>,<lvalue>)
         | Cast (_,_,<lvalue>)
         | Extract (_,_,<lvalue>)
         | Concat (_,_,<lvalue>)
```

The new `Interpreter.assign` primitive is now used to pass and return arguments to and from Primus Lisp interpreter, so now we can pass and return structures and other non-trivial objects.