### PR TITLE
makes BIL smart constructors smart

### DIFF
--- a/lib/bap_types/bap_common.ml
+++ b/lib/bap_types/bap_common.ml
@@ -33,27 +33,27 @@ module Size = struct
     | `r64
     | `r128
     | `r256
-  ] [@@deriving bin_io, compare, sexp, variants]
+  ] [@@deriving bin_io, compare, sexp, equal, variants]
 
   type 'a p = 'a constraint 'a = [< all]
-  [@@deriving bin_io, compare, sexp]
+  [@@deriving bin_io, compare, equal, sexp]
 
   type t = all p
-  [@@deriving bin_io, compare, sexp]
+  [@@deriving bin_io, compare, equal, sexp]
 
 
 end
 
 (** size of operand  *)
 type size = Size.t
-[@@deriving bin_io, compare, sexp]
+[@@deriving bin_io, compare, equal, sexp]
 
 (** size of address  *)
 type addr_size = [ `r32 | `r64 ] Size.p
-[@@deriving bin_io, compare, sexp]
+[@@deriving bin_io, compare, equal, sexp]
 
 type nat1 = int
-[@@deriving bin_io, compare, sexp]
+[@@deriving bin_io, compare, equal, sexp]
 
 (** The IR type of a BIL expression *)
 module Type = struct
@@ -63,11 +63,11 @@ module Type = struct
     (** [Mem (a,t)]memory with a specified addr_size *)
     | Mem of addr_size * size
     | Unk
-  [@@deriving bin_io, compare, sexp, variants]
+  [@@deriving bin_io, compare, equal, sexp, variants]
 end
 
 type typ = Type.t
-[@@deriving bin_io, compare, sexp]
+[@@deriving bin_io, compare, equal, sexp]
 
 
 (** Supported architectures  *)

--- a/lib/bap_types/bap_exp.ml
+++ b/lib/bap_types/bap_exp.ml
@@ -9,10 +9,7 @@ open Bap_bil
 module Var = Bap_var
 module Word = Bitvector
 module Size = Bap_size
-
-type binop = exp -> exp -> exp
-type unop = exp -> exp
-
+module Type_error = Bap_type_error
 
 module PP = struct
   open Bap_bil
@@ -129,26 +126,157 @@ module PP = struct
       pr "unknown[%s]:%a" s Bap_type.pp typ
 end
 
+(* maps BIL expressions to Word operations *)
+module Apply = struct
+  open Bap_bil
+  open Binop
+  open Unop
+  let is_shift = function
+    | LSHIFT | RSHIFT | ARSHIFT -> true
+    | _ -> false
 
-module Exp = struct
-  open Exp
-  let load ~mem ~addr e s = Load (mem,addr,e,s)
-  let store ~mem ~addr value e s = Store (mem,addr,value,e,s)
-  let binop op x y = BinOp (op,x,y)
-  let unop op x = UnOp (op,x)
-  let var v = Var v
-  let int w = Int w
-  let cast ct s e = Cast (ct,s,e)
-  let let_ v e b = Let (v,e,b)
-  let unknown s t = Unknown (s,t)
-  let ite ~if_ ~then_ ~else_ = Ite (if_,then_,else_)
-  let extract ~hi ~lo e = Extract (hi,lo,e)
-  let concat e1 e2 = Concat (e1,e2)
+  let unop op u = match op with
+    | NEG -> Word.neg u
+    | NOT -> Word.lnot u
+
+  let binop op u v =
+    let open Word in
+    match op with
+    | LSHIFT -> u lsl v
+    | RSHIFT -> u lsr v
+    | ARSHIFT -> u asr v
+    | _ ->
+      let hi = Int.(max (bitwidth u) (bitwidth v) - 1)  in
+      let u = extract_exn ~hi u
+      and v = extract_exn ~hi v in
+      match op with
+      | PLUS -> u + v
+      | MINUS -> u - v
+      | TIMES -> u * v
+      | DIVIDE -> u / v
+      | SDIVIDE -> signed u / signed v
+      | MOD -> u mod v
+      | SMOD -> signed u mod signed v
+      | AND -> u land v
+      | OR -> u lor v
+      | XOR -> u lxor v
+      | EQ -> Bitvector.(of_bool (u = v))
+      | NEQ -> Bitvector.(of_bool (u <> v))
+      | LT -> Bitvector.(of_bool (u < v))
+      | LE -> Bitvector.(of_bool (u <= v))
+      | SLT -> Bitvector.(of_bool (signed u < signed v))
+      | SLE  -> Bitvector.(of_bool (signed u <= signed v))
+      | (LSHIFT|RSHIFT|ARSHIFT) -> assert false
+
+  let cast ct sz u =
+    let ext = Bitvector.extract_exn in
+    match ct with
+    | Cast.UNSIGNED -> ext ~hi:Int.(sz - 1) u
+    | Cast.SIGNED   -> ext ~hi:Int.(sz - 1) (Bitvector.signed u)
+    | Cast.HIGH     -> ext ~lo:Int.(Bitvector.bitwidth u - sz) u
+    | Cast.LOW      -> ext ~hi:Int.(sz - 1) u
+
+  let extract hi lo x = Bitvector.extract_exn ~hi ~lo x
 end
-include Exp
+
+module Type = struct
+  let type_equal t t' = Type.compare t t' = 0
+
+  let rec infer : exp -> _ = function
+    | Var v -> Var.typ v
+    | Int x -> Type.Imm (Word.bitwidth x)
+    | Unknown (_,t) -> t
+    | Load (m,a,_,s) -> load m a s
+    | Cast (c,s,x) -> cast c s x
+    | Store (m,a,x,_,t) -> store m a x t
+    | BinOp (op,x,y) -> binop op x y
+    | UnOp (_,x) -> unop x
+    | Let (v,x,y) -> let_ v x y
+    | Ite (c,x,y) -> ite c x y
+    | Extract (hi,lo,x) -> extract hi lo x
+    | Concat (x,y) -> concat x y
+  and unify x y =
+    let t1 = infer x and t2 = infer y in
+    if type_equal t1 t2 then t1
+    else Type_error.expect t1 ~got:t2
+  and let_ v x y =
+    let t = Var.typ v and u = infer x in
+    if type_equal t u then infer y
+    else Type_error.expect t ~got:u
+  and ite c x y = match infer c with
+    | Type.Mem _ -> Type_error.expect_imm ()
+    | Type.Imm 1 -> unify x y
+    | t -> Type_error.expect (Type.Imm 1) ~got:t
+  and unop x = match infer x with
+    | Type.Mem _ -> Type_error.expect_imm ()
+    | t -> t
+  and binop op x y = match op with
+    | LSHIFT|RSHIFT|ARSHIFT -> shift x y
+    | _ -> match unify x y with
+      | Type.Mem _ | Type.Unk -> Type_error.expect_imm ()
+      | Type.Imm _ as t -> match op with
+        | LT|LE|EQ|NEQ|SLT|SLE -> Type.Imm 1
+        | _ -> t
+  and shift x y = match infer x, infer y with
+    | Type.Mem _,_ | _,Type.Mem _
+    | Type.Unk,_ | _,Type.Unk -> Type_error.expect_imm ()
+    | t, Type.Imm _ -> t
+  and load m a r = match infer m, infer a with
+    | (Type.Imm _|Unk),_ -> Type_error.expect_mem ()
+    | _,(Type.Mem _|Unk) -> Type_error.expect_imm ()
+    | Type.Mem (s,_),Type.Imm s' ->
+      let s = Size.in_bits s in
+      if s = s' then Type.Imm (Size.in_bits r)
+      else Type_error.expect (Type.Imm s) ~got:(Type.Imm s')
+  and store m a x _ =
+    match infer m, infer a, infer x with
+    | Type.Imm _,_,_ -> Type_error.expect_mem ()
+    | Type.Mem (s,_) as t, Type.Imm s', Type.Imm u ->
+      let s = Size.in_bits s in
+      if s <> s'
+      then Type_error.expect (Type.Imm s) ~got:(Type.Imm s')
+      else if is_error (Size.of_int u)
+      then Type_error.wrong_cast ()
+      else t
+    | _ -> Type_error.expect_imm ()
+  and cast c s x =
+    let t = Type.Imm s in
+    match c,infer x with
+    | _,(Type.Mem _|Unk) -> Type_error.expect_imm ()
+    | (UNSIGNED|SIGNED),_ -> t
+    | (HIGH|LOW), Type.Imm s' ->
+      if s' >= s then t else Type_error.wrong_cast ()
+  and extract hi lo x = match infer x with
+    | Type.Mem _ | Unk -> Type_error.expect_imm ()
+    | Type.Imm _ ->
+      (* we don't really need a type of x, as the extract operation
+         can both narrow and widen. Though it is a question whether it is
+         correct or not, especially wrt to the operational semantics, the
+         real life fact is that our lifters are (ab)using extract
+         instruction in both directions.  *)
+      if hi >= lo then Type.Imm (hi - lo + 1)
+      else Type_error.wrong_cast ()
+  and concat x y = match infer x, infer y with
+    | Type.Imm s, Type.Imm t -> Type.Imm (s+t)
+    | _ -> Type_error.expect_mem ()
+
+  let infer_exn = infer
+  let infer x =
+    try Ok (infer x) with
+    | Type_error.T err -> Error err
+end
 
 module Binop = struct
   open Binop
+
+  let is_commutative = function
+    | PLUS | TIMES | AND | XOR | OR | EQ | NEQ -> true
+    | _ -> false
+
+  let is_associative = function
+    | PLUS | TIMES | AND | OR | XOR -> true
+    | _ -> false
+
   let plus = PLUS
   let minus = MINUS
   let times = TIMES
@@ -169,17 +297,166 @@ module Binop = struct
   let slt = SLT
   let sle = SLE
 
-  let is_commutative = function
-    | PLUS | TIMES | AND | XOR | OR | EQ | NEQ -> true
-    | _ -> false
-
-  let is_associative = function
-    | PLUS | TIMES | AND | OR | XOR -> true
-    | _ -> false
-
   include PP
   let string_of_binop = asprintf "%a" pp_binop
 end
+
+module Exp = struct
+  open Exp
+
+
+  let is0 = Word.is_zero and is1 = Word.is_one
+  let ism1 x = Word.is_zero (Word.lnot x)
+  let app2 = Apply.binop
+
+  (* we can't fail in smart constructors and should allow
+     ill-formed BIL, which we should preserve for the later
+     error reporting. *)
+  let zero_or : exp -> exp = fun x -> match Type.infer x with
+    | Ok Imm m -> Int (Word.zero m)
+    | _ -> x
+
+  let binop : binop -> exp -> exp -> exp = fun op x y ->
+    let keep op x y = BinOp(op,x,y) in
+    let int f = function Int x -> f x | _ -> false in
+    let is0 = int is0 and is1 = int is1 and ism1 = int ism1 in
+    let (=) x y = compare_exp x y = 0 in
+    match op, x, y with
+    | op, Int x, Int y -> Int (app2 op x y)
+    | PLUS,BinOp(PLUS,x,Int y),Int z
+    | PLUS,BinOp(PLUS,Int y,x),Int z ->
+      BinOp(PLUS,x,Int (app2 PLUS y z))
+
+    | PLUS,x,y  when is0 x -> y
+    | PLUS,x,y  when is0 y -> x
+    | MINUS,x,y when is0 x -> UnOp(NEG,y)
+    | MINUS,x,y when is0 y -> x
+    | MINUS,x,y when x = y -> zero_or (keep op x y)
+    | MINUS,BinOp(MINUS,x,Int y), Int z ->
+      BinOp(MINUS,x,Int (app2 PLUS y z))
+    | MINUS,BinOp(PLUS,x,Int c1),Int c2
+    | MINUS,BinOp(PLUS,Int c1,x),Int c2 ->
+      BinOp(PLUS,x,Int (app2 MINUS c1 c2))
+
+    | TIMES,x,_ when is0 x -> x
+    | TIMES,_,y when is0 y -> y
+    | TIMES,x,y when is1 x -> y
+    | TIMES,x,y when is1 y -> x
+    | (DIVIDE|SDIVIDE),x,y when is1 y -> x
+    | (MOD|SMOD),x,y when is1 y -> zero_or (keep op x y)
+    | (LSHIFT|RSHIFT|ARSHIFT),x,y when is0 y -> x
+    | (LSHIFT|RSHIFT|ARSHIFT),x,_ when is0 x -> x
+    | ARSHIFT,x,_ when ism1 x -> x
+    | AND,x,_ when is0 x -> x
+    | AND,_,y when is0 y -> y
+    | AND,x,y when ism1 x -> y
+    | AND,x,y when ism1 y -> x
+    | AND,x,y when x = y -> x
+    | OR,x,y  when is0 x -> y
+    | OR,x,y  when is0 y -> x
+    | OR,x,_  when ism1 x -> x
+    | OR,_,y  when ism1 y -> y
+    | OR,x,y  when x = y -> x
+    | XOR,x,y when x = y -> zero_or (keep op x y)
+    | XOR,x,y when is0 x -> y
+    | XOR,x,y when is0 y -> x
+    | EQ,x,y  when x = y -> Int Word.b1
+    | NEQ,x,y when x = y -> Int Word.b0
+    | (LT|SLT), x, y when x = y -> Int Word.b0
+    | op,x,y -> keep op x y
+
+  module Syntax = struct
+    open Binop
+    let ( + ) = binop plus
+    let ( - ) = binop minus
+    let ( * ) = binop times
+    let ( / ) = binop divide
+    let ( /$ ) = binop sdivide
+    let ( mod ) = binop modulo
+    let ( %$ ) = binop smodulo
+    let ( lsl ) = binop lshift
+    let ( lsr ) = binop rshift
+    let ( asr ) = binop arshift
+    let ( land ) a b   = binop bit_and a b
+    let ( lor  ) a b   = binop bit_or  a b
+    let ( lxor ) a b   = binop bit_xor a b
+    let ( = )    a b   = binop eq  a b
+    let ( <> )    a b   = binop neq a b
+    let ( < )    a b   = binop lt  a b
+    let ( > )    a b   = binop lt  b a
+    let ( <= )    a b   = binop le  a b
+    let ( >= )    a b   = binop le  b a
+    let ( <$ )   a b   = binop slt a b
+    let ( >$ )   a b   = binop slt b a
+    let ( <=$ )  a b   = binop sle a b
+    let ( >=$ )  a b   = binop sle b a
+  end
+
+  let unop : unop -> exp -> exp = fun op x -> match op,x with
+    | op,Int x -> Int (Apply.unop op x)
+    | op,UnOp(op',x) when [%compare.equal: unop] op op' -> x
+    | NOT,BinOp(LT,x,y) -> Syntax.(x >= y)
+    | NOT,BinOp(LE,x,y) -> Syntax.(x > y)
+    | NOT,BinOp(SLT,x,y) -> Syntax.(x >=$ y)
+    | NOT,BinOp(SLE,x,y) -> Syntax.(x >$ y)
+    | NOT,BinOp(EQ,x,y) -> Syntax.(x <> y)
+    | NOT,BinOp(NEQ,x,y) -> Syntax.(x = y)
+    | op,x -> UnOp(op, x)
+
+  let equal_cast = [%compare.equal: cast]
+
+  let cast t s x = match x with
+    | Cast (_,s',_) as x when s = s' -> x
+    | Cast (t',s',x) when equal_cast t t' && s' >= s ->
+      Cast (t,s,x)
+    | Cast (UNSIGNED as t',s',x)
+    | Cast (SIGNED as t',s',x) when equal_cast t t' && s' <= s ->
+      Cast (t,s,x)
+    | Extract(p,_,x) when equal_cast t HIGH ->
+      Extract(p,p-s+1,x)
+    | Int w -> Int (Apply.cast t s w)
+    | x -> match Type.infer x with
+      | Ok Imm m when m = s -> x
+      | _ ->  Cast (t,s,x)
+
+  let ite ~if_:c ~then_:x ~else_:y = match c with
+    | Int c -> if Word.(c = b1) then x else y
+    | _ -> Ite(c,x,y)
+
+  let has_width n x = match Type.infer x with
+    | Ok Imm m -> m = n
+    | _ -> false
+
+  let extract ~hi ~lo x = match x with
+    | Int w -> Int (Word.extract_exn ~hi ~lo w)
+    | Extract (p,q,x) when hi <= p && lo >= q ->
+      Extract (hi,lo,x)
+    | x when lo = 0 && has_width (hi + 1) x -> x
+    | x -> Extract (hi,lo,x)
+
+  let concat x y = match x, y with
+    | Int x, Int y -> Int (Word.concat x y)
+    | Cast (HIGH,s,(Var x as v)), Extract(p,q,Var x')
+      when Var.equal x x' && has_width (p + s + 1) v ->
+      cast HIGH (s + p - q + 1) v
+    | Cast (HIGH,s,(Var x as v)), Concat ((Extract(p,q,Var x')),z)
+      when Var.equal x x' && has_width (p + s + 1) v ->
+      Concat (cast HIGH (s + p - q + 1) v, z)
+    | x,y -> Concat (x,y)
+
+  let var v = Var v
+  let int w = Int w
+  let let_ v e b = Let (v,e,b)
+  let unknown s t = Unknown (s,t)
+
+  let load_byte ~mem ~addr = Load (mem,addr,BigEndian,`r8)
+  let store_byte ~mem ~addr value = Store (mem,addr,value,BigEndian,`r8)
+  let load ~mem ~addr e s = Load (mem,addr,e,s)
+  let store ~mem ~addr value e s = Store (mem,addr,value,e,s)
+
+end
+include Exp
+
 
 module Unop = struct
   open Unop
@@ -205,38 +482,8 @@ module Infix = struct
   open Bap_bil.Exp
   open Binop
   open Unop
-
-
-  (** Arithmetic operations *)
-  let ( + ) = binop plus
-  let ( - ) = binop minus
-  let ( * ) = binop times
-  let ( / ) = binop divide
-  let ( /$ ) = binop sdivide
-  let ( mod ) = binop modulo
-  let ( %$ ) = binop smodulo
-
-  (** Bit operations *)
-  let ( lsl ) = binop lshift
-  let ( lsr ) = binop rshift
-  let ( asr ) = binop arshift
-  let ( land ) a b   = binop bit_and a b
-  let ( lor  ) a b   = binop bit_or  a b
-  let ( lxor ) a b   = binop bit_xor a b
+  include Exp.Syntax
   let lnot     a     = unop  not a
-
-  (** Equality tests *)
-  let ( = )    a b   = binop eq  a b
-  let ( <> )    a b   = binop neq a b
-  let ( < )    a b   = binop lt  a b
-  let ( > )    a b   = binop lt  b a
-  let ( <= )    a b   = binop le  a b
-  let ( >= )    a b   = binop le  b a
-  let ( <$ )   a b   = binop slt a b
-  let ( >$ )   a b   = binop slt b a
-  let ( <=$ )  a b   = binop sle a b
-  let ( >=$ )  a b   = binop sle b a
-
   (** Misc operations *)
   let ( ^ )    a b   = concat a b
 end
@@ -257,6 +504,7 @@ let slot = Knowledge.Class.property ~package:"bap"
     ~persistent Theory.Value.cls  "exp" domain
     ~public:true
     ~desc:"semantics of expressions in BIL"
+
 
 include Regular.Make(struct
     type t = Bap_bil.exp [@@deriving bin_io, compare, sexp]

--- a/lib/bap_types/bap_exp.mli
+++ b/lib/bap_types/bap_exp.mli
@@ -53,7 +53,9 @@ end
 
 module Exp : sig
   val load : mem:exp -> addr:exp -> endian -> size -> exp
+  val load_byte : mem:exp -> addr:exp -> exp
   val store : mem:exp -> addr:exp -> exp -> endian -> size -> exp
+  val store_byte : mem:exp -> addr:exp -> exp -> exp
   val binop : binop -> exp -> exp -> exp
   val unop : unop -> exp -> exp
   val var : var -> exp
@@ -101,5 +103,18 @@ module Infix : sig
   (** [a ^ b] contatenate [a] and [b]  *)
   val ( ^ )   : exp -> exp -> exp
 end
+
+module Apply : sig
+  val binop : binop -> word -> word -> word
+  val unop : unop -> word -> word
+  val cast : cast -> int -> word -> word
+  val extract : int -> int -> word -> word
+end
+
+module Type : sig
+  val infer : exp -> (typ, Bap_type_error.t) Result.t
+  val infer_exn : exp -> typ
+end
+
 
 val slot : (Theory.Value.cls, exp) Knowledge.slot

--- a/lib/bap_types/bap_helpers.ml
+++ b/lib/bap_types/bap_helpers.ml
@@ -112,161 +112,19 @@ let substitute_var x y ss =
   loop [] ss
 
 
-(* maps BIL expressions to Word operations *)
-module Apply = struct
-  open Bap_bil
-  open Binop
-  open Unop
-  let is_shift = function
-    | LSHIFT | RSHIFT | ARSHIFT -> true
-    | _ -> false
-
-  let unop op u = match op with
-    | NEG -> Word.neg u
-    | NOT -> Word.lnot u
-
-  let binop op u v =
-    let open Word in
-    match op with
-    | LSHIFT -> u lsl v
-    | RSHIFT -> u lsr v
-    | ARSHIFT -> u asr v
-    | _ ->
-      let hi = Int.(max (bitwidth u) (bitwidth v) - 1)  in
-      let u = extract_exn ~hi u
-      and v = extract_exn ~hi v in
-      match op with
-      | PLUS -> u + v
-      | MINUS -> u - v
-      | TIMES -> u * v
-      | DIVIDE -> u / v
-      | SDIVIDE -> signed u / signed v
-      | MOD -> u mod v
-      | SMOD -> signed u mod signed v
-      | AND -> u land v
-      | OR -> u lor v
-      | XOR -> u lxor v
-      | EQ -> Bitvector.(of_bool (u = v))
-      | NEQ -> Bitvector.(of_bool (u <> v))
-      | LT -> Bitvector.(of_bool (u < v))
-      | LE -> Bitvector.(of_bool (u <= v))
-      | SLT -> Bitvector.(of_bool (signed u < signed v))
-      | SLE  -> Bitvector.(of_bool (signed u <= signed v))
-      | (LSHIFT|RSHIFT|ARSHIFT) -> assert false
-
-  let cast ct sz u =
-    let ext = Bitvector.extract_exn in
-    match ct with
-    | Cast.UNSIGNED -> ext ~hi:Int.(sz - 1) u
-    | Cast.SIGNED   -> ext ~hi:Int.(sz - 1) (Bitvector.signed u)
-    | Cast.HIGH     -> ext ~lo:Int.(Bitvector.bitwidth u - sz) u
-    | Cast.LOW      -> ext ~hi:Int.(sz - 1) u
-
-end
+module Apply = Bap_exp.Apply
 
 module Type = struct
   open Bap_bil
-  open Binop
-  open Unop
-  open Exp
-  open Stmt
-  open Cast
   include Type
+  include Bap_exp.Type
 
-
-  let type_equal t t' = Type.compare t t' = 0
-
-  (** [infer x] infers the type of the expression [x].  Either returns
-      the inferred type, or terminates abnormally on the first type
-      error with the `Type_error.E` exception.  *)
-  let rec infer = function
-    | Var v -> Var.typ v
-    | Int x -> Type.Imm (Word.bitwidth x)
-    | Unknown (_,t) -> t
-    | Load (m,a,_,s) -> load m a s
-    | Cast (c,s,x) -> cast c s x
-    | Store (m,a,x,_,t) -> store m a x t
-    | BinOp (op,x,y) -> binop op x y
-    | UnOp (_,x) -> unop x
-    | Let (v,x,y) -> let_ v x y
-    | Ite (c,x,y) -> ite c x y
-    | Extract (hi,lo,x) -> extract hi lo x
-    | Concat (x,y) -> concat x y
-  and unify x y =
-    let t1 = infer x and t2 = infer y in
-    if type_equal t1 t2 then t1
-    else Type_error.expect t1 ~got:t2
-  and let_ v x y =
-    let t = Var.typ v and u = infer x in
-    if type_equal t u then infer y
-    else Type_error.expect t ~got:u
-  and ite c x y = match infer c with
-    | Type.Mem _ -> Type_error.expect_imm ()
-    | Type.Imm 1 -> unify x y
-    | t -> Type_error.expect (Type.Imm 1) ~got:t
-  and unop x = match infer x with
-    | Type.Mem _ -> Type_error.expect_imm ()
-    | t -> t
-  and binop op x y = match op with
-    | LSHIFT|RSHIFT|ARSHIFT -> shift x y
-    | _ -> match unify x y with
-      | Type.Mem _ | Type.Unk -> Type_error.expect_imm ()
-      | Type.Imm _ as t -> match op with
-        | LT|LE|EQ|NEQ|SLT|SLE -> Type.Imm 1
-        | _ -> t
-  and shift x y = match infer x, infer y with
-    | Type.Mem _,_ | _,Type.Mem _
-    | Type.Unk,_ | _,Type.Unk -> Type_error.expect_imm ()
-    | t, Type.Imm _ -> t
-  and load m a r = match infer m, infer a with
-    | (Type.Imm _|Unk),_ -> Type_error.expect_mem ()
-    | _,(Type.Mem _|Unk) -> Type_error.expect_imm ()
-    | Type.Mem (s,_),Type.Imm s' ->
-      let s = Size.in_bits s in
-      if s = s' then Type.Imm (Size.in_bits r)
-      else Type_error.expect (Type.Imm s) ~got:(Type.Imm s')
-  and store m a x _ =
-    match infer m, infer a, infer x with
-    | Type.Imm _,_,_ -> Type_error.expect_mem ()
-    | Type.Mem (s,_) as t, Type.Imm s', Type.Imm u ->
-      let s = Size.in_bits s in
-      if s <> s'
-      then Type_error.expect (Type.Imm s) ~got:(Type.Imm s')
-      else if is_error (Size.of_int u)
-      then Type_error.wrong_cast ()
-      else t
-    | _ -> Type_error.expect_imm ()
-  and cast c s x =
-    let t = Type.Imm s in
-    match c,infer x with
-    | _,(Type.Mem _|Unk) -> Type_error.expect_imm ()
-    | (UNSIGNED|SIGNED),_ -> t
-    | (HIGH|LOW), Type.Imm s' ->
-      if s' >= s then t else Type_error.wrong_cast ()
-  and extract hi lo x = match infer x with
-    | Type.Mem _ | Unk -> Type_error.expect_imm ()
-    | Type.Imm _ ->
-      (* we don't really need a type of x, as the extract operation
-         can both narrow and widen. Though it is a question whether it is
-         correct or not, especially wrt to the operational semantics, the
-         real life fact is that our lifters are (ab)using extract
-         instruction in both directions.  *)
-      if hi >= lo then Type.Imm (hi - lo + 1)
-      else Type_error.wrong_cast ()
-  and concat x y = match infer x, infer y with
-    | Type.Imm s, Type.Imm t -> Type.Imm (s+t)
-    | _ -> Type_error.expect_mem ()
-
-  let infer_exn = infer
-  let infer x =
-    try Ok (infer x) with
-    | Type_error.T err -> Error err
 
   let (&&&) = Option.first_some
 
 
   (** [check xs] verifies that [xs] is well-typed.  *)
-  let rec check bil =
+  let rec check : stmt list -> _ = fun bil ->
     List.find_map bil ~f:(function
         | Move (v,x) -> move v x
         | Jmp d -> jmp d
@@ -276,7 +134,7 @@ module Type = struct
   and move v x =
     let t = Var.typ v in
     match infer x with
-    | Ok u when type_equal t u -> None
+    | Ok u when equal_typ t u -> None
     | Ok u -> Some (Type_error.bad_type ~exp:t ~got:u)
     | Error err -> Some err
   and jmp x = match infer x with

--- a/lib/bap_types/bap_helpers.mli
+++ b/lib/bap_types/bap_helpers.mli
@@ -30,12 +30,7 @@ val fold_consts : bil -> bil
 val fixpoint : (bil -> bil) -> (bil -> bil)
 
 
-module Apply : sig
-  val binop : binop -> word -> word -> word
-  val unop : unop -> word -> word
-  val cast : cast -> int -> word -> word
-end
-
+module Apply = Bap_exp.Apply
 
 module Type : sig
   val check : stmt list -> (unit,Bap_type_error.t) Result.t


### PR DESCRIPTION
Up until now there was no smartness in the BIL smart constructors so that `Bil.(x + y)` was just `BinOp(PLUS,x,y)`. This PR adds some intelligence to smart constructors and teaches them a few identities, e.g., `Bil.(x - x)` will evaluate to `0`. In addition, all constants will be immediately evaluated. The optimization are as lightweight as possible (not to be confused with the BIL simplifications routines that will optimize code recursively).


The code was mostly moved from the BIL semantics implementation that was before that in the bil plugin with a small change to allow ill-formed BIL expressions. In case of the ill-formed expression we will just keep the expression untouched.