### PR TITLE
fixes the bitvector order function

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -1235,8 +1235,32 @@ module Std : sig
         expected from integral values.  *)
     include Integer.S with type t := t
 
-    (** A comparable interface with size-monomorphic comparison. *)
+    (** The comparable interface with size-monomorphic comparison. *)
     module Mono : Comparable with type t := t
+
+
+    (** The comparable interface using the unsigned order.
+
+        @since 2.5.0  *)
+    module Unsigned : sig
+      include Binable.S with type t = t
+      include Comparable.S_binable with type t := t
+      include Hashable.S_binable with type t := t
+    end
+
+    (** The comparable interface using the literal order.
+
+        In this order the bitvectors are compared literally, so that
+        bitvectors of different sizes but with equal values will be
+        different. This is the fastest order.
+
+        @since 2.5.0 *)
+    module Literal : sig
+      include Binable.S with type t = t
+      include Comparable.S_binable with type t := t
+      include Hashable.S_binable with type t := t
+    end
+
 
     (** Specifies the order of bytes in a word. *)
     type endian =

--- a/lib/bap_types/bap_bitvector.mli
+++ b/lib/bap_types/bap_bitvector.mli
@@ -13,6 +13,16 @@ type endian =
 include Regular.S with type t := t
 include Bap_integer.S with type t := t
 module Mono : Comparable.S with type t := t
+module Unsigned : sig
+  include Binable.S with type t = t
+  include Comparable.S_binable with type t := t
+  include Hashable.S_binable with type t := t
+end
+module Literal : sig
+  include Binable.S with type t = t
+  include Comparable.S_binable with type t := t
+  include Hashable.S_binable with type t := t
+end
 
 val create : Bitvec.t -> int -> t
 


### PR DESCRIPTION
After #1405 the bitvector order function started to take into account, in some cases, the length of the vector so that 0:8 < 0:32, which is not what we want or ever had.

This PR fixes this as well as provides two submodules to the bitvector module, `Unsigned` and `Literal` that provides alternative ordering. The former compares bitvectors unsigned and the latter treat them literally, i.e., compares them including their sizes, signedness, and values.