### PR TITLE
enables disabling patterns plugin for the thumb binaries as well

### DIFF
--- a/plugins/arm/semantics/thumb-patterns.lisp
+++ b/plugins/arm/semantics/thumb-patterns.lisp
@@ -1,6 +1,7 @@
 (in-package bap)
 
-(declare (context (target arm)))
+(declare (context (target arm)
+                  (patterns enabled)))
 
 (defmethod bap:patterns-action (action addr attrs)
   (when (= action 'setcontext)


### PR DESCRIPTION
Like #1481 but makes it work for the thumb binaries as well. Long story, the thumb plugin is also using a signal that is provided by the patterns plugin so when `--no-patterns` is specified for a thumb binary the disassembly is failing.

Thanks to @bmourad01 for reporting!