### PR TITLE
restores the old bitvector order, changes the Primus Value order

### DIFF
--- a/lib/bap_primus/bap_primus_value.ml
+++ b/lib/bap_primus/bap_primus_value.ml
@@ -17,7 +17,7 @@ end
 type id = Id.t [@@deriving bin_io, compare, sexp]
 
 
-let compare_value x y = Word.compare x.value y.value
+let compare_value x y = Word.Signed_value_order.compare x.value y.value
 type t = value [@@deriving bin_io, compare]
 
 

--- a/lib/bap_types/bap_bitvector.mli
+++ b/lib/bap_types/bap_bitvector.mli
@@ -13,12 +13,17 @@ type endian =
 include Regular.S with type t := t
 include Bap_integer.S with type t := t
 module Mono : Comparable.S with type t := t
-module Unsigned : sig
+module Signed_value_order : sig
   include Binable.S with type t = t
   include Comparable.S_binable with type t := t
   include Hashable.S_binable with type t := t
 end
-module Literal : sig
+module Unsigned_value_order : sig
+  include Binable.S with type t = t
+  include Comparable.S_binable with type t := t
+  include Hashable.S_binable with type t := t
+end
+module Literal_order : sig
   include Binable.S with type t = t
   include Comparable.S_binable with type t := t
   include Hashable.S_binable with type t := t


### PR DESCRIPTION
Restores the old default order for bitvectors that was broken in #1502. Despite what it is said in #1502, the default order of bitvectors was always taking the size into account and ordered `0:0` before `0:1`. It is even clearly stated in the documentation. Therefore, this commit restores the default order (and makes sure that the hash functions are consitent with the order).

Also adds a new order, `Signed_value_order` and renames the newly introduced orders with longer names that are more descriptive and has less chances to clash with the existing module names (as the Bitvector module is commonly locally-opened).

Finally, changes the default order for `Primus.Value`, which is now `Signed_value_order`. Note that the change of `Primus.Value` order doesn't really affect any Primus or Primus Lisp ordering operations as they are always well-typed and use the the default order of bitvectors. It affects, however dictionaries (and probably other direct uses of the `Primus.Value` module). The underlying reason why this change is necessary is to fix the symbolic executor that stores symbolic channels in a dictionary indexed by file descriptors. We store, the standard 0,1,2 descriptors are prefilled in the init method, and 0,1,2 literals evaluate to the machine word-sized bitvectors, however file descriptors of the `int` type might have a different size, and the lookup for the opened file descriptors fails. An alternative fix would be casting literals to a proper type, but since the current behavior is very unintutitive, it was decided to switch the order and compare Primus Values by values.

Thanks to @bmourad01 for noticing the strange new behavior and providing a good repo. 