### PR TITLE
adds an example on how to create a monad transformer stack (#1354)

### DIFF
--- a/lib/monads/monads.mli
+++ b/lib/monads/monads.mli
@@ -230,6 +230,27 @@ open Core_kernel[@@warning "-D"]
     Each monad transformer creates a module that has functions [lift]
     and [run]. The [lift] function lifts original computation into the
     transformed one, and [run] will run the computation.
+
+    In order to use the monad transformers to build up a monad
+    transformer stack, the inner module needs both the monad types and
+    monad functions, so that it satisfies the [Monad.S] signature.
+    Therefore, it needs to include both [T] and [Make] (or [T2] and
+    [Make2]), in order to use the [Make] functor of the outer monad.
+    For example, to create a state monad nested inside a writer monad,
+    you can do the following.
+
+    {[
+      module St = struct
+        module Env = struct
+          type t = int
+        end
+
+        include Monad.State.T1(Env)(Monad.Ident)      (* adds types *)
+        include Monad.State.Make(Env)(Monad.Ident)    (* adds functions and modules *)
+      end
+
+      module W = Monad.Writer.Make(Monoid.String)(St)
+    ]}
 *)
 module Std : sig
 


### PR DESCRIPTION
Hi,
I forgot about issue #1354 which I opened last year, but now I finally wanted to finish it.
I tried implementing it with a higher-order functor that includes the T1 & Make modules, but I do not think that this will work.
```
module MakeMakeT (TYPE_F: functor(T: T1) -> sig ??? end) (F: (M: Monad.S) -> sig ??? end) (M: Monad.S) : Monad.S = struct
    include TYPE_F(M)
    include F(M)
end

(* in module Option/List/... *)
MakeT(M) = MakeMakeT(T1)(Make)(M)
```

For `TYPE_F` the resulting signature is mostly the same for different monads (i.e. one that includes types `t`, `m` & `e`) but for `F` the signatures are of course very different between monads since they have different functions. And iiuc you cannot pass a signature itself to a functor. So I think this approach does not work.

Therefore I just added a small explanation on how to create a transformer stack based on how I used the library in the end.