### PR TITLE
Adds more missing Thumb instructions

### DIFF
--- a/plugins/arm/semantics/arm-bits.lisp
+++ b/plugins/arm/semantics/arm-bits.lisp
@@ -95,3 +95,16 @@
   (let ((bitv-length (word-width bitv)))
     (assert-msg (= 0 (mod n bitv-length)) "replicate-to-fill n not multiple of len(bitv)")
     (replicate bitv (/ n bitv-length))))
+
+(defun i-shift (r simm)
+  "(i-shift r simm) shifts r according to the encoded shift simm.
+   The first three bits of simm indicate the shift type, and the
+   remaining bits indicate the shift amount."
+  (let ((amt (rshift simm 3)))
+    (case (extract 2 0 simm)
+      0b000 r ; none
+      0b001 (arshift r amt) ; asr
+      0b010 (lshift r amt) ; lsl
+      0b011 (rshift r amt) ; lsr
+      0b100 (logor (rshift r amt) (lshift r (- 32 amt))) ; ror
+      0b101 (logor (lshift (cast-unsigned 32 CF) 31) (rshift r 1))))) ; rrx

--- a/plugins/arm/semantics/thumb.lisp
+++ b/plugins/arm/semantics/thumb.lisp
@@ -20,7 +20,8 @@
 (defun tADR (rd lbl cnd _)
   "adr rd, lbl"
   (when (condition-holds cnd)
-    (set$ rd (+ (thumb:t2pc) (lshift lbl 2)))))
+    (let ((pc (* 4 (/ (t2pc) 4))))
+      (set$ rd (+ pc (lshift lbl 2))))))
 
 (defmacro tLOGs (op rd rn rm cnd)
   (prog (set$ rd (op rn rm))

--- a/plugins/thumb/thumb_bits.ml
+++ b/plugins/thumb/thumb_bits.ml
@@ -7,9 +7,9 @@ module Make(CT : Theory.Core) = struct
   open Thumb_core.Make(CT)
   open Syntax
 
-  let sx rd rm =
-    rd <-? CT.signed s32 (var rm)
+  let sx s rd rm =
+    rd <-? CT.signed s32 (CT.low s (var rm))
 
-  let ux rd rm =
-    rd <-? CT.unsigned s32 (var rm)
+  let ux s rd rm =
+    rd <-? CT.unsigned s32 (CT.low s (var rm))
 end

--- a/plugins/thumb/thumb_bits.mli
+++ b/plugins/thumb/thumb_bits.mli
@@ -2,8 +2,8 @@ open Bap_core_theory
 open Thumb_core
 open Thumb_opcodes
 
-module Make(CT : Theory.Core) : sig
+module Make(_ : Theory.Core) : sig
   open Theory
-  val sx : r32 reg -> _ reg -> cond -> unit eff
-  val ux : r32 reg -> _ reg -> cond -> unit eff
+  val sx : 'a Bitv.t Value.sort -> r32 reg -> _ reg -> cond -> unit eff
+  val ux : 'a Bitv.t Value.sort -> r32 reg -> _ reg -> cond -> unit eff
 end

--- a/plugins/thumb/thumb_main.ml
+++ b/plugins/thumb/thumb_main.ml
@@ -174,11 +174,12 @@ module Thumb(CT : Theory.Core) = struct
 
   let lift_bits opcode insn =
     let open Thumb_bits.Make(CT) in
+    let open Thumb_core in
     match opcode, (MC.Insn.ops insn : Op.t array) with
-    | `tSXTB, [|Reg rd; Reg rm; Imm c; _|] -> sx (reg rd) (reg rm) (cnd c)
-    | `tSXTH, [|Reg rd; Reg rm; Imm c; _|] -> sx (reg rd) (reg rm) (cnd c)
-    | `tUXTB, [|Reg rd; Reg rm; Imm c; _|] -> ux (reg rd) (reg rm) (cnd c)
-    | `tUXTH, [|Reg rd; Reg rm; Imm c; _|] -> ux (reg rd) (reg rm) (cnd c)
+    | `tSXTB, [|Reg rd; Reg rm; Imm c; _|] -> sx s8 (reg rd) (reg rm) (cnd c)
+    | `tSXTH, [|Reg rd; Reg rm; Imm c; _|] -> sx s16 (reg rd) (reg rm) (cnd c)
+    | `tUXTB, [|Reg rd; Reg rm; Imm c; _|] -> ux s8 (reg rd) (reg rm) (cnd c)
+    | `tUXTH, [|Reg rd; Reg rm; Imm c; _|] -> ux s16 (reg rd) (reg rm) (cnd c)
     | #opbit,_ as insn ->
       info "unhandled bit-wise instruction: %a" pp_insn insn;
       !!Insn.empty


### PR DESCRIPTION
Thanks to `--print-missing` I was able to fill these in.

This also adds the `i-shift`  helper to the `arm-bits` file, which will make it easier to deal with register-shifted operands.