### PR TITLE
reimplements ARM ABI and target specification

### DIFF
--- a/lib/arm/arm_target.ml
+++ b/lib/arm/arm_target.ml
@@ -151,8 +151,8 @@ let regsv8 = Theory.Role.Register.[
     [general; floating], untyped xs;
     [stack_pointer], untyped [reg r64 "R31"];
     [frame_pointer], untyped [reg r64 "R29"];
-    [function_argument], array r64 "R" 8 @< array r64 "V" 8;
-    [function_return], [reg r64 "R0"] @< [reg r128 "V0"];
+    [function_argument; function_return],
+    array r64 "R" 8 @< array r64 "V" 8;
     [constant; zero; pseudo], untyped [reg r64 "XZR"; reg r64 "ZR"];
     [constant; zero; pseudo], untyped [reg r32 "WZR"];
     [link], untyped [reg r64 "R30"];
@@ -186,11 +186,17 @@ let aliasing = Theory.Alias.[
   ] |> List.concat
 
 
-let parent = CT.Target.declare ~package "arm"
+let parent = CT.Target.declare ~package "arm-family"
+let is_arm = CT.Target.belongs parent
+let is_64bit t = Theory.Target.bits t = 64
+let is_big t = Theory.Endianness.(equal eb (Theory.Target.endianness t))
+let is_little t = Theory.Target.endianness t = Theory.Endianness.le
 
 module type ARM = sig
   val endianness : CT.endianness
   val parent : CT.Target.t
+  val aarch32 : Theory.Target.t
+  val aarch64 : Theory.Target.t
   val v4 : CT.Target.t
   val v4t : CT.Target.t
   val v5 : CT.Target.t
@@ -220,6 +226,9 @@ module type Endianness =  sig val endianness : CT.endianness end
 module Family (Order : Endianness) = struct
   include Order
 
+  let is_little = Theory.Endianness.(equal endianness le)
+  let is_bi_endian = CT.Endianness.(equal bi) endianness
+
   let ordered name =
     let order = CT.Endianness.name endianness in
     name ^ "+" ^ KB.Name.unqualified order
@@ -233,7 +242,6 @@ module Family (Order : Endianness) = struct
 
   let (<:) parent name = def ~parent name
 
-  let is_bi_endian = CT.Endianness.(equal bi) endianness
 
   let v4 =
     if is_bi_endian
@@ -288,10 +296,24 @@ module Family (Order : Endianness) = struct
       ~vars:vars32_fp
       ~regs:(regs32@vfp3regs)
 
+  (* the generic final v7 incorporating all 32-bit targets *)
+  let aarch32 =
+    if is_bi_endian then Theory.Target.unknown
+    else
+      Theory.Target.declare ~package
+        (if is_little then "arm" else "armeb")
+        ~parent:v7afp
+        ~nicknames:[
+          if is_little
+          then "aarch32"
+          else "aarch32eb";
+        ]
 
-  let v8a =
-    CT.Target.declare ~package (ordered "armv8-a") ~parent:v7
-      ~nicknames:["armv8-a"; "aarch64"]
+
+  let v8 =
+    CT.Target.declare ~package (ordered "armv8")
+      ~parent:(if is_bi_endian then parent else aarch32)
+      ~nicknames:["aarch64"]
       ~aliasing
       ~code_alignment:32
       ~bits:64
@@ -299,6 +321,11 @@ module Family (Order : Endianness) = struct
       ~data:datav8
       ~vars:varsv8
       ~regs:regsv8
+
+
+  let v8a =
+    CT.Target.declare ~package (ordered "armv8-a") ~parent:v8
+      ~nicknames:["armv8-a"]
 
   let v8a32 =
     Theory.Target.declare ~package (ordered "armv8-a+aarch32")
@@ -321,6 +348,19 @@ module Family (Order : Endianness) = struct
   let v84a = v83a <: "armv8.4-a"
   let v85a = v84a <: "armv8.5-a"
   let v86a = v85a <: "armv8.6-a"
+
+  (* the generic final v8 incorporating all 32-bit targets *)
+  let aarch64 =
+    if is_bi_endian then Theory.Target.unknown
+    else
+      Theory.Target.declare ~package
+        (if is_little then "aarch64" else "aarch64_be")
+        ~parent:v86a
+        ~nicknames:[
+          if is_little
+          then "arm64"
+          else "arm64eb";
+        ]
 
   let v9a = v86a <: "armv9-a"
 
@@ -375,43 +415,39 @@ let enable_loader () =
       Ogre.request Image.Scheme.arch >>= fun arch ->
       Ogre.request Image.Scheme.subarch >>= fun sub ->
       Ogre.request Image.Scheme.is_little_endian >>= fun little ->
-      Ogre.return (arch,sub, little) in
+      Ogre.request Image.Scheme.format >>= fun filetype ->
+      Ogre.return (arch,sub,little,filetype) in
     match Ogre.eval request doc with
-    | Error _ -> None,None,None
+    | Error _ -> None,None,None,None
     | Ok info -> info in
   KB.promise CT.Unit.target @@ fun unit ->
   KB.collect Image.Spec.slot unit >>|
-  request_info >>| fun (arch,sub,is_little) ->
+  request_info >>| fun (arch,sub,is_little,filetype) ->
   if not (in_family arch) then CT.Target.unknown
   else
     let module Family = (val family_of_endian is_little) in
-    match normalize arch sub with
-    | "arm","v4"  -> Family.v4
-    | "arm","v4t" -> Family.v4t
-    | "arm","v5" -> Family.v5
-    | "arm","v5t" -> Family.v5t
-    | "arm","v5te" -> Family.v5te
-    | "arm","v5tej" -> Family.v5tej
-    | "arm","v6" -> Family.v6
-    | "arm","v6z" -> Family.v6z
-    | "arm","v6k" -> Family.v6k
-    | "arm","v6m" -> Family.v6m
-    | "arm","v6t2" -> Family.v6t2
-    | "arm","v7" -> Family.v7
-    | "arm","v7fp" -> Family.v7
-    | "arm","v7a" -> Family.v7a
-    | "arm","v7afp" -> Family.v7afp
-    | "arm","v8" -> Family.v8a
-    | "arm","v8a" -> Family.v8a
-    | "arm","v81a" -> Family.v81a
-    | "arm","v82a" -> Family.v82a
-    | "arm","v83a" -> Family.v83a
-    | "arm","v84a" -> Family.v84a
-    | "arm","v85a" -> Family.v85a
-    | "arm","v86a" -> Family.v86a
-    | "thumb",_     -> Family.v7m
-    | "aarch64",_   -> Family.v86a
-    | _ -> Family.v7
+    let parent = match normalize arch sub with
+      | "arm","v6m" -> Family.v6m
+      | "thumb",_   -> Family.v7m
+      | "arm",
+        ("v4"|"v4t"|
+         "v5"|"v5t"|"v5te"|"v5tej"|
+         "v6"|"v6z"|"v6k"|"v6t2"|
+         "v7"|"v7fp"|"v7a"|"v7afp") -> Family.aarch32
+      | "arm",
+        ("v8"|"v8a"|"v81a"|"v82a"|"v83a"|"v84a"|"v85a"|"v86a") ->
+        Family.aarch64
+      | "aarch64",_   -> Family.aarch64
+      | _ -> Family.v7 in
+    let is_64bit = Theory.Target.bits parent = 64 in
+    let filetype,system,abi = match filetype with
+      | Some "elf" -> Theory.Filetype.elf,
+                      Theory.System.linux,
+                      if is_64bit then Theory.Abi.gnu else Theory.Abi.gnueabi
+      | Some "coff" -> Theory.Filetype.coff,Theory.System.windows,Theory.Abi.eabi
+      | Some "macho" -> Theory.Filetype.macho, Theory.System.darwin,Theory.Abi.eabi
+      | _ -> Theory.Filetype.unknown,Theory.System.unknown,Theory.Abi.unknown in
+    Theory.Target.select ~strict:true ~system ~parent ~filetype ~abi ()
 
 
 type arms = [
@@ -424,6 +460,10 @@ type arms = [
 
 let arms : arms Map.M(CT.Target).t =
   Map.of_alist_exn (module CT.Target) [
+    LE.aarch32, `armv7;
+    EB.aarch32, `armv7eb;
+    LE.aarch64, `aarch64;
+    EB.aarch64, `aarch64_be;
     LE.v4, `armv4;
     LE.v4t, `armv4;
     LE.v5, `armv5;
@@ -475,6 +515,80 @@ let arms : arms Map.M(CT.Target).t =
   ]
 
 
+let smc = Theory.Abi.declare ~package:"arm" "smc"
+let hvc = Theory.Abi.declare ~package:"arm" "hvc"
+
+let subtargets = [
+  (*  32-bit targets *)
+
+  (* generic and standalone targets *)
+  [EB.aarch32; LE.aarch32],
+  Theory.System.[unknown; none],
+  Theory.Abi.[eabi],
+  Theory.Fabi.[unknown; hard],
+  Theory.Filetype.[unknown];
+
+  (* uefi  *)
+  [LE.aarch32],
+  Theory.System.[uefi],
+  Theory.Abi.[smc],
+  Theory.Fabi.[unknown],
+  Theory.Filetype.[unknown; coff];
+
+  (* linux targets *)
+  [EB.aarch32; LE.aarch32],
+  Theory.System.[linux],
+  Theory.Abi.[gnueabi; gnu],
+  Theory.Fabi.[unknown; hard],
+  Theory.Filetype.[unknown; elf];
+
+  (* darwin targets *)
+  [LE.aarch32],
+  Theory.System.[darwin],
+  Theory.Abi.[eabi],
+  Theory.Fabi.[unknown],
+  Theory.Filetype.[unknown; macho];
+
+  (* 64-bit targets  *)
+  [EB.aarch64; LE.aarch64],
+  Theory.System.[unknown; none],
+  Theory.Abi.[eabi],
+  Theory.Fabi.[unknown],
+  Theory.Filetype.[unknown];
+
+  (* uefi  *)
+  [LE.aarch64],
+  Theory.System.[uefi],
+  Theory.Abi.[smc],
+  Theory.Fabi.[unknown],
+  Theory.Filetype.[unknown; coff];
+
+  (* linux targets *)
+  [EB.aarch64; LE.aarch64],
+  Theory.System.[linux],
+  Theory.Abi.[gnu],
+  Theory.Fabi.[unknown],
+  Theory.Filetype.[unknown; elf];
+
+  (* darwin targets *)
+  [LE.aarch64],
+  Theory.System.[darwin],
+  Theory.Abi.[eabi],
+  Theory.Fabi.[unknown],
+  Theory.Filetype.[unknown; macho];
+
+  (* windows targets *)
+  [LE.aarch64],
+  Theory.System.[windows],
+  Theory.Abi.[eabi],
+  Theory.Fabi.[unknown],
+  Theory.Filetype.[unknown; coff];
+]
+
+let install_subtargets () =
+  List.iter subtargets ~f:(fun (family,systems,abis,fabis,filetypes) ->
+      List.iter family ~f:(Theory.Target.register ~systems ~abis ~fabis ~filetypes))
+
 let enable_arch () =
   let open KB.Syntax in
   KB.Rule.(declare ~package "arm-arch" |>
@@ -483,10 +597,15 @@ let enable_arch () =
            comment "computes Arch.t from the unit's target");
   KB.promise Arch.unit_slot @@ fun unit ->
   KB.collect CT.Unit.target unit >>| fun t ->
-  match Map.find arms t with
-  | Some arch -> (arch :> Arch.t)
-  | None -> `unknown
-
+  if is_arm t then match Map.find arms t with
+    | Some arch -> (arch :> Arch.t)
+    | None -> match is_64bit t,is_big t,is_little t with
+      | _,false,false -> `unknown
+      | true,true,_ -> `aarch64_be
+      | true,false,_ -> `aarch64
+      | false,true,_ -> `armv7eb
+      | false,false,_ -> `armv7
+  else `unknown
 
 let llvm_a32 = CT.Language.declare ~package "llvm-armv7"
 let llvm_t32 = CT.Language.declare ~package "llvm-thumb"
@@ -613,9 +732,6 @@ let compute_encoding_from_symbol_table label =
 let (>=) t p = CT.Target.belongs t p
 let (<) t p = t >= p && not (p >= t)
 let (<=) t p = t = p || t < p
-let is_arm = CT.Target.belongs parent
-
-let is_64bit t = LE.v8a <= t || EB.v8a <= t || Bi.v8a <= t
 
 let m_profiles = [
   LE.v7m; EB.v7m; Bi.v7m;
@@ -624,9 +740,6 @@ let m_profiles = [
 let is_thumb_only t =
   List.exists m_profiles ~f:(fun p -> p <= t)
 
-
-let is_big t = Theory.Target.endianness t = Theory.Endianness.eb
-let is_little t = Theory.Target.endianness t = Theory.Endianness.le
 
 let register_pcode () =
   Dis.register pcode @@ fun t ->
@@ -696,6 +809,7 @@ let enable_llvm ?(features=[]) ?interworking () =
   guess_encoding interworking label target mode
 
 let load ?features ?interworking ?(backend="llvm") () =
+  install_subtargets ();
   enable_loader ();
   enable_arch ();
   Encodings.provide ();

--- a/lib/arm/arm_target.mli
+++ b/lib/arm/arm_target.mli
@@ -21,7 +21,18 @@ val thumb : Theory.role
     Each version is the parent to the following version, with [parent]
     being the the earliest version.*)
 module LE : sig
-  val parent : Theory.Target.t (** currently the same as [v4]  *)
+  val parent : Theory.Target.t
+
+  (** a generic 32-bit target that accomodates all 32-bit targets.
+
+      @since 2.5.0  *)
+  val aarch32 : Theory.Target.t
+
+  (** a generic 64-bit target that accomodates all 64-bit targets.
+
+      @since 2.5.0 *)
+  val aarch64 : Theory.Target.t
+
   val v4 : Theory.Target.t
   val v4t : Theory.Target.t
   val v5 : Theory.Target.t
@@ -33,7 +44,6 @@ module LE : sig
   val v6z : Theory.Target.t
   val v6k : Theory.Target.t
   val v6m : Theory.Target.t
-  val v7 : Theory.Target.t
   val v7fp : Theory.Target.t
   val v7a : Theory.Target.t
   val v7afp : Theory.Target.t

--- a/plugins/arm/arm_gnueabi.ml
+++ b/plugins/arm/arm_gnueabi.ml
@@ -4,70 +4,59 @@ open Bap_c.Std
 
 include Self()
 
-let size = object(self)
-  inherit C.Size.base `ILP32
-  method! enum _ = self#integer `uint
+module Aapcs32 = struct
+  open Bap_core_theory
+  open Bap_c.Std
+  open Bap.Std
+
+  module Arg = C.Abi.Arg
+  open Arg.Language
+
+  let model = object(self)
+    inherit C.Size.base `ILP32
+    method! enum elts =
+      if Int64.(C.Size.max_enum_elt elts < (1L lsl 32))
+      then self#integer `uint
+      else self#integer `ulong_long
+    method! real = function
+      | `float -> `r32
+      | `double | `long_double -> `r64
+  end
+
+  let define t =
+    install t model @@ fun describe ->
+    let* iargs = Arg.Arena.iargs t in
+    let* irets = Arg.Arena.irets t in
+    let rev = Theory.Endianness.(Theory.Target.endianness t = le) in
+    let return ~alignment:_ size = select [
+        C.Type.is_basic, select [
+          is (size <= 32 * 2), Arg.registers ~rev  irets;
+          otherwise, Arg.reference iargs;
+        ];
+        is (size <= 32), Arg.register irets;
+        otherwise, Arg.reference iargs;
+      ] in
+    describe ~return @@ fun ~alignment _ ->
+    sequence [
+      is (alignment = 64), const (Arg.align_even iargs);
+      always, choose [
+        Arg.split_with_memory ~rev iargs;
+        Arg.memory
+      ];
+    ]
+
+  let supported_abis = Theory.Abi.[unknown; gnueabi; eabi]
+  let is_our_abi abi = List.exists supported_abis ~f:(Theory.Abi.equal abi)
+
+
+  let install () =
+    Theory.Target.family Arm_target.parent |>
+    List.iter ~f:(fun t ->
+        if Theory.Target.bits t = 32 &&
+           is_our_abi (Theory.Target.abi t)
+        then define t)
 end
 
-
-module Define(Arch : sig val name : arch end) = struct
-  let arch = Arch.name
-  let nats = Seq.unfold ~init:0 ~f:(fun n -> Some (n,n+1))
-  let regs = ARM.CPU.[r0;r1;r2;r3] |> List.map ~f:Bil.var
-  let mems = Seq.map nats ~f:(C.Abi.Stack.create arch)
-
-  let align ncrn t =
-    if Size.equal (size#alignment t) `r64 then match ncrn with
-      | [_;_;_;_] -> ncrn
-      | [_;r2;r3] -> [r2;r3]
-      | _ -> []
-    else ncrn
-
-  let concat = List.reduce_exn ~f:Bil.concat
-
-  let retregs = function
-    | #C.Type.scalar as t ->
-      List.take regs (Size.in_bytes (size#scalar t) / 4), [], regs
-    | t -> match size#bits (t :> C.Type.t) with
-      | Some sz when sz <= 32 -> List.take regs 1,[],regs
-      | _ -> List.take regs 1, List.take regs 1, List.tl_exn regs
-
-  let ret : C.Type.t -> 'a = function
-    | `Void -> None,[],regs
-    | t -> match retregs t with
-      | [],_,rest -> None,[],rest
-      | rets,hids,rest ->
-        let data = C.Abi.data size t in
-        Some (data, concat rets),
-        List.map hids ~f:(fun reg -> t,(C.Data.Ptr data, reg)),
-        rest
-
-  let args _ _ {C.Type.Proto.return; args=ps} =
-    let return,hidden,regs = ret return in
-    let _,_,params =
-      List.fold ps ~init:(regs,mems,[]) ~f:(fun (regs,mems,args) (_,t) ->
-          let words = Option.value (size#bits t) ~default:32 / 32 in
-          let exps,regs = List.split_n (align regs t) words in
-          let rest,mems = Seq.split_n mems (words - List.length exps) in
-          regs,mems, (C.Abi.data size t, (concat (exps@rest))) :: args) in
-    Some C.Abi.{return; hidden; params = List.rev params}
-
-  let abi = C.Abi.{
-      insert_args = args;
-      apply_attrs = fun _ -> Fn.id
-    }
-
-  let api size = C.Abi.create_api_processor size abi
-end
-
-let main proj = match Project.arch proj with
-  | #Arch.arm  | #Arch.thumb | #Arch.armeb | #Arch.thumbeb as arch ->
-    let open Define(struct let name = arch end) in
-    info "using armeabi ABI";
-    C.Abi.register "eabi" abi;
-    Bap_api.process (api size);
-    Project.set proj Bap_abi.name "eabi"
-  | _ -> proj
 
 module Aapcs64 = struct
   open Bap_core_theory
@@ -77,20 +66,20 @@ module Aapcs64 = struct
   let name = "aapcs64"
 
   module Arg = C.Abi.Arg
-  open Arg.Let
-  open Arg.Syntax
-
-  let is_floating = function
-    | `Basic {C.Type.Spec.t=#C.Type.real} -> true
-    | _ -> false
+  open Arg.Language
 
   let data_model t =
     let bits = Theory.Target.bits t in
     new C.Size.base (if bits = 32 then `ILP32 else `LP64)
 
+  let is_composite t =
+    C.Type.(is_structure t || is_union t)
+
   let define t =
     let model = data_model t in
-    C.Abi.define t model @@ fun _ {C.Type.Proto.return=r; args} ->
+    let rev = Theory.Endianness.(Theory.Target.endianness t = le) in
+
+    install t model @@ fun describe ->
     let* iargs = Arg.Arena.iargs t in
     let* irets = Arg.Arena.irets t in
     let* fargs = Arg.Arena.fargs t in
@@ -98,53 +87,59 @@ module Aapcs64 = struct
     let* x8 = Arg.Arena.create [
         Option.value_exn (Theory.Target.var t "X8")] in
 
-    (* integer calling convention *)
-    let pass_integer refs regs t =
-      Arg.count regs t >>= function
-      | Some 1 -> Arg.choice [
-          Arg.register regs t;
-          Arg.memory t;
-        ]
-      | Some 2 -> Arg.choice [
-          Arg.sequence [
-            Arg.align_even regs;
-            Arg.registers ~limit:2 regs t;
-          ];
-          Arg.memory t;
-        ]
-      | _ -> Arg.reference refs t in
-
-    (* floating-point calling convention *)
-    let pass_float refs regs t =
-      Arg.count regs t >>= function
-      | None -> Arg.reference refs t
-      | Some _ -> Arg.choice [
-          Arg.registers regs t;
-          Arg.sequence [
-            Arg.deplet regs;
-            Arg.memory t
+    let return ~alignment size = select [
+        C.Type.is_floating, choose [
+          Arg.registers ~rev frets;
+          Arg.reference x8;
+        ];
+        otherwise, sequence [
+          is (alignment >= 128), const (Arg.align_even irets);
+          always, select [
+            is (size > 16 * 8), Arg.reference x8;
+            always, choose [
+              Arg.registers ~rev irets;
+              Arg.reference x8;
+            ]
           ]
-        ] in
+        ]
+      ] in
+    describe ~return @@ fun ~alignment size -> select [
+      C.Type.is_floating, choose [
+        Arg.registers ~rev fargs;
+        Arg.reference iargs;
+      ];
+      otherwise, sequence [
+        is (alignment >= 128), const (Arg.align_even iargs);
+        always, select [
+          is (size > 16 * 8), Arg.reference iargs;
+          is_composite, choose [
+            Arg.split_with_memory ~rev iargs;
+            Arg.memory;
+          ];
+          otherwise, choose [
+            Arg.registers ~rev iargs;
+            combine [
+              const (Arg.deplet iargs);
+              Arg.memory;
+            ]
+          ]
+        ]
+      ]
+    ]
 
-    let arg refs iregs fregs r =
-      if is_floating r
-      then pass_float iregs fregs r
-      else pass_integer refs iregs r in
-
-    Arg.define ?return:(match r with
-        | `Void -> None
-        | r -> Some (arg x8 irets frets r))
-      (Arg.List.iter args ~f:(fun (_,t) ->
-           arg iargs iargs fargs t))
+  let is_our_abi abi = List.exists ~f:(Theory.Abi.equal abi) Theory.Abi.[
+      unknown; gnu; eabi;
+    ]
 
   let install () =
-    List.iter Arm_target.[LE.v8a;EB.v8a] ~f:(fun parent ->
-        Theory.Target.family parent |>
-        List.iter ~f:define)
+    Theory.Target.family Arm_target.parent |>
+    List.iter ~f:(fun t ->
+        if Theory.Target.bits t = 64 && is_our_abi (Theory.Target.abi t)
+        then define t)
 
 
 end
 
 let setup () =
-  Bap_abi.register_pass main;
+  Aapcs32.install ();
   Aapcs64.install ();

--- a/plugins/arm/semantics/aarch64-arithmetic.lisp
+++ b/plugins/arm/semantics/aarch64-arithmetic.lisp
@@ -1,4 +1,6 @@
-(declare (context (target arm armv8-a+le)))
+(declare (context (target arm-family)
+                  (bits 64)))
+
 
 (in-package aarch64)
 

--- a/plugins/arm/semantics/aarch64-atomic.lisp
+++ b/plugins/arm/semantics/aarch64-atomic.lisp
@@ -1,4 +1,5 @@
-(declare (context (target arm armv8-a+le)))
+(declare (context (target arm-family)
+                  (bits 64)))
 
 (in-package aarch64)
 

--- a/plugins/arm/semantics/aarch64-branch.lisp
+++ b/plugins/arm/semantics/aarch64-branch.lisp
@@ -1,4 +1,5 @@
-(declare (context (target arm armv8-a+le)))
+(declare (context (target arm-family)
+                  (bits 64)))
 
 (in-package aarch64)
 

--- a/plugins/arm/semantics/aarch64-data-movement.lisp
+++ b/plugins/arm/semantics/aarch64-data-movement.lisp
@@ -1,4 +1,6 @@
-(declare (context (target arm armv8-a+le)))
+(declare (context (target arm-family)
+                  (bits 64)))
+
 
 (in-package aarch64)
 

--- a/plugins/arm/semantics/aarch64-helper.lisp
+++ b/plugins/arm/semantics/aarch64-helper.lisp
@@ -1,6 +1,6 @@
 ;; Helper functions specific to aarch64.
-
-(declare (context (target arm armv8-a+le)))
+(declare (context (target arm-family)
+                  (bits 64)))
 
 (in-package aarch64)
 

--- a/plugins/arm/semantics/aarch64-logical.lisp
+++ b/plugins/arm/semantics/aarch64-logical.lisp
@@ -1,4 +1,5 @@
-(declare (context (target arm armv8-a+le)))
+(declare (context (target arm-family)
+                  (bits 64)))
 
 (in-package aarch64)
 

--- a/plugins/arm/semantics/aarch64-pstate.lisp
+++ b/plugins/arm/semantics/aarch64-pstate.lisp
@@ -1,4 +1,5 @@
-(declare (context (target arm armv8-a+le)))
+(declare (context (target arm-family)
+                  (bits 64)))
 
 (in-package aarch64)
 

--- a/plugins/arm/semantics/aarch64-special.lisp
+++ b/plugins/arm/semantics/aarch64-special.lisp
@@ -1,4 +1,5 @@
-(declare (context (target arm armv8-a+le)))
+(declare (context (target arm-family)
+                  (bits 64)))
 
 (in-package aarch64)
 

--- a/plugins/arm/semantics/aarch64.lisp
+++ b/plugins/arm/semantics/aarch64.lisp
@@ -1,4 +1,5 @@
-(declare (context (target arm armv8-a+le)))
+(declare (context (target arm-family)
+                  (bits 64)))
 
 (defpackage aarch64 (:use core target arm))
 (defpackage llvm-aarch64 (:use aarch64))

--- a/plugins/arm/semantics/arm-bits.lisp
+++ b/plugins/arm/semantics/arm-bits.lisp
@@ -1,5 +1,5 @@
 (defpackage arm (:use core target))
-(declare  (context (target arm)))
+(declare (context (target arm-family)))
 
 (in-package arm)
 

--- a/plugins/arm/semantics/arm.lisp
+++ b/plugins/arm/semantics/arm.lisp
@@ -1,4 +1,4 @@
-(declare  (context (target arm)))
+(declare  (context (target arm-family)))
 (defpackage llvm-armv7 (:use arm))
 (in-package arm)
 

--- a/plugins/arm/semantics/thumb-patterns.lisp
+++ b/plugins/arm/semantics/thumb-patterns.lisp
@@ -1,6 +1,6 @@
 (in-package bap)
 
-(declare (context (target arm)
+(declare (context (target arm-family)
                   (patterns enabled)))
 
 (defmethod bap:patterns-action (action addr attrs)

--- a/plugins/arm/semantics/thumb.lisp
+++ b/plugins/arm/semantics/thumb.lisp
@@ -4,7 +4,7 @@
 
 ;; Note: page references are from ARM DDI 0403E.b
 
-(declare (context (target arm)))
+(declare (context (target arm-family)))
 
 (defpackage thumb (:use core target arm))
 (defpackage llvm-thumb (:use thumb))

--- a/plugins/primus_lisp/site-lisp/libc-init.lisp
+++ b/plugins/primus_lisp/site-lisp/libc-init.lisp
@@ -12,7 +12,7 @@
 (defun init (main argc argv auxv)
   "GNU libc initialization stub"
   (declare (external "__libc_start_main")
-           (context (abi "eabi")))
+           (context (abi "gnueabi")))
   (exit-with (invoke-subroutine
               (logand main 0xfffffffe) ; to handle thumb jumps
               argc argv)))

--- a/plugins/primus_lisp/site-lisp/types.lisp
+++ b/plugins/primus_lisp/site-lisp/types.lisp
@@ -47,6 +47,12 @@
 (defun long ()  (declare (context (abi eabi))) (model-ilp32 'long))
 (defun ptr_t () (declare (context (abi eabi))) (model-ilp32 'ptr))
 
+(defun char ()  (declare (context (abi gnueabi))) (model-ilp32 'char))
+(defun short () (declare (context (abi gnueabi))) (model-ilp32 'short))
+(defun int ()   (declare (context (abi gnueabi))) (model-ilp32 'int))
+(defun long ()  (declare (context (abi gnueabi))) (model-ilp32 'long))
+(defun ptr_t () (declare (context (abi gnueabi))) (model-ilp32 'ptr))
+
 (defun char ()  (declare (context (abi mips32))) (model-ilp32 'char))
 (defun short () (declare (context (abi mips32))) (model-ilp32 'short))
 (defun int ()   (declare (context (abi mips32))) (model-ilp32 'int))


### PR DESCRIPTION
This PR rewrites the ABI specifications for ARM32 and ARM64. We also leverage the new target registration facility and tweak the target hierarchy of the ARM architectures. The naming scheme is now much closer to what is used in GNU and therefore are much more intuitive. For example, it is now possible just to specify `--target=arm` or `--target=aarch64` or even `--target=arm-linux-gnueabi`. As usual, use `bap list targets` for the full list. The name `arm` is now the catchall architecture for ARM32 (aka Aarch32), and `aarch64` is the catchall for all armv8. A slightly breaking change is that the new name for the arm parent target is `arm-family` not `arm` as it was before. The abi names were also slightly changed to match the names used by GCC and Debian. However, since the target nicknames are now made a part of the Primus Lisp context (and bare names were only used in the contexts), we do not expect that any changes are necessary to the existing code bases.