### PR TITLE
adds the pass by reference argument passing method

### DIFF
--- a/lib/bap_c/bap_c_abi.ml
+++ b/lib/bap_c/bap_c_abi.ml
@@ -169,14 +169,12 @@ let coerce ltyp rtyp exp = match ltyp,rtyp with
 
 
 let create_arg size i intent name t (data,exp) sub =
-  let ltyp = match size#bits t with
-    | None -> Type.imm (Size.in_bits size#pointer)
-    | Some m -> Type.imm m in
   let layout = match data with
     | Data.Ptr _ ->
       if Bap_c_type.is_pointer t then layout size t
       else layout size (Bap_c_type.pointer t)
     | _ -> layout size t in
+  let ltyp = Type.imm (size_of_layout size layout) in
   let rtyp = Type.infer_exn exp in
   let name = if String.is_empty name then sprintf "arg%d" (i+1) else name in
   let var = Var.create (Sub.name sub ^ "_" ^ name) ltyp in
@@ -631,6 +629,9 @@ module Arg = struct
 
   let reference file t =
     with_hidden @@ fun () ->
+    register file (C.Type.pointer t)
+
+  let pointer file t =
     register file (C.Type.pointer t)
 
   let update_stack f =

--- a/lib/bap_c/bap_c_abi.mli
+++ b/lib/bap_c/bap_c_abi.mli
@@ -322,17 +322,29 @@ module Arg : sig
       @since 2.5.0  *)
   val discard : ?n:int -> arena -> unit t
 
-  (** [reference arena t] passes the argument of type [t] as a pointer
-      to [t] via the first available register in [arena].
+  (** [reference arena t] passes a hidden pointer to [t] via
+      the first available register in [arena].
 
       Rejects the computation if there are no available registers in
-      [arena] or if the target doesn't have a register with the stack
-      pointer role. The size of [t] is not required. *)
+      [arena]. The size of [t] is not required.
+
+      Note, that [reference] and [hidden] are increasing the number of
+      hidden arguments of a subroutine, but do not add the actual
+      arguments.  *)
   val reference : arena -> ctype -> unit t
 
 
-  (** [hidden t] passes the argument of type [t] as a pointer
-      to [t] via the first available stack slot.
+  (** [pointer arena t] passes argument [t] as a pointer.
+
+      Rejects the computation if [arena] is empty. The size of [t] is
+      not required.
+
+      @since 2.5.0  *)
+  val pointer : arena -> ctype -> unit t
+
+
+  (** [hidden t] inserts a hidden pointer to [t] into the next
+      available stack slot.
 
       The computation is rejected if the target doesn't have a stack.
 


### PR DESCRIPTION
The existing `reference` method is used only to pass hidden references (like this, or a structure to be returned). However, some ABI, like powerpc, are passing structures by references.