### PR TITLE
restructures powerpc targets and reimplements ppc32 eabi

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -73,7 +73,7 @@ B lib/bap_llvm
 B lib/regular
 B lib/text_tags
 B lib/knowledge
-
+B lib/bap_powerpc
 
 S lib/bap
 S lib/bap_main

--- a/oasis/powerpc
+++ b/oasis/powerpc
@@ -16,7 +16,7 @@ Library powerpc_plugin
   Path:             plugins/powerpc
   Build$:           flag(everything) || flag(powerpc)
   BuildDepends:     bap, bap-abi, bap-c, zarith, monads, core_kernel,
-                    ppx_bap, regular, bap-api, bap-powerpc
+                    ppx_bap, regular, bap-api, bap-powerpc, bap-core-theory
   FindlibName:      bap-plugin-powerpc
   InternalModules:  Powerpc,
                     Powerpc_cpu,

--- a/plugins/primus_lisp/site-lisp/libc-init.lisp
+++ b/plugins/primus_lisp/site-lisp/libc-init.lisp
@@ -62,7 +62,7 @@
 
 (defun init (argc argv ubpev auxvec fini stinfo stack_on_entry)
   (declare (external "__libc_start_main")
-           (context (abi "ppc32")))
+           (context (target "powerpc") (abi "gnu")))
   (set R2 (+ stack_on_entry 0x7008))
   (let ((argc (read-word ptr_t stack_on_entry))
         (argv (ptr+1 ptr_t stack_on_entry))

--- a/plugins/primus_lisp/site-lisp/types.lisp
+++ b/plugins/primus_lisp/site-lisp/types.lisp
@@ -65,11 +65,11 @@
 (defun long ()  (declare (context (target mips64))) (model-ilp64 'long))
 (defun ptr_t () (declare (context (target mips64))) (model-ilp64 'ptr))
 
-(defun char ()  (declare (context (abi ppc32))) (model-ilp32 'char))
-(defun short () (declare (context (abi ppc32))) (model-ilp32 'short))
-(defun int ()   (declare (context (abi ppc32))) (model-ilp32 'int))
-(defun long ()  (declare (context (abi ppc32))) (model-ilp32 'long))
-(defun ptr_t () (declare (context (abi ppc32))) (model-ilp32 'ptr))
+(defun char ()  (declare (context (target powerpc) (bits 32))) (model-ilp32 'char))
+(defun short () (declare (context (target powerpc) (bits 32))) (model-ilp32 'short))
+(defun int ()   (declare (context (target powerpc) (bits 32))) (model-ilp32 'int))
+(defun long ()  (declare (context (target powerpc) (bits 32))) (model-ilp32 'long))
+(defun ptr_t () (declare (context (target powerpc) (bits 32))) (model-ilp32 'ptr))
 
 (defun char ()  (declare (context (arch x86_64 sysv))) (model-lp64 'char))
 (defun short () (declare (context (arch x86_64 sysv))) (model-lp64 'short))


### PR DESCRIPTION
The target names are now in line with the conventional naming schemes and the calling convention supports arbitrary arguments. The CPU model is also refined with more registers assigned their roles.