### PR TITLE
fixes calling convention for ms64

### DIFF
--- a/lib/x86_cpu/x86_target.ml
+++ b/lib/x86_cpu/x86_target.ml
@@ -440,7 +440,7 @@ module Abi = struct
         otherwise, pass Arg.register irets;
       ] in
     describe ~return @@ fun ~alignment:_ size -> select [
-      is (size > 64), pass Arg.reference iregs;
+      is (size > 64), pass Arg.pointer iregs;
       C.Type.is_floating, pass Arg.register vregs;
       otherwise, pass Arg.register iregs;
     ]


### PR DESCRIPTION
Large objects are passed via an explicit reference, not an implicit (hidden) one.