### PR TITLE
Fixes lifting of Thumb `cbz` instruction

### DIFF
--- a/plugins/thumb/thumb_branch.ml
+++ b/plugins/thumb/thumb_branch.ml
@@ -65,7 +65,7 @@ module Make(CT : Theory.Core) = struct
       (seq [])
 
   let cbz pc rn dst =
-    CT.branch CT.(inv@@is_zero (var rn))
+    CT.branch CT.(is_zero (var rn))
       (goto (pc +> dst))
       (seq [])
 end


### PR DESCRIPTION
It was checking `rn <> 0` when it needs to check `rn = 0`.