### PR TITLE
enables compatibility with 32 bit OCaml

### DIFF
--- a/lib/knowledge/bap_knowledge.ml
+++ b/lib/knowledge/bap_knowledge.ml
@@ -113,8 +113,8 @@ end
       let payload_size = 57
       let branching_size = 6
 
-      let branching_mask = of_int (-144115188075855872)  (* 0b1111110000....0 *)
-      let payload_mask = of_int 144115188075855871     (* 0b0000001111....1 *)
+      let branching_mask = of_int64_exn (-144115188075855872L)  (* 0b1111110000....0 *)
+      let payload_mask = of_int64_exn 144115188075855871L     (* 0b0000001111....1 *)
 
       let branching {key} =
         (key land branching_mask) lsr 57 [@@inline]


### PR DESCRIPTION
On 32-bit systems we currently have an error that this commit fixes,

```
File "lib/knowledge/bap_knowledge.ml", line 116, characters 34-55:
116 |       let branching_mask = of_int (-144115188075855872)  (* 0b1111110000....0 *)
                                        ^^^^^^^^^^^^^^^^^^^^^
Error: Integer literal exceeds the range of representable integers of type int
```