### PR TITLE
adds `Taint.Rel.{equal,compare}`

### DIFF
--- a/lib/bap_taint/bap_taint.ml
+++ b/lib/bap_taint/bap_taint.ml
@@ -106,7 +106,7 @@ type tainter = {
   indirect : objects Primus.Value.Map.t;
 } [@@deriving fields]
 
-type relation_kind = Direct | Indirect [@@deriving sexp_of]
+type relation_kind = Direct | Indirect [@@deriving compare, sexp_of]
 
 (* generalized access to the tainter fields
  *
@@ -171,8 +171,14 @@ end
 
 module Rel = struct
   type t = relation
+
   let direct = direct
   let indirect = indirect
+
+  let compare (Rel {kind = x; _}) (Rel {kind = y; _}) =
+    compare_relation_kind x y
+
+  let equal x y = compare x y = 0
 end
 
 (* a set of live tainted objects *)

--- a/lib/bap_taint/bap_taint.mli
+++ b/lib/bap_taint/bap_taint.mli
@@ -142,11 +142,13 @@ module Std : sig
           representation of the object or a part of it. *)
       val direct : t
 
-
       (** Denotes the indirect relation between a value and the object
           that we track, e.g., a value is a pointer that points to a
           value that has the direct relation with the object.  *)
       val indirect : t
+
+      val compare : t -> t -> int
+      val equal : t -> t -> bool
     end
 
     (** Each taint represents an abstract object that we would like

--- a/lib/bap_taint/bap_taint.mli
+++ b/lib/bap_taint/bap_taint.mli
@@ -147,7 +147,19 @@ module Std : sig
           value that has the direct relation with the object.  *)
       val indirect : t
 
+      (** [compare x y] returns a total ordering between two relations
+          [x] and [y]. If [x < y] then the result is less than [0]. If
+          [x = y] then the result is [0]. Otherwise, the result is
+          greater than [0].
+
+          @since 2.6.0
+      *)
       val compare : t -> t -> int
+
+      (** [equal x y] is equivalent to [compare x y = 0].
+
+          @since 2.6.0
+      *)
       val equal : t -> t -> bool
     end
 


### PR DESCRIPTION
It may be useful to interrogate some property of the `Taint.Rel.t` datatype, most obvious being the `relation_kind`.