### PR TITLE
fixes bap.top and baptop

### DIFF
--- a/lib/bap_plugins/bap_plugins_units.ml
+++ b/lib/bap_plugins/bap_plugins_units.ml
@@ -2,6 +2,8 @@ open Core_kernel[@@warning "-D"]
 
 let name = "dynlink"
 
+let is_toplevel = Caml.Sys.interactive.contents
+
 type reason = [
   | `In_core
   | `Provided_by of string
@@ -22,7 +24,7 @@ let copy_units_from_dynlink () =
   Dynlink.all_units () |>
   List.iter ~f:(fun unit -> Hashtbl.add_exn units unit `In_core)
 
-let init () = copy_units_from_dynlink ()
+let init () = if not is_toplevel then copy_units_from_dynlink ()
 let list () = Hashtbl.keys units
 let record name reason = match Hashtbl.add units name reason with
   | `Ok -> ()


### PR DESCRIPTION
This commit fixes the `bap.top` library and the `baptop` executable so that they can now be used. Before that, they were failing with

```
Exception:
(Invalid_argument
  "The dynlink.cma library cannot be used inside the OCaml toplevel")
```

The problem was that we were trying to use the dynlink facilities to track the missing units (before that we were using findlib for that so it was working). However, for toplevel we don't need to do this, as the toplevel loader will keep track of the loaded dependencies for us.