### PR TITLE
makes RSP correction for x86 targets observable

### DIFF
--- a/plugins/primus_x86/primus_x86_loader.ml
+++ b/plugins/primus_x86/primus_x86_loader.ml
@@ -23,7 +23,6 @@ module SetupPLT(Machine : Primus.Machine.S) = struct
 
   module Value = Primus.Value.Make(Machine)
   module Interpreter = Primus.Interpreter.Make(Machine)
-  module Env = Primus.Env.Make(Machine)
 
   let intrinsics =
     let+ prog = Machine.gets Project.program in
@@ -66,8 +65,9 @@ module SetupPLT(Machine : Primus.Machine.S) = struct
     if Set.mem ignore name
     then Machine.return ()
     else
-      Env.get sp >>= fun x ->
-      Interpreter.binop Bil.plus x addend >>= Env.set sp
+      Interpreter.get sp >>= fun x ->
+      Interpreter.binop Bil.plus x addend >>=
+      Interpreter.set sp
 
   let correct_sp ignore sp addend =
     match Var.typ sp with


### PR DESCRIPTION
After a call to the RSP target we have to restore the RSP value. The component that is responsible for that was doing the correction via the `Env` inteface directly so that the correction wasn't observable that was preventing tracking the change in the RSP value.