### PR TITLE
Fix BFM in ARM Primus Lisp semantics.

### DIFF
--- a/plugins/arm/semantics/aarch64-logical.lisp
+++ b/plugins/arm/semantics/aarch64-logical.lisp
@@ -46,16 +46,12 @@
 (defmacro make-eBFM (set cast xd xr ir is)
   "(make-BFM  cast xd xr ir is) implements bitfield move instructions
    accepting either a W or X register, with cast being an unsigned or signed cast."
-  (let ((rs (word)))
+  (let ((rs (word-width xd)))
     (if (< is ir)
-        (if (and (/= is (- rs 1)) (= (+ is 1) ir))
-            (set xd (lshift xr (- rs ir)))
-          (set xd (lshift
-                   (cast rs (extract is 0 xr))
-                   (- rs ir))))
-      (if (= is (- rs 1))
-          (set xd (rshift xr ir))
-        (set xd (cast rs (extract is ir xr)))))))
+        (set xd (lshift
+                 (cast rs (cast-low (+1 is) xr))
+                 (- rs ir)))
+      (set xd (cast rs (extract is ir xr))))))
 
 (defun UBFMXri (xd xr ir is)
   (make-eBFM set$ cast-unsigned xd xr ir is))

--- a/plugins/arm/semantics/aarch64-logical.lisp
+++ b/plugins/arm/semantics/aarch64-logical.lisp
@@ -70,14 +70,17 @@
   (make-eBFM setw cast-signed xd xr ir is))
 
 (defmacro BFM (set rd rn r s)
-  (if (>= s r)
-      (set rd (concat (cast-high (+1 (- s r)) rd)
-                      (if (= r 0)
-                          (cast-low (+1 s) rn)
-                        (extract s r rn))))
-    (set rd (concat
-             (cast-low (+1 s) rn)
-             (cast-low r rd)))))
+  (let ((size (word-width rd)))
+    (if (>= s r)
+      (set rd (concat 
+               (cast-high (- size (+1 (- s r))) rd)
+               (if (= r 0)
+                 (cast-low (+1 s) rn) 
+                 (extract s r rn))))
+      (set rd (concat
+               (cast-high (- r s) rd)
+               (cast-low (+1 s) rn)
+               (cast-low (-1 (- size r)) rd))))))
 
 (defun BFMXri (_ xd xr ir is)
   (BFM set$ xd xr ir is))


### PR DESCRIPTION
Previously, the BFM macro did not account for register widths while extracting and concatenating and also did not concatenate some parts of the old destination register.

First, we'll show the old behaviour.

```asm
bfm w3, w17, #3, #5
R3 := 31:29[R3].5:3[R17]
```
Here, r = 3 and s = 5 for the s >= r case. This should take bits from the middle of R17 and places them at the lower bits of R3. Slice of R17 is correct but slice of R3 is only 3 bits wide when it should be 29 bits wide.

```asm
bfm w3, w17, #6, #4
R3 := low:5[31:0[R17]].low:6[31:0[R3]]
```
Now, r = 6 and s = 4 for the s < r case. This should take the lower bits of R17 and inserts them into R3. Again, slice of R17 is correct but the slice of R3 is too small. This is also missing a concat with R3's upper bits which were not filled by the R17 slice.

----

This PR fixes these, matching the written description in the [A64 ISA](https://developer.arm.com/documentation/ddi0602/2022-03/Base-Instructions/BFM--Bitfield-Move-?lang=en).

```asm
bfm w3, w17, #3, #5
R3 := 31:3[R3].5:3[R17]

bfm w3, w17, #6, #4
R3 := 31:30[R3].low:5[31:0[R17]].low:25[31:0[R3]]
```

The make-eBFM macro was found to be mostly correct, except for its treatment of 32-bit registers which was fixed as well. Additionally, the special cases in the existing eBFM were also logically unreachable so we removed them.