### PR TITLE
Fix not propagating term attrs in `mangle_names` during lifting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ testsuite:
 	git clone https://github.com/BinaryAnalysisPlatform/bap-testsuite.git testsuite
 
 check: testsuite
-	make REVISION=ddb5e33ce1c -C testsuite
+	make REVISION=5909f59c5c29a7b143573bd49b8101a68ccded32 -C testsuite
 
 .PHONY: indent check-style status-clean
 

--- a/lib/bap_sema/bap_sema_lift.ml
+++ b/lib/bap_sema/bap_sema_lift.ml
@@ -434,12 +434,14 @@ let mangle_name addr tid name =
 
 let mangle_sub s =
   let tid = Term.tid s in
-  let addr = Term.get_attr s address in
+  let attrs = Term.attrs s in
+  let addr = Dict.find attrs address in
   let name = mangle_name addr tid (Ir_sub.name s) in
-  set_name_if_possible tid name >>| fun () ->
-  Ir_sub.create () ~tid ~name
-    ~args:(Term.enum arg_t s |> Seq.to_list)
-    ~blks:(Term.enum blk_t s |> Seq.to_list)
+    set_name_if_possible tid name >>| fun () ->
+  let s = Ir_sub.create () ~tid ~name
+      ~args:(Term.enum arg_t s |> Seq.to_list)
+      ~blks:(Term.enum blk_t s |> Seq.to_list) in
+  Term.with_attrs s attrs
 
 let fix_names prog =
   let is_new tid name =

--- a/lib/bap_sema/bap_sema_lift.ml
+++ b/lib/bap_sema/bap_sema_lift.ml
@@ -437,7 +437,7 @@ let mangle_sub s =
   let attrs = Term.attrs s in
   let addr = Dict.find attrs address in
   let name = mangle_name addr tid (Ir_sub.name s) in
-    set_name_if_possible tid name >>| fun () ->
+  set_name_if_possible tid name >>| fun () ->
   let s = Ir_sub.create () ~tid ~name
       ~args:(Term.enum arg_t s |> Seq.to_list)
       ~blks:(Term.enum blk_t s |> Seq.to_list) in


### PR DESCRIPTION
We mangle names in `bap_sema_lift.ml` when there are conflicting subroutine names. However, it creates a new subroutine term (to be KB friendly), and we were forgetting to preserve the old attributes dictionary in this new subroutine.