### PR TITLE
Expose `Bap_var.sort_of_typ`

### DIFF
--- a/lib/bap/bap.mli
+++ b/lib/bap/bap.mli
@@ -2806,6 +2806,12 @@ module Std : sig
     *)
     val check : bil -> (unit,error) Result.t
 
+    (** [sort t] translates the type [t] into a Core Theory sort.
+
+        @since 2.6.0
+    *)
+    val sort : t -> unit Theory.Value.sort
+
     (** BIL type errors.
 
         Not all syntactically correct expressions make sense. A

--- a/lib/bap_types/bap_helpers.ml
+++ b/lib/bap_types/bap_helpers.ml
@@ -150,6 +150,8 @@ module Type = struct
   let check xs = match check xs with
     | None -> Ok ()
     | Some err -> Error err
+
+  let sort = Bap_var.sort_of_typ
 end
 
 (*

--- a/lib/bap_types/bap_helpers.mli
+++ b/lib/bap_types/bap_helpers.mli
@@ -1,5 +1,6 @@
 (** BIL high level functions.   *)
 open Core_kernel[@@warning "-D"]
+open Bap_core_theory
 open Bap_common
 open Bap_bil
 open Bap_visitor
@@ -36,6 +37,7 @@ module Type : sig
   val check : stmt list -> (unit,Bap_type_error.t) Result.t
   val infer : exp -> (typ, Bap_type_error.t) Result.t
   val infer_exn : exp -> typ
+  val sort : typ -> unit Theory.Value.sort
 end
 
 module Eff : sig


### PR DESCRIPTION
For convenience, we can convert a BIL type to a Core Theory sort.