### PR TITLE
Fixes the stub resolver tests

### DIFF
--- a/oasis/stub-resolver
+++ b/oasis/stub-resolver
@@ -7,7 +7,7 @@ Library bap-plugin-stub_resolver
   Path:         plugins/stub_resolver/
   BuildDepends: bap, bap-abi, bap-knowledge, bap-core-theory, core_kernel,
                 bitvec, bitvec-order, bitvec-sexp,
-                bap-main, ppx_bap, ogre, bap-relation, graphlib, regular
+                bap-main, ppx_bap, ogre, graphlib, regular
   FindlibName:     bap-plugin-stub_resolver
   CompiledObject:  best
   Modules:         Stub_resolver

--- a/oasis/stub-resolver
+++ b/oasis/stub-resolver
@@ -7,7 +7,7 @@ Library bap-plugin-stub_resolver
   Path:         plugins/stub_resolver/
   BuildDepends: bap, bap-abi, bap-knowledge, bap-core-theory, core_kernel,
                 bitvec, bitvec-order, bitvec-sexp,
-                bap-main, ppx_bap, ogre, bap-relation
+                bap-main, ppx_bap, ogre, bap-relation, graphlib, regular
   FindlibName:     bap-plugin-stub_resolver
   CompiledObject:  best
   Modules:         Stub_resolver

--- a/oasis/stub-resolver
+++ b/oasis/stub-resolver
@@ -7,7 +7,7 @@ Library bap-plugin-stub_resolver
   Path:         plugins/stub_resolver/
   BuildDepends: bap, bap-abi, bap-knowledge, bap-core-theory, core_kernel,
                 bitvec, bitvec-order, bitvec-sexp,
-                bap-main, ppx_bap, ogre
+                bap-main, ppx_bap, ogre, bap-relation
   FindlibName:     bap-plugin-stub_resolver
   CompiledObject:  best
   Modules:         Stub_resolver

--- a/plugins/stub_resolver/stub_resolver_tests.ml
+++ b/plugins/stub_resolver/stub_resolver_tests.ml
@@ -218,8 +218,6 @@ let suite = "stub-resolver" >::: [
       stub "m10" [];
     ] ~expected:[
       "m0", "m1";
-      "m10", "m9";
-      "m5", "m6";
     ];
 
     test "several intersections 2" [
@@ -241,6 +239,7 @@ let suite = "stub-resolver" >::: [
     ] ~expected:[
       "p0", "p11";
       "p4", "p5";
+      "p6", "p5";
     ];
 
   ]

--- a/plugins/stub_resolver/stub_resolver_tests.ml
+++ b/plugins/stub_resolver/stub_resolver_tests.ml
@@ -177,13 +177,19 @@ let suite = "stub-resolver" >::: [
       real "h0" ["h1"; "h2"];
       stub "h1" [];
       stub "h2" [];
-    ] ~expected:[];
+    ] ~expected:[
+      "h1", "h0";
+      "h2", "h0";
+    ];
 
     test "ambiguous stubs" [
       real "i0" [];
       stub "i1" ["i0"];
       stub "i2" ["i0"];
-    ] ~expected:[];
+    ] ~expected:[
+      "i1", "i0";
+      "i2", "i0";
+    ];
 
     test "crossreference" [
       real "j0" ["j1"];
@@ -210,7 +216,11 @@ let suite = "stub-resolver" >::: [
       real "m6" ["m5"; "m9"];
       real "m9" ["m10"];
       stub "m10" [];
-    ] ~expected:["m0", "m1"; ];
+    ] ~expected:[
+      "m0", "m1";
+      "m10", "m9";
+      "m5", "m6";
+    ];
 
     test "several intersections 2" [
       stub "n0" ["n1"; "n2"; "n3"];
@@ -220,7 +230,7 @@ let suite = "stub-resolver" >::: [
       real "n6" [];
       stub "n7" ["n6"];
       real "n8" ["n1"; "n5"]
-    ] ~expected:["n7", "n6" ];
+    ] ~expected:["n7", "n6"];
 
     test "several intersections 3" [
       stub "p0" ["p1"; "p2"; "p3"];
@@ -228,6 +238,9 @@ let suite = "stub-resolver" >::: [
       real "p5" [];
       stub "p6" ["p8"; "p9"; "p10"; "p4"];
       real "p11" ["p12"; "p13"; "p1"];
-    ] ~expected:["p0", "p11" ];
+    ] ~expected:[
+      "p0", "p11";
+      "p4", "p5";
+    ];
 
   ]


### PR DESCRIPTION
The tests didn't reflect the new behavior of the stub resolver from #1547. The idea is that now we can have multiple stubs link to the same implementation, as is common when linking more than one shared library.

The algorithm is also cleaned up to use ~~`Bap_relation`~~ `Graphlib`, which ends up being simpler and produces better results.