### PR TITLE
allows to use bap instead of bap-std

### DIFF
--- a/lib/bap/dune
+++ b/lib/bap/dune
@@ -1,3 +1,7 @@
+(deprecated_library_name
+ (old_public_name bap)
+ (new_public_name bap-std))
+
 (library
  (name bap)
  (public_name bap-std)


### PR DESCRIPTION
This will break too much downstream code, as well as our own tooling like bapbuild