### PR TITLE
loads packages before plugins to prevent failures in dune loader

### DIFF
--- a/lib/bap_main/bap_main_log.ml
+++ b/lib/bap_main/bap_main_log.ml
@@ -107,9 +107,6 @@ let log_plugin_events () =
       | `Linking lib ->
         message Debug ~section "Linking library %s" lib)
 
-
-
-
 let process_events ppf =
   Stream.observe Event.stream (function
       | Event.Log.Message message -> print_message ppf message

--- a/lib/bap_plugins/bap_plugins.ml
+++ b/lib/bap_plugins/bap_plugins.ml
@@ -359,13 +359,13 @@ module Plugins = struct
 
 
   let list ?env ?provides ?library () =
-    list_bundles ?env ?provides ?library () @
-    list_packages ()
+    list_packages () @
+    list_bundles ?env ?provides ?library ()
 
   let collect ?env ?provides ?library () =
-    collect_bundles ?env ?provides ?library () @
-    List.map ~f:Result.return @@
-    list_packages ()
+    let packs = list_packages () |> List.map ~f:Result.return in
+    let bunds = collect_bundles ?env ?provides ?library () in
+    packs @ bunds
 
   let loaded,finished = Future.create ()
 


### PR DESCRIPTION
If bundled plugins are loaded before dune packaged plugins, the latter will fail on modules that were linked by the former. The old bap plugin system has no way to notify the dune plugin system on what units are loaded (no worries the dynlink system used by both will prevent double-loading). Instead of catching the Unit_already_loaded exception from dune, we better first load all dune packages and only after that handle the old bundled plugins with our old loader, which is capable of handling correctly this exception.