### PR TITLE
adds a missing module to the OASIS specification of bap-plugins

### DIFF
--- a/oasis/plugins
+++ b/oasis/plugins
@@ -11,6 +11,7 @@ Library bap_plugins
                    Bap_plugins_units,
                    Bap_plugins_units_intf,
                    Bap_common,
-                   Bap_plugins_loader_backend
+                   Bap_plugins_loader_backend,
+                   Bap_plugins_package
   BuildDepends:    core_kernel, dynlink, fileutils, findlib, bap-bundle, bap-future,
                    uri, ppx_bap


### PR DESCRIPTION
It's unclear how it was passing the tests but there is still a missing module the bap-plugins OASIS specification that breaks downstream builds.