### PR TITLE
Fixes a typo in the Primus Lisp IEEE754 semantics

### DIFF
--- a/plugins/primus_lisp/semantics/ieee754.lisp
+++ b/plugins/primus_lisp/semantics/ieee754.lisp
@@ -29,7 +29,7 @@
   (set y0 (cast-float :rne 64 x0)))
 
 (defun cast_sint_rne_ieee754_binary_64 ()
-  (set y0 (cast-sfloat :rne 64 x0)))
+  (set y0 (cast-sint :rne 64 x0)))
 
 (defun cast_int_rne_ieee754_binary_64 ()
-  (set y0 (cast-float :rne 64 x0)))
+  (set y0 (cast-int :rne 64 x0)))


### PR DESCRIPTION
They were using `cast-sfloat/cast-float` instead of `cast-sint/cast-int`.