### PR TITLE
Fixes a few bugs in the Thumb semantics

### DIFF
--- a/plugins/arm/semantics/thumb.lisp
+++ b/plugins/arm/semantics/thumb.lisp
@@ -12,7 +12,7 @@
 (in-package thumb)
 
 (defun tCMPhir (rn rm cnd _)
-  "cmp rn, rn"
+  "cmp rn, rm"
   (when (condition-holds cnd)
     (let ((r (- rn rm)))
       (set-nzcv-from-registers r rn (- rm)))))

--- a/plugins/arm/semantics/thumb.lisp
+++ b/plugins/arm/semantics/thumb.lisp
@@ -15,7 +15,7 @@
   "cmp rn, rn"
   (when (condition-holds cnd)
     (let ((r (- rn rm)))
-      (set-nzcv-from-registers r rn rm))))
+      (set-nzcv-from-registers r rn (- rm)))))
 
 (defun tADR (rd lbl cnd _)
   "adr rd, lbl"

--- a/plugins/arm/semantics/thumb.lisp
+++ b/plugins/arm/semantics/thumb.lisp
@@ -98,7 +98,7 @@
 (defun t2ADDrs (rd rn rm simm cnd _ _)
   "add.w rd, rn, rm, simm"
   (when (condition-holds cnd)
-    (set$ rd (+ rn (i-shift rn simm)))))
+    (set$ rd (+ rn (i-shift rm simm)))))
 
 (defun tSBC (rd _ rn rm cnd _)
   (add-with-carry/it-block rd rn (lnot rm) CF cnd))


### PR DESCRIPTION
The helper `set-nzcv-from-registers` calls additional helpers `overflow` and `carry`, which compute their results from the addition of two integers. However, the `cmp` instruction computes the subtraction of two integers, and this wasn't reflected in the usage of this helper function.

Also, the `t2ADDrs` semantics had a typo in it.