### PR TITLE
Adds compatibility with LLVM 15

### DIFF
--- a/bap-llvm.opam
+++ b/bap-llvm.opam
@@ -43,7 +43,7 @@ build: [
 ]
 
 depexts: [
-  ["clang" "libncurses5-dev"] {os-distribution = "ubuntu"}
+  ["clang" "libncurses5-dev" "libzstd-dev"] {os-distribution = "ubuntu"}
   ["clang"] {os-distribution = "debian"}
   ["clang" "libxml2-dev"] {os-distribution = "alpine"}
   ["clang"] {os-distribution = "fedora"}

--- a/bap-llvm.opam.template
+++ b/bap-llvm.opam.template
@@ -20,7 +20,7 @@ build: [
 ]
 
 depexts: [
-  ["clang" "libncurses5-dev"] {os-distribution = "ubuntu"}
+  ["clang" "libncurses5-dev" "libzstd-dev"] {os-distribution = "ubuntu"}
   ["clang"] {os-distribution = "debian"}
   ["clang" "libxml2-dev"] {os-distribution = "alpine"}
   ["clang"] {os-distribution = "fedora"}

--- a/lib/bap_llvm/config/llvm_configurator.ml
+++ b/lib/bap_llvm/config/llvm_configurator.ml
@@ -33,7 +33,7 @@ let () = C.main ~args ~name:"bap-llvm" @@ fun self ->
   C.Flags.write_sexp "link.flags" @@ List.concat [
     llvm self ["--link-static"; "--ldflags"];
     llvm self (["--link-static"; "--libs"] @ llvm_components);
-    ["-lstdc++"; "-lcurses"];
+    ["-lstdc++"; "-lcurses"; "-lzstd"];
   ];
   C.Flags.write_sexp "cxx.flags" @@ List.concat [
     ["-fPIC"];

--- a/lib/bap_llvm/llvm_disasm.cpp
+++ b/lib/bap_llvm/llvm_disasm.cpp
@@ -3,6 +3,9 @@
 #include <llvm/MC/MCInstPrinter.h>
 #include <llvm/MC/MCInstrInfo.h>
 #include <llvm/MC/MCRegisterInfo.h>
+#if LLVM_VERSION_MAJOR >= 15
+#include <llvm/MC/MCSubtargetInfo.h>
+#endif
 #include <llvm/Support/DataTypes.h>
 #include <llvm/Support/FormattedStream.h>
 #include <llvm/Support/CommandLine.h>

--- a/lib/bap_llvm/llvm_pdb_loader.hpp
+++ b/lib/bap_llvm/llvm_pdb_loader.hpp
@@ -50,6 +50,9 @@
 
 #include <llvm/Object/COFF.h>
 #include <llvm/Object/Binary.h>
+#if LLVM_VERSION_MAJOR >= 15
+#include "llvm/DebugInfo/MSF/MappedBlockStream.h"
+#endif
 #include "llvm/DebugInfo/PDB/PDB.h"
 #include "llvm/DebugInfo/PDB/PDBTypes.h"
 #include "llvm/DebugInfo/PDB/IPDBSession.h"

--- a/oasis/llvm
+++ b/oasis/llvm
@@ -18,7 +18,7 @@ Library bap_llvm
                  Bap_llvm_config,
                  Bap_llvm_disasm
   CCOpt:         $cc_optimization
-  CCLib:         $llvm_lib $cxxlibs $llvm_ldflags -lcurses
+  CCLib:         $llvm_lib $cxxlibs $llvm_ldflags -lcurses -lzstd
   CSources:      llvm_disasm.h,
                  llvm_disasm.c,
                  llvm_stubs.c,

--- a/vagrant/trusty64/Vagrantfile
+++ b/vagrant/trusty64/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure(2) do |config|
   end
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
 sudo apt-get update
-sudo apt-get install make git m4 libcap-dev gcc unzip libncurses5-dev --yes
+sudo apt-get install make git m4 libcap-dev gcc unzip libncurses5-dev libzstd-dev --yes
 
 wget https://github.com/projectatomic/bubblewrap/releases/download/v0.3.1/bubblewrap-0.3.1.tar.xz
 tar xvf bubblewrap-0.3.1.tar.xz

--- a/vagrant/xenial64/Vagrantfile
+++ b/vagrant/xenial64/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure(2) do |config|
   end
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
 sudo apt-get update
-sudo apt-get install make git m4 libcap-dev gcc unzip libncurses5-dev --yes
+sudo apt-get install make git m4 libcap-dev gcc unzip libncurses5-dev libzstd-dev --yes
 
 wget https://github.com/projectatomic/bubblewrap/releases/download/v0.3.1/bubblewrap-0.3.1.tar.xz
 tar xvf bubblewrap-0.3.1.tar.xz


### PR DESCRIPTION
It seems that with LLVM 15 a few fixes are needed to get BAP to compile, including linking against `libzstd`.