### PR TITLE
Support linking with LLVM shared libraries

### DIFF
--- a/bap-llvm.opam.template
+++ b/bap-llvm.opam.template
@@ -3,6 +3,7 @@ build: [
   [
   "ocaml" "tools/configure.ml"
   "--with-llvm-config=%{conf-bap-llvm:config}%"
+  "--%{llvm-shared?disable:enable}%-llvm-static"
   ]
   [
     "dune"

--- a/lib/bap_llvm/config/llvm_configurator.ml
+++ b/lib/bap_llvm/config/llvm_configurator.ml
@@ -30,9 +30,13 @@ let args = [
 
 
 let () = C.main ~args ~name:"bap-llvm" @@ fun self ->
+  let linkmode =
+    "--link-" ^
+    (String.strip @@
+     C.Process.run_capture_exn self llvm_config ["--shared-mode"]) in
   C.Flags.write_sexp "link.flags" @@ List.concat [
-    llvm self ["--link-static"; "--ldflags"];
-    llvm self (["--link-static"; "--libs"] @ llvm_components);
+    llvm self [linkmode; "--ldflags"];
+    llvm self ([linkmode; "--libs"] @ llvm_components);
     ["-lstdc++"; "-lcurses"; "-lzstd"];
   ];
   C.Flags.write_sexp "cxx.flags" @@ List.concat [

--- a/lib/bap_llvm/llvm_disasm.cpp
+++ b/lib/bap_llvm/llvm_disasm.cpp
@@ -12,6 +12,9 @@
 #if LLVM_VERSION_MAJOR >= 12
 #include <llvm/Support/Process.h>
 #include <llvm/Support/StringSaver.h>
+#if LLVM_VERSION_MAJOR <= 16
+#include <llvm/ADT/Optional.h>
+#endif
 #endif
 #include <llvm-c/Target.h>
 


### PR DESCRIPTION
This must be manually enabled by setting the variable `llvm-shared` to a true value in the current opam switch, similar to the existing `llvm-config` variable used by conf-bap-llvm.

* bap_llvm/config/llvm_configurator.ml: use `llvm-config --shared-mode` to get the appropriate linking mode

* bap_llvm/llvm_disasm.cpp: add missing include for Optional.h