### PR TITLE
Fix compatibility with LLVM 16

### DIFF
--- a/lib/bap_llvm/llvm_disasm.cpp
+++ b/lib/bap_llvm/llvm_disasm.cpp
@@ -652,7 +652,8 @@ struct create_llvm_disassembler : disasm_factory {
 
 static void parse_environment_options(const char *prog_name, const char *env_var) {
 #if LLVM_VERSION_MAJOR >= 12
-    llvm::Optional<std::string> env_value = llvm::sys::Process::GetEnv(llvm::StringRef(env_var));
+    // auto is llvm::Optional<std::string> or std::optional<std::string>
+    const auto& env_value = llvm::sys::Process::GetEnv(llvm::StringRef(env_var));
     if (!env_value)
         return;
 


### PR DESCRIPTION
LLVM 16 uses std::optional in place of llvm::Optional. Since these have very similar interfaces, we use auto to maintain backwards compatibility.

I haven't tested much, but it compiles successfully with LLVM 16 and LLVM 15.