### PR TITLE
Fixes for LLVM 17 (and 16)

### DIFF
--- a/lib/bap_llvm/llvm_loader_utils.hpp
+++ b/lib/bap_llvm/llvm_loader_utils.hpp
@@ -5,7 +5,11 @@
 #include <iomanip>
 #include <iostream>
 
+#if LLVM_VERSION_MAJOR >= 17
+#include <llvm/TargetParser/Triple.h>
+#else
 #include <llvm/ADT/Triple.h>
+#endif
 
 #include "llvm_error_or.hpp"
 

--- a/lib/bap_llvm/llvm_primitives.cpp
+++ b/lib/bap_llvm/llvm_primitives.cpp
@@ -1,6 +1,11 @@
 #include <iostream>
 
+#include <llvm/Config/llvm-config.h>
+#if LLVM_VERSION_MAJOR >= 17
+#include <llvm/TargetParser/Triple.h>
+#else
 #include <llvm/ADT/Triple.h>
+#endif
 
 #include "llvm_primitives.hpp"
 


### PR DESCRIPTION
This also covers #1595.

There was a really tricky segfault to track down in the call to `MCInstrDesc::mayAffectControlFlow`, see my comment as well as [here](https://github.com/llvm/llvm-project/blob/release/17.x/llvm/include/llvm/MC/MCInstrDesc.h#L200). This comment is also present in [LLVM 16](https://github.com/llvm/llvm-project/blob/release/16.x/llvm/include/llvm/MC/MCInstrDesc.h#L200).