### PR TITLE
Ensure compatibility with `camlzip` versions before 1.12

### DIFF
--- a/bap-byteweight.opam
+++ b/bap-byteweight.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "3.1"}
   "bap-signatures" {= version}
   "bap-std" {= version}
-  "camlzip" {>= "1.12" & < "2.0"}
+  "camlzip" {>= "1.0" & < "2.0"}
   "core_kernel" {>= "v0.14" & < "v0.16"}
   "bap-common" {= version}
   "ppx_bap" {= version}

--- a/dune-project
+++ b/dune-project
@@ -283,7 +283,7 @@
  (depends
   (bap-signatures (= :version))
   (bap-std (= :version))
-  (camlzip (and (>= 1.12) (< 2.0)))
+  (camlzip (and (>= 1.0) (< 2.0)))
   (core_kernel (and (>= v0.14) (< v0.16)))
   (bap-common (= :version))
   (ppx_bap (= :version))

--- a/lib/bap_byteweight/bap_byteweight_signatures.ml
+++ b/lib/bap_byteweight/bap_byteweight_signatures.ml
@@ -109,7 +109,7 @@ let update_or_fail ?compiler target data payload path =
   let path = make_entry ?compiler target data in
   let data = Bytes.unsafe_to_string (data.save payload) in
   Zip.add_entry data zip path;
-  List.iter entries ~f:(fun ({Zip.filename; comment; mtime},data) ->
+  List.iter entries ~f:(fun ({Zip.filename; comment; mtime; _},data) ->
       Zip.add_entry data zip filename ~comment ~mtime)
 
 let copy input output =


### PR DESCRIPTION
As noted by @xavierleroy in #1609, we can ensure compatibility with earlier versions of camlzip in light of the recent changes w.r.t. the `extra` field being removed in 1.12.