### PR TITLE
Specify ncurses directly

### DIFF
--- a/oasis/llvm
+++ b/oasis/llvm
@@ -18,7 +18,7 @@ Library bap_llvm
                  Bap_llvm_config,
                  Bap_llvm_disasm
   CCOpt:         $cc_optimization
-  CCLib:         $llvm_lib $cxxlibs $llvm_ldflags -lcurses -lzstd
+  CCLib:         $llvm_lib $cxxlibs $llvm_ldflags -lncurses -lzstd
   CSources:      llvm_disasm.h,
                  llvm_disasm.c,
                  llvm_stubs.c,


### PR DESCRIPTION
Multiple distributions have dropped the libcurses → libncurses alias.

This patch is upstreamed from [Guix](https://guix.gnu.org), the only [distribution currently packages bap](https://repology.org/project/bap/versions).