### PR TITLE
relaxes x86 operands deconstructor to address llvm changes

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build on Alpine
         uses: docker/build-push-action@v2

--- a/.github/workflows/archlinux.yml
+++ b/.github/workflows/archlinux.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build on Archlinux
         uses: docker/build-push-action@v2

--- a/.github/workflows/debian-testing.yml
+++ b/.github/workflows/debian-testing.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build on Debian Testing
         uses: docker/build-push-action@v2

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build on Fedora
         uses: docker/build-push-action@v2

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -26,7 +26,7 @@ jobs:
           sudo apt-get install dejagnu -y
 
       - name: Install OCaml
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 4.14.x
           dune-cache: true
@@ -38,13 +38,13 @@ jobs:
       - name: Run Functional Tests
         run: opam exec -- make check
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: bap-log
           path: ~/.local/state/bap
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: fun-tests-log

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup OCaml
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 4.14.x
           opam-pin: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Prepare Ubuntu
         if: matrix.os == 'ubuntu-20.04'
@@ -45,7 +45,7 @@ jobs:
           brew install deja-gnu
 
       - name: Install OCaml
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           dune-cache: ${{  matrix.os != 'macos-11' }}
@@ -68,19 +68,19 @@ jobs:
         run: |
           opam exec -- make TOOLS=mc check
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: bap-log
           path: ~/.local/state/bap
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: unit-tests-log
           path: _build/default/lib_test/*/oUnit-*.log
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: fun-tests-log

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,7 +32,7 @@ jobs:
           sudo apt-get install dejagnu -y
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           dune-cache: ${{  matrix.os != 'macos-11' }}
@@ -45,32 +45,32 @@ jobs:
         run: opam install bap-extra bap-radare2
 
       - name: Checkout the Tests
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: BinaryAnalysisPlatform/bap
 
       - name: Run Functional Tests
         run: opam exec -- make check
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: opam-log-${{ matrix.os }}-${{ matrix.ocaml-compiler }}
           path: ~/.opam/log
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: bap-log-${{ matrix.os }}-${{ matrix.ocaml-compiler }}
           path: ~/.local/state/bap
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: unit-tests-log-${{ matrix.os }}-${{ matrix.ocaml-compiler }}
           path: _build/oUnit-*.log
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: fun-tests-log-${{ matrix.os }}-${{ matrix.ocaml-compiler }}

--- a/.github/workflows/oasis.yml
+++ b/.github/workflows/oasis.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Prepare Ubuntu
         if: matrix.os == 'ubuntu-20.04'
@@ -45,7 +45,7 @@ jobs:
           brew install deja-gnu
 
       - name: Install OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           dune-cache: ${{  matrix.os != 'macos-11' }}
@@ -81,13 +81,13 @@ jobs:
       - name: Run functional tests
         run: opam exec -- make check
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: bap-log
           path: ~/.local/state/bap
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: fun-tests-log

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Ghidra and Dejagnu
         run: |
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get install dejagnu -y
 
       - name: Install OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           dune-cache: true
@@ -45,7 +45,7 @@ jobs:
       - name: Run functional tests
         run: opam exec -- make check
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: opam-log-${{ matrix.ocaml-compiler }}

--- a/.github/workflows/publish-docker-image-release.yml
+++ b/.github/workflows/publish-docker-image-release.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install OCaml
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ocaml-variants.4.11.2+flambda
           dune-cache: true

--- a/.github/workflows/ubuntu-bionic.yml
+++ b/.github/workflows/ubuntu-bionic.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build on Ubuntu Bionic
         uses: docker/build-push-action@v2

--- a/.github/workflows/weekly-regress.yml
+++ b/.github/workflows/weekly-regress.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           dune-cache: true
@@ -39,7 +39,7 @@ jobs:
         run: opam install bap bap-radare2
 
       - name: Checkout the Tests
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: BinaryAnalysisPlatform/bap
           ref: v2.5.0
@@ -50,19 +50,19 @@ jobs:
       - name: Run Functional Tests
         run: opam exec -- make check
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: opam-log-${{ matrix.ocaml-compiler }}
           path: ~/.opam/log
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: bap-log-${{ matrix.ocaml-compiler }}
           path: ~/.local/state/bap
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: fun-tests-log-${{ matrix.ocaml-compiler }}

--- a/plugins/x86/x86_operands.ml
+++ b/plugins/x86/x86_operands.ml
@@ -28,12 +28,16 @@ let m ~f mem insn =
 
 let rr ~f mem insn =
   match Insn.ops insn with
-  | [| Op.Reg reg1; Op.Reg reg2 |] -> f mem reg1 reg2
+  | [| _; Op.Reg reg1; Op.Reg reg2 |]
+  | [| Op.Reg reg1; Op.Reg reg2 |] ->
+    f mem reg1 reg2
   | _ -> invalid_operands ~here:[%here] insn
 
 let ri ~f mem insn =
   match Insn.ops insn with
-  | [| Op.Reg reg; Op.Imm imm |] -> f mem reg imm
+  | [| _; Op.Reg reg; Op.Imm imm |]
+  | [| Op.Reg reg; Op.Imm imm |] ->
+    f mem reg imm
   | _ -> invalid_operands ~here:[%here] insn
 
 let ir ~f mem insn =


### PR DESCRIPTION
Occasionally, llvm refines their instruction definitions and change the number of operands, for example this [commit][1] added an extra destination register operand. For the old lifters we used a pretty strict rules for operands deconstructing and for the bts, btc, and btr instructions we were expecting two operands (now there are three of them).

I decided to relax the deconstructor instead of changing the definition of instructions, first to preserve backward compatibility with the older versions of llvm and second because many other instructions could be affected by the same changes from the llvm side, and I don't see any harm if we will accept instructions with one more argument, knowing that destinations are always prepended.

[1]: https://github.com/llvm/llvm-project/commit/fe96ff73983e01c2fcc7efa23d4513f7c5290611