### PR TITLE
fixes dockerfiles to address change in the default OCaml version

### DIFF
--- a/docker/2.4.0/Dockerfile
+++ b/docker/2.4.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam:debian
+FROM ocaml/opam:debian-ocaml-4.14
 
 WORKDIR /home/opam
 

--- a/docker/2.5.0/Dockerfile
+++ b/docker/2.5.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam:debian
+FROM ocaml/opam:debian-ocaml-4.14
 
 WORKDIR /home/opam
 

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -1,18 +1,11 @@
-FROM ocaml/opam2:alpine
+FROM ocaml/opam:alpine-ocaml-4.14
 
 WORKDIR /home/opam
 
-RUN opam switch 4.09 \
- && eval "$(opam env)" \
- && opam remote set-url default https://opam.ocaml.org \
+RUN opam remote set-url default https://opam.ocaml.org \
  && opam repo add bap git+https://github.com/BinaryAnalysisPlatform/opam-repository#testing --all \
  && opam update \
- && opam depext --install bap --yes -j 1 \
- && opam clean -acrs \
- && rm -rf /home/opam/.opam/4.0[2-8] \
- && rm -rf /home/opam/.opam/4.09/.opam-switch/sources/* \
- && rm -rf /home/opam/opam-repository \
- && sudo apk add py-pip \
- && sudo pip install bap
+ && opam depext --install bap --yes -j 1
+
 
 ENTRYPOINT ["opam", "config", "exec", "--"]

--- a/docker/archlinux/Dockerfile
+++ b/docker/archlinux/Dockerfile
@@ -1,24 +1,9 @@
-FROM archlinux:latest
+FROM ocaml/opam:archlinux-ocaml-4.14
 
-RUN pacman -Syu --noconfirm && pacman -S sudo --noconfirm \
- && useradd -m bap \
- && echo 'bap ALL=(ALL:ALL) NOPASSWD:ALL' > /etc/sudoers.d/bap \
- && su bap
-
-USER bap
-WORKDIR /home/bap
-
-RUN sudo pacman -S --noconfirm m4 git unzip make curl wget \
-         diffutils patch make gcc pkgconfig llvm python2 \
-         which clang radare2 \
-  && wget https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh \
-  && echo "" | sudo sh install.sh \
-  && opam init --comp=4.09.1 --disable-sandboxing --yes \
-  && eval "$(opam env)" \
-  && opam repo add bap git+https://github.com/BinaryAnalysisPlatform/opam-repository#testing --all \
-  && opam update \
-  && opam install bap --yes -j 1 \
-  && opam clean -acrs \
-  && rm -rf /home/opam/.opam/4.09.1/.opam-switch/sources/*
+RUN opam remote set-url default https://opam.ocaml.org \
+ && opam repo add bap-testing git+https://github.com/BinaryAnalysisPlatform/opam-repository#testing --all \
+ && opam update \
+ && opam depext --install bap --yes -j 1 \
+ && opam clean -acrs
 
 ENTRYPOINT ["opam", "config", "exec", "--"]

--- a/docker/debian/testing/Dockerfile
+++ b/docker/debian/testing/Dockerfile
@@ -1,9 +1,9 @@
-FROM ocaml/opam:debian
+FROM ocaml/opam:debian-ocaml-4.14
 
 WORKDIR /home/opam
 
 RUN opam remote set-url default https://opam.ocaml.org \
- && opam repo add  bap-testing git+https://github.com/BinaryAnalysisPlatform/opam-repository#testing --all \
+ && opam repo add bap-testing git+https://github.com/BinaryAnalysisPlatform/opam-repository#testing --all \
  && opam update \
  && opam depext --install bap --yes -j 1 \
  && opam clean -acrs

--- a/docker/fedora/Dockerfile
+++ b/docker/fedora/Dockerfile
@@ -1,16 +1,11 @@
-FROM ocaml/opam2:fedora
+FROM ocaml/opam:fedora-ocaml-4.14
 
 WORKDIR /home/opam
 
-RUN opam switch 4.09 \
- && eval "$(opam env)" \
- && opam remote set-url default https://opam.ocaml.org \
- && opam repo add bap git+https://github.com/BinaryAnalysisPlatform/opam-repository#testing --all \
+RUN opam remote set-url default https://opam.ocaml.org \
+ && opam repo add bap-testing git+https://github.com/BinaryAnalysisPlatform/opam-repository#testing --all \
  && opam update \
  && opam depext --install bap --yes -j 1 \
- && opam clean -acrs \
- && rm -rf /home/opam/.opam/4.0[2-8,10] \
- && rm -rf /home/opam/.opam/4.09/.opam-switch/sources/* \
- && rm -rf /home/opam/opam-repository
+ && opam clean -acrs
 
 ENTRYPOINT ["opam", "config", "exec", "--"]

--- a/docker/ubuntu/bionic/Dockerfile
+++ b/docker/ubuntu/bionic/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam2:ubuntu-18.04
+FROM ocaml/opam:ubuntu-18.04-ocaml-4.14
 
 WORKDIR /home/opam
 
@@ -7,15 +7,10 @@ RUN sudo apt-get update  \
  && sudo add-apt-repository ppa:ivg/ghidra -y \
  && sudo apt-get install libghidra-dev -y \
  && sudo apt-get install libghidra-data -y \
- && opam switch 4.09 \
- && eval "$(opam env)" \
  && opam remote set-url default https://opam.ocaml.org \
  && opam repo add bap git+https://github.com/BinaryAnalysisPlatform/opam-repository --all \
  && opam update \
  && opam depext --install bap-extra --yes -j 1 \
- && opam clean -acrs \
- && rm -rf /home/opam/.opam/4.0[2-8,10] \
- && rm -rf /home/opam/.opam/4.09/.opam-switch/sources/* \
- && rm -rf /home/opam/opam-repository
+ && opam clean -acrs
 
 ENTRYPOINT ["opam", "config", "exec", "--"]

--- a/docker/ubuntu/noble/Dockerfile
+++ b/docker/ubuntu/noble/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam:ubuntu-16.04-ocaml-4.14
+FROM ocaml/opam:ubuntu-24.04-ocaml-4.14
 
 WORKDIR /home/opam
 


### PR DESCRIPTION
Since now the default version 5.x most of the builds were failing (except those that were installing an explicit version of OCaml).

After the update it looks like that all dockerfiles look nearly identicaly, so we should merge them in the future as only line that changes is the FROM.