### PR TITLE
adds semantics for `[v]{and[n],or,xor}p{d,s}` instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ opam switch create . --deps-only
 dune build && dune install
 ```
 
+Note, if you don't have the `llvm-config` executable in the path, then run
+```
+ocaml tools/configure.ml --with-llvm-config=<path-to-you-llvm-config>
+```
+where `<path-to-your-llvm-config>` is usually `llvm-config-<ver>`, e.g., `llvm-config-11`.
+
 ## Using
 
 BAP, like Docker or Git, is driven by a single command-line utility called [bap][man-bap]. Just type `bap` in your shell and it will print a message which shows BAP capabilities. The `disassemble` command will take a binary program, disassemble it, lift it into the intermediate architecture agnostic representation, build a control flow graph, and finally apply staged user-defined analysis in a form of disassembling passes. Finally, the `--dump` option (`-d` in short) will output the resulting program in the specified format. This is the default command, so you don't even need to specify it, e.g., the following will disassembled and dump the `/bin/echo` binary on your machine:

--- a/plugins/primus_lisp/lisp/init.lisp
+++ b/plugins/primus_lisp/lisp/init.lisp
@@ -162,6 +162,10 @@
 
 (defmacro dolist (f x xs) (prog (f x) (dolist f xs)))
 
+(defun ident (x)
+  "(ident X) is X"
+  x)
+
 (defmacro min (x)
   "(min X Y ...) returns the lower bound of the (X,Y,...) set"
       x)

--- a/plugins/x86/semantics/test.t
+++ b/plugins/x86/semantics/test.t
@@ -1317,3 +1317,231 @@ and the same for a memory operand
   {
     mem := mem with [RDI + 0x10, el]:u256 <- YMM0
   }
+
+[v]andp{d,s}:
+  $ mc 0x0f,0x54,0xca
+  andps %xmm2, %xmm1
+  {
+    YMM1 := high:128[YMM1].127:0[YMM1] & 127:0[YMM2]
+  }
+  $ mc 0x66,0x0f,0x54,0xca
+  andpd %xmm2, %xmm1
+  {
+    YMM1 := high:128[YMM1].127:0[YMM1] & 127:0[YMM2]
+  }
+  $ mc 0xc5,0xf0,0x54,0xc2
+  vandps %xmm2, %xmm1, %xmm0
+  {
+    YMM0 := 0.127:0[YMM1] & 127:0[YMM2]
+  }
+  $ mc 0xc5,0xf1,0x54,0xc2
+  vandpd %xmm2, %xmm1, %xmm0
+  {
+    YMM0 := 0.127:0[YMM1] & 127:0[YMM2]
+  }
+  $ mc 0x0f,0x54,0x4e,0x2a
+  andps 0x2a(%rsi), %xmm1
+  {
+    YMM1 := high:128[YMM1].127:0[YMM1] & mem[RSI + 0x2A, el]:u128
+  }
+  $ mc 0x0f,0x54,0x4e,0x2a
+  andps 0x2a(%rsi), %xmm1
+  {
+    YMM1 := high:128[YMM1].127:0[YMM1] & mem[RSI + 0x2A, el]:u128
+  }
+  $ mc 0x66,0x0f,0x54,0x4e,0x2a
+  andpd 0x2a(%rsi), %xmm1
+  {
+    YMM1 := high:128[YMM1].127:0[YMM1] & mem[RSI + 0x2A, el]:u128
+  }
+  $ mc 0xc5,0xf0,0x54,0x46,0x2a
+  vandps 0x2a(%rsi), %xmm1, %xmm0
+  {
+    YMM0 := 0.127:0[YMM1] & mem[RSI + 0x2A, el]:u128
+  }
+  $ mc 0xc5,0xf1,0x54,0x46,0x2a
+  vandpd 0x2a(%rsi), %xmm1, %xmm0
+  {
+    YMM0 := 0.127:0[YMM1] & mem[RSI + 0x2A, el]:u128
+  }
+  $ mc 0xc5,0xf4,0x54,0x46,0x2a
+  vandps 0x2a(%rsi), %ymm1, %ymm0
+  {
+    YMM0 := YMM1 & mem[RSI + 0x2A, el]:u256
+  }
+  $ mc 0xc5,0xf5,0x54,0x46,0x2a
+  vandpd 0x2a(%rsi), %ymm1, %ymm0
+  {
+    YMM0 := YMM1 & mem[RSI + 0x2A, el]:u256
+  }
+
+[v]orp{d,s}:
+  $ mc 0x0f,0x56,0xca
+  orps %xmm2, %xmm1
+  {
+    YMM1 := high:128[YMM1].127:0[YMM1] | 127:0[YMM2]
+  }
+  $ mc 0x66,0x0f,0x56,0xca
+  orpd %xmm2, %xmm1
+  {
+    YMM1 := high:128[YMM1].127:0[YMM1] | 127:0[YMM2]
+  }
+  $ mc 0xc5,0xf0,0x56,0xc2
+  vorps %xmm2, %xmm1, %xmm0
+  {
+    YMM0 := 0.127:0[YMM1] | 127:0[YMM2]
+  }
+  $ mc 0xc5,0xf1,0x56,0xc2
+  vorpd %xmm2, %xmm1, %xmm0
+  {
+    YMM0 := 0.127:0[YMM1] | 127:0[YMM2]
+  }
+  $ mc 0x0f,0x56,0x4e,0x2a
+  orps 0x2a(%rsi), %xmm1
+  {
+    YMM1 := high:128[YMM1].127:0[YMM1] | mem[RSI + 0x2A, el]:u128
+  }
+  $ mc 0x0f,0x56,0x4e,0x2a
+  orps 0x2a(%rsi), %xmm1
+  {
+    YMM1 := high:128[YMM1].127:0[YMM1] | mem[RSI + 0x2A, el]:u128
+  }
+  $ mc 0x66,0x0f,0x56,0x4e,0x2a
+  orpd 0x2a(%rsi), %xmm1
+  {
+    YMM1 := high:128[YMM1].127:0[YMM1] | mem[RSI + 0x2A, el]:u128
+  }
+  $ mc 0xc5,0xf0,0x56,0x46,0x2a
+  vorps 0x2a(%rsi), %xmm1, %xmm0
+  {
+    YMM0 := 0.127:0[YMM1] | mem[RSI + 0x2A, el]:u128
+  }
+  $ mc 0xc5,0xf1,0x56,0x46,0x2a
+  vorpd 0x2a(%rsi), %xmm1, %xmm0
+  {
+    YMM0 := 0.127:0[YMM1] | mem[RSI + 0x2A, el]:u128
+  }
+  $ mc 0xc5,0xf4,0x56,0x46,0x2a
+  vorps 0x2a(%rsi), %ymm1, %ymm0
+  {
+    YMM0 := YMM1 | mem[RSI + 0x2A, el]:u256
+  }
+  $ mc 0xc5,0xf5,0x56,0x46,0x2a
+  vorpd 0x2a(%rsi), %ymm1, %ymm0
+  {
+    YMM0 := YMM1 | mem[RSI + 0x2A, el]:u256
+  }
+
+[v]xorp{d,s}:
+  $ mc 0x0f,0x57,0xca
+  xorps %xmm2, %xmm1
+  {
+    YMM1 := high:128[YMM1].127:0[YMM1] ^ 127:0[YMM2]
+  }
+  $ mc 0x66,0x0f,0x57,0xca
+  xorpd %xmm2, %xmm1
+  {
+    YMM1 := high:128[YMM1].127:0[YMM1] ^ 127:0[YMM2]
+  }
+  $ mc 0xc5,0xf0,0x57,0xc2
+  vxorps %xmm2, %xmm1, %xmm0
+  {
+    YMM0 := 0.127:0[YMM1] ^ 127:0[YMM2]
+  }
+  $ mc 0xc5,0xf1,0x57,0xc2
+  vxorpd %xmm2, %xmm1, %xmm0
+  {
+    YMM0 := 0.127:0[YMM1] ^ 127:0[YMM2]
+  }
+  $ mc 0x0f,0x57,0x4e,0x2a
+  xorps 0x2a(%rsi), %xmm1
+  {
+    YMM1 := high:128[YMM1].127:0[YMM1] ^ mem[RSI + 0x2A, el]:u128
+  }
+  $ mc 0x0f,0x57,0x4e,0x2a
+  xorps 0x2a(%rsi), %xmm1
+  {
+    YMM1 := high:128[YMM1].127:0[YMM1] ^ mem[RSI + 0x2A, el]:u128
+  }
+  $ mc 0x66,0x0f,0x57,0x4e,0x2a
+  xorpd 0x2a(%rsi), %xmm1
+  {
+    YMM1 := high:128[YMM1].127:0[YMM1] ^ mem[RSI + 0x2A, el]:u128
+  }
+  $ mc 0xc5,0xf0,0x57,0x46,0x2a
+  vxorps 0x2a(%rsi), %xmm1, %xmm0
+  {
+    YMM0 := 0.127:0[YMM1] ^ mem[RSI + 0x2A, el]:u128
+  }
+  $ mc 0xc5,0xf1,0x57,0x46,0x2a
+  vxorpd 0x2a(%rsi), %xmm1, %xmm0
+  {
+    YMM0 := 0.127:0[YMM1] ^ mem[RSI + 0x2A, el]:u128
+  }
+  $ mc 0xc5,0xf4,0x57,0x46,0x2a
+  vxorps 0x2a(%rsi), %ymm1, %ymm0
+  {
+    YMM0 := YMM1 ^ mem[RSI + 0x2A, el]:u256
+  }
+  $ mc 0xc5,0xf5,0x57,0x46,0x2a
+  vxorpd 0x2a(%rsi), %ymm1, %ymm0
+  {
+    YMM0 := YMM1 ^ mem[RSI + 0x2A, el]:u256
+  }
+
+[v]andnp{d,s}:
+  $ mc 0x0f,0x55,0xca
+  andnps %xmm2, %xmm1
+  {
+    YMM1 := high:128[YMM1].~(127:0[YMM1] & 127:0[YMM2])
+  }
+  $ mc 0x66,0x0f,0x55,0xca
+  andnpd %xmm2, %xmm1
+  {
+    YMM1 := high:128[YMM1].~(127:0[YMM1] & 127:0[YMM2])
+  }
+  $ mc 0xc5,0xf0,0x55,0xc2
+  vandnps %xmm2, %xmm1, %xmm0
+  {
+    YMM0 := 0.~(127:0[YMM1] & 127:0[YMM2])
+  }
+  $ mc 0xc5,0xf1,0x55,0xc2
+  vandnpd %xmm2, %xmm1, %xmm0
+  {
+    YMM0 := 0.~(127:0[YMM1] & 127:0[YMM2])
+  }
+  $ mc 0x0f,0x55,0x4e,0x2a
+  andnps 0x2a(%rsi), %xmm1
+  {
+    YMM1 := high:128[YMM1].~(127:0[YMM1] & mem[RSI + 0x2A, el]:u128)
+  }
+  $ mc 0x0f,0x55,0x4e,0x2a
+  andnps 0x2a(%rsi), %xmm1
+  {
+    YMM1 := high:128[YMM1].~(127:0[YMM1] & mem[RSI + 0x2A, el]:u128)
+  }
+  $ mc 0x66,0x0f,0x55,0x4e,0x2a
+  andnpd 0x2a(%rsi), %xmm1
+  {
+    YMM1 := high:128[YMM1].~(127:0[YMM1] & mem[RSI + 0x2A, el]:u128)
+  }
+  $ mc 0xc5,0xf0,0x55,0x46,0x2a
+  vandnps 0x2a(%rsi), %xmm1, %xmm0
+  {
+    YMM0 := 0.~(127:0[YMM1] & mem[RSI + 0x2A, el]:u128)
+  }
+  $ mc 0xc5,0xf1,0x55,0x46,0x2a
+  vandnpd 0x2a(%rsi), %xmm1, %xmm0
+  {
+    YMM0 := 0.~(127:0[YMM1] & mem[RSI + 0x2A, el]:u128)
+  }
+  $ mc 0xc5,0xf4,0x55,0x46,0x2a
+  vandnps 0x2a(%rsi), %ymm1, %ymm0
+  {
+    YMM0 := ~(YMM1 & mem[RSI + 0x2A, el]:u256)
+  }
+  $ mc 0xc5,0xf5,0x55,0x46,0x2a
+  vandnpd 0x2a(%rsi), %ymm1, %ymm0
+  {
+    YMM0 := ~(YMM1 & mem[RSI + 0x2A, el]:u256)
+  }

--- a/plugins/x86/semantics/x86-64-sse-intrinsics.lisp
+++ b/plugins/x86/semantics/x86-64-sse-intrinsics.lisp
@@ -175,12 +175,6 @@
 (defun MFENCE ()
   (intrinsic 'mfence))
 
-(defun ANDPDrr (rd rn rm)
-  (set-sse rd (logand rn rm)))
-
-(defun ANDPDrm (rd rn ptr _ _ off _)
-  (set-sse rd (logand rn (load-mem ptr off))))
-
 (defun sse-truncate (name rt rs rn)
   (intrinsic
    (symbol-concat name 'rtz *sse-format* :sep '_)

--- a/plugins/x86/semantics/x86-64.lisp
+++ b/plugins/x86/semantics/x86-64.lisp
@@ -283,3 +283,152 @@
 ;; to be overriden by specialized analyses
 (defun non-temporal-store-word (base off src)
   (store-word (+ base off) src))
+
+;; [v]andp{s,d}
+(defun ANDPSrr (rd rn rm)
+  (bitwise-rrr set$ ident logand rd rn rm))
+
+(defun ANDPDrr (rd rn rm)
+  (bitwise-rrr set$ ident logand rd rn rm))
+
+(defun VANDPSrr (rd rn rm)
+  (bitwise-rrr setv ident logand rd rn rm))
+
+(defun VANDPDrr (rd rn rm)
+  (bitwise-rrr setv ident logand rd rn rm))
+
+(defun VANDPDYrr (rd rn rm)
+  (bitwise-rrr set$ ident logand rd rn rm))
+
+(defun ANDPSrm (rd rn ptr _ _ off _)
+  (bitwise-rrm set$ ident logand rd rn ptr off))
+
+(defun ANDPDrm (rd rn ptr _ _ off _)
+  (bitwise-rrm set$ ident logand rd rn ptr off))
+
+(defun VANDPSrm (rd rn ptr _ _ off _)
+  (bitwise-rrm setv ident logand rd rn ptr off))
+
+(defun VANDPDrm (rd rn ptr _ _ off _)
+  (bitwise-rrm setv ident logand rd rn ptr off))
+
+(defun VANDPSYrm (rd rn ptr _ _ off _)
+  (bitwise-rrm set$ ident logand rd rn ptr off))
+
+(defun VANDPDYrm (rd rn ptr _ _ off _)
+  (bitwise-rrm set$ ident logand rd rn ptr off))
+
+;; [v]orp{s,d}
+(defun ORPSrr (rd rn rm)
+  (bitwise-rrr set$ ident logor rd rn rm))
+
+(defun ORPDrr (rd rn rm)
+  (bitwise-rrr set$ ident logor rd rn rm))
+
+(defun VORPSrr (rd rn rm)
+  (bitwise-rrr setv ident logor rd rn rm))
+
+(defun VORPDrr (rd rn rm)
+  (bitwise-rrr setv ident logor rd rn rm))
+
+(defun VORPDYrr (rd rn rm)
+  (bitwise-rrr set$ ident logor rd rn rm))
+
+(defun ORPSrm (rd rn ptr _ _ off _)
+  (bitwise-rrm set$ ident logor rd rn ptr off))
+
+(defun ORPDrm (rd rn ptr _ _ off _)
+  (bitwise-rrm set$ ident logor rd rn ptr off))
+
+(defun VORPSrm (rd rn ptr _ _ off _)
+  (bitwise-rrm setv ident logor rd rn ptr off))
+
+(defun VORPDrm (rd rn ptr _ _ off _)
+  (bitwise-rrm setv ident logor rd rn ptr off))
+
+(defun VORPSYrm (rd rn ptr _ _ off _)
+  (bitwise-rrm set$ ident logor rd rn ptr off))
+
+(defun VORPDYrm (rd rn ptr _ _ off _)
+  (bitwise-rrm set$ ident logor rd rn ptr off))
+
+;; [v]xorp{s,d}
+(defun XORPSrr (rd rn rm)
+  (bitwise-rrr set$ ident logxor rd rn rm))
+
+(defun XORPDrr (rd rn rm)
+  (bitwise-rrr set$ ident logxor rd rn rm))
+
+(defun VXORPSrr (rd rn rm)
+  (bitwise-rrr setv ident logxor rd rn rm))
+
+(defun VXORPDrr (rd rn rm)
+  (bitwise-rrr setv ident logxor rd rn rm))
+
+(defun VXORPDYrr (rd rn rm)
+  (bitwise-rrr set$ ident logxor rd rn rm))
+
+(defun XORPSrm (rd rn ptr _ _ off _)
+  (bitwise-rrm set$ ident logxor rd rn ptr off))
+
+(defun XORPDrm (rd rn ptr _ _ off _)
+  (bitwise-rrm set$ ident logxor rd rn ptr off))
+
+(defun VXORPSrm (rd rn ptr _ _ off _)
+  (bitwise-rrm setv ident logxor rd rn ptr off))
+
+(defun VXORPDrm (rd rn ptr _ _ off _)
+  (bitwise-rrm setv ident logxor rd rn ptr off))
+
+(defun VXORPSYrm (rd rn ptr _ _ off _)
+  (bitwise-rrm set$ ident logxor rd rn ptr off))
+
+(defun VXORPDYrm (rd rn ptr _ _ off _)
+  (bitwise-rrm set$ ident logxor rd rn ptr off))
+
+
+;; [v]andnp{s,d}
+(defun ANDNPSrr (rd rn rm)
+  (bitwise-rrr set$ lnot logand rd rn rm))
+
+(defun ANDNPDrr (rd rn rm)
+  (bitwise-rrr set$ lnot logand rd rn rm))
+
+(defun VANDNPSrr (rd rn rm)
+  (bitwise-rrr setv lnot logand rd rn rm))
+
+(defun VANDNPDrr (rd rn rm)
+  (bitwise-rrr setv lnot logand rd rn rm))
+
+(defun VANDNPDYrr (rd rn rm)
+  (bitwise-rrr set$ lnot logand rd rn rm))
+
+(defun ANDNPSrm (rd rn ptr _ _ off _)
+  (bitwise-rrm set$ lnot logand rd rn ptr off))
+
+(defun ANDNPDrm (rd rn ptr _ _ off _)
+  (bitwise-rrm set$ lnot logand rd rn ptr off))
+
+(defun VANDNPSrm (rd rn ptr _ _ off _)
+  (bitwise-rrm setv lnot logand rd rn ptr off))
+
+(defun VANDNPDrm (rd rn ptr _ _ off _)
+  (bitwise-rrm setv lnot logand rd rn ptr off))
+
+(defun VANDNPSYrm (rd rn ptr _ _ off _)
+  (bitwise-rrm set$ lnot logand rd rn ptr off))
+
+(defun VANDNPDYrm (rd rn ptr _ _ off _)
+  (bitwise-rrm set$ lnot logand rd rn ptr off))
+
+(defun setv (r x)
+  "(setv XMMx X) assigns X to lower bits of XMMx and zeros the upper.
+   (word-width X) must be 128"
+  (set$ (alias-base-register r)
+        (concat (cast-unsigned (word-width x) 0) x)))
+
+(defmacro bitwise-rrr (set opo opi rd rn rm)
+  (set rd (opo (opi rn rm))))
+
+(defmacro bitwise-rrm (set opo opi rd rn ptr off)
+  (set rd (opo (opi rn (load-bits (word-width (unquote rn)) (+ ptr off))))))

--- a/plugins/x86/x86_disasm.ml
+++ b/plugins/x86/x86_disasm.ml
@@ -970,10 +970,7 @@ let parse_instr mode mem addr =
         | 0x4a | 0x4b | 0x4c | 0x4d | 0x4e | 0x4f ->
           let (r, rm, na) = parse_modrm_addr None na in
           (Mov(prefix.opsize, r, rm, Some(cc_to_exp b2)), na)
-        | 0x57 ->
-          let r, rm, rv, na = parse_modrm_vec None na in
-          let t = if Type.equal prefix.mopsize reg256_t then reg256_t else reg128_t in
-          (Ppackedbinop(t, prefix.opsize, Bil.(lxor), "xorp", r, rm, rv), na)
+        | 0x57 -> unimplemented "now it is handled by lisp loader"
         | 0x60 | 0x61 | 0x62 | 0x68 | 0x69 | 0x6a ->
           let order = match b2 with
             | 0x60 | 0x61 | 0x62 -> Low


### PR DESCRIPTION
These instructions apply bitwise operations on the packed data, in total 16 instructions. Suprisingly, out of this family we already handled the packed xor variant, but the semantics was very ineffcient as it wasn't using the fact that all bitwise operations are distributive over concatenation.